### PR TITLE
SolrIndexSearcher makes no DelegatingCollector.finish() call when ...

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -222,14 +222,21 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable,SolrIn
     
     try {
       super.search(query, luceneFilter, collector);
-      if(collector instanceof DelegatingCollector) {
-        ((DelegatingCollector)collector).finish();
-      }
     }
     catch( TimeLimitingCollector.TimeExceededException x ) {
       log.warn( "Query: " + query + "; " + x.getMessage() );
       qr.setPartialResults(true);
     }        
+    catch (EarlyTerminatingCollectorException etce) {
+      if(collector instanceof DelegatingCollector) {
+        ((DelegatingCollector)collector).finish();
+      }
+      throw etce;
+    }
+
+    if(collector instanceof DelegatingCollector) {
+      ((DelegatingCollector)collector).finish();
+    }
   }
   
   public SolrIndexSearcher(SolrCore core, String path, IndexSchema schema, SolrIndexConfig config, String name, boolean enableCache, DirectoryFactory directoryFactory) throws IOException {


### PR DESCRIPTION
SolrIndexSearcher makes no DelegatingCollector.finish() call when IndexSearcher throws an expected exception. This seems like an omission.

This pull request is for https://issues.apache.org/jira/i#browse/SOLR-6087 re-baselined against trunk which now contains the SOLR-6067 refactor.
