### PR TITLE
Use JUnit rules instead of inheritance with distributed Solr tests to allow for multiple tests without the same class

### DIFF
--- a/solr/contrib/clustering/src/test/org/apache/solr/handler/clustering/DistributedClusteringComponentTest.java
+++ b/solr/contrib/clustering/src/test/org/apache/solr/handler/clustering/DistributedClusteringComponentTest.java
@@ -20,6 +20,7 @@ package org.apache.solr.handler.clustering;
 import org.apache.solr.BaseDistributedSearchTestCase;
 import org.apache.solr.SolrTestCaseJ4.SuppressSSL;
 import org.apache.solr.common.params.CommonParams;
+import org.junit.Test;
 
 @SuppressSSL
 public class DistributedClusteringComponentTest extends
@@ -30,8 +31,8 @@ public class DistributedClusteringComponentTest extends
     return getFile("clustering/solr/collection1").getParent();
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  public void test() throws Exception {
     del("*:*");
     int numberOfDocs = 0;
     for (String[] doc : AbstractClusteringTestCase.DOCUMENTS) {
@@ -47,7 +48,7 @@ public class DistributedClusteringComponentTest extends
         CommonParams.Q, "*:*",
         CommonParams.SORT, id + " desc",
         ClusteringParams.USE_SEARCH_RESULTS, "true");
-    // destroy is not needed because tearDown method of base class does it.
+    // destroy is not needed because distribTearDown method of base class does it.
     //destroyServers();
   }
 

--- a/solr/contrib/map-reduce/src/test/org/apache/solr/hadoop/MorphlineGoLiveMiniMRTest.java
+++ b/solr/contrib/map-reduce/src/test/org/apache/solr/hadoop/MorphlineGoLiveMiniMRTest.java
@@ -71,9 +71,7 @@ import org.apache.solr.common.util.NamedList;
 import org.apache.solr.hadoop.hack.MiniMRClientCluster;
 import org.apache.solr.hadoop.hack.MiniMRClientClusterFactory;
 import org.apache.solr.morphlines.solr.AbstractSolrMorphlineTestBase;
-import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -120,10 +118,9 @@ public class MorphlineGoLiveMiniMRTest extends AbstractFullDistribZkTestBase {
     this.inputAvroFile1 = "sample-statuses-20120521-100919.avro";
     this.inputAvroFile2 = "sample-statuses-20120906-141433.avro";
     this.inputAvroFile3 = "sample-statuses-20120906-141433-medium.avro";
-    
-    fixShardCount = true;
+
     sliceCount = TEST_NIGHTLY ? 7 : 3;
-    shardCount = TEST_NIGHTLY ? 7 : 3;
+    fixShardCount(TEST_NIGHTLY ? 7 : 3);
   }
   
   @BeforeClass
@@ -199,9 +196,8 @@ public class MorphlineGoLiveMiniMRTest extends AbstractFullDistribZkTestBase {
   }
   
   @Override
