### PR TITLE
SOLR-8626: Fix urls for nodes in cloud graph view

### DIFF
--- a/solr/webapp/web/js/angular/controllers/cloud.js
+++ b/solr/webapp/web/js/angular/controllers/cloud.js
@@ -313,6 +313,32 @@ solrAdminApp.directive('graph', function(Constants) {
                 }
             });
 
+
+            function setNodeNavigationBehavior(node, view){
+                node
+                .attr('data-href', function (d) {
+                    if (d.type == "node"){
+                        return getNodeUrl(d, view);
+                    }
+                    else{
+                        return "";
+                    }
+                })
+                .on('click', function(d) {
+                    if (d.data.type == "node"){
+                        location.href = getNodeUrl(d, view);
+                    }
+                });
+            }
+
+            function getNodeUrl(d, view){
+                var url = d.name + Constants.ROOT_URL + "#/~cloud";
+                if (view != undefined){
+                    url += "?view=" + view;
+                }
+                return url;
+            }
+
             var flatGraph = function(element, graphData, leafCount) {
                 var w = element.width(),
                     h = leafCount * 20;
@@ -358,14 +384,10 @@ solrAdminApp.directive('graph', function(Constants) {
                     })
                     .attr('text-anchor', function (d) {
                         return 0 === d.depth ? 'end' : 'start';
-                    })
-                    .attr('data-href', function (d) {
-                        return d.name + Constants.ROOT_URL + "#/~cloud";
-                    })
-                    .text(helper_node_text)
-                    .on('click', function(d,i) {
-                        location.href = d.name+Constants.ROOT_URL+"#/~cloud";
-                    });
+                    })                    
+                    .text(helper_node_text);
+
+                setNodeNavigationBehavior(node);
             };
 
             var radialGraph = function(element, graphData, leafCount) {
@@ -417,13 +439,9 @@ solrAdminApp.directive('graph', function(Constants) {
                     .attr('transform', function (d) {
                         return d.x < 180 ? null : 'rotate(180)';
                     })
-                    .attr('data-href', function (d) {
-                        return d.name;
-                    })
-                    .text(helper_node_text)
-                    .on('click', function(d,i) {
-                        location.href = d.name+Constants.ROOT_URL+"#/~cloud";
-                    });
+                    .text(helper_node_text);
+
+                setNodeNavigationBehavior(node, "rgraph");
             }
         }
     };


### PR DESCRIPTION
This fixes SOLR-8626 (identical patch submitted on JIRA) by removing the invalid (404) links on collections and cores in the graph view. The issue existed - and has been fixed - in both the flat graph view and the radial view. Additionally, when one was in the radial view and clicked on the link for a node, it would switch back to flat graph view when navigating to the other node, so the patch also improves the link in the radial view so that it preserves the user's current view type on the URL when navigating between nodes.