### PR TITLE
LUCENE-7064: Make MultiPhraseQuery immutable

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/QueryBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/QueryBuilder.java
@@ -354,8 +354,8 @@ public class QueryBuilder {
    * Creates complex phrase query from the cached tokenstream contents 
    */
   private Query analyzeMultiPhrase(String field, TokenStream stream, int slop) throws IOException {
-    MultiPhraseQuery mpq = newMultiPhraseQuery();
-    mpq.setSlop(slop);
+    MultiPhraseQuery.Builder mpqb = newMultiPhraseQueryBuilder();
+    mpqb.setSlop(slop);
     
     TermToBytesRefAttribute termAtt = stream.getAttribute(TermToBytesRefAttribute.class);
 
@@ -369,9 +369,9 @@ public class QueryBuilder {
       
       if (positionIncrement > 0 && multiTerms.size() > 0) {
         if (enablePositionIncrements) {
-          mpq.add(multiTerms.toArray(new Term[0]), position);
+          mpqb.add(multiTerms.toArray(new Term[0]), position);
         } else {
-          mpq.add(multiTerms.toArray(new Term[0]));
+          mpqb.add(multiTerms.toArray(new Term[0]));
         }
         multiTerms.clear();
       }
@@ -380,11 +380,11 @@ public class QueryBuilder {
     }
     
     if (enablePositionIncrements) {
-      mpq.add(multiTerms.toArray(new Term[0]), position);
+      mpqb.add(multiTerms.toArray(new Term[0]), position);
     } else {
-      mpq.add(multiTerms.toArray(new Term[0]));
+      mpqb.add(multiTerms.toArray(new Term[0]));
     }
-    return mpq;
+    return mpqb.build();
   }
   
   /**
@@ -424,7 +424,7 @@ public class QueryBuilder {
    * This is intended for subclasses that wish to customize the generated queries.
    * @return new MultiPhraseQuery instance
    */
-  protected MultiPhraseQuery newMultiPhraseQuery() {
-    return new MultiPhraseQuery();
+  protected MultiPhraseQuery.Builder newMultiPhraseQueryBuilder() {
+    return new MultiPhraseQuery.Builder();
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestComplexExplanations.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestComplexExplanations.java
@@ -231,11 +231,11 @@ public class TestComplexExplanations extends BaseExplanationTestCase {
   }
   
   public void testMPQ7() throws Exception {
-    MultiPhraseQuery q = new MultiPhraseQuery();
-    q.add(ta(new String[] {"w1"}));
-    q.add(ta(new String[] {"w2"}));
-    q.setSlop(1);
-    bqtest(new BoostQuery(q, 0), new int[] { 0,1,2 });
+    MultiPhraseQuery.Builder qb = new MultiPhraseQuery.Builder();
+    qb.add(ta(new String[] {"w1"}));
+    qb.add(ta(new String[] {"w2"}));
+    qb.setSlop(1);
+    bqtest(new BoostQuery(qb.build(), 0), new int[] { 0,1,2 });
   }
   
   public void testBQ12() throws Exception {

--- a/lucene/core/src/test/org/apache/lucene/search/TestPhrasePrefixQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestPhrasePrefixQuery.java
@@ -63,11 +63,11 @@ public class TestPhrasePrefixQuery extends LuceneTestCase {
     IndexSearcher searcher = newSearcher(reader);
     
     // PhrasePrefixQuery query1 = new PhrasePrefixQuery();
-    MultiPhraseQuery query1 = new MultiPhraseQuery();
+    MultiPhraseQuery.Builder query1builder = new MultiPhraseQuery.Builder();
     // PhrasePrefixQuery query2 = new PhrasePrefixQuery();
-    MultiPhraseQuery query2 = new MultiPhraseQuery();
-    query1.add(new Term("body", "blueberry"));
-    query2.add(new Term("body", "strawberry"));
+    MultiPhraseQuery.Builder query2builder = new MultiPhraseQuery.Builder();
+    query1builder.add(new Term("body", "blueberry"));
+    query2builder.add(new Term("body", "strawberry"));
     
     LinkedList<Term> termsWithPrefix = new LinkedList<>();
     
@@ -84,14 +84,14 @@ public class TestPhrasePrefixQuery extends LuceneTestCase {
       }
     } while (te.next() != null);
     
-    query1.add(termsWithPrefix.toArray(new Term[0]));
-    query2.add(termsWithPrefix.toArray(new Term[0]));
+    query1builder.add(termsWithPrefix.toArray(new Term[0]));
+    query2builder.add(termsWithPrefix.toArray(new Term[0]));
     
     ScoreDoc[] result;
-    result = searcher.search(query1, 1000).scoreDocs;
+    result = searcher.search(query1builder.build(), 1000).scoreDocs;
     assertEquals(2, result.length);
     
-    result = searcher.search(query2, 1000).scoreDocs;
+    result = searcher.search(query2builder.build(), 1000).scoreDocs;
     assertEquals(0, result.length);
     reader.close();
     indexStore.close();

--- a/lucene/core/src/test/org/apache/lucene/search/TestPositionIncrement.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestPositionIncrement.java
@@ -175,9 +175,9 @@ public class TestPositionIncrement extends LuceneTestCase {
 
     // multi-phrase query should succed for non existing searched term
     // because there exist another searched terms in the same searched position. 
-    MultiPhraseQuery mq = new MultiPhraseQuery();
-    mq.add(new Term[]{new Term("field", "3"),new Term("field", "9")},0);
-    hits = searcher.search(mq, 1000).scoreDocs;
+    MultiPhraseQuery.Builder mqb = new MultiPhraseQuery.Builder();
+    mqb.add(new Term[]{new Term("field", "3"),new Term("field", "9")},0);
+    hits = searcher.search(mqb.build(), 1000).scoreDocs;
     assertEquals(1, hits.length);
 
     q = new PhraseQuery("field", "2", "4");

--- a/lucene/core/src/test/org/apache/lucene/search/TestSimpleExplanations.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSimpleExplanations.java
@@ -200,42 +200,42 @@ public class TestSimpleExplanations extends BaseExplanationTestCase {
   /* MultiPhraseQuery */
   
   public void testMPQ1() throws Exception {
-    MultiPhraseQuery q = new MultiPhraseQuery();
-    q.add(ta(new String[] {"w1"}));
-    q.add(ta(new String[] {"w2","w3", "xx"}));
-    qtest(q, new int[] { 0,1,2,3 });
+    MultiPhraseQuery.Builder qb = new MultiPhraseQuery.Builder();
+    qb.add(ta(new String[] {"w1"}));
+    qb.add(ta(new String[] {"w2","w3", "xx"}));
+    qtest(qb.build(), new int[] { 0,1,2,3 });
   }
   public void testMPQ2() throws Exception {
-    MultiPhraseQuery q = new MultiPhraseQuery();
-    q.add(ta(new String[] {"w1"}));
-    q.add(ta(new String[] {"w2","w3"}));
-    qtest(q, new int[] { 0,1,3 });
+    MultiPhraseQuery.Builder qb = new MultiPhraseQuery.Builder();
+    qb.add(ta(new String[] {"w1"}));
+    qb.add(ta(new String[] {"w2","w3"}));
+    qtest(qb.build(), new int[] { 0,1,3 });
   }
   public void testMPQ3() throws Exception {
-    MultiPhraseQuery q = new MultiPhraseQuery();
-    q.add(ta(new String[] {"w1","xx"}));
-    q.add(ta(new String[] {"w2","w3"}));
-    qtest(q, new int[] { 0,1,2,3 });
+    MultiPhraseQuery.Builder qb = new MultiPhraseQuery.Builder();
+    qb.add(ta(new String[] {"w1","xx"}));
+    qb.add(ta(new String[] {"w2","w3"}));
+    qtest(qb.build(), new int[] { 0,1,2,3 });
   }
   public void testMPQ4() throws Exception {
-    MultiPhraseQuery q = new MultiPhraseQuery();
-    q.add(ta(new String[] {"w1"}));
-    q.add(ta(new String[] {"w2"}));
-    qtest(q, new int[] { 0 });
+    MultiPhraseQuery.Builder qb = new MultiPhraseQuery.Builder();
+    qb.add(ta(new String[] {"w1"}));
+    qb.add(ta(new String[] {"w2"}));
+    qtest(qb.build(), new int[] { 0 });
   }
   public void testMPQ5() throws Exception {
-    MultiPhraseQuery q = new MultiPhraseQuery();
-    q.add(ta(new String[] {"w1"}));
-    q.add(ta(new String[] {"w2"}));
-    q.setSlop(1);
-    qtest(q, new int[] { 0,1,2 });
+    MultiPhraseQuery.Builder qb = new MultiPhraseQuery.Builder();
+    qb.add(ta(new String[] {"w1"}));
+    qb.add(ta(new String[] {"w2"}));
+    qb.setSlop(1);
+    qtest(qb.build(), new int[] { 0,1,2 });
   }
   public void testMPQ6() throws Exception {
-    MultiPhraseQuery q = new MultiPhraseQuery();
-    q.add(ta(new String[] {"w1","w3"}));
-    q.add(ta(new String[] {"w2"}));
-    q.setSlop(1);
-    qtest(q, new int[] { 0,1,2,3 });
+    MultiPhraseQuery.Builder qb = new MultiPhraseQuery.Builder();
+    qb.add(ta(new String[] {"w1","w3"}));
+    qb.add(ta(new String[] {"w2"}));
+    qb.setSlop(1);
+    qtest(qb.build(), new int[] { 0,1,2,3 });
   }
 
   /* some simple tests of boolean queries containing term queries */

--- a/lucene/core/src/test/org/apache/lucene/search/TestSimpleSearchEquivalence.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSimpleSearchEquivalence.java
@@ -145,10 +145,10 @@ public class TestSimpleSearchEquivalence extends SearchEquivalenceTestBase {
     Term t2 = randomTerm();
     PhraseQuery q1 = new PhraseQuery(t1.field(), t1.bytes(), t2.bytes());
     Term t3 = randomTerm();
-    MultiPhraseQuery q2 = new MultiPhraseQuery();
-    q2.add(t1);
-    q2.add(new Term[] { t2, t3 });
-    assertSubsetOf(q1, q2);
+    MultiPhraseQuery.Builder q2b = new MultiPhraseQuery.Builder();
+    q2b.add(t1);
+    q2b.add(new Term[] { t2, t3 });
+    assertSubsetOf(q1, q2b.build());
   }
   
   /** same as above, with posincs */
@@ -160,10 +160,10 @@ public class TestSimpleSearchEquivalence extends SearchEquivalenceTestBase {
     builder.add(t2, 2);
     PhraseQuery q1 = builder.build();
     Term t3 = randomTerm();
-    MultiPhraseQuery q2 = new MultiPhraseQuery();
-    q2.add(t1);
-    q2.add(new Term[] { t2, t3 }, 2);
-    assertSubsetOf(q1, q2);
+    MultiPhraseQuery.Builder q2b = new MultiPhraseQuery.Builder();
+    q2b.add(t1);
+    q2b.add(new Term[] { t2, t3 }, 2);
+    assertSubsetOf(q1, q2b.build());
   }
   
   /** "A B"~∞ = +A +B if A != B */

--- a/lucene/core/src/test/org/apache/lucene/search/TestSloppyPhraseQuery2.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSloppyPhraseQuery2.java
@@ -147,8 +147,8 @@ public class TestSloppyPhraseQuery2 extends SearchEquivalenceTestBase {
     for (int i = 0; i < 10; i++) {
       MultiPhraseQuery q1 = randomPhraseQuery(seed);
       MultiPhraseQuery q2 = randomPhraseQuery(seed);
-      q1.setSlop(i);
-      q2.setSlop(i+1);
+      q1 = new MultiPhraseQuery.Builder(q1).setSlop(i).build();
+      q2 = new MultiPhraseQuery.Builder(q2).setSlop(i+1).build();
       assertSubsetOf(q1, q2);
     }
   }
@@ -156,7 +156,7 @@ public class TestSloppyPhraseQuery2 extends SearchEquivalenceTestBase {
   private MultiPhraseQuery randomPhraseQuery(long seed) {
     Random random = new Random(seed);
     int length = TestUtil.nextInt(random, 2, 5);
-    MultiPhraseQuery pq = new MultiPhraseQuery();
+    MultiPhraseQuery.Builder pqb = new MultiPhraseQuery.Builder();
     int position = 0;
     for (int i = 0; i < length; i++) {
       int depth = TestUtil.nextInt(random, 1, 3);
@@ -164,9 +164,9 @@ public class TestSloppyPhraseQuery2 extends SearchEquivalenceTestBase {
       for (int j = 0; j < depth; j++) {
         terms[j] = new Term("field", "" + (char) TestUtil.nextInt(random, 'a', 'z'));
       }
-      pq.add(terms, position);
+      pqb.add(terms, position);
       position += TestUtil.nextInt(random, 1, 3);
     }
-    return pq;
+    return pqb.build();
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/util/TestQueryBuilder.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestQueryBuilder.java
@@ -173,11 +173,11 @@ public class TestQueryBuilder extends LuceneTestCase {
   
   /** forms multiphrase query */
   public void testSynonymsPhrase() throws Exception {
-    MultiPhraseQuery expected = new MultiPhraseQuery();
-    expected.add(new Term("field", "old"));
-    expected.add(new Term[] { new Term("field", "dogs"), new Term("field", "dog") });
+    MultiPhraseQuery.Builder expectedBuilder = new MultiPhraseQuery.Builder();
+    expectedBuilder.add(new Term("field", "old"));
+    expectedBuilder.add(new Term[] { new Term("field", "dogs"), new Term("field", "dog") });
     QueryBuilder builder = new QueryBuilder(new MockSynonymAnalyzer());
-    assertEquals(expected, builder.createPhraseQuery("field", "old dogs"));
+    assertEquals(expectedBuilder.build(), builder.createPhraseQuery("field", "old dogs"));
   }
 
   protected static class SimpleCJKTokenizer extends Tokenizer {
@@ -331,13 +331,13 @@ public class TestQueryBuilder extends LuceneTestCase {
   
   /** forms multiphrase query */
   public void testCJKSynonymsPhrase() throws Exception {
-    MultiPhraseQuery expected = new MultiPhraseQuery();
-    expected.add(new Term("field", "中"));
-    expected.add(new Term[] { new Term("field", "国"), new Term("field", "國")});
+    MultiPhraseQuery.Builder expectedBuilder = new MultiPhraseQuery.Builder();
+    expectedBuilder.add(new Term("field", "中"));
+    expectedBuilder.add(new Term[] { new Term("field", "国"), new Term("field", "國")});
     QueryBuilder builder = new QueryBuilder(new MockCJKSynonymAnalyzer());
-    assertEquals(expected, builder.createPhraseQuery("field", "中国"));
-    expected.setSlop(3);
-    assertEquals(expected, builder.createPhraseQuery("field", "中国", 3));
+    assertEquals(expectedBuilder.build(), builder.createPhraseQuery("field", "中国"));
+    expectedBuilder.setSlop(3);
+    assertEquals(expectedBuilder.build(), builder.createPhraseQuery("field", "中国", 3));
   }
 
   public void testNoTermAttribute() {

--- a/lucene/highlighter/src/java/org/apache/lucene/search/highlight/WeightedSpanTermExtractor.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/highlight/WeightedSpanTermExtractor.java
@@ -156,7 +156,7 @@ public class WeightedSpanTermExtractor {
       extract(((ToChildBlockJoinQuery) query).getParentQuery(), boost, terms);
     } else if (query instanceof MultiPhraseQuery) {
       final MultiPhraseQuery mpq = (MultiPhraseQuery) query;
-      final List<Term[]> termArrays = mpq.getTermArrays();
+      final Term[][] termArrays = mpq.getTermArrays();
       final int[] positions = mpq.getPositions();
       if (positions.length > 0) {
 
@@ -171,8 +171,8 @@ public class WeightedSpanTermExtractor {
         final List<SpanQuery>[] disjunctLists = new List[maxPosition + 1];
         int distinctPositions = 0;
 
-        for (int i = 0; i < termArrays.size(); ++i) {
-          final Term[] termArray = termArrays.get(i);
+        for (int i = 0; i < termArrays.length; ++i) {
+          final Term[] termArray = termArrays[i];
           List<SpanQuery> disjuncts = disjunctLists[positions[i]];
           if (disjuncts == null) {
             disjuncts = (disjunctLists[positions[i]] = new ArrayList<>(termArray.length));

--- a/lucene/highlighter/src/test/org/apache/lucene/search/highlight/HighlighterTest.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/highlight/HighlighterTest.java
@@ -793,29 +793,29 @@ public class HighlighterTest extends BaseTokenStreamTestCase implements Formatte
   }
 
   public void testQueryScorerMultiPhraseQueryHighlighting() throws Exception {
-    MultiPhraseQuery mpq = new MultiPhraseQuery();
+    MultiPhraseQuery.Builder mpqb = new MultiPhraseQuery.Builder();
 
-    mpq.add(new Term[] { new Term(FIELD_NAME, "wordx"), new Term(FIELD_NAME, "wordb") });
-    mpq.add(new Term(FIELD_NAME, "wordy"));
+    mpqb.add(new Term[] { new Term(FIELD_NAME, "wordx"), new Term(FIELD_NAME, "wordb") });
+    mpqb.add(new Term(FIELD_NAME, "wordy"));
 
-    doSearching(mpq);
+    doSearching(mpqb.build());
 
     final int maxNumFragmentsRequired = 2;
     assertExpectedHighlightCount(maxNumFragmentsRequired, 6);
   }
 
   public void testQueryScorerMultiPhraseQueryHighlightingWithGap() throws Exception {
-    MultiPhraseQuery mpq = new MultiPhraseQuery();
+    MultiPhraseQuery.Builder mpqb = new MultiPhraseQuery.Builder();
 
     /*
      * The toString of MultiPhraseQuery doesn't work so well with these
      * out-of-order additions, but the Query itself seems to match accurately.
      */
 
-    mpq.add(new Term[] { new Term(FIELD_NAME, "wordz") }, 2);
-    mpq.add(new Term[] { new Term(FIELD_NAME, "wordx") }, 0);
+    mpqb.add(new Term[] { new Term(FIELD_NAME, "wordz") }, 2);
+    mpqb.add(new Term[] { new Term(FIELD_NAME, "wordx") }, 0);
 
-    doSearching(mpq);
+    doSearching(mpqb.build());
 
     final int maxNumFragmentsRequired = 1;
     final int expectedHighlights = 2;

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/MultiFieldQueryParser.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/MultiFieldQueryParser.java
@@ -134,7 +134,11 @@ public class MultiFieldQueryParser extends QueryParser
       }
       q = builder.build();
     } else if (q instanceof MultiPhraseQuery) {
-      ((MultiPhraseQuery) q).setSlop(slop);
+      MultiPhraseQuery mpq = (MultiPhraseQuery)q;
+      
+      if (slop != mpq.getSlop()) {
+        q = new MultiPhraseQuery.Builder(mpq).setSlop(slop).build();
+      }
     }
     return q;
   }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParserBase.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParserBase.java
@@ -502,9 +502,12 @@ public abstract class QueryParserBase extends QueryBuilder implements CommonQuer
         builder.add(terms[i], positions[i]);
       }
       query = builder.build();
-    }
-    if (query instanceof MultiPhraseQuery) {
-      ((MultiPhraseQuery) query).setSlop(slop);
+    } else if (query instanceof MultiPhraseQuery) {
+      MultiPhraseQuery mpq = (MultiPhraseQuery)query;
+      
+      if (slop != mpq.getSlop()) {
+        query = new MultiPhraseQuery.Builder(mpq).setSlop(slop).build();
+      }
     }
 
     return query;

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/MultiPhraseQueryNodeBuilder.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/MultiPhraseQueryNodeBuilder.java
@@ -43,7 +43,7 @@ public class MultiPhraseQueryNodeBuilder implements StandardQueryBuilder {
   public MultiPhraseQuery build(QueryNode queryNode) throws QueryNodeException {
     MultiPhraseQueryNode phraseNode = (MultiPhraseQueryNode) queryNode;
 
-    MultiPhraseQuery phraseQuery = new MultiPhraseQuery();
+    MultiPhraseQuery.Builder phraseQueryBuilder = new MultiPhraseQuery.Builder();
 
     List<QueryNode> children = phraseNode.getChildren();
 
@@ -70,14 +70,14 @@ public class MultiPhraseQueryNodeBuilder implements StandardQueryBuilder {
       for (int positionIncrement : positionTermMap.keySet()) {
         List<Term> termList = positionTermMap.get(positionIncrement);
 
-        phraseQuery.add(termList.toArray(new Term[termList.size()]),
+        phraseQueryBuilder.add(termList.toArray(new Term[termList.size()]),
             positionIncrement);
 
       }
 
     }
 
-    return phraseQuery;
+    return phraseQueryBuilder.build();
 
   }
 

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/SlopQueryNodeBuilder.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/SlopQueryNodeBuilder.java
@@ -55,7 +55,13 @@ public class SlopQueryNodeBuilder implements StandardQueryBuilder {
       query = builder.build();
 
     } else {
-      ((MultiPhraseQuery) query).setSlop(phraseSlopNode.getValue());
+      MultiPhraseQuery mpq = (MultiPhraseQuery)query;
+      
+      int slop = phraseSlopNode.getValue();
+      
+      if (slop != mpq.getSlop()) {
+        query = new MultiPhraseQuery.Builder(mpq).setSlop(slop).build();
+      }
     }
 
     return query;

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/classic/TestMultiPhraseQueryParsing.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/classic/TestMultiPhraseQueryParsing.java
@@ -100,12 +100,12 @@ public class TestMultiPhraseQueryParsing extends LuceneTestCase {
     Query q = qp.parse("\"this text is acually ignored\"");
     assertTrue("wrong query type!", q instanceof MultiPhraseQuery);
 
-    MultiPhraseQuery multiPhraseQuery = new MultiPhraseQuery();
-    multiPhraseQuery.add(new Term[]{ new Term("field", "a"), new Term("field", "1") }, -1);
-    multiPhraseQuery.add(new Term[]{ new Term("field", "b"), new Term("field", "1") }, 0);
-    multiPhraseQuery.add(new Term[]{ new Term("field", "c") }, 1);
+    MultiPhraseQuery.Builder multiPhraseQueryBuilder = new MultiPhraseQuery.Builder();
+    multiPhraseQueryBuilder.add(new Term[]{ new Term("field", "a"), new Term("field", "1") }, -1);
+    multiPhraseQueryBuilder.add(new Term[]{ new Term("field", "b"), new Term("field", "1") }, 0);
+    multiPhraseQueryBuilder.add(new Term[]{ new Term("field", "c") }, 1);
 
-    assertEquals(multiPhraseQuery, q);
+    assertEquals(multiPhraseQueryBuilder.build(), q);
   }
 
 }

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/classic/TestQueryParser.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/classic/TestQueryParser.java
@@ -338,16 +338,17 @@ public class TestQueryParser extends QueryParserTestBase {
   
   /** forms multiphrase query */
   public void testSynonymsPhrase() throws Exception {
-    MultiPhraseQuery expectedQ = new MultiPhraseQuery();
-    expectedQ.add(new Term("field", "old"));
-    expectedQ.add(new Term[] { new Term("field", "dogs"), new Term("field", "dog") });
+    MultiPhraseQuery.Builder expectedQBuilder = new MultiPhraseQuery.Builder();
+    expectedQBuilder.add(new Term("field", "old"));
+    expectedQBuilder.add(new Term[] { new Term("field", "dogs"), new Term("field", "dog") });
     QueryParser qp = new QueryParser("field", new MockSynonymAnalyzer());
-    assertEquals(expectedQ, qp.parse("\"old dogs\""));
+    assertEquals(expectedQBuilder.build(), qp.parse("\"old dogs\""));
     qp.setDefaultOperator(Operator.AND);
-    assertEquals(expectedQ, qp.parse("\"old dogs\""));
-    BoostQuery expected = new BoostQuery(expectedQ, 2f);
+    assertEquals(expectedQBuilder.build(), qp.parse("\"old dogs\""));
+    BoostQuery expected = new BoostQuery(expectedQBuilder.build(), 2f);
     assertEquals(expected, qp.parse("\"old dogs\"^2"));
-    expectedQ.setSlop(3);
+    expectedQBuilder.setSlop(3);
+    expected = new BoostQuery(expectedQBuilder.build(), 2f);
     assertEquals(expected, qp.parse("\"old dogs\"~3^2"));
   }
   
@@ -461,15 +462,16 @@ public class TestQueryParser extends QueryParserTestBase {
   
   /** forms multiphrase query */
   public void testCJKSynonymsPhrase() throws Exception {
-    MultiPhraseQuery expectedQ = new MultiPhraseQuery();
-    expectedQ.add(new Term("field", "中"));
-    expectedQ.add(new Term[] { new Term("field", "国"), new Term("field", "國")});
+    MultiPhraseQuery.Builder expectedQBuilder = new MultiPhraseQuery.Builder();
+    expectedQBuilder.add(new Term("field", "中"));
+    expectedQBuilder.add(new Term[] { new Term("field", "国"), new Term("field", "國")});
     QueryParser qp = new QueryParser("field", new MockCJKSynonymAnalyzer());
     qp.setDefaultOperator(Operator.AND);
-    assertEquals(expectedQ, qp.parse("\"中国\""));
-    Query expected = new BoostQuery(expectedQ, 2f);
+    assertEquals(expectedQBuilder.build(), qp.parse("\"中国\""));
+    Query expected = new BoostQuery(expectedQBuilder.build(), 2f);
     assertEquals(expected, qp.parse("\"中国\"^2"));
-    expectedQ.setSlop(3);
+    expectedQBuilder.setSlop(3);
+    expected = new BoostQuery(expectedQBuilder.build(), 2f);
     assertEquals(expected, qp.parse("\"中国\"~3^2"));
   }
 

--- a/lucene/sandbox/src/java/org/apache/lucene/payloads/PayloadSpanUtil.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/payloads/PayloadSpanUtil.java
@@ -114,7 +114,7 @@ public class PayloadSpanUtil {
 
     } else if (query instanceof MultiPhraseQuery) {
       final MultiPhraseQuery mpq = (MultiPhraseQuery) query;
-      final List<Term[]> termArrays = mpq.getTermArrays();
+      final Term[][] termArrays = mpq.getTermArrays();
       final int[] positions = mpq.getPositions();
       if (positions.length > 0) {
 
@@ -129,8 +129,8 @@ public class PayloadSpanUtil {
             new List[maxPosition + 1];
         int distinctPositions = 0;
 
-        for (int i = 0; i < termArrays.size(); ++i) {
-          final Term[] termArray = termArrays.get(i);
+        for (int i = 0; i < termArrays.length; ++i) {
+          final Term[] termArray = termArrays[i];
           List<Query> disjuncts = disjunctLists[positions[i]];
           if (disjuncts == null) {
             disjuncts = (disjunctLists[positions[i]] = new ArrayList<>(

--- a/lucene/sandbox/src/test/org/apache/lucene/search/TestTermAutomatonQuery.java
+++ b/lucene/sandbox/src/test/org/apache/lucene/search/TestTermAutomatonQuery.java
@@ -522,15 +522,15 @@ public class TestTermAutomatonQuery extends LuceneTestCase {
           }
         }
         String string = sb.toString();
-        MultiPhraseQuery mpq = new MultiPhraseQuery();
+        MultiPhraseQuery.Builder mpqb = new MultiPhraseQuery.Builder();
         for(int j=0;j<string.length();j++) {
           if (string.charAt(j) == '*') {
-            mpq.add(allTerms);
+            mpqb.add(allTerms);
           } else {
-            mpq.add(new Term("field", ""+string.charAt(j)));
+            mpqb.add(new Term("field", ""+string.charAt(j)));
           }
         }
-        bq.add(mpq, BooleanClause.Occur.SHOULD);
+        bq.add(mpqb.build(), BooleanClause.Occur.SHOULD);
         strings.add(new BytesRef(string));
       }
 

--- a/solr/core/src/java/org/apache/solr/parser/SolrQueryParserBase.java
+++ b/solr/core/src/java/org/apache/solr/parser/SolrQueryParserBase.java
@@ -387,7 +387,6 @@ public abstract class SolrQueryParserBase extends QueryBuilder {
     // only set slop of the phrase query was a result of this parser
     // and not a sub-parser.
     if (subQParser == null) {
-
       if (query instanceof PhraseQuery) {
         PhraseQuery pq = (PhraseQuery) query;
         Term[] terms = pq.getTerms();
@@ -398,11 +397,13 @@ public abstract class SolrQueryParserBase extends QueryBuilder {
         }
         builder.setSlop(slop);
         query = builder.build();
+      } else if (query instanceof MultiPhraseQuery) {
+        MultiPhraseQuery mpq = (MultiPhraseQuery)query;
+      
+        if (slop != mpq.getSlop()) {
+          query = new MultiPhraseQuery.Builder(mpq).setSlop(slop).build();
+        }
       }
-      if (query instanceof MultiPhraseQuery) {
-        ((MultiPhraseQuery) query).setSlop(slop);
-      }
-
     }
 
     return query;

--- a/solr/core/src/java/org/apache/solr/search/ExtendedDismaxQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/ExtendedDismaxQParser.java
@@ -1236,7 +1236,7 @@ public class ExtendedDismaxQParser extends QParser {
               query = builder.build();
             } else if (query instanceof MultiPhraseQuery) {
               MultiPhraseQuery mpq = (MultiPhraseQuery)query;
-              if (minClauseSize > 1 && mpq.getTermArrays().size() < minClauseSize) return null;
+              if (minClauseSize > 1 && mpq.getTermArrays().length < minClauseSize) return null;
               if (slop != mpq.getSlop()) {
                 query = new MultiPhraseQuery.Builder(mpq).setSlop(slop).build();
               }

--- a/solr/core/src/java/org/apache/solr/search/ExtendedDismaxQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/ExtendedDismaxQParser.java
@@ -1235,9 +1235,11 @@ public class ExtendedDismaxQParser extends QParser {
               builder.setSlop(slop);
               query = builder.build();
             } else if (query instanceof MultiPhraseQuery) {
-              MultiPhraseQuery pq = (MultiPhraseQuery)query;
-              if (minClauseSize > 1 && pq.getTermArrays().size() < minClauseSize) return null;
-              ((MultiPhraseQuery)query).setSlop(slop);
+              MultiPhraseQuery mpq = (MultiPhraseQuery)query;
+              if (minClauseSize > 1 && mpq.getTermArrays().size() < minClauseSize) return null;
+              if (slop != mpq.getSlop()) {
+                query = new MultiPhraseQuery.Builder(mpq).setSlop(slop).build();
+              }
             } else if (minClauseSize > 1) {
               // if it's not a type of phrase query, it doesn't meet the minClauseSize requirements
               return null;


### PR DESCRIPTION
This PR is based at the highest commit point common to master, branch_6x and branch_6_0 so it should be easy to merge with any or all of them.

My original mail to the dev list doesn't seem to get through, so I repeat it here:

> While checking how to migrate my custom components from lucene/solr 5.1 to 6.x I stumbled upon the fact that oal.search.MultiPhraseQuery is not immutable like most other implementations (see e.g.: https://issues.apache.org/jira/browse/LUCENE-6531)
> 
> Since it is part of the public API I would suggest splitting it in an immutable class and a builder like was done for most other Queries *before* releasing an official 6.x version.
> 
> I did a quick scan through all derived classes of Query and I compiled the following list (ignoring sources in test or contrib folders)
> Some of them are already marked as experimental (but should perhaps receive the "official" @lucene.experimental tag ?)
> For some it's possibly not an issue since they should never end up in a filter cache (like MoreLikeThisQuery ?), but then a comment specifying the exception to the rule should perhaps be added.
> 
> I'll probably already have a go at the MultiPhraseQuery case shortly and create a JIRA issue with a PR for it.
> 
> Luc Vanlerberghe
> 
> lucene/search:
> - org.apache.lucene.search.MultiPhraseQuery
> 
> lucene/queries:
> - org.apache.lucene.queries.CommonTermsQuery
> - org.apache.lucene.queries.CustomScoreQuery (marked as @lucene.experimental)
> - org.apache.lucene.queries.mlt.MoreLikeThisQuery
> 
> lucene/suggest:
> - org.apache.lucene.search.suggest.document.ContextQuery (marked as @lucene.experimental)
> 
> lucene/facet:
> - org.apache.lucene.facet.DrillDownQuery (marked as @lucene.experimental)
> 
> solr/core:
> - org.apache.solr.search.ExtendedQueryBase
>   Several derived classes, among which:
>   - org.apache.solr.query.FilterQuery
>   - org.apache.solr.query.SolrRangeQuery (marked as @lucene.experimental)
>   - org.apache.solr.search.RankQuery (marked in comment as experimental, but not its derived classes)
>   - org.apache.solr.search.WrappedQuery
> - org.apache.solr.search.join.GraphQuery (marked as @lucene.experimental)
> - org.apache.solr.search.SolrConstantScoreQuery (marked in comment as experimental, but not the derived FunctionRangeQuery)
> 