### PR TITLE
solr: add buildAndRunCollectorChain methods to reduce code duplication

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/Grouping.java
+++ b/solr/core/src/java/org/apache/solr/search/Grouping.java
@@ -359,18 +359,10 @@ public class Grouping {
       }
     }
 
-    if (pf.postFilter != null) {
-      pf.postFilter.setLastDelegate(allCollectors);
-      allCollectors = pf.postFilter;
-    }
-
     if (allCollectors != null) {
-      searchWithTimeLimiter(luceneFilter, allCollectors);
-
-      if(allCollectors instanceof DelegatingCollector) {
-        ((DelegatingCollector) allCollectors).finish();
-      }
+      buildAndRunCollectorChain(luceneFilter, allCollectors, pf.postFilter);
     }
+
 
     if (getGroupedDocSet && allGroupHeadsCollector != null) {
       qr.setDocSet(new BitDocSet(allGroupHeadsCollector.retrieveGroupHeads(maxDoc)));
@@ -395,18 +387,10 @@ public class Grouping {
             signalCacheWarning = true;
             logger.warn(String.format(Locale.ROOT, "The grouping cache is active, but not used because it exceeded the max cache limit of %d percent", maxDocsPercentageToCache));
             logger.warn("Please increase cache size or disable group caching.");
-            searchWithTimeLimiter(luceneFilter, secondPhaseCollectors);
+            buildAndRunCollectorChain(luceneFilter, secondPhaseCollectors, null);
           }
         } else {
-          if (pf.postFilter != null) {
-            pf.postFilter.setLastDelegate(secondPhaseCollectors);
-            secondPhaseCollectors = pf.postFilter;
-          }
-          searchWithTimeLimiter(luceneFilter, secondPhaseCollectors);
-
-          if(secondPhaseCollectors instanceof DelegatingCollector) {
-            ((DelegatingCollector) secondPhaseCollectors).finish();
-          }
+          buildAndRunCollectorChain(luceneFilter, secondPhaseCollectors, pf.postFilter);
         }
       }
     }
