### PR TITLE
SOLR-8059 - NPE distributed DebugComponent. Test reproducer

### DIFF
--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedDebugComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedDebugComponentTest.java
@@ -263,6 +263,30 @@ public class DistributedDebugComponentTest extends SolrJettyTestBase {
     verifyDebugSections(query, collection1);
     
   }
+
+  @Test
+  public void testDebugSection_fl_param() throws Exception {
+    SolrQuery query = new SolrQuery();
+    query.setQuery("*%3A*");
+    query.set("fl", "id");
+
+    query.set("shards", shard1 + "," + shard2);
+    query.set("debug", "results");
+
+    QueryResponse response = client.query(query);
+    assertNotNull(response);
+    assertNotNull(response.getDebugMap());
+    NamedList<Object> results = (NamedList<Object>) response.getDebugMap().get("results");
+    assertNotNull(results);
+
+    query.remove("debug");
+    query.set("debug", "true");
+    response = client.query(query);
+    assertNotNull(response);
+    assertNotNull(response.getDebugMap());
+    results = (NamedList<Object>) response.getDebugMap().get("results");
+    assertNotNull(results);
+  }
   
   private void verifyDebugSections(SolrQuery query, SolrClient client) throws SolrServerException, IOException {
     query.set("debugQuery", "true");


### PR DESCRIPTION
This patch reproduces the NPE exception thrown when fl=id query param used along with debug=true or debug=results.

Example
curl "http://localhost:8983/solr/techproducts/select?q=*%3A*&wt=json&indent=true&debug=true&fl=id,score" => NPE thrown
curl "http://localhost:8983/solr/techproducts/select?q=*%3A*&wt=ruby&indent=true&debug=results&fl=id,score" => NPE thrown