### PR TITLE
add support for request parameter placeholders to property writer conf

### DIFF
--- a/solr/contrib/dataimporthandler/src/java/org/apache/solr/handler/dataimport/SimplePropertiesWriter.java
+++ b/solr/contrib/dataimporthandler/src/java/org/apache/solr/handler/dataimport/SimplePropertiesWriter.java
@@ -81,7 +81,7 @@ public class SimplePropertiesWriter extends DIHProperties {
   @Override
   public void init(DataImporter dataImporter, Map<String, String> params) {
     if(params.get(FILENAME) != null) {
-      filename = params.get(FILENAME);
+      filename = createVariableResolver(params).replaceTokens(params.get(FILENAME));
     } else if(dataImporter.getHandlerName()!=null) {
       filename = dataImporter.getHandlerName() +  ".properties";
     } else {
@@ -108,6 +108,11 @@ public class SimplePropertiesWriter extends DIHProperties {
       dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", locale);
     }    
   }  
+
+  protected VariableResolver createVariableResolver(Map<String, String> params) {
+    return new VariableResolver(new HashMap<String,Object>(params));
+  }
+
   protected void findDirectory(DataImporter dataImporter, Map<String, String> params) {
     if(params.get(DIRECTORY) != null) {
       configDir = params.get(DIRECTORY);


### PR DESCRIPTION
It would be nice to be able to use placeholders (getting values from request parameters) when configuring the "filename" property of a PropertyWriter.

In our use case, we have a single collection that contains a few millions documents. Let's say each document has, among all its fields, a field named "country".
We must support incremental updates of the collection. We must fetch the updates from a set of databases, one for each country. Updates of the data pertaining to different countries must be scheduled indepdendently and with different delays.
So, to support the delta-update on our collection, we can pass a parameter to the Data Import Handler saying which country to update, and the DIH reads and writes from/to a properties file named <collection>_<country>.properties. This way, each country has its own last_index_time stored in its own property file (all of the properties files refer to the same collection, but to different subset of data, based on the country).
This is useful as the documents related to some countries are updated hourly, some every 30 minutes and so on.

I looked forward to write some sort of test for this, but I couldn't figure out how to do it in the current test suite (I think there was only an integration test related to placeholder substitution, but I don't remember why it wasn't easy to add an assertion or a separate test method for this).