### PR TITLE
SOLR-7557: Fix parsing of child documents using queryAndStreamResponse

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/StreamingBinaryResponseParser.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/StreamingBinaryResponseParser.java
@@ -48,11 +48,21 @@ public class StreamingBinaryResponseParser extends BinaryResponseParser {
     try {
       JavaBinCodec codec = new JavaBinCodec() {
 
+        private int nestedLevel;
+
         @Override
         public SolrDocument readSolrDocument(DataInputInputStream dis) throws IOException {
+          nestedLevel++;
           SolrDocument doc = super.readSolrDocument(dis);
-          callback.streamSolrDocument( doc );
-          return null;
+          nestedLevel--;
+          if (nestedLevel == 0) {
+            // parent document
+            callback.streamSolrDocument(doc);
+            return null;
+          } else {
+            // child document
+            return doc;
+          }
         }
 
         @Override


### PR DESCRIPTION
Details in Jira: https://issues.apache.org/jira/browse/SOLR-7557