### PR TITLE
Resolution for SOLR-2798 (add support for multi-valued localParams)

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/FunctionQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/FunctionQParser.java
@@ -20,13 +20,13 @@ import org.apache.lucene.queries.function.FunctionQuery;
 import org.apache.lucene.queries.function.ValueSource;
 import org.apache.lucene.queries.function.valuesource.*;
 import org.apache.lucene.search.Query;
+import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.schema.SchemaField;
 import org.apache.solr.search.facet.AggValueSource;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 
 public class FunctionQParser extends QParser {
@@ -252,7 +252,7 @@ public class FunctionQParser extends QParser {
       String v = sp.val;
   
       String qs = v;
-      HashMap nestedLocalParams = new HashMap<String,String>();
+      ModifiableSolrParams nestedLocalParams = new ModifiableSolrParams();
       int end = QueryParsing.parseLocalParams(qs, start, nestedLocalParams, getParams());
   
       QParser sub;

--- a/solr/core/src/java/org/apache/solr/search/QParser.java
+++ b/solr/core/src/java/org/apache/solr/search/QParser.java
@@ -19,7 +19,7 @@ package org.apache.solr.search;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Sort;
 import org.apache.solr.common.params.CommonParams;
-import org.apache.solr.common.params.MapSolrParams;
+import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.StrUtils;
@@ -277,16 +277,16 @@ public abstract class QParser {
     // SolrParams localParams = QueryParsing.getLocalParams(qstr, req.getParams());
 
     String stringIncludingLocalParams = qstr;
-    SolrParams localParams = null;
+    ModifiableSolrParams localParams = null;
     SolrParams globalParams = req.getParams();
     boolean valFollowedParams = true;
     int localParamsEnd = -1;
 
     if (qstr != null && qstr.startsWith(QueryParsing.LOCALPARAM_START)) {
-      Map<String, String> localMap = new HashMap<>();
-      localParamsEnd = QueryParsing.parseLocalParams(qstr, 0, localMap, globalParams);
+      localParams = new ModifiableSolrParams();
+      localParamsEnd = QueryParsing.parseLocalParams(qstr, 0, localParams, globalParams);
 
-      String val = localMap.get(QueryParsing.V);
+      String val = localParams.get(QueryParsing.V);
       if (val != null) {
         // val was directly specified in localParams via v=<something> or v=$arg
         valFollowedParams = false;
@@ -294,9 +294,8 @@ public abstract class QParser {
         // use the remainder of the string as the value
         valFollowedParams = true;
         val = qstr.substring(localParamsEnd);
-        localMap.put(QueryParsing.V, val);
+        localParams.set(QueryParsing.V, val);
       }
-      localParams = new MapSolrParams(localMap);
     }
 
 

--- a/solr/core/src/java/org/apache/solr/search/QueryParsing.java
+++ b/solr/core/src/java/org/apache/solr/search/QueryParsing.java
@@ -86,11 +86,28 @@ public class QueryParsing {
     return df != null ? df : s.getDefaultSearchFieldName();
   }
 
-  // note to self: something needs to detect infinite recursion when parsing queries
+  /**
+   * @param txt Text to parse
+   * @param start Index into text for start of parsing
+   * @param target Object to inject with parsed settings
+   * @param params Additional existing parameters
+   * @deprecated use {@link #parseLocalParams(String, int, ModifiableSolrParams, SolrParams)} instead
+   */
+  @Deprecated
   public static int parseLocalParams(String txt, int start, Map<String, String> target, SolrParams params) throws SyntaxError {
     return parseLocalParams(txt, start, target, params, LOCALPARAM_START, LOCALPARAM_END);
   }
 
+  /**
+   * @param txt Text to parse
+   * @param start Index into text for start of parsing
+   * @param target Object to inject with parsed settings
+   * @param params Additional existing parameters
+   * @param startString String that indicates the start of a localParams section
+   * @param endChar Character that indicates the end of a localParams section
+   * @deprecated use {@link #parseLocalParams(String, int, ModifiableSolrParams, SolrParams, String, char)} instead
+   */
+  @Deprecated
   public static int parseLocalParams(String txt, int start, Map<String, String> target, SolrParams params, String startString, char endChar) throws SyntaxError {
     ModifiableSolrParams newTarget = new ModifiableSolrParams();
     int retVal = parseLocalParams(txt, start, newTarget, params, startString, endChar);
@@ -103,11 +120,26 @@ public class QueryParsing {
     return retVal;
   }
 
+  /**
+   * @param txt Text to parse
+   * @param start Index into text for start of parsing
+   * @param target Object to inject with parsed settings
+   * @param params Additional existing parameters
+   */
   public static int parseLocalParams(String txt, int start, ModifiableSolrParams target, SolrParams params) throws SyntaxError {
     return parseLocalParams(txt, start, target, params, LOCALPARAM_START, LOCALPARAM_END);
   }
 
+  /**
+   * @param txt Text to parse
+   * @param start Index into text for start of parsing
+   * @param target Object to inject with parsed settings
+   * @param params Additional existing parameters
+   * @param startString String that indicates the start of a localParams section
+   * @param endChar Character that indicates the end of a localParams section
+   */
   public static int parseLocalParams(String txt, int start, ModifiableSolrParams target, SolrParams params, String startString, char endChar) throws SyntaxError {
+    // note to self: something needs to detect infinite recursion when parsing queries
     int off = start;
     if (!txt.startsWith(startString, off)) return start;
     StrParser p = new StrParser(txt, start, txt.length());

--- a/solr/core/src/java/org/apache/solr/search/QueryParsing.java
+++ b/solr/core/src/java/org/apache/solr/search/QueryParsing.java
@@ -32,6 +32,7 @@ import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.CharsRefBuilder;
 import org.apache.solr.common.params.MapSolrParams;
+import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.parser.QueryParser;
 import org.apache.solr.schema.FieldType;
@@ -90,8 +91,23 @@ public class QueryParsing {
     return parseLocalParams(txt, start, target, params, LOCALPARAM_START, LOCALPARAM_END);
   }
 
-
   public static int parseLocalParams(String txt, int start, Map<String, String> target, SolrParams params, String startString, char endChar) throws SyntaxError {
+    ModifiableSolrParams newTarget = new ModifiableSolrParams();
+    int retVal = parseLocalParams(txt, start, newTarget, params, startString, endChar);
+    // Translate ModifiableSolrParams to Map<String, String>, implementing "last value wins" for multi-valued params for backward compatibility
+    for (String param : newTarget.getParameterNames()) {
+      for (String value : newTarget.getParams(param)) {
+        target.put(param, value);
+      }
+    }
+    return retVal;
+  }
+
+  public static int parseLocalParams(String txt, int start, ModifiableSolrParams target, SolrParams params) throws SyntaxError {
+    return parseLocalParams(txt, start, target, params, LOCALPARAM_START, LOCALPARAM_END);
+  }
+
+  public static int parseLocalParams(String txt, int start, ModifiableSolrParams target, SolrParams params, String startString, char endChar) throws SyntaxError {
     int off = start;
     if (!txt.startsWith(startString, off)) return start;
     StrParser p = new StrParser(txt, start, txt.length());
@@ -156,7 +172,7 @@ public class QueryParsing {
           }
         }
       }
-      if (target != null) target.put(id, val);
+      if (target != null) target.add(id, val);
     }
   }
 

--- a/solr/core/src/test/org/apache/solr/search/QueryEqualityTest.java
+++ b/solr/core/src/test/org/apache/solr/search/QueryEqualityTest.java
@@ -354,6 +354,19 @@ public class QueryEqualityTest extends SolrTestCaseJ4 {
     checkQuerySpatial("bbox");
   }
 
+  public void testLocalParamsWithRepeatingParam() throws Exception {
+    SolrQueryRequest req = req("q", "foo",
+                               "bq", "111",
+                               "bq", "222");
+    try {
+      assertQueryEquals("dismax", req, 
+                        "{!dismax bq=111 bq=222}foo",
+                        "{!dismax bq=222 bq=111}foo");
+    } finally {
+      req.close();
+    }
+  }
+
   private void checkQuerySpatial(final String type) throws Exception {
     SolrQueryRequest req = req("myVar", "5",
                                "d","109",

--- a/solr/core/src/test/org/apache/solr/search/QueryParsingTest.java
+++ b/solr/core/src/test/org/apache/solr/search/QueryParsingTest.java
@@ -20,12 +20,14 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.schema.SchemaField;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 
 /**
@@ -72,6 +74,22 @@ public class QueryParsingTest extends SolrTestCaseJ4 {
     }
   }
   
+  public void testLocalParamsWithLinkedHashMap() throws Exception {
+    LinkedHashMap<String, String> target = new LinkedHashMap<String, String>();
+    QueryParsing.parseLocalParams("{!handler foo1=bar1 foo2=bar2 multi=loser multi=winner}", 0, target, new ModifiableSolrParams(), "{!", '}');
+    assertEquals("bar1", target.get("foo1"));
+    assertEquals("bar2", target.get("foo2"));
+    assertEquals("winner", target.get("multi"));
+  }
+
+  public void testLocalParamsWithModifiableSolrParams() throws Exception {
+    ModifiableSolrParams target = new ModifiableSolrParams();
+    QueryParsing.parseLocalParams("{!handler foo1=bar1 foo2=bar2 multi=loser multi=winner}", 0, target, new ModifiableSolrParams(), "{!", '}');
+    assertEquals("bar1", target.get("foo1"));
+    assertEquals("bar2", target.get("foo2"));
+    assertArrayEquals(new String[]{"loser", "winner"}, target.getParams("multi"));
+  }
+
   public void testLiteralFunction() throws Exception {
     
     final String NAME = FunctionQParserPlugin.NAME;


### PR DESCRIPTION
Previous to this fix, when using localParams syntax, a repeated parameter would be handled with a "last value wins" policy. This PR changes the behavior to allow all values of the parameter to be accepted, which seems like it should be the expected behavior, since many Solr parameters are intended to be repeatable.