-  @Before
-  public void setUp() throws Exception {
-    super.setUp();
+  public void distribSetUp() throws Exception {
+    super.distribSetUp();
     System.setProperty("host", "127.0.0.1");
     System.setProperty("numShards", Integer.toString(sliceCount));
     URI uri = dfsCluster.getFileSystem().getUri();
@@ -210,9 +206,8 @@ public class MorphlineGoLiveMiniMRTest extends AbstractFullDistribZkTestBase {
   }
   
   @Override
-  @After
-  public void tearDown() throws Exception {
-    super.tearDown();
+  public void distribTearDown() throws Exception {
+    super.distribTearDown();
     System.clearProperty("host");
     System.clearProperty("numShards");
     System.clearProperty("solr.hdfs.home");
@@ -242,12 +237,6 @@ public class MorphlineGoLiveMiniMRTest extends AbstractFullDistribZkTestBase {
   private JobConf getJobConf() throws IOException {
     JobConf jobConf = new JobConf(mrCluster.getConfig());
     return jobConf;
-  }
-  
-  @Test
-  @Override
-  public void testDistribSearch() throws Exception {
-    super.testDistribSearch();
   }
   
   @Test
@@ -352,9 +341,9 @@ public class MorphlineGoLiveMiniMRTest extends AbstractFullDistribZkTestBase {
     };
     return concat(head, args); 
   }
-  
-  @Override
-  public void doTest() throws Exception {
+
+  @Test
+  public void test() throws Exception {
     
     waitForRecoveriesToFinish(false);
     
@@ -693,7 +682,7 @@ public class MorphlineGoLiveMiniMRTest extends AbstractFullDistribZkTestBase {
   }
 
   private void getShardUrlArgs(List<String> args) {
-    for (int i = 0; i < shardCount; i++) {
+    for (int i = 0; i < getShardCount(); i++) {
       args.add("--shard-url");
       args.add(cloudJettys.get(i).url);
     }

--- a/solr/contrib/morphlines-core/src/test/org/apache/solr/morphlines/solr/AbstractSolrMorphlineZkTestBase.java
+++ b/solr/contrib/morphlines-core/src/test/org/apache/solr/morphlines/solr/AbstractSolrMorphlineZkTestBase.java
@@ -29,10 +29,7 @@ import org.apache.solr.cloud.AbstractFullDistribZkTestBase;
 import org.apache.solr.cloud.AbstractZkTestCase;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.cloud.SolrZkClient;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Test;
 import org.kitesdk.morphline.api.Collector;
 import org.kitesdk.morphline.api.Command;
 import org.kitesdk.morphline.api.MorphlineContext;
@@ -62,9 +59,8 @@ public abstract class AbstractSolrMorphlineZkTestBase extends AbstractFullDistri
   }
   
   public AbstractSolrMorphlineZkTestBase() {
-    fixShardCount = true;
     sliceCount = 3;
-    shardCount = 3;
+    fixShardCount(3);
   }
   
   @BeforeClass
@@ -77,9 +73,8 @@ public abstract class AbstractSolrMorphlineZkTestBase extends AbstractFullDistri
   }
   
   @Override
-  @Before
-  public void setUp() throws Exception {
-    super.setUp();
+  public void distribSetUp() throws Exception {
+    super.distribSetUp();
     System.setProperty("host", "127.0.0.1");
     System.setProperty("numShards", Integer.toString(sliceCount));
     uploadConfFiles();
@@ -87,17 +82,10 @@ public abstract class AbstractSolrMorphlineZkTestBase extends AbstractFullDistri
   }
   
   @Override
-  @After
-  public void tearDown() throws Exception {
-    super.tearDown();
+  public void distribTearDown() throws Exception {
+    super.distribTearDown();
     System.clearProperty("host");
     System.clearProperty("numShards");
-  }
-  
-  @Test
-  @Override
-  public void testDistribSearch() throws Exception {
-    super.testDistribSearch();
   }
   
   @Override

--- a/solr/contrib/morphlines-core/src/test/org/apache/solr/morphlines/solr/SolrMorphlineZkAliasTest.java
+++ b/solr/contrib/morphlines-core/src/test/org/apache/solr/morphlines/solr/SolrMorphlineZkAliasTest.java
@@ -31,6 +31,7 @@ import org.apache.solr.common.params.CollectionParams.CollectionAction;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.junit.BeforeClass;
+import org.junit.Test;
 import org.kitesdk.morphline.api.Record;
 import org.kitesdk.morphline.base.Fields;
 import org.kitesdk.morphline.base.Notifications;
@@ -55,9 +56,9 @@ public class SolrMorphlineZkAliasTest extends AbstractSolrMorphlineZkTestBase {
     assumeFalse("FIXME: This test fails under Java 8 due to the Saxon dependency - see SOLR-1301", Constants.JRE_IS_MINIMUM_JAVA8);
     assumeFalse("FIXME: This test fails under J9 due to the Saxon dependency - see SOLR-1301", System.getProperty("java.vm.info", "<?>").contains("IBM J9"));
   }
-  
-  @Override
-  public void doTest() throws Exception {
+
+  @Test
+  public void test() throws Exception {
     
     waitForRecoveriesToFinish(false);
     

--- a/solr/contrib/morphlines-core/src/test/org/apache/solr/morphlines/solr/SolrMorphlineZkAvroTest.java
+++ b/solr/contrib/morphlines-core/src/test/org/apache/solr/morphlines/solr/SolrMorphlineZkAvroTest.java
@@ -34,6 +34,7 @@ import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrDocument;
 import org.junit.BeforeClass;
+import org.junit.Test;
 import org.kitesdk.morphline.api.Record;
 import org.kitesdk.morphline.base.Fields;
 import org.kitesdk.morphline.base.Notifications;
@@ -61,9 +62,9 @@ public class SolrMorphlineZkAvroTest extends AbstractSolrMorphlineZkTestBase {
     assumeFalse("FIXME: This test fails under Java 8 due to the Saxon dependency - see SOLR-1301", Constants.JRE_IS_MINIMUM_JAVA8);
     assumeFalse("FIXME: This test fails under J9 due to the Saxon dependency - see SOLR-1301", System.getProperty("java.vm.info", "<?>").contains("IBM J9"));
   }
-  
-  @Override
-  public void doTest() throws Exception {
+
+  @Test
+  public void test() throws Exception {
     Joiner joiner = Joiner.on(File.separator);
     File file = new File(joiner.join(RESOURCES_DIR, "test-documents", "sample-statuses-20120906-141433-medium.avro"));
     

--- a/solr/contrib/morphlines-core/src/test/org/apache/solr/morphlines/solr/SolrMorphlineZkTest.java
+++ b/solr/contrib/morphlines-core/src/test/org/apache/solr/morphlines/solr/SolrMorphlineZkTest.java
@@ -25,6 +25,7 @@ import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrDocument;
 import org.junit.BeforeClass;
+import org.junit.Test;
 import org.kitesdk.morphline.api.Record;
 import org.kitesdk.morphline.base.Fields;
 import org.kitesdk.morphline.base.Notifications;
@@ -49,9 +50,9 @@ public class SolrMorphlineZkTest extends AbstractSolrMorphlineZkTestBase {
     assumeFalse("FIXME: This test fails under Java 8 due to the Saxon dependency - see SOLR-1301", Constants.JRE_IS_MINIMUM_JAVA8);
     assumeFalse("FIXME: This test fails under J9 due to the Saxon dependency - see SOLR-1301", System.getProperty("java.vm.info", "<?>").contains("IBM J9"));
   }
-  
-  @Override
-  public void doTest() throws Exception {
+
+  @Test
+  public void test() throws Exception {
     
     waitForRecoveriesToFinish(false);
     

--- a/solr/core/src/test/org/apache/solr/DistributedIntervalFacetingTest.java
+++ b/solr/core/src/test/org/apache/solr/DistributedIntervalFacetingTest.java
@@ -10,6 +10,7 @@ import org.apache.solr.client.solrj.response.IntervalFacet.Count;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -37,8 +38,8 @@ public class DistributedIntervalFacetingTest extends
     configString = "solrconfig-basic.xml";
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  public void test() throws Exception {
     del("*:*");
     commit();
     testRandom();

--- a/solr/core/src/test/org/apache/solr/TestDistributedGrouping.java
+++ b/solr/core/src/test/org/apache/solr/TestDistributedGrouping.java
@@ -24,6 +24,7 @@ import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.NamedList;
+import org.junit.Test;
 
 /**
  * TODO? perhaps use:
@@ -43,8 +44,8 @@ public class TestDistributedGrouping extends BaseDistributedSearchTestCase {
   String tdate_b = "b_n_tdt";
   String oddField="oddField_s";
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  public void test() throws Exception {
     del("*:*");
     commit();
 

--- a/solr/core/src/test/org/apache/solr/TestDistributedMissingSort.java
+++ b/solr/core/src/test/org/apache/solr/TestDistributedMissingSort.java
@@ -19,6 +19,7 @@ package org.apache.solr;
 
 import org.apache.lucene.util.LuceneTestCase.Slow;
 import org.apache.solr.client.solrj.response.QueryResponse;
+import org.junit.Test;
 
 /**
  * Tests sortMissingFirst and sortMissingLast in distributed sort
@@ -37,8 +38,8 @@ public class TestDistributedMissingSort extends BaseDistributedSearchTestCase {
   String string1_ml = "five_s1_ml"; // StringField, sortMissingLast=true, multiValued=false
   String string1_mf = "six_s1_mf";  // StringField, sortMissingFirst=true, multiValued=false
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  public void test() throws Exception {
     index();
     testSortMissingLast();
     testSortMissingFirst();

--- a/solr/core/src/test/org/apache/solr/TestDistributedSearch.java
+++ b/solr/core/src/test/org/apache/solr/TestDistributedSearch.java
@@ -37,6 +37,7 @@ import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.ShardParams;
 import org.apache.solr.common.util.NamedList;
+import org.junit.Test;
 
 /**
  * TODO? perhaps use:
@@ -61,8 +62,8 @@ public class TestDistributedSearch extends BaseDistributedSearchTestCase {
   String missingField="ignore_exception__missing_but_valid_field_t";
   String invalidField="ignore_exception__invalid_field_not_in_schema";
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  public void test() throws Exception {
     QueryResponse rsp = null;
     int backupStress = stress; // make a copy so we can restore
 

--- a/solr/core/src/test/org/apache/solr/TestHighlightDedupGrouping.java
+++ b/solr/core/src/test/org/apache/solr/TestHighlightDedupGrouping.java
@@ -18,10 +18,10 @@
 package org.apache.solr;
 
 import org.apache.lucene.util.TestUtil;
-import org.apache.lucene.util.TestUtil;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrInputDocument;
+import org.junit.Test;
 
 import java.io.IOException;
 
@@ -35,14 +35,9 @@ public class TestHighlightDedupGrouping extends BaseDistributedSearchTestCase {
   private static final String group_ti1 = "group_ti1";
   private static final String shard_i1 = "shard_i1";
 
-  public TestHighlightDedupGrouping() {
-    super();
-    fixShardCount = true;
-    shardCount = 2;
-  }
-
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  @ShardsFixed(num = 2)
+  public void test() throws Exception {
     basicTest();
     randomizedTest();
   }
@@ -57,7 +52,7 @@ public class TestHighlightDedupGrouping extends BaseDistributedSearchTestCase {
 
     int docid = 1;
     int group = 5;
-    for (int shard = 0 ; shard < shardCount ; ++shard) {
+    for (int shard = 0 ; shard < getShardCount(); ++shard) {
       addDoc(docid, group, shard); // add the same doc to both shards
       clients.get(shard).commit();
     }
@@ -67,7 +62,7 @@ public class TestHighlightDedupGrouping extends BaseDistributedSearchTestCase {
          "shards",      shards,
          "group",       "true",
          "group.field", id_s1,
-         "group.limit", Integer.toString(shardCount),
+         "group.limit", Integer.toString(getShardCount()),
          "hl",          "true",
          "hl.fl",       id_s1
         ));
@@ -93,15 +88,15 @@ public class TestHighlightDedupGrouping extends BaseDistributedSearchTestCase {
       ++docsInGroup[group];
       boolean makeDuplicate = 0 == TestUtil.nextInt(random(), 0, numDocs / percentDuplicates);
       if (makeDuplicate) {
-        for (int shard = 0 ; shard < shardCount ; ++shard) {
+        for (int shard = 0 ; shard < getShardCount(); ++shard) {
           addDoc(docid, group, shard);
         }
       } else {
-        int shard = TestUtil.nextInt(random(), 0, shardCount - 1);
+        int shard = TestUtil.nextInt(random(), 0, getShardCount() - 1);
         addDoc(docid, group, shard);
       }
     }
-    for (int shard = 0 ; shard < shardCount ; ++shard) {
+    for (int shard = 0 ; shard < getShardCount(); ++shard) {
       clients.get(shard).commit();
     }
 

--- a/solr/core/src/test/org/apache/solr/cloud/AliasIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/AliasIntegrationTest.java
@@ -37,10 +37,9 @@ import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.params.CollectionParams.CollectionAction;
 import org.apache.solr.common.params.ModifiableSolrParams;
-import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 /**
  * Test sync phase that occurs when Leader goes down and a new Leader is
@@ -58,28 +57,20 @@ public class AliasIntegrationTest extends AbstractFullDistribZkTestBase {
     
   }
   
-  @Before
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
+  public void distribSetUp() throws Exception {
+    super.distribSetUp();
     System.setProperty("numShards", Integer.toString(sliceCount));
-  }
-  
-  @Override
-  @After
-  public void tearDown() throws Exception {
-    super.tearDown();
-    resetExceptionIgnores();
   }
   
   public AliasIntegrationTest() {
     super();
     sliceCount = 1;
-    shardCount = random().nextBoolean() ? 3 : 4;
+    fixShardCount(random().nextBoolean() ? 3 : 4);
   }
-  
-  @Override
-  public void doTest() throws Exception {
+
+  @Test
+  public void test() throws Exception {
     
     handle.clear();
     handle.put("timestamp", SKIPVAL);

--- a/solr/core/src/test/org/apache/solr/cloud/AsyncMigrateRouteKeyTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/AsyncMigrateRouteKeyTest.java
@@ -25,6 +25,7 @@ import org.apache.solr.common.params.CollectionParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.junit.Before;
+import org.junit.Test;
 
 import java.io.IOException;
 
@@ -36,13 +37,8 @@ public class AsyncMigrateRouteKeyTest extends MigrateRouteKeyTest {
 
   private static final int MAX_WAIT_SECONDS = 2 * 60;
 
-  @Override
-  @Before
-  public void setUp() throws Exception {
-    super.setUp();
-  }
-
-  public void doTest() throws Exception {
+  @Test
+  public void test() throws Exception {
     waitForThingsToLevelOut(15);
 
     multipleShardMigrateTest();

--- a/solr/core/src/test/org/apache/solr/cloud/BasicDistributedZk2Test.java
+++ b/solr/core/src/test/org/apache/solr/cloud/BasicDistributedZk2Test.java
@@ -38,6 +38,7 @@ import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.handler.ReplicationHandler;
+import org.junit.Test;
 
 import java.io.File;
 import java.io.FilenameFilter;
@@ -58,21 +59,12 @@ public class BasicDistributedZk2Test extends AbstractFullDistribZkTestBase {
   
   public BasicDistributedZk2Test() {
     super();
-    fixShardCount = true;
-    
     sliceCount = 2;
-    shardCount = 4;
   }
   
-  /*
-   * (non-Javadoc)
-   * 
-   * @see org.apache.solr.BaseDistributedSearchTestCase#doTest()
-   * 
-   * Create 3 shards, each with one replica
-   */
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  @ShardsFixed(num = 4)
+  public void test() throws Exception {
     boolean testFinished = false;
     try {
       handle.clear();

--- a/solr/core/src/test/org/apache/solr/cloud/BasicDistributedZkTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/BasicDistributedZkTest.java
@@ -50,8 +50,8 @@ import org.apache.solr.common.params.UpdateParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.update.DirectUpdateHandler2;
 import org.apache.solr.util.DefaultSolrThreadFactory;
-import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -106,20 +106,16 @@ public class BasicDistributedZkTest extends AbstractFullDistribZkTestBase {
   public static void beforeThisClass2() throws Exception {
   }
   
-  @Before
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
+  public void distribSetUp() throws Exception {
+    super.distribSetUp();
     System.setProperty("numShards", Integer.toString(sliceCount));
     System.setProperty("solr.xml.persist", "true");
   }
 
   
   public BasicDistributedZkTest() {
-    fixShardCount = true;
-    
     sliceCount = 2;
-    shardCount = 4;
     completionService = new ExecutorCompletionService<>(executor);
     pending = new HashSet<>();
     
@@ -133,7 +129,7 @@ public class BasicDistributedZkTest extends AbstractFullDistribZkTestBase {
     } else {
       // use shard ids rather than physical locations
       StringBuilder sb = new StringBuilder();
-      for (int i = 0; i < shardCount; i++) {
+      for (int i = 0; i < getShardCount(); i++) {
         if (i > 0)
           sb.append(',');
         sb.append("shard" + (i + 3));
@@ -141,9 +137,10 @@ public class BasicDistributedZkTest extends AbstractFullDistribZkTestBase {
       params.set("shards", sb.toString());
     }
   }
-  
-  @Override
-  public void doTest() throws Exception {
+
+  @Test
+  @ShardsFixed(num = 4)
+  public void test() throws Exception {
     // setLoggingLevel(null);
 
     ZkStateReader zkStateReader = cloudClient.getZkStateReader();
@@ -1162,8 +1159,8 @@ public class BasicDistributedZkTest extends AbstractFullDistribZkTestBase {
   }
   
   @Override
-  public void tearDown() throws Exception {
-    super.tearDown();
+  public void distribTearDown() throws Exception {
+    super.distribTearDown();
     if (commondCloudSolrClient != null) {
       commondCloudSolrClient.shutdown();
     }
@@ -1177,9 +1174,8 @@ public class BasicDistributedZkTest extends AbstractFullDistribZkTestBase {
     otherCollectionClients = null;
     List<Runnable> tasks = executor.shutdownNow();
     assertTrue(tasks.isEmpty());
-    
+
     System.clearProperty("numShards");
-    System.clearProperty("zkHost");
     System.clearProperty("solr.xml.persist");
     
     // insurance

--- a/solr/core/src/test/org/apache/solr/cloud/ChaosMonkeyNothingIsSafeTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ChaosMonkeyNothingIsSafeTest.java
@@ -37,6 +37,7 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -88,10 +89,9 @@ public class ChaosMonkeyNothingIsSafeTest extends AbstractFullDistribZkTestBase 
     return randVals;
   }
   
-  @Before
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
+  public void distribSetUp() throws Exception {
+    super.distribSetUp();
     // can help to hide this when testing and looking at logs
     //ignoreException("shard update error");
     System.setProperty("numShards", Integer.toString(sliceCount));
@@ -99,28 +99,27 @@ public class ChaosMonkeyNothingIsSafeTest extends AbstractFullDistribZkTestBase 
   }
   
   @Override
-  @After
-  public void tearDown() throws Exception {
+  public void distribTearDown() throws Exception {
     System.clearProperty("numShards");
-    super.tearDown();
-    resetExceptionIgnores();
+    super.distribTearDown();
   }
   
   public ChaosMonkeyNothingIsSafeTest() {
     super();
     sliceCount = Integer.parseInt(System.getProperty("solr.tests.cloud.cm.slicecount", "-1"));
-    shardCount = Integer.parseInt(System.getProperty("solr.tests.cloud.cm.shardcount", "-1"));
-    
     if (sliceCount == -1) {
       sliceCount = random().nextInt(TEST_NIGHTLY ? 5 : 3) + 1;
     }
-    if (shardCount == -1) {
-      shardCount = sliceCount + random().nextInt(TEST_NIGHTLY ? 12 : 2);
+
+    int numShards = Integer.parseInt(System.getProperty("solr.tests.cloud.cm.shardcount", "-1"));
+    if (numShards == -1) {
+      numShards = sliceCount + random().nextInt(TEST_NIGHTLY ? 12 : 2);
     }
+    fixShardCount(numShards);
   }
-  
-  @Override
-  public void doTest() throws Exception {
+
+  @Test
+  public void test() throws Exception {
     boolean testsSuccesful = false;
     try {
       handle.clear();

--- a/solr/core/src/test/org/apache/solr/cloud/ChaosMonkeySafeLeaderTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ChaosMonkeySafeLeaderTest.java
@@ -32,6 +32,7 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 @Slow
 public class ChaosMonkeySafeLeaderTest extends AbstractFullDistribZkTestBase {
@@ -69,39 +70,37 @@ public class ChaosMonkeySafeLeaderTest extends AbstractFullDistribZkTestBase {
     return randVals;
   }
   
-  @Before
   @Override
-  public void setUp() throws Exception {
+  public void distribSetUp() throws Exception {
     useFactory("solr.StandardDirectoryFactory");
 
-    super.setUp();
+    super.distribSetUp();
     
     System.setProperty("numShards", Integer.toString(sliceCount));
   }
   
   @Override
-  @After
-  public void tearDown() throws Exception {
+  public void distribTearDown() throws Exception {
     System.clearProperty("numShards");
-    super.tearDown();
-    resetExceptionIgnores();
+    super.distribTearDown();
   }
   
   public ChaosMonkeySafeLeaderTest() {
     super();
     sliceCount = Integer.parseInt(System.getProperty("solr.tests.cloud.cm.slicecount", "-1"));
-    shardCount = Integer.parseInt(System.getProperty("solr.tests.cloud.cm.shardcount", "-1"));
-    
     if (sliceCount == -1) {
       sliceCount = random().nextInt(TEST_NIGHTLY ? 5 : 3) + 1;
     }
-    if (shardCount == -1) {
-      shardCount = sliceCount + random().nextInt(TEST_NIGHTLY ? 12 : 2);
+
+    int numShards = Integer.parseInt(System.getProperty("solr.tests.cloud.cm.shardcount", "-1"));
+    if (numShards == -1) {
+      numShards = sliceCount + random().nextInt(TEST_NIGHTLY ? 12 : 2);
     }
+    fixShardCount(numShards);
   }
-  
-  @Override
-  public void doTest() throws Exception {
+
+  @Test
+  public void test() throws Exception {
     
     handle.clear();
     handle.put("timestamp", SKIPVAL);

--- a/solr/core/src/test/org/apache/solr/cloud/ChaosMonkeyShardSplitTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ChaosMonkeyShardSplitTest.java
@@ -34,6 +34,7 @@ import org.apache.zookeeper.KeeperException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -50,20 +51,8 @@ public class ChaosMonkeyShardSplitTest extends ShardSplitTest {
   static final int TIMEOUT = 10000;
   private AtomicInteger killCounter = new AtomicInteger();
 
-  @Before
-  @Override
-  public void setUp() throws Exception {
-    super.setUp();
-  }
-
-  @Override
-  @After
-  public void tearDown() throws Exception {
-    super.tearDown();
-  }
-
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  public void test() throws Exception {
     waitForThingsToLevelOut(15);
 
     ClusterState clusterState = cloudClient.getZkStateReader().getClusterState();

--- a/solr/core/src/test/org/apache/solr/cloud/CloudExitableDirectoryReaderTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/CloudExitableDirectoryReaderTest.java
@@ -22,6 +22,7 @@ import org.apache.lucene.util.LuceneTestCase.Slow;
 import org.apache.lucene.util.TestUtil;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.params.ModifiableSolrParams;
+import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,8 +44,8 @@ public class CloudExitableDirectoryReaderTest extends AbstractFullDistribZkTestB
     return configString;
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  public void test() throws Exception {
     handle.clear();
     handle.put("timestamp", SKIPVAL);
     waitForRecoveriesToFinish(false);

--- a/solr/core/src/test/org/apache/solr/cloud/CollectionsAPIAsyncDistributedZkTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/CollectionsAPIAsyncDistributedZkTest.java
@@ -29,6 +29,7 @@ import org.apache.solr.client.solrj.response.CollectionAdminResponse;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.update.DirectUpdateHandler2;
 import org.junit.Before;
+import org.junit.Test;
 
 import java.io.IOException;
 
@@ -40,10 +41,9 @@ public class CollectionsAPIAsyncDistributedZkTest extends AbstractFullDistribZkT
   private static final int MAX_TIMEOUT_SECONDS = 60;
   private static final boolean DEBUG = false;
 
-  @Before
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
+  public void distribSetUp() throws Exception {
+    super.distribSetUp();
 
     useJettyDataDir = false;
 
@@ -52,23 +52,12 @@ public class CollectionsAPIAsyncDistributedZkTest extends AbstractFullDistribZkT
   }
 
   public CollectionsAPIAsyncDistributedZkTest() {
-    fixShardCount = true;
-
     sliceCount = 1;
-    shardCount = 1;
   }
 
-  @Override
-  public void doTest() throws Exception {
-
-    testSolrJAPICalls();
-
-    if (DEBUG) {
-      super.printLayout();
-    }
-  }
-
-  private void testSolrJAPICalls() throws Exception {
+  @Test
+  @ShardsFixed(num = 1)
+  public void testSolrJAPICalls() throws Exception {
     SolrClient client = createNewSolrClient("", getBaseUrl((HttpSolrClient) clients.get(0)));
     try {
       Create createCollectionRequest = new Create();
@@ -115,6 +104,10 @@ public class CollectionsAPIAsyncDistributedZkTest extends AbstractFullDistribZkT
     } finally {
       client.shutdown();
     }
+
+    if (DEBUG) {
+      printLayout();
+    }
   }
 
   private String getRequestStateAfterCompletion(String requestId, int waitForSeconds, SolrClient client)
@@ -141,10 +134,9 @@ public class CollectionsAPIAsyncDistributedZkTest extends AbstractFullDistribZkT
   }
 
   @Override
-  public void tearDown() throws Exception {
-    super.tearDown();
+  public void distribTearDown() throws Exception {
+    super.distribTearDown();
     System.clearProperty("numShards");
-    System.clearProperty("zkHost");
     System.clearProperty("solr.xml.persist");
     
     // insurance

--- a/solr/core/src/test/org/apache/solr/cloud/CollectionsAPIDistributedZkTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/CollectionsAPIDistributedZkTest.java
@@ -58,8 +58,8 @@ import org.apache.solr.core.SolrResourceLoader;
 import org.apache.solr.servlet.SolrDispatchFilter;
 import org.apache.solr.update.DirectUpdateHandler2;
 import org.apache.solr.util.DefaultSolrThreadFactory;
-import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 import javax.management.MBeanServer;
 import javax.management.MBeanServerFactory;
@@ -117,10 +117,9 @@ public class CollectionsAPIDistributedZkTest extends AbstractFullDistribZkTestBa
 
   }
   
-  @Before
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
+  public void distribSetUp() throws Exception {
+    super.distribSetUp();
     
     useJettyDataDir = false;
     
@@ -168,10 +167,7 @@ public class CollectionsAPIDistributedZkTest extends AbstractFullDistribZkTestBa
 
   
   public CollectionsAPIDistributedZkTest() {
-    fixShardCount = true;
-    
     sliceCount = 2;
-    shardCount = 4;
     completionService = new ExecutorCompletionService<>(executor);
     pending = new HashSet<>();
     checkCreatedVsState = false;
@@ -186,7 +182,7 @@ public class CollectionsAPIDistributedZkTest extends AbstractFullDistribZkTestBa
     } else {
       // use shard ids rather than physical locations
       StringBuilder sb = new StringBuilder();
-      for (int i = 0; i < shardCount; i++) {
+      for (int i = 0; i < getShardCount(); i++) {
         if (i > 0)
           sb.append(',');
         sb.append("shard" + (i + 3));
@@ -194,9 +190,10 @@ public class CollectionsAPIDistributedZkTest extends AbstractFullDistribZkTestBa
       params.set("shards", sb.toString());
     }
   }
-  
-  @Override
-  public void doTest() throws Exception {
+
+  @Test
+  @ShardsFixed(num = 4)
+  public void test() throws Exception {
     testNodesUsedByCreate();
     testCollectionsAPI();
     testCollectionsAPIAddRemoveStress();
@@ -607,7 +604,7 @@ public class CollectionsAPIDistributedZkTest extends AbstractFullDistribZkTestBa
     int cnt = random().nextInt(TEST_NIGHTLY ? 6 : 1) + 1;
     
     for (int i = 0; i < cnt; i++) {
-      int numShards = TestUtil.nextInt(random(), 0, shardCount) + 1;
+      int numShards = TestUtil.nextInt(random(), 0, getShardCount()) + 1;
       int replicationFactor = TestUtil.nextInt(random(), 0, 3) + 1;
       int maxShardsPerNode = (((numShards * replicationFactor) / getCommonCloudSolrClient()
           .getZkStateReader().getClusterState().getLiveNodes().size())) + 1;
@@ -903,7 +900,7 @@ public class CollectionsAPIDistributedZkTest extends AbstractFullDistribZkTestBa
         
         for (int i = 0; i < cnt; i++) {
           String collectionName = "awholynewstresscollection_" + name + "_" + i;
-          int numShards = TestUtil.nextInt(random(), 0, shardCount * 2) + 1;
+          int numShards = TestUtil.nextInt(random(), 0, getShardCount() * 2) + 1;
           int replicationFactor = TestUtil.nextInt(random(), 0, 3) + 1;
           int maxShardsPerNode = (((numShards * 2 * replicationFactor) / getCommonCloudSolrClient()
               .getZkStateReader().getClusterState().getLiveNodes().size())) + 1;
@@ -1218,10 +1215,9 @@ public class CollectionsAPIDistributedZkTest extends AbstractFullDistribZkTestBa
   }
   
   @Override
-  public void tearDown() throws Exception {
-    super.tearDown();
+  public void distribTearDown() throws Exception {
+    super.distribTearDown();
     System.clearProperty("numShards");
-    System.clearProperty("zkHost");
     System.clearProperty("solr.xml.persist");
 
     // insurance

--- a/solr/core/src/test/org/apache/solr/cloud/CollectionsAPISolrJTests.java
+++ b/solr/core/src/test/org/apache/solr/cloud/CollectionsAPISolrJTests.java
@@ -34,6 +34,7 @@ import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.common.params.CoreAdminParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.zookeeper.KeeperException;
+import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -49,9 +50,9 @@ import static org.apache.solr.cloud.ReplicaPropertiesBase.verifyUniqueAcrossColl
 
 @LuceneTestCase.Slow
 public class CollectionsAPISolrJTests extends AbstractFullDistribZkTestBase {
-  
-  @Override
-  public void doTest() throws Exception {
+
+  @Test
+  public void test() throws Exception {
     testCreateAndDeleteCollection();
     testCreateAndDeleteShard();
     testReloadCollection();
@@ -65,19 +66,6 @@ public class CollectionsAPISolrJTests extends AbstractFullDistribZkTestBase {
     testList();
     testAddAndDeleteReplicaProp();
     testBalanceShardUnique();
-  }
-
-  public void tearDown() throws Exception {
-    if (controlClient != null) {
-      controlClient.shutdown();
-    }
-    if (cloudClient != null) {
-      cloudClient.shutdown();
-    }
-    if (controlClientCloud != null) {
-      controlClientCloud.shutdown();
-    }
-    super.tearDown();
   }
 
   protected void testCreateAndDeleteCollection() throws Exception {

--- a/solr/core/src/test/org/apache/solr/cloud/CustomCollectionTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/CustomCollectionTest.java
@@ -60,8 +60,8 @@ import org.apache.solr.common.params.CollectionParams.CollectionAction;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.update.DirectUpdateHandler2;
 import org.apache.solr.util.DefaultSolrThreadFactory;
-import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 /**
  * Tests the Custom Sharding API.
@@ -84,10 +84,9 @@ public class CustomCollectionTest extends AbstractFullDistribZkTestBase {
   public static void beforeThisClass2() throws Exception {
   }
 
-  @Before
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
+  public void distribSetUp() throws Exception {
+    super.distribSetUp();
     System.setProperty("numShards", Integer.toString(sliceCount));
     System.setProperty("solr.xml.persist", "true");
   }
@@ -98,10 +97,7 @@ public class CustomCollectionTest extends AbstractFullDistribZkTestBase {
 
 
   public CustomCollectionTest() {
-    fixShardCount = true;
-
     sliceCount = 2;
-    shardCount = 4;
     completionService = new ExecutorCompletionService<>(executor);
     pending = new HashSet<>();
     checkCreatedVsState = false;
@@ -116,7 +112,7 @@ public class CustomCollectionTest extends AbstractFullDistribZkTestBase {
     } else {
       // use shard ids rather than physical locations
       StringBuilder sb = new StringBuilder();
-      for (int i = 0; i < shardCount; i++) {
+      for (int i = 0; i < getShardCount(); i++) {
         if (i > 0)
           sb.append(',');
         sb.append("shard" + (i + 3));
@@ -125,8 +121,9 @@ public class CustomCollectionTest extends AbstractFullDistribZkTestBase {
     }
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  @ShardsFixed(num = 4)
+  public void test() throws Exception {
     testCustomCollectionsAPI();
     testRouteFieldForHashRouter();
     testCreateShardRepFactor();
@@ -492,10 +489,9 @@ public class CustomCollectionTest extends AbstractFullDistribZkTestBase {
   }
 
   @Override
-  public void tearDown() throws Exception {
-    super.tearDown();
+  public void distribTearDown() throws Exception {
+    super.distribTearDown();
     System.clearProperty("numShards");
-    System.clearProperty("zkHost");
     System.clearProperty("solr.xml.persist");
 
     // insurance

--- a/solr/core/src/test/org/apache/solr/cloud/DeleteInactiveReplicaTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/DeleteInactiveReplicaTest.java
@@ -31,6 +31,7 @@ import org.apache.solr.common.params.MapSolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Test;
 
 import java.net.URL;
 import java.util.Map;
@@ -41,22 +42,8 @@ import static org.apache.solr.common.cloud.ZkNodeProps.makeMap;
 //@Ignore("Not currently valid see SOLR-5580")
 public class DeleteInactiveReplicaTest extends DeleteReplicaTest{
 
-  @Override
-  public void doTest() throws Exception {
-    deleteInactiveReplicaTest();
-  }
-
-  @Before
-  public void setUp() throws Exception {
-    super.setUp();
-  }
-  
-  @After
-  public void tearDown() throws Exception {
-    super.tearDown();
-  }
-  
-  private void deleteInactiveReplicaTest() throws Exception {
+  @Test
+  public void deleteInactiveReplicaTest() throws Exception {
     CloudSolrClient client = createCloudClient(null);
 
     String collectionName = "delDeadColl";

--- a/solr/core/src/test/org/apache/solr/cloud/DeleteLastCustomShardedReplicaTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/DeleteLastCustomShardedReplicaTest.java
@@ -31,6 +31,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -53,18 +54,17 @@ public class DeleteLastCustomShardedReplicaTest extends AbstractFullDistribZkTes
 
   }
 
-  @Before
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
+  public void distribSetUp() throws Exception {
+    super.distribSetUp();
     System.setProperty("numShards", Integer.toString(sliceCount));
     System.setProperty("solr.xml.persist", "true");
     client = createCloudClient(null);
   }
 
-  @After
-  public void tearDown() throws Exception {
-    super.tearDown();
+  @Override
+  public void distribTearDown() throws Exception {
+    super.distribTearDown();
     client.shutdown();
   }
 
@@ -73,16 +73,13 @@ public class DeleteLastCustomShardedReplicaTest extends AbstractFullDistribZkTes
   }
 
   public DeleteLastCustomShardedReplicaTest() {
-    fixShardCount = true;
-
     sliceCount = 2;
-    shardCount = 2;
-
     checkCreatedVsState = false;
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  @ShardsFixed(num = 2)
+  public void test() throws Exception {
     int replicationFactor = 1;
     int maxShardsPerNode = 5;
 

--- a/solr/core/src/test/org/apache/solr/cloud/DeleteReplicaTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/DeleteReplicaTest.java
@@ -35,6 +35,7 @@ import org.apache.solr.common.util.NamedList;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -56,18 +57,17 @@ public class DeleteReplicaTest extends AbstractFullDistribZkTestBase {
 
   }
 
-  @Before
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
+  public void distribSetUp() throws Exception {
+    super.distribSetUp();
     System.setProperty("numShards", Integer.toString(sliceCount));
     System.setProperty("solr.xml.persist", "true");
     client = createCloudClient(null);
   }
 
-  @After
-  public void tearDown() throws Exception {
-    super.tearDown();
+  @Override
+  public void distribTearDown() throws Exception {
+    super.distribTearDown();
     client.shutdown();
   }
 
@@ -76,20 +76,13 @@ public class DeleteReplicaTest extends AbstractFullDistribZkTestBase {
   }
 
   public DeleteReplicaTest() {
-    fixShardCount = true;
-
     sliceCount = 2;
-    shardCount = 4;
-
     checkCreatedVsState = false;
   }
 
-  @Override
-  public void doTest() throws Exception {
-    deleteLiveReplicaTest();
-  }
-
-  private void deleteLiveReplicaTest() throws Exception {
+  @Test
+  @ShardsFixed(num = 4)
+  public void deleteLiveReplicaTest() throws Exception {
     String collectionName = "delLiveColl";
     CloudSolrClient client = createCloudClient(null);
     try {

--- a/solr/core/src/test/org/apache/solr/cloud/DeleteShardTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/DeleteShardTest.java
@@ -32,6 +32,7 @@ import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.zookeeper.KeeperException;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -41,46 +42,28 @@ public class DeleteShardTest extends AbstractFullDistribZkTestBase {
 
   public DeleteShardTest() {
     super();
-    fixShardCount = true;
-    shardCount = 2;
     sliceCount = 2;
   }
 
   @Override
-  @Before
-  public void setUp() throws Exception {
-    super.setUp();
+  public void distribSetUp() throws Exception {
+    super.distribSetUp();
     System.setProperty("numShards", "2");
     System.setProperty("solr.xml.persist", "true");
   }
 
   @Override
-  @After
-  public void tearDown() throws Exception {
-    super.tearDown();
-
-    if (VERBOSE || printLayoutOnTearDown) {
-      super.printLayout();
-    }
-    if (controlClient != null) {
-      controlClient.shutdown();
-    }
-    if (cloudClient != null) {
-      cloudClient.shutdown();
-    }
-    if (controlClientCloud != null) {
-      controlClientCloud.shutdown();
-    }
-    super.tearDown();
-
+  public void distribTearDown() throws Exception {
+    super.distribTearDown();
     System.clearProperty("numShards");
     System.clearProperty("solr.xml.persist");
   }
 
   // TODO: Custom hash slice deletion test
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  @ShardsFixed(num = 2)
+  public void test() throws Exception {
     ClusterState clusterState = cloudClient.getZkStateReader().getClusterState();
 
     Slice slice1 = clusterState.getSlice(AbstractDistribZkTestBase.DEFAULT_COLLECTION, SHARD1);

--- a/solr/core/src/test/org/apache/solr/cloud/DistribCursorPagingTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/DistribCursorPagingTest.java
@@ -37,6 +37,7 @@ import static org.apache.solr.common.params.CursorMarkParams.CURSOR_MARK_NEXT;
 import static org.apache.solr.common.params.CursorMarkParams.CURSOR_MARK_START;
 import org.apache.solr.search.CursorMark; //jdoc
 
+import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,8 +70,8 @@ public class DistribCursorPagingTest extends AbstractFullDistribZkTestBase {
     return configString;
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  public void test() throws Exception {
     boolean testFinished = false;
     try {
       handle.clear();

--- a/solr/core/src/test/org/apache/solr/cloud/DistribDocExpirationUpdateProcessorTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/DistribDocExpirationUpdateProcessorTest.java
@@ -26,6 +26,7 @@ import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.update.processor.DocExpirationUpdateProcessorFactory; // jdoc
 import org.apache.solr.update.processor.DocExpirationUpdateProcessorFactoryTest;
 
+import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,8 +53,8 @@ public class DistribDocExpirationUpdateProcessorTest extends AbstractFullDistrib
     return configString;
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  public void test() throws Exception {
     assertTrue("only one shard?!?!?!", 1 < shardToJetty.keySet().size());
     log.info("number of shards: {}", shardToJetty.keySet().size());
 

--- a/solr/core/src/test/org/apache/solr/cloud/ExternalCollectionsTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ExternalCollectionsTest.java
@@ -28,27 +28,22 @@ import org.apache.zookeeper.data.Stat;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 public class ExternalCollectionsTest extends AbstractFullDistribZkTestBase {
   private CloudSolrClient client;
 
-  @BeforeClass
-  public static void beforeThisClass2() throws Exception {
-
-  }
-
-  @Before
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
+  public void distribSetUp() throws Exception {
+    super.distribSetUp();
     System.setProperty("numShards", Integer.toString(sliceCount));
     System.setProperty("solr.xml.persist", "true");
     client = createCloudClient(null);
   }
 
-  @After
-  public void tearDown() throws Exception {
-    super.tearDown();
+  @Override
+  public void distribTearDown() throws Exception {
+    super.distribTearDown();
     client.shutdown();
   }
 
@@ -57,20 +52,9 @@ public class ExternalCollectionsTest extends AbstractFullDistribZkTestBase {
   }
 
   public ExternalCollectionsTest() {
-    fixShardCount = true;
-
     sliceCount = 2;
-    shardCount = 4;
-
     checkCreatedVsState = false;
   }
-
-
-  @Override
-  public void doTest() throws Exception {
-    testZkNodeLocation();
-  }
-
 
 
   @Override
@@ -78,7 +62,9 @@ public class ExternalCollectionsTest extends AbstractFullDistribZkTestBase {
     return 2;
   }
 
-  private void testZkNodeLocation() throws Exception{
+  @Test
+  @ShardsFixed(num = 4)
+  public void testZkNodeLocation() throws Exception{
 
     String collectionName = "myExternColl";
 

--- a/solr/core/src/test/org/apache/solr/cloud/FullSolrCloudDistribCmdsTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/FullSolrCloudDistribCmdsTest.java
@@ -39,6 +39,7 @@ import org.apache.solr.update.VersionInfo;
 import org.apache.solr.update.processor.DistributedUpdateProcessor;
 import org.apache.zookeeper.CreateMode;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -58,13 +59,12 @@ public class FullSolrCloudDistribCmdsTest extends AbstractFullDistribZkTestBase 
   
   public FullSolrCloudDistribCmdsTest() {
     super();
-    fixShardCount = true;
-    shardCount = 6;
     sliceCount = 3;
   }
-  
-  @Override
-  public void doTest() throws Exception {
+
+  @Test
+  @ShardsFixed(num = 6)
+  public void test() throws Exception {
     handle.clear();
     handle.put("timestamp", SKIPVAL);
     
@@ -499,11 +499,6 @@ public class FullSolrCloudDistribCmdsTest extends AbstractFullDistribZkTestBase 
   private QueryResponse query(SolrClient client) throws SolrServerException {
     SolrQuery query = new SolrQuery("*:*");
     return client.query(query);
-  }
-  
-  @Override
-  public void tearDown() throws Exception {
-    super.tearDown();
   }
   
   protected SolrInputDocument addRandFields(SolrInputDocument sdoc) {

--- a/solr/core/src/test/org/apache/solr/cloud/HttpPartitionTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/HttpPartitionTest.java
@@ -38,6 +38,7 @@ import org.apache.solr.core.CoreContainer;
 import org.apache.solr.servlet.SolrDispatchFilter;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -73,24 +74,13 @@ public class HttpPartitionTest extends AbstractFullDistribZkTestBase {
   public HttpPartitionTest() {
     super();
     sliceCount = 2;
-    shardCount = 3;
+    fixShardCount(3);
   }
   
-  @Before
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
+  public void distribSetUp() throws Exception {
+    super.distribSetUp();
     System.setProperty("numShards", Integer.toString(sliceCount));
-  }
-  
-  @Override
-  @After
-  public void tearDown() throws Exception {    
-    try {
-      super.tearDown();
-    } catch (Exception exc) {}
-    
-    resetExceptionIgnores();
   }
   
   /**
@@ -104,8 +94,8 @@ public class HttpPartitionTest extends AbstractFullDistribZkTestBase {
     return createProxiedJetty(solrHome, dataDir, shardList, solrConfigOverride, schemaOverride);
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  public void test() throws Exception {
     waitForThingsToLevelOut(30000);
 
     testLeaderInitiatedRecoveryCRUD();

--- a/solr/core/src/test/org/apache/solr/cloud/LeaderFailoverAfterPartitionTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/LeaderFailoverAfterPartitionTest.java
@@ -28,6 +28,7 @@ import org.apache.solr.client.solrj.embedded.JettySolrRunner;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.common.cloud.Replica;
+import org.junit.Test;
 
 /**
  * Tests leader-initiated recovery scenarios after a leader node fails
@@ -42,8 +43,8 @@ public class LeaderFailoverAfterPartitionTest extends HttpPartitionTest {
   }
 
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  public void test() throws Exception {
     waitForThingsToLevelOut(30000);
 
     // kill a leader and make sure recovery occurs as expected

--- a/solr/core/src/test/org/apache/solr/cloud/LeaderInitiatedRecoveryOnCommitTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/LeaderInitiatedRecoveryOnCommitTest.java
@@ -24,6 +24,7 @@ import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.cloud.ZkCoreNodeProps;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Test;
 
 import java.io.File;
 import java.util.List;
@@ -35,29 +36,22 @@ public class LeaderInitiatedRecoveryOnCommitTest extends BasicDistributedZkTest 
   public LeaderInitiatedRecoveryOnCommitTest() {
     super();
     sliceCount = 1;
-    shardCount = 4;
+    fixShardCount(4);
   }
 
-  @Before
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
+  public void distribSetUp() throws Exception {
+    super.distribSetUp();
     System.setProperty("numShards", Integer.toString(sliceCount));
   }
 
   @Override
-  @After
-  public void tearDown() throws Exception {
+  public void distribTearDown() throws Exception {
     System.clearProperty("numShards");
 
-    try {
-      super.tearDown();
-    } catch (Exception exc) {
-    }
+    super.distribTearDown();
 
-    resetExceptionIgnores();
-
-    // close socket proxies after super.tearDown
+    // close socket proxies after super.distribTearDown
     if (!proxies.isEmpty()) {
       for (SocketProxy proxy : proxies.values()) {
         proxy.close();
@@ -65,8 +59,8 @@ public class LeaderInitiatedRecoveryOnCommitTest extends BasicDistributedZkTest 
     }
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  public void test() throws Exception {
     oneShardTest();
     multiShardTest();
   }

--- a/solr/core/src/test/org/apache/solr/cloud/MigrateRouteKeyTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/MigrateRouteKeyTest.java
@@ -35,6 +35,7 @@ import org.apache.solr.update.DirectUpdateHandler2;
 import org.apache.zookeeper.KeeperException;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -52,31 +53,15 @@ public class MigrateRouteKeyTest extends BasicDistributedZkTest {
   }
 
   @Override
-  @Before
-  public void setUp() throws Exception {
-    super.setUp();
+  public void distribSetUp() throws Exception {
+    super.distribSetUp();
     System.setProperty("numShards", Integer.toString(sliceCount));
     System.setProperty("solr.xml.persist", "true");
   }
 
   @Override
-  @After
-  public void tearDown() throws Exception {
-    super.tearDown();
-
-    if (VERBOSE || printLayoutOnTearDown) {
-      super.printLayout();
-    }
-    if (controlClient != null) {
-      controlClient.shutdown();
-    }
-    if (cloudClient != null) {
-      cloudClient.shutdown();
-    }
-    if (controlClientCloud != null) {
-      controlClientCloud.shutdown();
-    }
-    super.tearDown();
+  public void distribTearDown() throws Exception {
+    super.distribTearDown();
 
     System.clearProperty("zkHost");
     System.clearProperty("numShards");
@@ -86,8 +71,8 @@ public class MigrateRouteKeyTest extends BasicDistributedZkTest {
     DirectUpdateHandler2.commitOnClose = true;
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  public void test() throws Exception {
     waitForThingsToLevelOut(15);
 
     if (usually()) {

--- a/solr/core/src/test/org/apache/solr/cloud/MultiThreadedOCPTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/MultiThreadedOCPTest.java
@@ -31,6 +31,7 @@ import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.update.DirectUpdateHandler2;
 import org.junit.Before;
+import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,10 +50,9 @@ public class MultiThreadedOCPTest extends AbstractFullDistribZkTestBase {
 
   private static final int NUM_COLLECTIONS = 4;
 
-  @Before
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
+  public void distribSetUp() throws Exception {
+    super.distribSetUp();
 
     useJettyDataDir = false;
 
@@ -61,13 +61,12 @@ public class MultiThreadedOCPTest extends AbstractFullDistribZkTestBase {
   }
 
   public MultiThreadedOCPTest() {
-    fixShardCount = true;
     sliceCount = 2;
-    shardCount = 4;
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  @ShardsFixed(num = 4)
+  public void test() throws Exception {
 
     testParallelCollectionAPICalls();
     testTaskExclusivity();
@@ -311,10 +310,9 @@ public class MultiThreadedOCPTest extends AbstractFullDistribZkTestBase {
   }
 
   @Override
-  public void tearDown() throws Exception {
-    super.tearDown();
+  public void distribTearDown() throws Exception {
+    super.distribTearDown();
     System.clearProperty("numShards");
-    System.clearProperty("zkHost");
     System.clearProperty("solr.xml.persist");
     
     // insurance

--- a/solr/core/src/test/org/apache/solr/cloud/OverseerRolesTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/OverseerRolesTest.java
@@ -46,9 +46,8 @@ import org.apache.solr.common.params.CollectionParams.CollectionAction;
 import org.apache.solr.common.params.MapSolrParams;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.zookeeper.data.Stat;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 @LuceneTestCase.Slow
 @SuppressSSL     // See SOLR-5776
@@ -60,18 +59,17 @@ public class OverseerRolesTest  extends AbstractFullDistribZkTestBase{
 
   }
 
-  @Before
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
+  public void distribSetUp() throws Exception {
+    super.distribSetUp();
     System.setProperty("numShards", Integer.toString(sliceCount));
     System.setProperty("solr.xml.persist", "true");
     client = createCloudClient(null);
   }
 
-  @After
-  public void tearDown() throws Exception {
-    super.tearDown();
+  @Override
+  public void distribTearDown() throws Exception {
+    super.distribTearDown();
     client.shutdown();
   }
 
@@ -80,16 +78,14 @@ public class OverseerRolesTest  extends AbstractFullDistribZkTestBase{
   }
 
   public OverseerRolesTest() {
-    fixShardCount = true;
-
     sliceCount = 2;
-    shardCount = TEST_NIGHTLY ? 6 : 2;
+    fixShardCount(TEST_NIGHTLY ? 6 : 2);
 
     checkCreatedVsState = false;
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  public void test() throws Exception {
     testQuitCommand();
     testOverseerRole();
   }

--- a/solr/core/src/test/org/apache/solr/cloud/OverseerStatusTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/OverseerStatusTest.java
@@ -17,20 +17,13 @@ package org.apache.solr.cloud;
  * limitations under the License.
  */
 
-import org.apache.solr.client.solrj.SolrRequest;
-import org.apache.solr.client.solrj.SolrServerException;
-import org.apache.solr.client.solrj.impl.HttpSolrClient;
-import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.client.solrj.response.CollectionAdminResponse;
-import org.apache.solr.common.cloud.DocRouter;
 import org.apache.solr.common.params.CollectionParams;
-import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
 import org.junit.After;
 import org.junit.Before;
-
-import java.io.IOException;
+import org.junit.Test;
 
 public class OverseerStatusTest extends BasicDistributedZkTest {
 
@@ -39,33 +32,14 @@ public class OverseerStatusTest extends BasicDistributedZkTest {
   }
 
   @Override
-  @Before
-  public void setUp() throws Exception {
-    super.setUp();
+  public void distribSetUp() throws Exception {
+    super.distribSetUp();
     System.setProperty("numShards", Integer.toString(sliceCount));
     System.setProperty("solr.xml.persist", "true");
   }
 
-  @Override
-  @After
-  public void tearDown() throws Exception {
-    if (VERBOSE || printLayoutOnTearDown) {
-      super.printLayout();
-    }
-    if (controlClient != null) {
-      controlClient.shutdown();
-    }
-    if (cloudClient != null) {
-      cloudClient.shutdown();
-    }
-    if (controlClientCloud != null) {
-      controlClientCloud.shutdown();
-    }
-    super.tearDown();
-  }
-
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  public void test() throws Exception {
     waitForThingsToLevelOut(15);
 
     // find existing command counts because collection may be created by base test class too

--- a/solr/core/src/test/org/apache/solr/cloud/RecoveryZkTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/RecoveryZkTest.java
@@ -25,6 +25,7 @@ import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.embedded.JettySolrRunner;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.cloud.ZkStateReader;
+import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,7 +40,7 @@ public class RecoveryZkTest extends AbstractFullDistribZkTestBase {
   public RecoveryZkTest() {
     super();
     sliceCount = 1;
-    shardCount = 2;
+    fixShardCount(2);
     schemaString = "schema15.xml";      // we need a string id
   }
   
@@ -54,8 +55,8 @@ public class RecoveryZkTest extends AbstractFullDistribZkTestBase {
     return randVals;
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  public void test() throws Exception {
     handle.clear();
     handle.put("timestamp", SKIPVAL);
     
@@ -148,7 +149,7 @@ public class RecoveryZkTest extends AbstractFullDistribZkTestBase {
 
   
   @Override
-  public void tearDown() throws Exception {
+  public void distribTearDown() throws Exception {
     // make sure threads have been stopped...
     indexThread.safeStop();
     indexThread2.safeStop();
@@ -156,7 +157,7 @@ public class RecoveryZkTest extends AbstractFullDistribZkTestBase {
     indexThread.join();
     indexThread2.join();
     
-    super.tearDown();
+    super.distribTearDown();
   }
   
   // skip the randoms - they can deadlock...

--- a/solr/core/src/test/org/apache/solr/cloud/RemoteQueryErrorTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/RemoteQueryErrorTest.java
@@ -21,6 +21,7 @@ import org.apache.lucene.util.LuceneTestCase.Slow;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrInputDocument;
+import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,11 +37,11 @@ public class RemoteQueryErrorTest extends AbstractFullDistribZkTestBase {
   public RemoteQueryErrorTest() {
     super();
     sliceCount = 1;
-    shardCount = random().nextBoolean() ? 3 : 4;
+    fixShardCount(random().nextBoolean() ? 3 : 4);
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  public void test() throws Exception {
     handle.clear();
     handle.put("timestamp", SKIPVAL);
     

--- a/solr/core/src/test/org/apache/solr/cloud/ReplicationFactorTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ReplicationFactorTest.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import org.apache.lucene.util.LuceneTestCase.AwaitsFix;
 import org.apache.lucene.util.LuceneTestCase.Slow;
 import org.apache.solr.SolrTestCaseJ4.SuppressSSL;
 import org.apache.solr.client.solrj.embedded.JettySolrRunner;
@@ -40,6 +39,7 @@ import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.common.util.NamedList;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,31 +59,25 @@ public class ReplicationFactorTest extends AbstractFullDistribZkTestBase {
   public ReplicationFactorTest() {
     super();
     sliceCount = 3;
-    shardCount = 3;
+    fixShardCount(3);
   }
   
-  @Before
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
+  public void distribSetUp() throws Exception {
+    super.distribSetUp();
     System.setProperty("numShards", Integer.toString(sliceCount));
   }
   
   @Override
-  @After
-  public void tearDown() throws Exception {
+  public void distribTearDown() throws Exception {
     
     log.info("tearing down replicationFactorTest!");
     
     System.clearProperty("numShards");
     
-    try {
-      super.tearDown();
-    } catch (Exception exc) {}
-    
-    resetExceptionIgnores();    
-    
-    log.info("super.tearDown complete, closing all socket proxies");
+    super.distribTearDown();
+
+    log.info("super.distribTearDown complete, closing all socket proxies");
     if (!proxies.isEmpty()) {
       for (SocketProxy proxy : proxies.values()) {
         proxy.close();
@@ -111,10 +105,10 @@ public class ReplicationFactorTest extends AbstractFullDistribZkTestBase {
       port = s.getLocalPort();
     }
     return port;
-  }  
-   
-  @Override
-  public void doTest() throws Exception {
+  }
+
+  @Test
+  public void test() throws Exception {
     log.info("replication factor test running");
     waitForThingsToLevelOut(30000);
     

--- a/solr/core/src/test/org/apache/solr/cloud/RollingRestartTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/RollingRestartTest.java
@@ -21,8 +21,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.solr.common.cloud.SolrZkClient;
 import org.apache.solr.common.params.CollectionParams;
 import org.apache.zookeeper.KeeperException;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,29 +35,25 @@ public class RollingRestartTest extends AbstractFullDistribZkTestBase {
   private static final long MAX_WAIT_TIME = TimeUnit.NANOSECONDS.convert(300, TimeUnit.SECONDS);
 
   public RollingRestartTest() {
-    fixShardCount = true;
     sliceCount = 2;
-    shardCount = TEST_NIGHTLY ? 16 : 2;
+    fixShardCount(TEST_NIGHTLY ? 16 : 2);
   }
 
-  @Before
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
+  public void distribSetUp() throws Exception {
+    super.distribSetUp();
     System.setProperty("numShards", Integer.toString(sliceCount));
     useFactory("solr.StandardDirectoryFactory");
   }
 
   @Override
-  @After
-  public void tearDown() throws Exception {
+  public void distribTearDown() throws Exception {
     System.clearProperty("numShards");
-    super.tearDown();
-    resetExceptionIgnores();
+    super.distribTearDown();
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  public void test() throws Exception {
     waitForRecoveriesToFinish(false);
 
     restartWithRolesTest();
@@ -75,11 +70,11 @@ public class RollingRestartTest extends AbstractFullDistribZkTestBase {
     cloudClient.getZkStateReader().getZkClient().printLayoutToStdOut();
 
     int numDesignateOverseers = TEST_NIGHTLY ? 16 : 2;
-    numDesignateOverseers = Math.max(shardCount, numDesignateOverseers);
+    numDesignateOverseers = Math.max(getShardCount(), numDesignateOverseers);
     List<String> designates = new ArrayList<>();
     List<CloudJettyRunner> designateJettys = new ArrayList<>();
     for (int i = 0; i < numDesignateOverseers; i++) {
-      int n = random().nextInt(shardCount);
+      int n = random().nextInt(getShardCount());
       String nodeName = cloudJettys.get(n).nodeName;
       log.info("Chose {} as overseer designate", nodeName);
       invokeCollectionApi(CollectionParams.ACTION, CollectionParams.CollectionAction.ADDROLE.toLower(), "role", "overseer", "node", nodeName);

--- a/solr/core/src/test/org/apache/solr/cloud/SSLMigrationTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/SSLMigrationTest.java
@@ -41,6 +41,7 @@ import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.util.SSLTestConfig;
 import org.apache.solr.SolrTestCaseJ4.SuppressSSL;
 import org.apache.lucene.util.LuceneTestCase.Slow;
+import org.junit.Test;
 
 /**
  * We want to make sure that when migrating between http and https modes the
@@ -51,9 +52,9 @@ import org.apache.lucene.util.LuceneTestCase.Slow;
 @SuppressSSL
 @BadApple(bugUrl = "https://issues.apache.org/jira/browse/SOLR-6213")
 public class SSLMigrationTest extends AbstractFullDistribZkTestBase {
-  
-  @Override
-  public void doTest() throws Exception {
+
+  @Test
+  public void test() throws Exception {
     //Migrate from HTTP -> HTTPS -> HTTP
     assertReplicaInformation("http");
     testMigrateSSL(new SSLTestConfig(true, false));

--- a/solr/core/src/test/org/apache/solr/cloud/ShardRoutingCustomTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ShardRoutingCustomTest.java
@@ -18,6 +18,7 @@ package org.apache.solr.cloud;
  */
 
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 
 public class ShardRoutingCustomTest extends AbstractFullDistribZkTestBase {
@@ -34,8 +35,8 @@ public class ShardRoutingCustomTest extends AbstractFullDistribZkTestBase {
     sliceCount = 0;
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  public void test() throws Exception {
     boolean testFinished = false;
     try {
       doCustomSharding();

--- a/solr/core/src/test/org/apache/solr/cloud/ShardRoutingTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ShardRoutingTest.java
@@ -17,32 +17,16 @@ package org.apache.solr.cloud;
  * limitations under the License.
  */
 
-import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrClient;
-import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.embedded.JettySolrRunner;
-import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.request.UpdateRequest;
 import org.apache.solr.client.solrj.response.QueryResponse;
-import org.apache.solr.common.SolrDocument;
-import org.apache.solr.common.SolrException;
-import org.apache.solr.common.SolrInputDocument;
-import org.apache.solr.common.cloud.CompositeIdRouter;
-import org.apache.solr.common.cloud.ZkNodeProps;
-import org.apache.solr.common.cloud.ZkStateReader;
-import org.apache.solr.common.params.CommonParams;
-import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.ShardParams;
-import org.apache.solr.common.util.StrUtils;
-import org.apache.solr.servlet.SolrDispatchFilter;
-import org.apache.solr.update.DirectUpdateHandler2;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
+import org.junit.Test;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 
 public class ShardRoutingTest extends AbstractFullDistribZkTestBase {
@@ -66,8 +50,6 @@ public class ShardRoutingTest extends AbstractFullDistribZkTestBase {
   public ShardRoutingTest() {
     schemaString = "schema15.xml";      // we need a string id
     super.sliceCount = 4;
-    super.shardCount = 8;
-    super.fixShardCount = true;  // we only want to test with exactly 4 slices.
 
     // from negative to positive, the upper bits of the hash ranges should be
     // shard1: top bits:10  80000000:bfffffff
@@ -109,8 +91,9 @@ public class ShardRoutingTest extends AbstractFullDistribZkTestBase {
      ***/
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  @ShardsFixed(num = 8)
+  public void test() throws Exception {
     boolean testFinished = false;
     try {
       handle.clear();
@@ -349,10 +332,4 @@ public class ShardRoutingTest extends AbstractFullDistribZkTestBase {
     req.setParams(params(reqParams));
     req.process(cloudClient);
   }
-
-  @Override
-  public void tearDown() throws Exception {
-    super.tearDown();
-  }
-
 }

--- a/solr/core/src/test/org/apache/solr/cloud/ShardSplitTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ShardSplitTest.java
@@ -41,6 +41,7 @@ import org.apache.solr.common.params.CollectionParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -66,33 +67,14 @@ public class ShardSplitTest extends BasicDistributedZkTest {
   }
 
   @Override
-  @Before
-  public void setUp() throws Exception {
-    super.setUp();
+  public void distribSetUp() throws Exception {
+    super.distribSetUp();
     System.setProperty("numShards", Integer.toString(sliceCount));
     System.setProperty("solr.xml.persist", "true");
   }
 
-  @Override
-  @After
-  public void tearDown() throws Exception {
-    if (VERBOSE || printLayoutOnTearDown) {
-      super.printLayout();
-    }
-    if (controlClient != null) {
-      controlClient.shutdown();
-    }
-    if (cloudClient != null) {
-      cloudClient.shutdown();
-    }
-    if (controlClientCloud != null) {
-      controlClientCloud.shutdown();
-    }
-    super.tearDown();
-  }
-
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  public void test() throws Exception {
     waitForThingsToLevelOut(15);
 
     if (usually()) {

--- a/solr/core/src/test/org/apache/solr/cloud/SharedFSAutoReplicaFailoverTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/SharedFSAutoReplicaFailoverTest.java
@@ -49,6 +49,7 @@ import org.apache.solr.util.DefaultSolrThreadFactory;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 import static org.apache.solr.common.cloud.ZkNodeProps.makeMap;
 
@@ -80,10 +81,9 @@ public class SharedFSAutoReplicaFailoverTest extends AbstractFullDistribZkTestBa
     dfsCluster = null;
   }
   
-  @Before
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
+  public void distribSetUp() throws Exception {
+    super.distribSetUp();
     useJettyDataDir = false;
     System.setProperty("solr.xml.persist", "true");
   }
@@ -94,18 +94,16 @@ public class SharedFSAutoReplicaFailoverTest extends AbstractFullDistribZkTestBa
 
   
   public SharedFSAutoReplicaFailoverTest() {
-    fixShardCount = true;
-    
     sliceCount = 2;
-    shardCount = 4;
     completionService = new ExecutorCompletionService<>(executor);
     pending = new HashSet<>();
     checkCreatedVsState = false;
     
   }
-  
-  @Override
-  public void doTest() throws Exception {
+
+  @Test
+  @ShardsFixed(num = 4)
+  public void test() throws Exception {
     try {
       testBasics();
     } finally {
@@ -238,8 +236,8 @@ public class SharedFSAutoReplicaFailoverTest extends AbstractFullDistribZkTestBa
   }
   
   @Override
-  public void tearDown() throws Exception {
-    super.tearDown();
+  public void distribTearDown() throws Exception {
+    super.distribTearDown();
     System.clearProperty("solr.xml.persist");
   }
 }

--- a/solr/core/src/test/org/apache/solr/cloud/SimpleCollectionCreateDeleteTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/SimpleCollectionCreateDeleteTest.java
@@ -22,17 +22,17 @@ import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.NamedList;
+import org.junit.Test;
 
 public class SimpleCollectionCreateDeleteTest extends AbstractFullDistribZkTestBase {
 
   public SimpleCollectionCreateDeleteTest() {
-    fixShardCount = true;
     sliceCount = 1;
-    shardCount = 1;
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  @ShardsFixed(num = 1)
+  public void test() throws Exception {
     String overseerNode = OverseerCollectionProcessor.getLeaderNode(cloudClient.getZkStateReader().getZkClient());
     String notOverseerNode = null;
     for (CloudJettyRunner cloudJetty : cloudJettys) {

--- a/solr/core/src/test/org/apache/solr/cloud/SyncSliceTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/SyncSliceTest.java
@@ -32,10 +32,9 @@ import org.apache.solr.common.cloud.Slice;
 import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.common.params.CollectionParams.CollectionAction;
 import org.apache.solr.common.params.ModifiableSolrParams;
-import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -61,33 +60,30 @@ public class SyncSliceTest extends AbstractFullDistribZkTestBase {
     
   }
   
-  @Before
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
+  public void distribSetUp() throws Exception {
+    super.distribSetUp();
     // we expect this time of exception as shards go up and down...
     //ignoreException(".*");
     System.setProperty("numShards", Integer.toString(sliceCount));
   }
   
   @Override
-  @After
-  public void tearDown() throws Exception {
+  public void distribTearDown() throws Exception {
     if (!success) {
       printLayoutOnTearDown = true;
     }
-    super.tearDown();
-    resetExceptionIgnores();
+    super.distribTearDown();
   }
   
   public SyncSliceTest() {
     super();
     sliceCount = 1;
-    shardCount = TEST_NIGHTLY ? 7 : 4;
+    fixShardCount(TEST_NIGHTLY ? 7 : 4);
   }
-  
-  @Override
-  public void doTest() throws Exception {
+
+  @Test
+  public void test() throws Exception {
     
     handle.clear();
     handle.put("timestamp", SKIPVAL);
@@ -160,7 +156,7 @@ public class SyncSliceTest extends AbstractFullDistribZkTestBase {
     Set<CloudJettyRunner> jetties = new HashSet<>();
     jetties.addAll(shardToJetty.get("shard1"));
     jetties.remove(leaderJetty);
-    assertEquals(shardCount - 1, jetties.size());
+    assertEquals(getShardCount() - 1, jetties.size());
     
     chaosMonkey.killJetty(leaderJetty);
     
@@ -224,7 +220,7 @@ public class SyncSliceTest extends AbstractFullDistribZkTestBase {
     jetties = new HashSet<>();
     jetties.addAll(shardToJetty.get("shard1"));
     jetties.remove(leaderJetty);
-    assertEquals(shardCount - 1, jetties.size());
+    assertEquals(getShardCount() - 1, jetties.size());
 
     
     // kill the current leader

--- a/solr/core/src/test/org/apache/solr/cloud/TestCloudPivotFacet.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestCloudPivotFacet.java
@@ -38,6 +38,7 @@ import org.apache.commons.lang.StringUtils;
 
 import org.junit.BeforeClass;
 
+import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -95,8 +96,8 @@ public class TestCloudPivotFacet extends AbstractFullDistribZkTestBase {
     log.info("init'ing useFieldRandomizedFactor = {}", useFieldRandomizedFactor);
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  public void test() throws Exception {
 
     sanityCheckAssertDoubles();
 

--- a/solr/core/src/test/org/apache/solr/cloud/TestCollectionAPI.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestCollectionAPI.java
@@ -34,6 +34,7 @@ import org.apache.solr.common.params.ShardParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.zookeeper.KeeperException;
 import org.junit.Before;
+import org.junit.Test;
 
 import static org.apache.solr.cloud.OverseerCollectionProcessor.SHARD_UNIQUE;
 
@@ -54,16 +55,14 @@ public class TestCollectionAPI extends ReplicaPropertiesBase {
   }
 
   @Override
-  @Before
-  public void setUp() throws Exception {
-    fixShardCount = true;
+  public void distribSetUp() throws Exception {
     sliceCount = 2;
-    shardCount = 2;
-    super.setUp();
+    super.distribSetUp();
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  @ShardsFixed(num = 2)
+  public void test() throws Exception {
     CloudSolrClient client = createCloudClient(null);
     try {
       createCollection(null, COLLECTION_NAME, 2, 2, 2, client, null, "conf1");

--- a/solr/core/src/test/org/apache/solr/cloud/TestDistribDocBasedVersion.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestDistribDocBasedVersion.java
@@ -24,6 +24,7 @@ import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.util.StrUtils;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -53,8 +54,6 @@ public class TestDistribDocBasedVersion extends AbstractFullDistribZkTestBase {
   public TestDistribDocBasedVersion() {
     schemaString = "schema15.xml";      // we need a string id
     super.sliceCount = 2;
-    super.shardCount = 4;
-    super.fixShardCount = true;  // we only want to test with exactly 2 slices.
 
 
     /***
@@ -87,8 +86,9 @@ public class TestDistribDocBasedVersion extends AbstractFullDistribZkTestBase {
      ***/
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  @ShardsFixed(num = 4)
+  public void test() throws Exception {
     boolean testFinished = false;
     try {
       handle.clear();
@@ -346,10 +346,4 @@ public class TestDistribDocBasedVersion extends AbstractFullDistribZkTestBase {
     req.setParams(params(reqParams));
     req.process(cloudClient);
   }
-
-  @Override
-  public void tearDown() throws Exception {
-    super.tearDown();
-  }
-
 }

--- a/solr/core/src/test/org/apache/solr/cloud/TestRebalanceLeaders.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestRebalanceLeaders.java
@@ -28,6 +28,7 @@ import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.zookeeper.KeeperException;
 import org.junit.Before;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -42,15 +43,7 @@ public class TestRebalanceLeaders extends AbstractFullDistribZkTestBase {
 
   public TestRebalanceLeaders() {
     schemaString = "schema15.xml";      // we need a string id
-  }
-
-  @Override
-  @Before
-  public void setUp() throws Exception {
-    fixShardCount = true;
     sliceCount = 4;
-    shardCount = 4;
-    super.setUp();
   }
 
   int reps = 10;
@@ -60,8 +53,9 @@ public class TestRebalanceLeaders extends AbstractFullDistribZkTestBase {
   Map<String, Replica> expected = new HashMap<>();
 
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  @ShardsFixed(num = 4)
+  public void test() throws Exception {
     CloudSolrClient client = createCloudClient(null);
     reps = random().nextInt(9) + 1; // make sure and do at least one.
     try {

--- a/solr/core/src/test/org/apache/solr/cloud/TestReplicaProperties.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestReplicaProperties.java
@@ -37,6 +37,7 @@ import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.zookeeper.KeeperException;
 import org.junit.Before;
+import org.junit.Test;
 
 @Slow
 public class TestReplicaProperties extends ReplicaPropertiesBase {
@@ -45,19 +46,12 @@ public class TestReplicaProperties extends ReplicaPropertiesBase {
 
   public TestReplicaProperties() {
     schemaString = "schema15.xml";      // we need a string id
-  }
-
-  @Override
-  @Before
-  public void setUp() throws Exception {
-    fixShardCount = true;
     sliceCount = 2;
-    shardCount = 4;
-    super.setUp();
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  @ShardsFixed(num = 4)
+  public void test() throws Exception {
     CloudSolrClient client = createCloudClient(null);
     try {
       // Mix up a bunch of different combinations of shards and replicas in order to exercise boundary cases.

--- a/solr/core/src/test/org/apache/solr/cloud/TestRequestStatusCollectionAPI.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestRequestStatusCollectionAPI.java
@@ -25,6 +25,7 @@ import org.apache.solr.common.params.CollectionParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.junit.Before;
+import org.junit.Test;
 
 import java.io.IOException;
 
@@ -36,14 +37,8 @@ public class TestRequestStatusCollectionAPI extends BasicDistributedZkTest {
     schemaString = "schema15.xml";      // we need a string id
   }
 
-  @Override
-  @Before
-  public void setUp() throws Exception {
-    super.setUp();
-
-  }
-
-  public void doTest() {
+  @Test
+  public void test() throws Exception {
     ModifiableSolrParams params = new ModifiableSolrParams();
 
     params.set(CollectionParams.ACTION, CollectionParams.CollectionAction.CREATE.toString());

--- a/solr/core/src/test/org/apache/solr/cloud/TestShortCircuitedRequests.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestShortCircuitedRequests.java
@@ -23,18 +23,18 @@ import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.params.ShardParams;
 import org.apache.solr.common.util.NamedList;
+import org.junit.Test;
 
 public class TestShortCircuitedRequests extends AbstractFullDistribZkTestBase {
 
   public TestShortCircuitedRequests() {
     schemaString = "schema15.xml";      // we need a string id
     super.sliceCount = 4;
-    super.shardCount = 4;
-    super.fixShardCount = true;  // we only want to test with exactly 4 slices.
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  @ShardsFixed(num = 4)
+  public void test() throws Exception {
     waitForRecoveriesToFinish(false);
     assertEquals(4, cloudClient.getZkStateReader().getClusterState().getCollection(DEFAULT_COLLECTION).getSlices().size());
     index("id", "a!doc1");  // shard3

--- a/solr/core/src/test/org/apache/solr/cloud/TriLevelCompositeIdRoutingTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TriLevelCompositeIdRoutingTest.java
@@ -21,6 +21,7 @@ import org.apache.lucene.util.LuceneTestCase.Slow;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrDocument;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -47,14 +48,12 @@ public class TriLevelCompositeIdRoutingTest extends ShardRoutingTest {
 
   public TriLevelCompositeIdRoutingTest() {
     schemaString = "schema15.xml";      // we need a string id
-    super.sliceCount = TEST_NIGHTLY ? 12 : 2;             // a lot of slices for more ranges and buckets
-    super.shardCount = TEST_NIGHTLY ? 24 : 3;
-    super.fixShardCount = true;
-
+    sliceCount = TEST_NIGHTLY ? 12 : 2;             // a lot of slices for more ranges and buckets
+    fixShardCount(TEST_NIGHTLY ? 24 : 3);
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  public void test() throws Exception {
     boolean testFinished = false;
     try {
       handle.clear();
@@ -73,7 +72,6 @@ public class TriLevelCompositeIdRoutingTest extends ShardRoutingTest {
       }
     }
   }
-
 
   private void doTriLevelHashingTest() throws Exception {
     log.info("### STARTING doTriLevelHashingTest");
@@ -153,10 +151,4 @@ public class TriLevelCompositeIdRoutingTest extends ShardRoutingTest {
   private String getKey(String id) {
     return id.substring(0, id.lastIndexOf('!'));
   }
-
-  @Override
-  public void tearDown() throws Exception {
-    super.tearDown();
-  }
-
 }

--- a/solr/core/src/test/org/apache/solr/cloud/UnloadDistributedZkTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/UnloadDistributedZkTest.java
@@ -33,6 +33,7 @@ import org.apache.solr.update.DirectUpdateHandler2;
 import org.apache.solr.util.DefaultSolrThreadFactory;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -48,17 +49,6 @@ import java.util.concurrent.TimeUnit;
 @Slow
 @SuppressSSL(bugUrl = "https://issues.apache.org/jira/browse/SOLR-5776")
 public class UnloadDistributedZkTest extends BasicDistributedZkTest {
-  
-  @BeforeClass
-  public static void beforeThisClass3() throws Exception {
- 
-  }
-  
-  @Before
-  @Override
-  public void setUp() throws Exception {
-    super.setUp();
-  }
 
   protected String getSolrXml() {
     return "solr-no-core.xml";
@@ -68,9 +58,9 @@ public class UnloadDistributedZkTest extends BasicDistributedZkTest {
     super();
     checkCreatedVsState = false;
   }
-  
-  @Override
-  public void doTest() throws Exception {
+
+  @Test
+  public void test() throws Exception {
     
     testCoreUnloadAndLeaders(); // long
     testUnloadLotsOfCores(); // long
@@ -428,14 +418,5 @@ public class UnloadDistributedZkTest extends BasicDistributedZkTest {
     executor.shutdown();
     executor.awaitTermination(120, TimeUnit.SECONDS);
     adminClient.shutdown();
-  }
-
-
-
-
-  
-  @Override
-  public void tearDown() throws Exception {
-    super.tearDown();
   }
 }

--- a/solr/core/src/test/org/apache/solr/cloud/hdfs/HdfsChaosMonkeySafeLeaderTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/hdfs/HdfsChaosMonkeySafeLeaderTest.java
@@ -47,10 +47,9 @@ public class HdfsChaosMonkeySafeLeaderTest extends ChaosMonkeySafeLeaderTest {
     dfsCluster = null;
   }
   
-  @Before
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
+  public void distribSetUp() throws Exception {
+    super.distribSetUp();
     
     // super class may hard code directory
     useFactory("org.apache.solr.core.HdfsDirectoryFactory");

--- a/solr/core/src/test/org/apache/solr/cloud/hdfs/HdfsSyncSliceTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/hdfs/HdfsSyncSliceTest.java
@@ -46,14 +46,7 @@ public class HdfsSyncSliceTest extends SyncSliceTest {
     HdfsTestUtil.teardownClass(dfsCluster);
     dfsCluster = null;
   }
-  
-  @Before
-  @Override
-  public void setUp() throws Exception {
-    super.setUp();
-  }
 
-  
   @Override
   protected String getDataDir(String dataDir) throws IOException {
     return HdfsTestUtil.getDataDir(dfsCluster, dataDir);

--- a/solr/core/src/test/org/apache/solr/cloud/hdfs/HdfsWriteToMultipleCollectionsTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/hdfs/HdfsWriteToMultipleCollectionsTest.java
@@ -40,6 +40,7 @@ import org.apache.solr.store.blockcache.Cache;
 import org.apache.solr.util.RefCounted;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -77,15 +78,15 @@ public class HdfsWriteToMultipleCollectionsTest extends BasicDistributedZkTest {
   public HdfsWriteToMultipleCollectionsTest() {
     super();
     sliceCount = 1;
-    shardCount = 3;
+    fixShardCount(3);
   }
   
   protected String getSolrXml() {
     return "solr-no-core.xml";
   }
-  
-  @Override
-  public void doTest() throws Exception {
+
+  @Test
+  public void test() throws Exception {
     int docCount = random().nextInt(1313) + 1;
     int cnt = random().nextInt(4) + 1;
     for (int i = 0; i < cnt; i++) {

--- a/solr/core/src/test/org/apache/solr/cloud/hdfs/StressHdfsTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/hdfs/StressHdfsTest.java
@@ -48,6 +48,7 @@ import org.junit.BeforeClass;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope.Scope;
+import org.junit.Test;
 
 @Slow
 @ThreadLeakScope(Scope.NONE) // hdfs client currently leaks thread(s)
@@ -80,16 +81,16 @@ public class StressHdfsTest extends BasicDistributedZkTest {
   public StressHdfsTest() {
     super();
     sliceCount = 1;
-    shardCount = TEST_NIGHTLY ? 7 : random().nextInt(2) + 1;
+    fixShardCount(TEST_NIGHTLY ? 7 : random().nextInt(2) + 1);
     testRestartIntoSafeMode = random().nextBoolean();
   }
   
   protected String getSolrXml() {
     return "solr-no-core.xml";
   }
-  
-  @Override
-  public void doTest() throws Exception {
+
+  @Test
+  public void test() throws Exception {
     randomlyEnableAutoSoftCommit();
     
     int cnt = random().nextInt(2) + 1;
@@ -138,11 +139,11 @@ public class StressHdfsTest extends BasicDistributedZkTest {
     int nShards;
     int maxReplicasPerNode;
     if (overshard) {
-      nShards = shardCount * 2;
+      nShards = getShardCount() * 2;
       maxReplicasPerNode = 8;
       rep = 1;
     } else {
-      nShards = shardCount / 2;
+      nShards = getShardCount() / 2;
       maxReplicasPerNode = 1;
       rep = 2;
       if (nShards == 0) nShards = 1;

--- a/solr/core/src/test/org/apache/solr/core/TestDynamicLoading.java
+++ b/solr/core/src/test/org/apache/solr/core/TestDynamicLoading.java
@@ -26,7 +26,7 @@ import org.apache.solr.handler.TestBlobHandler;
 import org.apache.solr.util.RESTfulServerProvider;
 import org.apache.solr.util.RestTestHarness;
 import org.apache.solr.util.SimplePostTool;
-import org.junit.After;
+import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,21 +56,17 @@ public class TestDynamicLoading extends AbstractFullDistribZkTestBase {
     }
   }
 
-  @After
-  public void testDown() throws Exception {
-    super.tearDown();
+  @Override
+  public void distribTearDown() throws Exception {
+    super.distribTearDown();
     for (RestTestHarness r : restTestHarnesses) {
       r.close();
     }
   }
 
-  @Override
-  public void doTest() throws Exception {
-   setupHarnesses();
-   dynamicLoading();
-  }
-
-  private void dynamicLoading() throws Exception {
+  @Test
+  public void testDynamicLoading() throws Exception {
+    setupHarnesses();
     String payload = "{\n" +
         "'create-requesthandler' : { 'name' : '/test1', 'class': 'org.apache.solr.core.BlobStoreTestRequestHandler' , 'lib':'test','version':'1'}\n" +
         "}";

--- a/solr/core/src/test/org/apache/solr/handler/TestBlobHandler.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestBlobHandler.java
@@ -37,6 +37,7 @@ import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.core.ConfigOverlay;
 import org.apache.solr.update.DirectUpdateHandler2;
 import org.apache.solr.util.SimplePostTool;
+import org.junit.Test;
 import org.noggit.JSONParser;
 import org.noggit.ObjectBuilder;
 import org.slf4j.Logger;
@@ -58,7 +59,8 @@ import static org.apache.solr.core.ConfigOverlay.getObjectByPath;
 public class TestBlobHandler extends AbstractFullDistribZkTestBase {
   static final Logger log =  LoggerFactory.getLogger(TestBlobHandler.class);
 
-  private void doBlobHandlerTest() throws Exception {
+  @Test
+  public void doBlobHandlerTest() throws Exception {
     SolrClient client = createNewSolrClient("", getBaseUrl((HttpSolrClient) clients.get(0)));
     try {
       CollectionAdminResponse response1;
@@ -116,8 +118,8 @@ public class TestBlobHandler extends AbstractFullDistribZkTestBase {
   }
 
   @Override
-  public void tearDown() throws Exception {
-    super.tearDown();
+  public void distribTearDown() throws Exception {
+    super.distribTearDown();
     System.clearProperty("numShards");
     System.clearProperty("zkHost");
 
@@ -193,11 +195,5 @@ public class TestBlobHandler extends AbstractFullDistribZkTestBase {
     } finally {
       httpPost.releaseConnection();
     }
-  }
-
-  @Override
-  public void doTest() throws Exception {
-    doBlobHandlerTest();
-
   }
 }

--- a/solr/core/src/test/org/apache/solr/handler/TestConfigReload.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestConfigReload.java
@@ -47,7 +47,7 @@ import org.apache.solr.util.RestTestHarness;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.Stat;
-import org.junit.After;
+import org.junit.Test;
 import org.noggit.JSONParser;
 import org.noggit.ObjectBuilder;
 import org.slf4j.Logger;
@@ -71,16 +71,16 @@ public class TestConfigReload extends AbstractFullDistribZkTestBase {
     }
   }
   
-  @After
-  public void tearDown() throws Exception {
-    super.tearDown();
+  @Override
+  public void distribTearDown() throws Exception {
+    super.distribTearDown();
     for (RestTestHarness h : restTestHarnesses) {
       h.close();
     }
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  public void test() throws Exception {
     setupHarnesses();
     try {
       reloadTest();

--- a/solr/core/src/test/org/apache/solr/handler/TestSolrConfigHandlerCloud.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestSolrConfigHandlerCloud.java
@@ -35,7 +35,7 @@ import org.apache.solr.core.ConfigOverlay;
 import org.apache.solr.core.TestSolrConfigHandler;
 import org.apache.solr.util.RESTfulServerProvider;
 import org.apache.solr.util.RestTestHarness;
-import org.junit.After;
+import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,17 +54,17 @@ public class TestSolrConfigHandlerCloud extends AbstractFullDistribZkTestBase {
       restTestHarnesses.add(harness);
     }
   }
-  
-  @After
-  public void tearDown() throws Exception {
-    super.tearDown();
+
+  @Override
+  public void distribTearDown() throws Exception {
+    super.distribTearDown();
     for (RestTestHarness r : restTestHarnesses) {
       r.close();
     }
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  public void test() throws Exception {
     setupHarnesses();
     testReqHandlerAPIs();
     testReqParams();

--- a/solr/core/src/test/org/apache/solr/handler/TestSolrConfigHandlerConcurrent.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestSolrConfigHandlerConcurrent.java
@@ -47,7 +47,7 @@ import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.core.ConfigOverlay;
 import org.apache.solr.util.RESTfulServerProvider;
 import org.apache.solr.util.RestTestHarness;
-import org.junit.After;
+import org.junit.Test;
 import org.noggit.JSONParser;
 import org.noggit.ObjectBuilder;
 import org.slf4j.Logger;
@@ -71,17 +71,17 @@ public class TestSolrConfigHandlerConcurrent extends AbstractFullDistribZkTestBa
       restTestHarnesses.add(harness);
     }
   }
-  
-  @After
-  public void tearDown() throws Exception {
-    super.tearDown();
+
+  @Override
+  public void distribTearDown() throws Exception {
+    super.distribTearDown();
     for (RestTestHarness h : restTestHarnesses) {
       h.close();
     }
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  public void test() throws Exception {
     Map editable_prop_map = (Map) new ObjectBuilder(new JSONParser(new StringReader(
         ConfigOverlay.MAPPING))).getObject();
     Map caches = (Map) editable_prop_map.get("query");

--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedExpandComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedExpandComponentTest.java
@@ -25,6 +25,7 @@ import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 import java.nio.ByteBuffer;
 import java.util.Map;
@@ -38,8 +39,6 @@ import java.util.Iterator;
 public class DistributedExpandComponentTest extends BaseDistributedSearchTestCase {
 
   public DistributedExpandComponentTest() {
-    fixShardCount = true;
-    shardCount = 3;
     stress = 0;
   }
 
@@ -48,8 +47,9 @@ public class DistributedExpandComponentTest extends BaseDistributedSearchTestCas
     initCore("solrconfig-collapseqparser.xml", "schema11.xml");
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  @ShardsFixed(num = 3)
+  public void test() throws Exception {
     final String group = (random().nextBoolean() ? "group_s" : "group_s_dv");
     
     del("*:*");

--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedFacetPivotLargeTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedFacetPivotLargeTest.java
@@ -32,18 +32,15 @@ import org.apache.solr.common.params.FacetParams;
 import org.apache.solr.common.params.SolrParams;
 
 import junit.framework.AssertionFailedError;
+import org.junit.Test;
 
 public class DistributedFacetPivotLargeTest extends BaseDistributedSearchTestCase {
   
   public static final String SPECIAL = ""; 
 
-  public DistributedFacetPivotLargeTest() {
-    this.fixShardCount = true;
-    this.shardCount = 4; // we leave one empty as an edge case
-  }
-  
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  @ShardsFixed(num = 4)
+  public void test() throws Exception {
     this.stress = 0 ;
     handle.clear();
     handle.put("QTime", SKIPVAL);

--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedFacetPivotLongTailTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedFacetPivotLongTailTest.java
@@ -26,6 +26,7 @@ import org.apache.solr.client.solrj.response.PivotField;
 import org.apache.solr.common.params.FacetParams;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
+import org.junit.Test;
 
 /**
  * test demonstrating how overrequesting helps finds top-terms in the "long tail" 
@@ -39,11 +40,6 @@ import org.apache.solr.common.params.ModifiableSolrParams;
  */
 public class DistributedFacetPivotLongTailTest extends BaseDistributedSearchTestCase {
   
-  public DistributedFacetPivotLongTailTest(){
-    this.fixShardCount = true;
-    this.shardCount = 3;
-  }
-
   private int docNumber = 0;
   
   public int getDocNum() {
@@ -51,8 +47,9 @@ public class DistributedFacetPivotLongTailTest extends BaseDistributedSearchTest
     return docNumber;
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  @ShardsFixed(num = 3)
+  public void test() throws Exception {
 
     final SolrClient shard0 = clients.get(0);
     final SolrClient shard1 = clients.get(1);

--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedFacetPivotSmallAdvancedTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedFacetPivotSmallAdvancedTest.java
@@ -25,6 +25,7 @@ import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.params.FacetParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.SolrParams;
+import org.junit.Test;
 
 import java.util.List;
 
@@ -37,13 +38,9 @@ import java.util.List;
  */
 public class DistributedFacetPivotSmallAdvancedTest extends BaseDistributedSearchTestCase {
 
-  public DistributedFacetPivotSmallAdvancedTest() {
-    this.fixShardCount = true;
-    this.shardCount = 2;
-  }
-
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  @ShardsFixed(num = 2)
+  public void test() throws Exception {
 
     del("*:*");
     final SolrClient shard0 = clients.get(0);

--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedFacetPivotSmallTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedFacetPivotSmallTest.java
@@ -32,16 +32,13 @@ import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 
 import junit.framework.AssertionFailedError;
+import org.junit.Test;
 
 public class DistributedFacetPivotSmallTest extends BaseDistributedSearchTestCase {
-  
-  public DistributedFacetPivotSmallTest() {
-    this.fixShardCount = true;
-    this.shardCount = 4;
-  }
-  
-  @Override
-  public void doTest() throws Exception {
+
+  @Test
+  @ShardsFixed(num = 4)
+  public void test() throws Exception {
     
     del("*:*");
 

--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedFacetPivotWhiteBoxTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedFacetPivotWhiteBoxTest.java
@@ -22,18 +22,15 @@ import org.apache.solr.client.solrj.response.PivotField;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.SolrParams;
+import org.junit.Test;
 
 import java.util.List;
 
 public class DistributedFacetPivotWhiteBoxTest extends BaseDistributedSearchTestCase {
 
-  public DistributedFacetPivotWhiteBoxTest() {
-    this.fixShardCount = true;
-    this.shardCount = 4;
-  }
-
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  @ShardsFixed(num = 4)
+  public void test() throws Exception {
 
     del("*:*");
 

--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedMLTComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedMLTComponentTest.java
@@ -22,6 +22,7 @@ import org.apache.solr.BaseDistributedSearchTestCase;
 import org.apache.solr.common.params.MoreLikeThisParams;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
+import org.junit.Test;
 
 /**
  * Test for distributed MoreLikeThisComponent's 
@@ -38,29 +39,18 @@ public class DistributedMLTComponentTest extends BaseDistributedSearchTestCase {
 
   public DistributedMLTComponentTest()
   {
-    fixShardCount=true;
-    shardCount=3;
     stress=0;
   }
 
-  @BeforeClass
-  public static void beforeClass() throws Exception {
-
-  }
-
   @Override
-  public void setUp() throws Exception {
+  public void distribSetUp() throws Exception {
     requestHandlerName = "mltrh";
-    super.setUp();
+    super.distribSetUp();
   }
   
-  @Override
-  public void tearDown() throws Exception {
-    super.tearDown();
-  }
-  
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  @ShardsFixed(num = 3)
+  public void test() throws Exception {
     del("*:*");
     index(id, "1", "lowerfilt", "toyota");
     index(id, "2", "lowerfilt", "chevrolet");

--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedQueryComponentCustomSortTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedQueryComponentCustomSortTest.java
@@ -22,6 +22,7 @@ import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 import java.nio.ByteBuffer;
 
@@ -33,8 +34,6 @@ import java.nio.ByteBuffer;
 public class DistributedQueryComponentCustomSortTest extends BaseDistributedSearchTestCase {
 
   public DistributedQueryComponentCustomSortTest() {
-    fixShardCount = true;
-    shardCount = 3;
     stress = 0;
   }
 
@@ -43,8 +42,9 @@ public class DistributedQueryComponentCustomSortTest extends BaseDistributedSear
     initCore("solrconfig.xml", "schema-custom-field.xml");
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  @ShardsFixed(num = 3)
+  public void test() throws Exception {
     del("*:*");
 
     index(id, "1", "text", "a", "payload", ByteBuffer.wrap(new byte[] { 0x12, 0x62, 0x15 }),                     //  2 

--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedQueryComponentOptimizationTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedQueryComponentOptimizationTest.java
@@ -25,6 +25,7 @@ import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.ShardParams;
 import org.apache.solr.common.util.SimpleOrderedMap;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 import java.nio.ByteBuffer;
 import java.util.Map;
@@ -40,8 +41,6 @@ import java.util.Map;
 public class DistributedQueryComponentOptimizationTest extends BaseDistributedSearchTestCase {
 
   public DistributedQueryComponentOptimizationTest() {
-    fixShardCount = true;
-    shardCount = 3;
     stress = 0;
   }
 
@@ -50,8 +49,9 @@ public class DistributedQueryComponentOptimizationTest extends BaseDistributedSe
     initCore("solrconfig.xml", "schema-custom-field.xml");
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  @ShardsFixed(num = 3)
+  public void test() throws Exception {
     del("*:*");
 
     index(id, "1", "text", "a", "test_sS", "21", "payload", ByteBuffer.wrap(new byte[] { 0x12, 0x62, 0x15 }),                     //  2

--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedQueryElevationComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedQueryElevationComponentTest.java
@@ -26,6 +26,7 @@ import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.params.CommonParams;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 /**
  * 
@@ -39,8 +40,6 @@ public class DistributedQueryElevationComponentTest extends BaseDistributedSearc
   }
 
   public DistributedQueryElevationComponentTest() {
-    fixShardCount = true;
-    shardCount = 3;
     stress = 0;
 
     // TODO: a better way to do this?
@@ -59,8 +58,9 @@ public class DistributedQueryElevationComponentTest extends BaseDistributedSearc
     System.clearProperty("elevate.data.file");
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  @ShardsFixed(num = 3)
+  public void test() throws Exception {
     
     
     del("*:*");

--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedSpellCheckComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedSpellCheckComponentTest.java
@@ -32,6 +32,7 @@ import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.SpellingParams;
 import org.apache.solr.common.util.NamedList;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 /**
  * Test for SpellCheckComponent's distributed querying
@@ -57,16 +58,6 @@ public class DistributedSpellCheckComponentTest extends BaseDistributedSearchTes
     useFactory(null); // need an FS factory
   }
 
-  @Override
-  public void setUp() throws Exception {
-    super.setUp();
-  }
-  
-  @Override
-  public void tearDown() throws Exception {
-    super.tearDown();
-  }
-  
   private void q(Object... q) throws Exception {
     final ModifiableSolrParams params = new ModifiableSolrParams();
 
@@ -95,9 +86,9 @@ public class DistributedSpellCheckComponentTest extends BaseDistributedSearchTes
       Assert.fail("Control data did not return any suggestions.");
     }
   }
-  
-  @Override
-  public void doTest() throws Exception {
+
+  @Test
+  public void test() throws Exception {
     del("*:*");
     index(id, "1", "lowerfilt", "toyota");
     index(id, "2", "lowerfilt", "chevrolet");

--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedSuggestComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedSuggestComponentTest.java
@@ -31,6 +31,7 @@ import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
 import org.apache.solr.spelling.suggest.SuggesterParams;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 /**
  * Test for SuggestComponent's distributed querying
@@ -55,16 +56,6 @@ public class DistributedSuggestComponentTest extends BaseDistributedSearchTestCa
   }
 
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
-  }
-  
-  @Override
-  public void tearDown() throws Exception {
-    super.tearDown();
-  }
-  
-  @Override
   public void validateControlData(QueryResponse control) throws Exception
   {    
     NamedList<Object> nl = control.getResponse();
@@ -74,10 +65,10 @@ public class DistributedSuggestComponentTest extends BaseDistributedSearchTestCa
     if(sc.size() == 0 && command == null) {
       Assert.fail("Control data did not return any suggestions or execute any command");
     }
-  } 
-  
-  @Override
-  public void doTest() throws Exception {
+  }
+
+  @Test
+  public void test() throws Exception {
     del("*:*");
     index(id, "1", "cat", "This is another title", "price", "10", "weight", "10");
     index(id, "2", "cat", "Yet another", "price", "15", "weight", "10");

--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedTermsComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedTermsComponentTest.java
@@ -18,6 +18,7 @@ package org.apache.solr.handler.component;
  */
 
 import org.apache.solr.BaseDistributedSearchTestCase;
+import org.junit.Test;
 
 /**
  * Test for TermsComponent distributed querying
@@ -27,8 +28,8 @@ import org.apache.solr.BaseDistributedSearchTestCase;
  */
 public class DistributedTermsComponentTest extends BaseDistributedSearchTestCase {
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  public void test() throws Exception {
     del("*:*");
     index(id, 18, "b_t", "snake spider shark snail slug seal");
     index(id, 19, "b_t", "snake spider shark snail slug");

--- a/solr/core/src/test/org/apache/solr/handler/component/TermVectorComponentDistributedTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/TermVectorComponentDistributedTest.java
@@ -22,6 +22,7 @@ import org.apache.lucene.util.Constants;
 import org.apache.solr.BaseDistributedSearchTestCase;
 import org.apache.solr.common.params.TermVectorParams;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 public class TermVectorComponentDistributedTest extends BaseDistributedSearchTestCase {
   @BeforeClass
@@ -30,8 +31,8 @@ public class TermVectorComponentDistributedTest extends BaseDistributedSearchTes
                 Constants.JAVA_VENDOR.startsWith("IBM"));
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  public void test() throws Exception {
 
     handle.clear();
     handle.put("timestamp", SKIPVAL);

--- a/solr/core/src/test/org/apache/solr/schema/TestBulkSchemaConcurrent.java
+++ b/solr/core/src/test/org/apache/solr/schema/TestBulkSchemaConcurrent.java
@@ -39,8 +39,8 @@ import org.apache.solr.cloud.AbstractFullDistribZkTestBase;
 import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.util.RESTfulServerProvider;
 import org.apache.solr.util.RestTestHarness;
-import org.junit.After;
 import org.junit.BeforeClass;
+import org.junit.Test;
 import org.noggit.JSONParser;
 import org.noggit.ObjectBuilder;
 import org.slf4j.Logger;
@@ -71,17 +71,17 @@ public class TestBulkSchemaConcurrent  extends AbstractFullDistribZkTestBase {
       restTestHarnesses.add(harness);
     }
   }
-  
-  @After
-  public void tearDown() throws Exception {
-    super.tearDown();
+
+  @Override
+  public void distribTearDown() throws Exception {
+    super.distribTearDown();
     for (RestTestHarness r : restTestHarnesses) {
       r.close();
     }
   }
-  
-  @Override
-  public void doTest() throws Exception {
+
+  @Test
+  public void test() throws Exception {
 
     final int threadCount = 5;
     setupHarnesses();

--- a/solr/core/src/test/org/apache/solr/schema/TestCloudManagedSchema.java
+++ b/solr/core/src/test/org/apache/solr/schema/TestCloudManagedSchema.java
@@ -26,6 +26,7 @@ import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.zookeeper.KeeperException;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -47,9 +48,9 @@ public class TestCloudManagedSchema extends AbstractFullDistribZkTestBase {
   protected String getCloudSolrConfig() {
     return "solrconfig-managed-schema.xml";
   }
-      
-  @Override
-  public void doTest() throws Exception {
+
+  @Test
+  public void test() throws Exception {
     ModifiableSolrParams params = new ModifiableSolrParams();
     params.set(CoreAdminParams.ACTION, CoreAdminParams.CoreAdminAction.STATUS.toString());
     QueryRequest request = new QueryRequest(params);

--- a/solr/core/src/test/org/apache/solr/schema/TestCloudManagedSchemaConcurrent.java
+++ b/solr/core/src/test/org/apache/solr/schema/TestCloudManagedSchemaConcurrent.java
@@ -36,8 +36,8 @@ import org.apache.solr.util.RESTfulServerProvider;
 import org.apache.solr.util.RestTestHarness;
 import org.apache.zookeeper.data.Stat;
 import org.eclipse.jetty.servlet.ServletHolder;
-import org.junit.After;
 import org.junit.BeforeClass;
+import org.junit.Test;
 import org.restlet.ext.servlet.ServerServlet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,10 +54,7 @@ public class TestCloudManagedSchemaConcurrent extends AbstractFullDistribZkTestB
 
   public TestCloudManagedSchemaConcurrent() {
     super();
-    fixShardCount = true;
-
     sliceCount = 4;
-    shardCount = 8;
   }
 
   @BeforeClass
@@ -65,10 +62,10 @@ public class TestCloudManagedSchemaConcurrent extends AbstractFullDistribZkTestB
     System.setProperty("managed.schema.mutable", "true");
     System.setProperty("enable.update.log", "true");
   }
-  
-  @After
-  public void tearDown() throws Exception {
-    super.tearDown();
+
+  @Override
+  public void distribTearDown() throws Exception {
+    super.distribTearDown();
     for (RestTestHarness h : restTestHarnesses) {
       h.close();
     }
@@ -245,10 +242,11 @@ public class TestCloudManagedSchemaConcurrent extends AbstractFullDistribZkTestB
 
     return expectedAddFieldTypes;
   }
-  
 
-  @Override
-  public void doTest() throws Exception {
+
+  @Test
+  @ShardsFixed(num = 8)
+  public void test() throws Exception {
     verifyWaitForSchemaUpdateToPropagate();
     setupHarnesses();
     concurrentOperationsTest();

--- a/solr/core/src/test/org/apache/solr/schema/TestCloudSchemaless.java
+++ b/solr/core/src/test/org/apache/solr/schema/TestCloudSchemaless.java
@@ -30,6 +30,7 @@ import org.eclipse.jetty.servlet.ServletHolder;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Before;
+import org.junit.Test;
 import org.restlet.ext.servlet.ServerServlet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,11 +50,10 @@ public class TestCloudSchemaless extends AbstractFullDistribZkTestBase {
   private static final Logger log = LoggerFactory.getLogger(TestCloudManagedSchemaConcurrent.class);
   private static final String SUCCESS_XPATH = "/response/lst[@name='responseHeader']/int[@name='status'][.='0']";
 
-  @Before
   @Override
-  public void setUp() throws Exception {
+  public void distribSetUp() throws Exception {
 
-    super.setUp();
+    super.distribSetUp();
 
     useJettyDataDir = false;
 
@@ -70,10 +70,7 @@ public class TestCloudSchemaless extends AbstractFullDistribZkTestBase {
 
   public TestCloudSchemaless() {
     schemaString = "schema-add-schema-fields-update-processor.xml";
-    fixShardCount = true;
-
     sliceCount = 4;
-    shardCount = 8;
   }
 
   @BeforeClass
@@ -122,8 +119,9 @@ public class TestCloudSchemaless extends AbstractFullDistribZkTestBase {
     return expectedAddFields;
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  @ShardsFixed(num = 8)
+  public void test() throws Exception {
     setupHarnesses();
 
     // First, add a bunch of documents in a single update with the same new field.

--- a/solr/core/src/test/org/apache/solr/search/AnalyticsMergeStrategyTest.java
+++ b/solr/core/src/test/org/apache/solr/search/AnalyticsMergeStrategyTest.java
@@ -22,6 +22,7 @@ import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 /**
  * Test for QueryComponent's distributed querying
@@ -31,8 +32,6 @@ import org.junit.BeforeClass;
 public class AnalyticsMergeStrategyTest extends BaseDistributedSearchTestCase {
 
   public AnalyticsMergeStrategyTest() {
-    fixShardCount = true;
-    shardCount = 3;
     stress = 0;
   }
 
@@ -41,8 +40,9 @@ public class AnalyticsMergeStrategyTest extends BaseDistributedSearchTestCase {
     initCore("solrconfig-analytics-query.xml", "schema15.xml");
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  @ShardsFixed(num = 3)
+  public void test() throws Exception {
     del("*:*");
 
     index_specific(0,"id","1", "sort_i", "5");

--- a/solr/core/src/test/org/apache/solr/search/MergeStrategyTest.java
+++ b/solr/core/src/test/org/apache/solr/search/MergeStrategyTest.java
@@ -28,6 +28,7 @@ import org.apache.solr.handler.component.MergeStrategy;
 import org.apache.solr.handler.component.ResponseBuilder;
 import org.apache.solr.handler.component.ShardRequest;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 import java.util.Arrays;
 
@@ -39,8 +40,6 @@ import java.util.Arrays;
 public class MergeStrategyTest extends BaseDistributedSearchTestCase {
 
   public MergeStrategyTest() {
-    fixShardCount = true;
-    shardCount = 3;
     stress = 0;
   }
 
@@ -49,8 +48,9 @@ public class MergeStrategyTest extends BaseDistributedSearchTestCase {
     initCore("solrconfig-plugcollector.xml", "schema15.xml");
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  @ShardsFixed(num = 3)
+  public void test() throws Exception {
     del("*:*");
 
     index_specific(0,"id","1", "sort_i", "5");

--- a/solr/core/src/test/org/apache/solr/search/mlt/CloudMLTQParserTest.java
+++ b/solr/core/src/test/org/apache/solr/search/mlt/CloudMLTQParserTest.java
@@ -23,6 +23,7 @@ import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
+import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,8 +36,6 @@ public class CloudMLTQParserTest extends AbstractFullDistribZkTestBase {
   static Logger log = LoggerFactory.getLogger(CloudMLTQParserTest.class);
   
   public CloudMLTQParserTest() {
-    fixShardCount = true;
-    shardCount = 2;
     sliceCount = 2;
     
     configString = "solrconfig.xml";
@@ -47,8 +46,10 @@ public class CloudMLTQParserTest extends AbstractFullDistribZkTestBase {
   protected String getCloudSolrConfig() {
     return configString;
   }
-  
-  public void doTest() throws Exception {
+
+  @Test
+  @ShardsFixed(num = 2)
+  public void test() throws Exception {
     
     waitForRecoveriesToFinish(false);
 

--- a/solr/core/src/test/org/apache/solr/search/stats/TestBaseStatsCache.java
+++ b/solr/core/src/test/org/apache/solr/search/stats/TestBaseStatsCache.java
@@ -30,13 +30,13 @@ public abstract class TestBaseStatsCache extends TestDefaultStatsCache {
   protected abstract String getStatsCacheClassName();
 
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
+  public void distribSetUp() throws Exception {
+    super.distribSetUp();
     System.setProperty("solr.statsCache", getStatsCacheClassName());
   }
 
-  public void tearDown() throws Exception {
-    super.tearDown();
+  public void distribTearDown() throws Exception {
+    super.distribTearDown();
     System.clearProperty("solr.statsCache");
   }
   

--- a/solr/core/src/test/org/apache/solr/search/stats/TestDefaultStatsCache.java
+++ b/solr/core/src/test/org/apache/solr/search/stats/TestDefaultStatsCache.java
@@ -22,23 +22,24 @@ import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.params.ModifiableSolrParams;
+import org.junit.Test;
 
 public class TestDefaultStatsCache extends BaseDistributedSearchTestCase {
   private int docId = 0;
   
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
+  public void distribSetUp() throws Exception {
+    super.distribSetUp();
     System.setProperty("solr.statsCache", LocalStatsCache.class.getName());
   }
   
-  public void tearDown() throws Exception {
-    super.tearDown();
+  public void distribTearDown() throws Exception {
+    super.distribTearDown();
     System.clearProperty("solr.statsCache");
   }
-  
-  @Override
-  public void doTest() throws Exception {
+
+  @Test
+  public void test() throws Exception {
     del("*:*");
     for (int i = 0; i < clients.size(); i++) {
       int shard = i + 1;

--- a/solr/core/src/test/org/apache/solr/update/PeerSyncTest.java
+++ b/solr/core/src/test/org/apache/solr/update/PeerSyncTest.java
@@ -25,6 +25,7 @@ import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.StrUtils;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -41,18 +42,16 @@ public class PeerSyncTest extends BaseDistributedSearchTestCase {
     params(DISTRIB_UPDATE_PARAM, FROM_LEADER);
   
   public PeerSyncTest() {
-    fixShardCount = true;
-    shardCount = 3;
     stress = 0;
 
     // TODO: a better way to do this?
     configString = "solrconfig-tlog.xml";
     schemaString = "schema.xml";
   }
-  
-  
-  @Override
-  public void doTest() throws Exception {
+
+  @Test
+  @ShardsFixed(num = 3)
+  public void test() throws Exception {
     handle.clear();
     handle.put("timestamp", SKIPVAL);
     handle.put("score", SKIPVAL);

--- a/solr/core/src/test/org/apache/solr/update/SolrCmdDistributorTest.java
+++ b/solr/core/src/test/org/apache/solr/update/SolrCmdDistributorTest.java
@@ -47,6 +47,7 @@ import org.apache.solr.update.SolrCmdDistributor.RetryNode;
 import org.apache.solr.update.SolrCmdDistributor.StdNode;
 import org.apache.solr.update.processor.DistributedUpdateProcessor;
 import org.junit.BeforeClass;
+import org.junit.Test;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -87,8 +88,6 @@ public class SolrCmdDistributorTest extends BaseDistributedSearchTestCase {
         return false;
       }});
     
-    fixShardCount = true;
-    shardCount = 4;
     stress = 0;
   }
 
@@ -125,9 +124,10 @@ public class SolrCmdDistributorTest extends BaseDistributedSearchTestCase {
 
     shards = sb.toString();
   }
-  
-  @Override
-  public void doTest() throws Exception {
+
+  @Test
+  @ShardsFixed(num = 4)
+  public void test() throws Exception {
     del("*:*");
     
     SolrCmdDistributor cmdDistrib = new SolrCmdDistributor(updateShardHandler);
@@ -309,7 +309,7 @@ public class SolrCmdDistributorTest extends BaseDistributedSearchTestCase {
     
     cmdDistrib.finish();
 
-    assertEquals(shardCount, commits.get());
+    assertEquals(getShardCount(), commits.get());
     
     for (SolrClient c : clients) {
       NamedList<Object> resp = c.request(new LukeRequest());
@@ -506,14 +506,9 @@ public class SolrCmdDistributorTest extends BaseDistributedSearchTestCase {
   }
   
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
-  }
-  
-  @Override
-  public void tearDown() throws Exception {
+  public void distribTearDown() throws Exception {
     updateShardHandler.close();
-    super.tearDown();
+    super.distribTearDown();
   }
 
   private void testDistribOpenSearcher() {

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/CloudSolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/CloudSolrClientTest.java
@@ -50,6 +50,7 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -97,31 +98,23 @@ public class CloudSolrClientTest extends AbstractFullDistribZkTestBase {
     return SOLR_HOME;
   }
   
-  @Before
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
+  public void distribSetUp() throws Exception {
+    super.distribSetUp();
     // we expect this time of exception as shards go up and down...
     //ignoreException(".*");
     
     System.setProperty("numShards", Integer.toString(sliceCount));
   }
   
-  @Override
-  @After
-  public void tearDown() throws Exception {
-    super.tearDown();
-    resetExceptionIgnores();
-  }
-  
   public CloudSolrClientTest() {
     super();
     sliceCount = 2;
-    shardCount = 3;
+    fixShardCount(3);
   }
 
-  @Override
-  public void doTest() throws Exception {
+  @Test
+  public void test() throws Exception {
     allTests();
     stateVersionParamTest();
     customHttpClientTest();

--- a/solr/test-framework/src/java/org/apache/solr/BaseDistributedSearchTestCase.java
+++ b/solr/test-framework/src/java/org/apache/solr/BaseDistributedSearchTestCase.java
@@ -39,12 +39,19 @@ import org.apache.solr.schema.TrieDateField;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.Rule;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -60,6 +67,20 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Helper base class for distributed search test cases
+ *
+ * By default, all tests in sub-classes will be executed with
+ * 1, 2, ... DEFAULT_MAX_SHARD_COUNT number of shards set up repeatedly.
+ *
+ * In general, it's preferable to annotate the tests in sub-classes with a
+ * @ShardsFixed(num = N) or a @ShardsRepeat(min = M, max = N) to indicate
+ * whether the test should be called once, with a fixed number of shards,
+ * or called repeatedly for number of shards = M to N.
+ *
+ * In some cases though, if the number of shards has to be fixed, but the number
+ * itself is dynamic, or if it has to be set as a default for all sub-classes
+ * of a sub-class, there's a fixShardCount(N) available, which is identical to
+ * @ShardsFixed(num = N) for all tests without annotations in that class hierarchy.
+ * Ideally this function should be retired in favour of better annotations..
  *
  * @since solr 1.5
  */
@@ -172,16 +193,19 @@ public abstract class BaseDistributedSearchTestCase extends SolrTestCaseJ4 {
                                      "[ff01::213]:33332" + context};
   }
 
-  protected int shardCount = 4;      // the actual number of solr cores that will be created in the cluster
+  private final static int DEFAULT_MAX_SHARD_COUNT = 3;
 
-  /**
-   * Sub classes can set this flag in their constructor to true if they
-   * want to fix the number of shards to 'shardCount'
-   *
-   * The default is false which means that test will be executed with
-   * 1, 2, 3, ....shardCount number of shards repeatedly
-   */
-  protected boolean fixShardCount = false;
+  private int shardCount = -1;      // the actual number of solr cores that will be created in the cluster
+  public int getShardCount() {
+    return shardCount;
+  }
+
+  private boolean isShardCountFixed = false;
+
+  public void fixShardCount(int count) {
+    isShardCountFixed = true;
+    shardCount = count;
+  }
 
   protected JettySolrRunner controlJetty;
   protected List<SolrClient> clients = new ArrayList<>();
@@ -243,13 +267,6 @@ public abstract class BaseDistributedSearchTestCase extends SolrTestCaseJ4 {
 
   public static RandVal rdate = new RandDate();
 
-  /**
-   * Perform the actual tests here
-   *
-   * @throws Exception on error
-   */
-  public abstract void doTest() throws Exception;
-
   public static String[] fieldNames = new String[]{"n_ti1", "n_f1", "n_tf1", "n_d1", "n_td1", "n_l1", "n_tl1", "n_dt1", "n_tdt1"};
   public static RandVal[] randVals = new RandVal[]{rint, rfloat, rfloat, rdouble, rdouble, rlong, rlong, rdate, rdate};
 
@@ -268,20 +285,20 @@ public abstract class BaseDistributedSearchTestCase extends SolrTestCaseJ4 {
   public String getSolrHome() {
     return SolrTestCaseJ4.TEST_HOME();
   }
-  
-  @Override
-  public void setUp() throws Exception {
+
+  private boolean distribSetUpCalled = false;
+  public void distribSetUp() throws Exception {
+    distribSetUpCalled = true;
     SolrTestCaseJ4.resetExceptionIgnores();  // ignore anything with ignore_exception in it
-    super.setUp();
     System.setProperty("solr.test.sys.prop1", "propone");
     System.setProperty("solr.test.sys.prop2", "proptwo");
     testDir = createTempDir().toFile();
   }
 
-  @Override
-  public void tearDown() throws Exception {
+  private boolean distribTearDownCalled = false;
+  public void distribTearDown() throws Exception {
+    distribTearDownCalled = true;
     destroyServers();
-    super.tearDown();
   }
 
   protected JettySolrRunner createControlJetty() throws Exception {
@@ -860,22 +877,106 @@ public abstract class BaseDistributedSearchTestCase extends SolrTestCaseJ4 {
     compareSolrResponses(a, b);
   }
 
-  @Test
-  public void testDistribSearch() throws Exception {
-    if (fixShardCount) {
-      createServers(shardCount);
-      RandVal.uniqueValues = new HashSet(); //reset random values
-      doTest();
-      destroyServers();
-    } else {
-      for (int nServers = 1; nServers < shardCount; nServers++) {
-        createServers(nServers);
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target(ElementType.METHOD)
+  public @interface ShardsRepeat {
+    public abstract int min() default 1;
+    public abstract int max() default DEFAULT_MAX_SHARD_COUNT;
+  }
+
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target(ElementType.METHOD)
+  public @interface ShardsFixed {
+    public abstract int num();
+  }
+
+  public class ShardsRepeatRule implements TestRule {
+
+    private abstract class ShardsStatement extends Statement {
+      abstract protected void callStatement() throws Throwable;
+
+      @Override
+      public void evaluate() throws Throwable {
+        distribSetUp();
+        if (! distribSetUpCalled) {
+          Assert.fail("One of the overrides of distribSetUp does not propagate the call.");
+        }
+        try {
+          callStatement();
+        } finally {
+          distribTearDown();
+          if (! distribTearDownCalled) {
+            Assert.fail("One of the overrides of distribTearDown does not propagate the call.");
+          }
+        }
+      }
+    }
+
+    private class ShardsFixedStatement extends ShardsStatement {
+
+      private final int numShards;
+      private final Statement statement;
+
+      private ShardsFixedStatement(int numShards, Statement statement) {
+        this.numShards = numShards;
+        this.statement = statement;
+      }
+
+      @Override
+      public void callStatement() throws Throwable {
+        fixShardCount(numShards);
+        createServers(numShards);
         RandVal.uniqueValues = new HashSet(); //reset random values
-        doTest();
+        statement.evaluate();
         destroyServers();
       }
     }
+
+    private class ShardsRepeatStatement extends ShardsStatement {
+
+      private final int min;
+      private final int max;
+      private final Statement statement;
+
+      private ShardsRepeatStatement(int min, int max, Statement statement) {
+        this.min = min;
+        this.max = max;
+        this.statement = statement;
+      }
+
+      @Override
+      public void callStatement() throws Throwable {
+        for (shardCount = min; shardCount <= max; shardCount++) {
+          createServers(shardCount);
+          RandVal.uniqueValues = new HashSet(); //reset random values
+          statement.evaluate();
+          destroyServers();
+        }
+      }
+    }
+
+    @Override
+    public Statement apply(Statement statement, Description description) {
+      ShardsFixed fixed = description.getAnnotation(ShardsFixed.class);
+      ShardsRepeat repeat = description.getAnnotation(ShardsRepeat.class);
+      if (fixed != null && repeat != null) {
+        throw new RuntimeException("ShardsFixed and ShardsRepeat annotations can't coexist");
+      }
+      else if (fixed != null) {
+        return new ShardsFixedStatement(fixed.num(), statement);
+      }
+      else if (repeat != null) {
+        return new ShardsRepeatStatement(repeat.min(), repeat.max(), statement);
+      }
+      else {
+        return (isShardCountFixed ? new ShardsFixedStatement(shardCount, statement) :
+          new ShardsRepeatStatement(1, DEFAULT_MAX_SHARD_COUNT, statement));
+      }
+    }
   }
+
+  @Rule
+  public ShardsRepeatRule repeatRule = new ShardsRepeatRule();
 
   public static Object[] getRandFields(String[] fields, RandVal[] randVals) {
     Object[] o = new Object[fields.length * 2];

--- a/solr/test-framework/src/java/org/apache/solr/cloud/AbstractDistribZkTestBase.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/AbstractDistribZkTestBase.java
@@ -54,11 +54,9 @@ public abstract class AbstractDistribZkTestBase extends BaseDistributedSearchTes
     //useFactory(null);
   }
 
-
-  @Before
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
+  public void distribSetUp() throws Exception {
+    super.distribSetUp();
     
     String zkDir = testDir.getAbsolutePath() + File.separator
     + "zookeeper/server1/data";
@@ -212,8 +210,7 @@ public abstract class AbstractDistribZkTestBase extends BaseDistributedSearchTes
   }
   
   @Override
-  @After
-  public void tearDown() throws Exception {
+  public void distribTearDown() throws Exception {
     if (DEBUG) {
       printLayout();
     }
@@ -228,7 +225,7 @@ public abstract class AbstractDistribZkTestBase extends BaseDistributedSearchTes
     System.clearProperty(MockDirectoryFactory.SOLR_TESTS_ALLOW_READING_FILES_STILL_OPEN_FOR_WRITE);
     
     resetExceptionIgnores();
-    super.tearDown();
+    super.distribTearDown();
     zkServer.shutdown();
   }
   

--- a/solr/test-framework/src/java/org/apache/solr/cloud/AbstractFullDistribZkTestBase.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/AbstractFullDistribZkTestBase.java
@@ -55,9 +55,7 @@ import org.apache.solr.core.SolrResourceLoader;
 import org.apache.solr.servlet.SolrDispatchFilter;
 import org.apache.solr.update.DirectUpdateHandler2;
 import org.apache.zookeeper.CreateMode;
-import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.noggit.CharArr;
 import org.noggit.JSONWriter;
@@ -95,18 +93,18 @@ import static org.apache.solr.common.cloud.ZkStateReader.REPLICATION_FACTOR;
 @Slow
 public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTestBase {
   static Logger log = LoggerFactory.getLogger(AbstractFullDistribZkTestBase.class);
-  
+
   @BeforeClass
   public static void beforeFullSolrCloudTest() {
     // shorten the log output more for this test type
     if (formatter != null) formatter.setShorterFormat();
   }
-  
+
   public static final String SHARD1 = "shard1";
   public static final String SHARD2 = "shard2";
-  
+
   protected boolean printLayoutOnTearDown = false;
-  
+
   String t1 = "a_t";
   String i1 = "a_i1";
   String tlong = "other_tl1";
@@ -122,14 +120,14 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
   protected Map<String,List<CloudJettyRunner>> shardToJetty = new HashMap<>();
   private AtomicInteger jettyIntCntr = new AtomicInteger(0);
   protected ChaosMonkey chaosMonkey;
-  
+
   protected Map<String,CloudJettyRunner> shardToLeaderJetty = new HashMap<>();
   private boolean cloudInit;
   protected boolean checkCreatedVsState;
   protected boolean useJettyDataDir = true;
 
   protected Map<URI,SocketProxy> proxies = new HashMap<URI,SocketProxy>();
-  
+
   public static class CloudJettyRunner {
     public JettySolrRunner jetty;
     public String nodeName;
@@ -160,19 +158,19 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
       return "CloudJettyRunner [url=" + url + "]";
     }
   }
-  
+
   static class CloudSolrServerClient {
     SolrClient solrClient;
     String shardName;
     int port;
     public ZkNodeProps info;
-    
+
     public CloudSolrServerClient() {}
     
     public CloudSolrServerClient(SolrClient client) {
       this.solrClient = client;
     }
-    
+
     @Override
     public int hashCode() {
       final int prime = 31;
@@ -180,7 +178,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
       result = prime * result + ((solrClient == null) ? 0 : solrClient.hashCode());
       return result;
     }
-    
+
     @Override
     public boolean equals(Object obj) {
       if (this == obj) return true;
@@ -192,69 +190,67 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
       } else if (!solrClient.equals(other.solrClient)) return false;
       return true;
     }
-    
+
   }
-  
-  @Before
+
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
+  public void distribSetUp() throws Exception {
+    super.distribSetUp();
     // ignoreException(".*");
     if (sliceCount > 0) {
       System.setProperty("numShards", Integer.toString(sliceCount));
     } else {
       System.clearProperty("numShards");
     }
-    
+
     if (isSSLMode()) {
       System.clearProperty("urlScheme");
       ZkStateReader zkStateReader = new ZkStateReader(zkServer.getZkAddress(),
           AbstractZkTestCase.TIMEOUT, AbstractZkTestCase.TIMEOUT);
       try {
         zkStateReader.getZkClient().create(ZkStateReader.CLUSTER_PROPS,
-          ZkStateReader.toJSON(Collections.singletonMap("urlScheme","https")), 
+          ZkStateReader.toJSON(Collections.singletonMap("urlScheme","https")),
           CreateMode.PERSISTENT, true);
       } finally {
         zkStateReader.close();
       }
     }
   }
-  
+
   @BeforeClass
   public static void beforeClass() {
     System.setProperty("solrcloud.update.delay", "0");
   }
-  
+
   @AfterClass
   public static void afterClass() throws Exception {
     System.clearProperty("solrcloud.update.delay");
     System.clearProperty("genericCoreNodeNames");
   }
-  
+
   public AbstractFullDistribZkTestBase() {
-    fixShardCount = true;
-    
-    shardCount = 4;
     sliceCount = 2;
+    fixShardCount(4);
+
     // TODO: for now, turn off stress because it uses regular clients, and we
     // need the cloud client because we kill servers
     stress = 0;
-    
+
     useExplicitNodeNames = random().nextBoolean();
   }
-  
+
   protected String getDataDir(String dataDir) throws IOException {
     return dataDir;
   }
-  
+
   protected void initCloud() throws Exception {
     assert(cloudInit == false);
     cloudInit = true;
     cloudClient = createCloudClient(DEFAULT_COLLECTION);
     cloudClient.connect();
-    
+
     ZkStateReader zkStateReader = cloudClient.getZkStateReader();
-    
+
     chaosMonkey = new ChaosMonkey(zkServer, zkStateReader, DEFAULT_COLLECTION,
         shardToJetty, shardToLeaderJetty);
   }
@@ -269,21 +265,21 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
     .setParameter(CoreConnectionPNames.SO_TIMEOUT, 60000);
     return client;
   }
-  
+
   @Override
   protected void createServers(int numServers) throws Exception {
-    
+
     System.setProperty("collection", "control_collection");
 
     // we want hashes by default for the control, so set to 1 shard as opposed to leaving unset
     String oldNumShards = System.getProperty(ZkStateReader.NUM_SHARDS_PROP);
     System.setProperty(ZkStateReader.NUM_SHARDS_PROP, "1");
-    
+
     try {
-      
+
       File controlJettyDir = createTempDir().toFile();
       setupJettySolrHome(controlJettyDir);
-      
+
       controlJetty = createJetty(controlJettyDir, useJettyDataDir ? getDataDir(testDir
           + "/control/data") : null); // don't pass shard name... let it default to
                                // "shard1"
@@ -304,7 +300,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
                                           // cloudClient
         return;
       }
-      
+
     } finally {
       System.clearProperty("collection");
       if (oldNumShards != null) {
@@ -316,9 +312,9 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
 
 
     initCloud();
-    
+
     createJettys(numServers, checkCreatedVsState).size();
-    
+
     int cnt = getTotalReplicas(DEFAULT_COLLECTION);
     if (cnt > 0) {
       waitForCollection(cloudClient.getZkStateReader(), DEFAULT_COLLECTION, sliceCount);
@@ -347,7 +343,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
       Thread.sleep(500);
     }
   }
-  
+
   protected List<JettySolrRunner> createJettys(int numJettys) throws Exception {
     return createJettys(numJettys, false);
   }
@@ -404,22 +400,22 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
       SolrClient client = createNewSolrClient(j.getLocalPort());
       clients.add(client);
     }
-  
+
     this.jettys.addAll(jettys);
     this.clients.addAll(clients);
-    
+
     int numShards = getTotalReplicas(DEFAULT_COLLECTION);
     if (checkCreatedVsState) {
       // now wait until we see that the number of shards in the cluster state
       // matches what we expect
       int retries = 0;
-      while (numShards != shardCount) {
+      while (numShards != getShardCount()) {
         numShards = getTotalReplicas(DEFAULT_COLLECTION);
-        if (numShards == shardCount) break;
+        if (numShards == getShardCount()) break;
         if (retries++ == 60) {
           printLayoutOnTearDown = true;
           fail("Shards in the state does not match what we set:" + numShards
-              + " vs " + shardCount);
+              + " vs " + getShardCount());
         }
         Thread.sleep(500);
       }
@@ -434,7 +430,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
     if (numShards > 0) {
       updateMappingsFromZk(this.jettys, this.clients);
     }
-    
+
     // build the shard string
     for (int i = 1; i <= numJettys / 2; i++) {
       JettySolrRunner j = this.jettys.get(i);
@@ -444,7 +440,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
       sb.append("|").append(buildUrl(j2.getLocalPort()));
     }
     shards = sb.toString();
-    
+
     return jettys;
   }
 
@@ -496,30 +492,30 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
     }
     return cnt;
   }
-  
+
   public JettySolrRunner createJetty(String dataDir, String ulogDir, String shardList,
       String solrConfigOverride) throws Exception {
-    
+
     JettySolrRunner jetty = new JettySolrRunner(getSolrHome(), context, 0,
         solrConfigOverride, null, false, getExtraServlets(), sslConfig, getExtraRequestFilters());
     jetty.setShards(shardList);
     jetty.setDataDir(getDataDir(dataDir));
     jetty.start();
-    
+
     return jetty;
   }
-  
+
   public JettySolrRunner createJetty(File solrHome, String dataDir, String shardList, String solrConfigOverride, String schemaOverride) throws Exception {
     // randomly test a relative solr.home path
     if (random().nextBoolean()) {
       solrHome = getRelativeSolrHomePath(solrHome);
     }
-    
+
     JettySolrRunner jetty = new JettySolrRunner(solrHome.getPath(), context, 0, solrConfigOverride, schemaOverride, false, getExtraServlets(), sslConfig, getExtraRequestFilters());
     jetty.setShards(shardList);
     jetty.setDataDir(getDataDir(dataDir));
     jetty.start();
-    
+
     return jetty;
   }
 
@@ -600,7 +596,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
   private File getRelativeSolrHomePath(File solrHome) {
     String path = SolrResourceLoader.normalizeDir(new File(".").getAbsolutePath());
     String base = new File(solrHome.getPath()).getAbsolutePath();
-    
+
     if (base.startsWith(".")) {
       base = base.replaceFirst("\\.", new File(".").getName());
     }
@@ -608,14 +604,14 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
     if (path.endsWith(File.separator + ".")) {
       path = path.substring(0, path.length() - 2);
     }
-    
+
     int splits = path.split("\\" + File.separator).length;
-    
+
     StringBuilder p = new StringBuilder();
     for (int i = 0; i < splits - 2; i++) {
       p.append("..").append(File.separator);
-    }   
-    
+    }
+
     String prefix = FilenameUtils.getPrefix(path);
     if (base.startsWith(prefix)) {
       base = base.substring(prefix.length());
@@ -634,7 +630,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
     zkStateReader.updateClusterState(true);
     cloudJettys.clear();
     shardToJetty.clear();
-    
+
     ClusterState clusterState = zkStateReader.getClusterState();
     DocCollection coll = clusterState.getCollection(DEFAULT_COLLECTION);
 
@@ -647,28 +643,28 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
         for (Replica replica : slice.getReplicas()) {
           int port = new URI(((HttpSolrClient) client).getBaseURL())
               .getPort();
-          
+
           if (replica.getStr(ZkStateReader.BASE_URL_PROP).contains(":" + port)) {
             CloudSolrServerClient csc = new CloudSolrServerClient();
             csc.solrClient = client;
             csc.port = port;
             csc.shardName = replica.getStr(ZkStateReader.NODE_NAME_PROP);
             csc.info = replica;
-            
+
             theClients .add(csc);
-            
+
             break nextClient;
           }
         }
       }
     }
- 
+
     for (JettySolrRunner jetty : jettys) {
       int port = jetty.getLocalPort();
       if (port == -1) {
         throw new RuntimeException("Cannot find the port for jetty");
       }
-      
+
       nextJetty:
       for (Slice slice : coll.getSlices()) {
         Set<Entry<String,Replica>> entries = slice.getReplicasMap().entrySet();
@@ -698,7 +694,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
         }
       }
     }
-    
+
     // # of jetties may not match replicas in shard here, because we don't map
     // jetties that are not running - every shard should have at least one
     // running jetty though
@@ -708,13 +704,13 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
       if (!allowOverSharding) {
         assertNotNull("Test setup problem: We found no jetties for shard: "
             + slice.getName() + " just:" + shardToJetty.keySet(), jetties);
-        
+
         assertEquals("slice:" + slice.getName(), slice.getReplicas().size(),
             jetties.size());
       }
     }
   }
-  
+
   private CloudSolrServerClient findClientByPort(int port, List<CloudSolrServerClient> theClients) {
     for (CloudSolrServerClient client : theClients) {
       if (client.port == port) {
@@ -726,7 +722,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
 
   @Override
   protected void setDistributedParams(ModifiableSolrParams params) {
-    
+
     if (r.nextBoolean()) {
       // don't set shards, let that be figured out from the cloud state
     } else {
@@ -739,19 +735,19 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
       params.set("shards", sb.toString());
     }
   }
-  
+
   @Override
   protected void indexDoc(SolrInputDocument doc) throws IOException,
       SolrServerException {
-    
+
     UpdateRequest req = new UpdateRequest();
     req.add(doc);
     req.setParam("CONTROL", "TRUE");
     req.process(controlClient);
-    
+
     // if we wanted to randomly pick a client - but sometimes they may be
     // down...
-    
+
     // boolean pick = random.nextBoolean();
     //
     // int which = (doc.getField(id).toString().hashCode() & 0x7fffffff) %
@@ -764,13 +760,13 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
     //
     // HttpSolrServer client = (HttpSolrServer)
     // clients.get(which);
-    
+
     UpdateRequest ureq = new UpdateRequest();
     ureq.add(doc);
     // ureq.setParam(UpdateParams.UPDATE_CHAIN, DISTRIB_UPDATE_CHAIN);
     ureq.process(cloudClient);
   }
-  
+
   @Override
   protected void index_specific(int serverNumber, Object... fields)
       throws Exception {
@@ -782,7 +778,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
     
     HttpSolrClient client = (HttpSolrClient) clients
         .get(serverNumber);
-    
+
     UpdateRequest ureq = new UpdateRequest();
     ureq.add(doc);
     // ureq.setParam("update.chain", DISTRIB_UPDATE_CHAIN);
@@ -795,16 +791,16 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
     for (int i = 0; i < fields.length; i += 2) {
       doc.addField((String) (fields[i]), fields[i + 1]);
     }
-    
+
     UpdateRequest ureq = new UpdateRequest();
     ureq.add(doc);
     // ureq.setParam("update.chain", DISTRIB_UPDATE_CHAIN);
     ureq.process(client);
-    
+
     // add to control second in case adding to shards fails
     controlClient.add(doc);
   }
-  
+
   @Override
   protected void del(String q) throws Exception {
     controlClient.deleteByQuery(q);
@@ -818,25 +814,25 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
     }
      ***/
   }// serial commit...
-  
+
   protected void waitForRecoveriesToFinish(boolean verbose)
       throws Exception {
     ZkStateReader zkStateReader = cloudClient.getZkStateReader();
     super.waitForRecoveriesToFinish(DEFAULT_COLLECTION, zkStateReader, verbose);
   }
-  
+
   protected void waitForRecoveriesToFinish(String collection, boolean verbose)
       throws Exception {
     ZkStateReader zkStateReader = cloudClient.getZkStateReader();
     super.waitForRecoveriesToFinish(collection, zkStateReader, verbose);
   }
-  
+
   protected void waitForRecoveriesToFinish(boolean verbose, int timeoutSeconds)
       throws Exception {
     ZkStateReader zkStateReader = cloudClient.getZkStateReader();
     super.waitForRecoveriesToFinish(DEFAULT_COLLECTION, zkStateReader, verbose, true, timeoutSeconds);
   }
-  
+
   protected void checkQueries() throws Exception {
 
     handle.put("_version_", SKIPVAL);
@@ -860,7 +856,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
       query("q", "*:*", "sort", f + " desc");
       query("q", "*:*", "sort", f + " asc");
     }
-    
+
     // these queries should be exactly ordered and scores should exactly match
     query("q", "*:*", "sort", i1 + " desc");
     query("q", "*:*", "sort", i1 + " asc");
@@ -877,30 +873,30 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
     handle.remove("maxScore");
     query("q", "{!func}" + i1, "fl", "*,score"); // even scores should match
                                                  // exactly here
-    
+
     handle.put("highlighting", UNORDERED);
     handle.put("response", UNORDERED);
-    
+
     handle.put("maxScore", SKIPVAL);
     query("q", "quick");
     query("q", "all", "fl", "id", "start", "0");
     query("q", "all", "fl", "foofoofoo", "start", "0"); // no fields in returned
                                                         // docs
     query("q", "all", "fl", "id", "start", "100");
-    
+
     handle.put("score", SKIPVAL);
     query("q", "quick", "fl", "*,score");
     query("q", "all", "fl", "*,score", "start", "1");
     query("q", "all", "fl", "*,score", "start", "100");
-    
+
     query("q", "now their fox sat had put", "fl", "*,score", "hl", "true",
         "hl.fl", t1);
-    
+
     query("q", "now their fox sat had put", "fl", "foofoofoo", "hl", "true",
         "hl.fl", t1);
-    
+
     query("q", "matchesnothing", "fl", "*,score");
-    
+
     query("q", "*:*", "rows", 100, "facet", "true", "facet.field", t1);
     query("q", "*:*", "rows", 100, "facet", "true", "facet.field", t1,
         "facet.limit", -1, "facet.sort", "count");
@@ -918,11 +914,11 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
         "facet.offset", 1);
     query("q", "*:*", "rows", 100, "facet", "true", "facet.field", t1,
         "facet.mincount", 2);
-    
+
     // test faceting multiple things at once
     query("q", "*:*", "rows", 100, "facet", "true", "facet.query", "quick",
         "facet.query", "all", "facet.query", "*:*", "facet.field", t1);
-    
+
     // test filter tagging, facet exclusion, and naming (multi-select facet
     // support)
     query("q", "*:*", "rows", 100, "facet", "true", "facet.query",
@@ -935,16 +931,16 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
         "{!ex=t1}SubjectTerms_mfacet", "fq",
         "{!tag=t1}SubjectTerms_mfacet:(test 1)", "facet.limit", "10",
         "facet.mincount", "1");
-    
+
     // test field that is valid in schema but missing in all shards
     query("q", "*:*", "rows", 100, "facet", "true", "facet.field",
         missingField, "facet.mincount", 2);
     // test field that is valid in schema and missing in some shards
     query("q", "*:*", "rows", 100, "facet", "true", "facet.field", oddField,
         "facet.mincount", 2);
-    
+
     query("q", "*:*", "sort", i1 + " desc", "stats", "true", "stats.field", i1);
-    
+
     // Try to get better coverage for refinement queries by turning off over
     // requesting.
     // This makes it much more likely that we may not get the top facet values
@@ -958,15 +954,15 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
         "{!key='a b/c \\' \\} foo'}" + t1, "facet.limit", 5,
         "facet.shard.limit", 5);
     handle.remove("facet_fields");
-    
+
     query("q", "*:*", "sort", "n_tl1 desc");
-    
+
     // index the same document to two shards and make sure things
     // don't blow up.
     // assumes first n clients are first n shards
     if (clients.size() >= 2) {
       index(id, 100, i1, 107, t1, "oh no, a duplicate!");
-      for (int i = 0; i < shardCount; i++) {
+      for (int i = 0; i < getShardCount(); i++) {
         index_specific(i, id, 100, i1, 107, t1, "oh no, a duplicate!");
       }
       commit();
@@ -975,7 +971,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
       query("q", "*:*", "rows", 100);
     }
   }
-  
+
   protected void indexAbunchOfDocs() throws Exception {
     indexr(id, 2, i1, 50, t1, "to come to the aid of their country.");
     indexr(id, 3, i1,  2, t1, "how now brown cow");
@@ -995,7 +991,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
         "Great works are performed, not by strength, but by perseverance.");
     indexr(id, 13, i1, 232, t1, "no eggs on wall, lesson learned",
         oddField, "odd man out");
-    
+
     indexr(id, 14, "SubjectTerms_mfacet", new String[] {"mathematical models",
         "mathematical analysis"});
     indexr(id, 15, "SubjectTerms_mfacet", new String[] {"test 1", "test 2",
@@ -1007,19 +1003,19 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
       vals[i] = "test " + i;
     }
     indexr(id, 17, "SubjectTerms_mfacet", vals);
-    
+
     for (int i = 100; i < 150; i++) {
       indexr(id, i);
     }
   }
-  
+
   /**
-   * Executes a query against each live and active replica of the specified shard 
+   * Executes a query against each live and active replica of the specified shard
    * and aserts that the results are identical.
    *
    * @see #queryAndCompare
    */
-  public QueryResponse queryAndCompareReplicas(SolrParams params, String shard) 
+  public QueryResponse queryAndCompareReplicas(SolrParams params, String shard)
     throws Exception {
 
     ArrayList<SolrClient> shardClients = new ArrayList<>(7);
@@ -1044,9 +1040,9 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
 
   /**
    * For each Shard, executes a query against each live and active replica of that shard
-   * and asserts that the results are identical for each replica of the same shard.  
-   * Because results are not compared between replicas of different shards, this method 
-   * should be safe for comparing the results of any query, even if it contains 
+   * and asserts that the results are identical for each replica of the same shard.
+   * Because results are not compared between replicas of different shards, this method
+   * should be safe for comparing the results of any query, even if it contains
    * "distrib=false", because the replicas should all be identical.
    *
    * @see AbstractFullDistribZkTestBase#queryAndCompareReplicas(SolrParams, String)
@@ -1060,25 +1056,25 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
     }
   }
 
-  /** 
-   * Returns a non-null string if replicas within the same shard do not have a 
-   * consistent number of documents. 
+  /**
+   * Returns a non-null string if replicas within the same shard do not have a
+   * consistent number of documents.
    */
   protected void checkShardConsistency(String shard) throws Exception {
     checkShardConsistency(shard, false, false);
   }
 
-  /** 
-   * Returns a non-null string if replicas within the same shard do not have a 
+  /**
+   * Returns a non-null string if replicas within the same shard do not have a
    * consistent number of documents.
-   * If expectFailure==false, the exact differences found will be logged since 
+   * If expectFailure==false, the exact differences found will be logged since
    * this would be an unexpected failure.
-   * verbose causes extra debugging into to be displayed, even if everything is 
+   * verbose causes extra debugging into to be displayed, even if everything is
    * consistent.
    */
   protected String checkShardConsistency(String shard, boolean expectFailure, boolean verbose)
       throws Exception {
-    
+
     List<CloudJettyRunner> solrJetties = shardToJetty.get(shard);
     if (solrJetties == null) {
       throw new RuntimeException("shard not found:" + shard + " keys:"
@@ -1114,7 +1110,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
             + e.getMessage() + "\n");
         continue;
       }
-      
+
       boolean live = false;
       String nodeName = props.getStr(ZkStateReader.NODE_NAME_PROP);
       if (zkStateReader.getClusterState().liveNodesContain(nodeName)) {
@@ -1151,19 +1147,19 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
       }
     }
     return failMessage;
-    
+
   }
-  
+
   public void showCounts() {
     Set<String> theShards = shardToJetty.keySet();
-    
+
     for (String shard : theShards) {
       List<CloudJettyRunner> solrJetties = shardToJetty.get(shard);
-      
+
       for (CloudJettyRunner cjetty : solrJetties) {
         ZkNodeProps props = cjetty.info;
         System.err.println("PROPS:" + props);
-        
+
         try {
           SolrParams query = params("q", "*:*", "rows", "0", "distrib",
               "false", "tests", "checkShardConsistency"); // "tests" is just a
@@ -1189,11 +1185,11 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
           live = true;
         }
         System.err.println(" live:" + live);
-        
+
       }
     }
   }
-  
+
   protected void randomlyEnableAutoSoftCommit() {
     if (r.nextBoolean()) {
       enableAutoSoftCommit(1000);
@@ -1201,7 +1197,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
       log.info("Not turning on auto soft commit");
     }
   }
-  
+
   protected void enableAutoSoftCommit(int time) {
     log.info("Turning on auto soft commit: " + time);
     for (List<CloudJettyRunner> jettyList : shardToJetty.values()) {
@@ -1230,7 +1226,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
       throws Exception {
     checkShardConsistency(checkVsControl, verbose, null, null);
   }
-  
+
   /* Checks shard consistency and optionally checks against the control shard.
    * The test will be failed if differences are found.
    */
@@ -1238,7 +1234,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
       throws Exception {
 
     updateMappingsFromZk(jettys, clients, true);
-    
+
     Set<String> theShards = shardToJetty.keySet();
     String failMessage = null;
     for (String shard : theShards) {
@@ -1247,7 +1243,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
         failMessage = shardFailMessage;
       }
     }
-    
+
     if (failMessage != null) {
       fail(failMessage);
     }
@@ -1262,7 +1258,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
     SolrDocumentList cloudDocList = cloudClient.query(q).getResults();
     long cloudClientDocs = cloudDocList.getNumFound();
 
-    
+
     // now check that the right # are on each shard
     theShards = shardToJetty.keySet();
     int cnt = 0;
@@ -1316,7 +1312,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
     }
     return null;
   }
-  
+
   protected void assertDocCounts(boolean verbose) throws Exception {
     // TODO: as we create the clients, we should build a map from shard to
     // node/client
@@ -1326,7 +1322,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
         + "\n\n");
     long controlCount = controlClient.query(new SolrQuery("*:*")).getResults()
         .getNumFound();
-    
+
     // do some really inefficient mapping...
     ZkStateReader zk = new ZkStateReader(zkServer.getZkAddress(), 10000,
         AbstractZkTestCase.TIMEOUT);
@@ -1339,12 +1335,12 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
     } finally {
       zk.close();
     }
-    
+
     if (slices == null) {
       throw new RuntimeException("Could not find collection "
           + DEFAULT_COLLECTION + " in " + clusterState.getCollections());
     }
-    
+
     for (CloudJettyRunner cjetty : cloudJettys) {
       CloudSolrServerClient client = cjetty.client;
       for (Map.Entry<String,Slice> slice : slices.entrySet()) {
@@ -1370,7 +1366,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
         query.set("distrib", false);
         count = client.solrClient.query(query).getResults().getNumFound();
       }
-      
+
       if (verbose) System.err.println("client docs:" + count + "\n\n");
     }
     if (verbose) System.err.println("control docs:"
@@ -1380,39 +1376,39 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
     assertEquals("Doc Counts do not add up", controlCount,
         cloudClient.query(query).getResults().getNumFound());
   }
-  
+
   @Override
   protected QueryResponse queryServer(ModifiableSolrParams params)
       throws SolrServerException {
-    
+
     if (r.nextBoolean()) params.set("collection", DEFAULT_COLLECTION);
-    
+
     QueryResponse rsp = cloudClient.query(params);
     return rsp;
   }
-  
+
   static abstract class StopableThread extends Thread {
     public StopableThread(String name) {
       super(name);
     }
     public abstract void safeStop();
   }
-  
+
   class StopableSearchThread extends StopableThread {
     private volatile boolean stop = false;
     protected final AtomicInteger queryFails = new AtomicInteger();
     private String[] QUERIES = new String[] {"to come","their country","aid","co*"};
-    
+
     public StopableSearchThread() {
       super("StopableSearchThread");
       setDaemon(true);
     }
-    
+
     @Override
     public void run() {
       Random random = random();
       int numSearches = 0;
-      
+
       while (true && !stop) {
         numSearches++;
         try {
@@ -1433,43 +1429,43 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
           Thread.currentThread().interrupt();
         }
       }
-      
+
       System.err.println("num searches done:" + numSearches + " with " + queryFails + " fails");
     }
-    
+
     @Override
     public void safeStop() {
       stop = true;
     }
-    
+
     public int getFails() {
       return queryFails.get();
     }
-    
+
   };
-  
+
   public void waitForThingsToLevelOut(int waitForRecTimeSeconds) throws Exception {
     log.info("Wait for recoveries to finish - wait " + waitForRecTimeSeconds + " for each attempt");
     int cnt = 0;
     boolean retry = false;
     do {
       waitForRecoveriesToFinish(VERBOSE, waitForRecTimeSeconds);
-      
+
       try {
         commit();
       } catch (Throwable t) {
         t.printStackTrace();
         // we don't care if this commit fails on some nodes
       }
-      
+
       updateMappingsFromZk(jettys, clients);
-      
+
       Set<String> theShards = shardToJetty.keySet();
       String failMessage = null;
       for (String shard : theShards) {
         failMessage = checkShardConsistency(shard, true, false);
       }
-      
+
       if (failMessage != null) {
         log.info("shard inconsistency - waiting ...");
         retry = true;
@@ -1481,8 +1477,8 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
       Thread.sleep(2000);
     } while (retry);
   }
-  
-  
+
+
   public void waitForNoShardInconsistency() throws Exception {
     log.info("Wait for no shard inconsistency");
     int cnt = 0;
@@ -1494,9 +1490,9 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
         t.printStackTrace();
         // we don't care if this commit fails on some nodes
       }
-      
+
       updateMappingsFromZk(jettys, clients);
-      
+
       Set<String> theShards = shardToJetty.keySet();
       String failMessage = null;
       for (String shard : theShards) {
@@ -1507,7 +1503,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
           failMessage="hit exception:" + e.getMessage();
         }
       }
-      
+
       if (failMessage != null) {
         log.info("shard inconsistency - waiting ...");
         retry = true;
@@ -1533,8 +1529,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
   }
 
   @Override
-  @After
-  public void tearDown() throws Exception {
+  public void distribTearDown() throws Exception {
     if (VERBOSE || printLayoutOnTearDown) {
       super.printLayout();
     }
@@ -1550,25 +1545,25 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
     if (controlClientCloud != null) {
       controlClientCloud.shutdown();
     }
-    super.tearDown();
-    
+    super.distribTearDown();
+
     System.clearProperty("zkHost");
     System.clearProperty("numShards");
 
-    // close socket proxies after super.tearDown
+    // close socket proxies after super.distribTearDown
     if (!proxies.isEmpty()) {
       for (SocketProxy proxy : proxies.values()) {
         proxy.close();
       }
     }
   }
-  
+
   @Override
   protected void commit() throws Exception {
     controlClient.commit();
     cloudClient.commit();
   }
-  
+
   @Override
   protected void destroyServers() throws Exception {
     if (controlJetty != null) {
@@ -1583,7 +1578,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
     }
     super.destroyServers();
   }
-  
+
   protected CollectionAdminResponse createCollection(String collectionName, int numShards, int replicationFactor, int maxShardsPerNode) throws SolrServerException, IOException {
     return createCollection(null, collectionName, numShards, replicationFactor, maxShardsPerNode, null, null);
   }
@@ -1655,7 +1650,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
         MAX_SHARDS_PER_NODE, maxShardsPerNode),
         client);
   }
-  
+
   protected CollectionAdminResponse createCollection(Map<String, List<Integer>> collectionInfos,
                                                      String collectionName, int numShards, int replicationFactor, int maxShardsPerNode, SolrClient client, String createNodeSetStr, String configName) throws SolrServerException, IOException {
 
@@ -1704,7 +1699,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
         0, client.getBaseURL().length()
             - DEFAULT_COLLECTION.length() - 1);
   }
-  
+
   protected SolrInputDocument getDoc(Object... fields) throws Exception {
     SolrInputDocument doc = new SolrInputDocument();
     addFields(doc, fields);
@@ -1718,7 +1713,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
     // The Math.min thing is here, because we expect replication-factor to be reduced to if there are not enough live nodes to spread all shards of a collection over different nodes
     int expectedShardsPerSlice = numShardsNumReplicaList.get(1);
     int expectedTotalShards = expectedSlices * expectedShardsPerSlice;
-    
+
 //      Map<String,DocCollection> collections = clusterState
 //          .getCollectionStates();
       if (clusterState.hasCollection(collectionName)) {
@@ -1737,14 +1732,14 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
         totalShards += slices.get(sliceName).getReplicas().size();
       }
       if (totalShards != expectedTotalShards) {
-        return "Found new collection " + collectionName + " with correct number of slices, but mismatch on number of shards. Expected: " + expectedTotalShards + ", actual: " + totalShards; 
+        return "Found new collection " + collectionName + " with correct number of slices, but mismatch on number of shards. Expected: " + expectedTotalShards + ", actual: " + totalShards;
         }
       return null;
     } else {
       return "Could not find new collection " + collectionName;
     }
   }
-  
+
   protected void checkForCollection(String collectionName,
       List<Integer> numShardsNumReplicaList,
       List<String> nodesAllowedToRunShards) throws Exception {
@@ -1782,7 +1777,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
     }
     return commondCloudSolrClient;
   }
-  
+
   public static String getUrlFromZk(ClusterState clusterState, String collection) {
     Map<String,Slice> slices = clusterState.getCollection(collection).getSlicesMap();
 
@@ -1891,9 +1886,9 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
 
   protected List<Replica> ensureAllReplicasAreActive(String testCollectionName, String shardId, int shards, int rf, int maxWaitSecs) throws Exception {
     long startMs = System.currentTimeMillis();
-    
+
     Map<String,Replica> notLeaders = new HashMap<String,Replica>();
-    
+
     ZkStateReader zkr = cloudClient.getZkStateReader();
     zkr.updateClusterState(true); // force the state to be fresh
 
@@ -1908,7 +1903,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
       // refresh state every 2 secs
       if (waitMs % 2000 == 0)
         cloudClient.getZkStateReader().updateClusterState(true);
-      
+
       cs = cloudClient.getZkStateReader().getClusterState();
       assertNotNull(cs);
       Slice shard = cs.getSlice(testCollectionName, shardId);
@@ -1921,7 +1916,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
       assertNotNull(leader);
       log.info("Found "+replicas.size()+" replicas and leader on "+
         leader.getNodeName()+" for "+shardId+" in "+testCollectionName);
-      
+
       // ensure all replicas are "active" and identify the non-leader replica
       for (Replica replica : replicas) {
         String replicaState = replica.getStr(ZkStateReader.STATE_PROP);
@@ -1929,11 +1924,11 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
           log.info("Replica " + replica.getName() + " is currently " + replicaState);
           allReplicasUp = false;
         }
-        
-        if (!leader.equals(replica)) 
+
+        if (!leader.equals(replica))
           notLeaders.put(replica.getName(), replica);
       }
-      
+
       if (!allReplicasUp) {
         try {
           Thread.sleep(500L);
@@ -1941,22 +1936,22 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
         waitMs += 500L;
       }
     } // end while
-    
-    if (!allReplicasUp) 
+
+    if (!allReplicasUp)
       fail("Didn't see all replicas for shard "+shardId+" in "+testCollectionName+
           " come up within " + maxWaitMs + " ms! ClusterState: " + printClusterStateInfo());
-    
-    if (notLeaders.isEmpty()) 
+
+    if (notLeaders.isEmpty())
       fail("Didn't isolate any replicas that are not the leader! ClusterState: " + printClusterStateInfo());
-    
+
     long diffMs = (System.currentTimeMillis() - startMs);
     log.info("Took " + diffMs + " ms to see all replicas become active.");
-    
+
     List<Replica> replicas = new ArrayList<Replica>();
     replicas.addAll(notLeaders.values());
     return replicas;
-  }  
-  
+  }
+
   protected String printClusterStateInfo() throws Exception {
     return printClusterStateInfo(null);
   }

--- a/solr/test-framework/src/java/org/apache/solr/cloud/ZkTestServer.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/ZkTestServer.java
@@ -419,7 +419,7 @@ public class ZkTestServer {
 
   public void run() throws InterruptedException {
     log.info("STARTING ZK TEST SERVER");
-    // we don't call super.setUp
+    // we don't call super.distribSetUp
     zooThread = new Thread() {
       
       @Override


### PR DESCRIPTION
Patch for SOLR-6902