@@ -432,7 +416,7 @@ public class Grouping {
    * Invokes search with the specified filter and collector.  
    * If a time limit has been specified, wrap the collector in a TimeLimitingCollector
    */
-  private void searchWithTimeLimiter(final Filter luceneFilter, Collector collector) throws IOException {
+  private void buildAndRunCollectorChain(final Filter luceneFilter, Collector collector, DelegatingCollector postFilter) throws IOException {
     if (cmd.getTimeAllowed() > 0) {
       if (timeLimitingCollector == null) {
         timeLimitingCollector = new TimeLimitingCollector(collector, TimeLimitingCollector.getGlobalCounter(), cmd.getTimeAllowed());
@@ -447,12 +431,23 @@ public class Grouping {
       }
       collector = timeLimitingCollector;
     }
+    
+    if (postFilter != null) {
+      postFilter.setLastDelegate(collector);
+      collector = postFilter;
+    }
+
     try {
       searcher.search(query, luceneFilter, collector);
     } catch (TimeLimitingCollector.TimeExceededException x) {
       logger.warn( "Query: " + query + "; " + x.getMessage() );
       qr.setPartialResults(true);
     }
+
+    if(collector instanceof DelegatingCollector) {
+      ((DelegatingCollector) collector).finish();
+    }
+    
   }
 
   /**

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -181,6 +181,36 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable,SolrIn
     return reader;
   }
 
+  private void buildAndRunCollectorChain(QueryResult qr, Query query, Filter luceneFilter,
+      Collector collector, QueryCommand cmd, DelegatingCollector postFilter) throws IOException {
+    
+    final boolean terminateEarly = (cmd.getFlags() & TERMINATE_EARLY) == TERMINATE_EARLY;
+    if (terminateEarly) {
+      collector = new EarlyTerminatingCollector(collector, cmd.len);
+    }
+
+    final long timeAllowed = cmd.getTimeAllowed();
+    if( timeAllowed > 0 ) {
+      collector = new TimeLimitingCollector(collector, TimeLimitingCollector.getGlobalCounter(), timeAllowed);
+    }
+    
+    if (postFilter != null) {
+      postFilter.setLastDelegate(collector);
+      collector = postFilter;
+    }
+    
+    try {
+      super.search(query, luceneFilter, collector);
+      if(collector instanceof DelegatingCollector) {
+        ((DelegatingCollector)collector).finish();
+      }
+    }
+    catch( TimeLimitingCollector.TimeExceededException x ) {
+      log.warn( "Query: " + query + "; " + x.getMessage() );
+      qr.setPartialResults(true);
+    }        
+  }
+  
   public SolrIndexSearcher(SolrCore core, String path, IndexSchema schema, SolrIndexConfig config, String name, boolean enableCache, DirectoryFactory directoryFactory) throws IOException {
     // we don't need to reserve the directory because we get it from the factory
     this(core, path, schema, config, name, null, true, enableCache, false, directoryFactory);
@@ -1498,7 +1528,6 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable,SolrIn
   }
 
   private void getDocListNC(QueryResult qr,QueryCommand cmd) throws IOException {
-    final long timeAllowed = cmd.getTimeAllowed();
     int len = cmd.getSupersetMaxDoc();
     int last = len;
     if (last < 0 || last > maxDoc()) last=maxDoc();
@@ -1510,7 +1539,6 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable,SolrIn
     float[] scores;
 
     boolean needScores = (cmd.getFlags() & GET_SCORES) != 0;
-    boolean terminateEarly = (cmd.getFlags() & TERMINATE_EARLY) == TERMINATE_EARLY;
     
     Query query = QueryUtils.makeQueryable(cmd.getQuery());
 
@@ -1563,27 +1591,8 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable,SolrIn
           }
         };
       }
-      if (terminateEarly) {
-        collector = new EarlyTerminatingCollector(collector, cmd.len);
-      }
-      if( timeAllowed > 0 ) {
-        collector = new TimeLimitingCollector(collector, TimeLimitingCollector.getGlobalCounter(), timeAllowed);
-      }
-      if (pf.postFilter != null) {
-        pf.postFilter.setLastDelegate(collector);
-        collector = pf.postFilter;
-      }
-
-      try {
-        super.search(query, luceneFilter, collector);
-        if(collector instanceof DelegatingCollector) {
-          ((DelegatingCollector)collector).finish();
-        }
-      }
-      catch( TimeLimitingCollector.TimeExceededException x ) {
-        log.warn( "Query: " + query + "; " + x.getMessage() );
-        qr.setPartialResults(true);
-      }
+      
+      buildAndRunCollectorChain(qr, query, luceneFilter, collector, cmd, pf.postFilter);
 
       nDocsReturned=0;
       ids = new int[nDocsReturned];
@@ -1594,27 +1603,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable,SolrIn
       qr.setNextCursorMark(cmd.getCursorMark());
     } else {
       final TopDocsCollector topCollector = buildTopDocsCollector(len, cmd);
-      Collector collector = topCollector;
-      if (terminateEarly) {
-        collector = new EarlyTerminatingCollector(collector, cmd.len);
-      }
-      if( timeAllowed > 0 ) {
-        collector = new TimeLimitingCollector(collector, TimeLimitingCollector.getGlobalCounter(), timeAllowed);
-      }
-      if (pf.postFilter != null) {
-        pf.postFilter.setLastDelegate(collector);
-        collector = pf.postFilter;
-      }
-      try {
-        super.search(query, luceneFilter, collector);
-        if(collector instanceof DelegatingCollector) {
-          ((DelegatingCollector)collector).finish();
-        }
-      }
-      catch( TimeLimitingCollector.TimeExceededException x ) {
-        log.warn( "Query: " + query + "; " + x.getMessage() );
-        qr.setPartialResults(true);
-      }
+      buildAndRunCollectorChain(qr, query, luceneFilter, topCollector, cmd, pf.postFilter);
 
       totalHits = topCollector.getTotalHits();
       TopDocs topDocs = topCollector.topDocs(0, len);
@@ -1651,7 +1640,6 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable,SolrIn
     DocSet set;
 
     boolean needScores = (cmd.getFlags() & GET_SCORES) != 0;
-    boolean terminateEarly = (cmd.getFlags() & TERMINATE_EARLY) == TERMINATE_EARLY;
     int maxDoc = maxDoc();
     int smallSetSize = maxDoc>>6;
 
@@ -1659,7 +1647,6 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable,SolrIn
     final Filter luceneFilter = pf.filter;
 
     Query query = QueryUtils.makeQueryable(cmd.getQuery());
-    final long timeAllowed = cmd.getTimeAllowed();
 
     // handle zero case...
     if (lastDocRequested<=0) {
@@ -1691,27 +1678,8 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable,SolrIn
            }
          });
        }
-       if (terminateEarly) {
-         collector = new EarlyTerminatingCollector(collector, cmd.len);
-       }
-       if( timeAllowed > 0 ) {
-         collector = new TimeLimitingCollector(collector, TimeLimitingCollector.getGlobalCounter(), timeAllowed);
-       }
-      if (pf.postFilter != null) {
-        pf.postFilter.setLastDelegate(collector);
-        collector = pf.postFilter;
-      }
-
-       try {
-         super.search(query, luceneFilter, collector);
-         if(collector instanceof DelegatingCollector) {
-           ((DelegatingCollector)collector).finish();
-         }
-       }
-       catch( TimeLimitingCollector.TimeExceededException x ) {
-         log.warn( "Query: " + query + "; " + x.getMessage() );
-         qr.setPartialResults(true);
-       }
+       
+       buildAndRunCollectorChain(qr, query, luceneFilter, collector, cmd, pf.postFilter);
 
       set = setCollector.getDocSet();
 
@@ -1726,27 +1694,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable,SolrIn
 
       final TopDocsCollector topCollector = buildTopDocsCollector(len, cmd);
       DocSetCollector setCollector = new DocSetDelegateCollector(maxDoc>>6, maxDoc, topCollector);
-      Collector collector = setCollector;
-      if (terminateEarly) {
-        collector = new EarlyTerminatingCollector(collector, cmd.len);
-      }
-      if( timeAllowed > 0 ) {
-        collector = new TimeLimitingCollector(collector, TimeLimitingCollector.getGlobalCounter(), timeAllowed );
-      }
-      if (pf.postFilter != null) {
-        pf.postFilter.setLastDelegate(collector);
-        collector = pf.postFilter;
-      }
-      try {
-        super.search(query, luceneFilter, collector);
-        if(collector instanceof DelegatingCollector) {
-          ((DelegatingCollector)collector).finish();
-        }
-      }
-      catch( TimeLimitingCollector.TimeExceededException x ) {
-        log.warn( "Query: " + query + "; " + x.getMessage() );
-        qr.setPartialResults(true);
-      }
+      buildAndRunCollectorChain(qr, query, luceneFilter, setCollector, cmd, pf.postFilter);
 
       set = setCollector.getDocSet();      
 

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -1603,7 +1603,8 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable,SolrIn
       qr.setNextCursorMark(cmd.getCursorMark());
     } else {
       final TopDocsCollector topCollector = buildTopDocsCollector(len, cmd);
-      buildAndRunCollectorChain(qr, query, luceneFilter, topCollector, cmd, pf.postFilter);
+      Collector collector = topCollector;
+      buildAndRunCollectorChain(qr, query, luceneFilter, collector, cmd, pf.postFilter);
 
       totalHits = topCollector.getTotalHits();
       TopDocs topDocs = topCollector.topDocs(0, len);
@@ -1694,7 +1695,8 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable,SolrIn
 
       final TopDocsCollector topCollector = buildTopDocsCollector(len, cmd);
       DocSetCollector setCollector = new DocSetDelegateCollector(maxDoc>>6, maxDoc, topCollector);
-      buildAndRunCollectorChain(qr, query, luceneFilter, setCollector, cmd, pf.postFilter);
+      Collector collector = setCollector;
+      buildAndRunCollectorChain(qr, query, luceneFilter, collector, cmd, pf.postFilter);
 
       set = setCollector.getDocSet();      
 


### PR DESCRIPTION
Adds buildAndRunCollectorChain method to reduce code duplication in SolrIndexSearcher class. No SOLR JIRA ticket opened as yet.