### PR TITLE
Correct typo in analysis package documentation.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/analysis/package-info.java
+++ b/lucene/core/src/java/org/apache/lucene/analysis/package-info.java
@@ -389,7 +389,7 @@
  *    Given that position(magenta) = 0 + position(red), they are at the same position, so anything
  *    working with analyzers will return the exact same result if you replace "magenta" with "red"
  *    in the input. However, multi-word synonyms are more tricky. Let's say that you want to build
- *    a TokenStream where "IBM" is a synonym of "Internal Business Machines". Position increments
+ *    a TokenStream where "IBM" is a synonym of "International Business Machines". Position increments
  *    are not enough anymore:
  * </p>
  * <table summary="position increments where international is zero">


### PR DESCRIPTION
Correct typo : Internal Business Machines => International Business Machines