### PR TITLE
SOLR-8639 replace static SimpleDateFormat with threadsafe jodatimeDateFormatter

### DIFF
--- a/solr/contrib/dataimporthandler-extras/ivy.xml
+++ b/solr/contrib/dataimporthandler-extras/ivy.xml
@@ -33,7 +33,8 @@
   <dependencies>
     <dependency org="javax.activation" name="activation" rev="${/javax.activation/activation}" conf="compile"/>
     <dependency org="com.sun.mail" name="javax.mail" rev="${/com.sun.mail/javax.mail}" conf="compile"/>
-    <dependency org="com.sun.mail" name="gimap" rev="${/com.sun.mail/gimap}" conf="compile"/>  
+    <dependency org="com.sun.mail" name="gimap" rev="${/com.sun.mail/gimap}" conf="compile"/>
+    <dependency org="joda-time" name="joda-time" rev="${/joda-time/joda-time}" conf="compile"/>
 
     <exclude org="*" ext="*" matcher="regexp" type="${ivy.exclude.types}"/>
   </dependencies>

--- a/solr/contrib/dataimporthandler-extras/src/java/org/apache/solr/handler/dataimport/MailEntityProcessor.java
+++ b/solr/contrib/dataimporthandler-extras/src/java/org/apache/solr/handler/dataimport/MailEntityProcessor.java
@@ -36,8 +36,6 @@ import javax.mail.search.*;
 
 import java.io.InputStream;
 import java.lang.invoke.MethodHandles;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.*;
 
 import com.sun.mail.gimap.GmailFolder;


### PR DESCRIPTION
Resolve issue SOLR-8639: 
sinceDateParser and afterFmt are declared as static variables of type SimpleDateFormat which is not threadsafe. This may cause data corruption and an incorrect value to be returned by the methods that use them.
