### PR TITLE
Do not log error messages, if client has been interrupted

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudSolrClient.java
@@ -897,11 +897,16 @@ public class CloudSolrClient extends SolrClient {
         }
       }
 
+      if (rootCause instanceof InterruptedException) {
+        log.debug("Request to collection {} has been interrupted.", collection);
+        throw exc;
+      }
+
       int errorCode = (rootCause instanceof SolrException) ?
           ((SolrException)rootCause).code() : SolrException.ErrorCode.UNKNOWN.code;
 
-      log.error("Request to collection {} failed due to ("+errorCode+
-          ") {}, retry? "+retryCount, collection, rootCause.toString());
+      log.error("Request to collection {} failed due to ({}) {}, retry? {}",
+          collection, errorCode, rootCause, retryCount);
 
       boolean wasCommError =
           (rootCause instanceof ConnectException ||


### PR DESCRIPTION
It is annoying to get the log flushed with error messages, if the CloudSolrClient has been interrupted during a request. So instead a debug message will be logged and the exception re-thrown.