### PR TITLE
Loading the AuthenticationPlugin using the ResourceLoader.

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -242,12 +242,7 @@ public class CoreContainer {
 
     // Initialize the filter
     if (pluginClassName != null) {
-      try {
-        Class cl = Class.forName(pluginClassName);
-        authenticationPlugin = (AuthenticationPlugin) cl.newInstance();
-      } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
-        throw new SolrException(ErrorCode.SERVER_ERROR, e);
-      }
+      authenticationPlugin = getResourceLoader().newInstance((String) pluginClassName, AuthenticationPlugin.class);
     }
     if (authenticationPlugin != null) {
       authenticationPlugin.init(authenticationConfig);


### PR DESCRIPTION
Tried to use an <b>AuthenticationPlugin</b> but it seems that loading it using <b>Class.forName</b> introduces an issue to find Solr's <b>AuthenticationPlugin</b>.

Furthermore, I think the way of loading the <b>AuthenticationPlugin</b> should be the same as loading the <b>AuthorizationPlugin</b>.