### PR TITLE
Limit threadpools by default to 128

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
@@ -15,6 +15,20 @@
  * limitations under the License.
  */
 package org.apache.solr.handler.component;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.client.HttpClient;
 import org.apache.http.impl.client.DefaultHttpClient;
@@ -35,19 +49,6 @@ import org.apache.solr.util.DefaultSolrThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.lang.invoke.MethodHandles;
-import java.util.Collections;
-import java.util.List;
-import java.util.Random;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CompletionService;
-import java.util.concurrent.ExecutorCompletionService;
-import java.util.concurrent.SynchronousQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-
 
 public class HttpShardHandlerFactory extends ShardHandlerFactory implements org.apache.solr.util.plugin.PluginInfoInitialized {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -61,7 +62,7 @@ public class HttpShardHandlerFactory extends ShardHandlerFactory implements org.
   // requests at some point (or should we simply return failure?)
   private ThreadPoolExecutor commExecutor = new ExecutorUtil.MDCAwareThreadPoolExecutor(
       0,
-      Integer.MAX_VALUE,
+      128,
       5, TimeUnit.SECONDS, // terminate idle threads after 5 sec
       new SynchronousQueue<Runnable>(),  // directly hand off tasks
       new DefaultSolrThreadFactory("httpShardExecutor")
@@ -75,7 +76,7 @@ public class HttpShardHandlerFactory extends ShardHandlerFactory implements org.
   int maxConnectionsPerHost = 20;
   int maxConnections = 10000;
   int corePoolSize = 0;
-  int maximumPoolSize = Integer.MAX_VALUE;
+  int maximumPoolSize = 128;
   int keepAliveTime = 5;
   int queueSize = -1;
   boolean accessPolicy = false;

--- a/solr/core/src/java/org/apache/solr/request/SimpleFacets.java
+++ b/solr/core/src/java/org/apache/solr/request/SimpleFacets.java
@@ -642,7 +642,7 @@ public class SimpleFacets {
 
   static final Executor facetExecutor = new ExecutorUtil.MDCAwareThreadPoolExecutor(
           0,
-          Integer.MAX_VALUE,
+          128,
           10, TimeUnit.SECONDS, // terminate idle threads after 10 sec
           new SynchronousQueue<Runnable>()  // directly hand off tasks
           , new DefaultSolrThreadFactory("facetExecutor")

--- a/solr/core/src/java/org/apache/solr/update/UpdateLog.java
+++ b/solr/core/src/java/org/apache/solr/update/UpdateLog.java
@@ -1495,7 +1495,7 @@ public class UpdateLog implements PluginInfoInitialized {
   }
 
   ThreadPoolExecutor recoveryExecutor = new ExecutorUtil.MDCAwareThreadPoolExecutor(0,
-      Integer.MAX_VALUE, 1, TimeUnit.SECONDS, new SynchronousQueue<Runnable>(),
+      128, 1, TimeUnit.SECONDS, new SynchronousQueue<Runnable>(),
       new DefaultSolrThreadFactory("recoveryExecutor"));
 
 

--- a/solr/solrj/src/java/org/apache/solr/common/util/ExecutorUtil.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/ExecutorUtil.java
@@ -19,16 +19,9 @@ package org.apache.solr.common.util;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collection;
-
-import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionHandler;
@@ -157,7 +150,7 @@ public class ExecutorUtil {
    * See {@link java.util.concurrent.Executors#newCachedThreadPool(ThreadFactory)}
    */
   public static ExecutorService newMDCAwareCachedThreadPool(ThreadFactory threadFactory) {
-    return new MDCAwareThreadPoolExecutor(0, Integer.MAX_VALUE,
+    return new MDCAwareThreadPoolExecutor(0, 128,
         60L, TimeUnit.SECONDS,
         new SynchronousQueue<Runnable>(),
         threadFactory);


### PR DESCRIPTION
Integer.MAX_VALUE could kill the VM instead of providing useful error
messages.

128 is a wild guess by myself. Let's discuss a good default value for
this :)

Jira: https://issues.apache.org/jira/browse/SOLR-8727