### PR TITLE
No need to call isIndexStale if full copy is already needed

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/IndexFetcher.java
+++ b/solr/core/src/java/org/apache/solr/handler/IndexFetcher.java
@@ -351,7 +351,7 @@ public class IndexFetcher {
 
       try {
         
-        if (isIndexStale(indexDir)) {
+        if (!isFullCopyNeeded && isIndexStale(indexDir)) {
           isFullCopyNeeded = true;
         }
         


### PR DESCRIPTION
This will avoid having the message "File _3ww7_Lucene41_0.tim expected to be 2027667 while it is 1861076" when in fact there was already a match on commit.getGeneration() >= latestGeneration