### PR TITLE
SOLR-8858 SolrIndexSearcher#doc() Completely Ignores Field Filters Unless Lazy Field Loading is Enabled

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -770,12 +770,16 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable,SolrIn
       if (d!=null) return d;
     }
 
-    if(!enableLazyFieldLoading || fields == null) {
-      d = getIndexReader().document(i);
+    if (fields != null) {
+      if (enableLazyFieldLoading) {
+        final SetNonLazyFieldSelector visitor = new SetNonLazyFieldSelector(fields, getIndexReader(), i);
+        getIndexReader().document(i, visitor);
+        d = visitor.doc;
+      } else {
+        d = getIndexReader().document(i, fields);
+      }
     } else {
-      final SetNonLazyFieldSelector visitor = new SetNonLazyFieldSelector(fields, getIndexReader(), i);
-      getIndexReader().document(i, visitor);
-      d = visitor.doc;
+      d = getIndexReader().document(i);
     }
 
     if (documentCache != null) {


### PR DESCRIPTION
Instead of just discarding fields if lazy loading is not enabled, SolrIndexSearcher now passes them through to IndexReader. This means IndexReader creates a DocumentStoredFieldVisitor that we can use to later determine which fields need to be read.

https://issues.apache.org/jira/browse/SOLR-8858