### PR TITLE
SOLR-8785: Use Metrics library for core metrics

### DIFF
--- a/lucene/ivy-versions.properties
+++ b/lucene/ivy-versions.properties
@@ -13,9 +13,9 @@ com.carrotsearch.randomizedtesting.version = 2.3.2
 
 /com.carrotsearch/hppc = 0.7.1
 
-com.codahale.metrics.version = 3.0.1
-/com.codahale.metrics/metrics-core = ${com.codahale.metrics.version}
-/com.codahale.metrics/metrics-healthchecks = ${com.codahale.metrics.version}
+io.dropwizard.metrics.version = 3.1.2
+/io.dropwizard.metrics/metrics-core = ${io.dropwizard.metrics.version}
+/io.dropwizard.metrics/metrics-healthchecks = ${io.dropwizard.metrics.version}
 
 /com.cybozu.labs/langdetect = 1.1-20120112
 /com.drewnoakes/metadata-extractor = 2.6.2

--- a/solr/contrib/analytics/src/java/org/apache/solr/analytics/plugin/AnalyticsStatisticsCollector.java
+++ b/solr/contrib/analytics/src/java/org/apache/solr/analytics/plugin/AnalyticsStatisticsCollector.java
@@ -16,13 +16,14 @@
  */
 package org.apache.solr.analytics.plugin;
 
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
+import com.codahale.metrics.Snapshot;
+import com.codahale.metrics.Timer;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
-import org.apache.solr.util.stats.Snapshot;
-import org.apache.solr.util.stats.Timer;
-import org.apache.solr.util.stats.TimerContext;
+import org.apache.solr.util.stats.Metrics;
 
 public class AnalyticsStatisticsCollector {
   private final AtomicLong numRequests;
@@ -35,7 +36,7 @@ public class AnalyticsStatisticsCollector {
   private final AtomicLong numQueries;
   private final Timer requestTimes;
   
-  public TimerContext currentTimer;
+  public Timer.Context currentTimer;
   
   public AnalyticsStatisticsCollector() {
     numRequests = new AtomicLong();
@@ -97,17 +98,7 @@ public class AnalyticsStatisticsCollector {
     lst.add("rangeFacets", numRangeFacets.longValue());
     lst.add("queryFacets", numQueryFacets.longValue());
     lst.add("queriesInQueryFacets", numQueries.longValue());
-    lst.add("totalTime", requestTimes.getSum());
-    lst.add("avgRequestsPerSecond", requestTimes.getMeanRate());
-    lst.add("5minRateReqsPerSecond", requestTimes.getFiveMinuteRate());
-    lst.add("15minRateReqsPerSecond", requestTimes.getFifteenMinuteRate());
-    lst.add("avgTimePerRequest", requestTimes.getMean());
-    lst.add("medianRequestTime", snapshot.getMedian());
-    lst.add("75thPcRequestTime", snapshot.get75thPercentile());
-    lst.add("95thPcRequestTime", snapshot.get95thPercentile());
-    lst.add("99thPcRequestTime", snapshot.get99thPercentile());
-    lst.add("999thPcRequestTime", snapshot.get999thPercentile());
+    Metrics.addTimerMetrics(lst, requestTimes);
     return lst;
   }
-  
 }

--- a/solr/contrib/morphlines-core/ivy.xml
+++ b/solr/contrib/morphlines-core/ivy.xml
@@ -34,8 +34,8 @@
 
     <dependency org="org.kitesdk" name="kite-morphlines-avro" rev="${/org.kitesdk/kite-morphlines-avro}" conf="compile" />
     
-    <dependency org="com.codahale.metrics" name="metrics-core" rev="${/com.codahale.metrics/metrics-core}" conf="compile" />
-    <dependency org="com.codahale.metrics" name="metrics-healthchecks" rev="${/com.codahale.metrics/metrics-healthchecks}" conf="compile" />
+    <dependency org="io.dropwizard.metrics" name="metrics-core" rev="${/io.dropwizard.metrics/metrics-core}" conf="compile" />
+    <dependency org="io.dropwizard.metrics" name="metrics-healthchecks" rev="${/io.dropwizard.metrics/metrics-healthchecks}" conf="compile" />
     <dependency org="com.typesafe" name="config" rev="${/com.typesafe/config}" conf="compile" />
     
     <!-- Test Dependencies -->

--- a/solr/core/ivy.xml
+++ b/solr/core/ivy.xml
@@ -49,6 +49,7 @@
     <dependency org="log4j" name="log4j" rev="${/log4j/log4j}" conf="compile"/>
     <dependency org="org.slf4j" name="slf4j-log4j12" rev="${/org.slf4j/slf4j-log4j12}" conf="compile"/>
     <dependency org="org.slf4j" name="jcl-over-slf4j" rev="${/org.slf4j/jcl-over-slf4j}" conf="compile"/>
+    <dependency org="io.dropwizard.metrics" name="metrics-core" rev="${/io.dropwizard.metrics/metrics-core}" conf="compile" />
 
     <dependency org="org.easymock" name="easymock" rev="${/org.easymock/easymock}" conf="test"/>
     <dependency org="cglib" name="cglib-nodep" rev="${/cglib/cglib-nodep}" conf="test"/>

--- a/solr/core/src/java/org/apache/solr/cloud/DistributedQueue.java
+++ b/solr/core/src/java/org/apache/solr/cloud/DistributedQueue.java
@@ -26,13 +26,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
+import com.codahale.metrics.Timer;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrException.ErrorCode;
 import org.apache.solr.common.cloud.SolrZkClient;
 import org.apache.solr.common.cloud.ZkCmdExecutor;
-import org.apache.solr.util.stats.TimerContext;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
@@ -123,7 +123,7 @@ public class DistributedQueue {
    * @return data at the first element of the queue, or null.
    */
   public byte[] peek() throws KeeperException, InterruptedException {
-    TimerContext time = stats.time(dir + "_peek");
+    Timer.Context time = stats.time(dir + "_peek");
     try {
       return firstElement();
     } finally {
@@ -151,7 +151,7 @@ public class DistributedQueue {
    */
   public byte[] peek(long wait) throws KeeperException, InterruptedException {
     Preconditions.checkArgument(wait > 0);
-    TimerContext time;
+    Timer.Context time;
     if (wait == Long.MAX_VALUE) {
       time = stats.time(dir + "_peek_wait_forever");
     } else {
@@ -181,7 +181,7 @@ public class DistributedQueue {
    * @return Head of the queue or null.
    */
   public byte[] poll() throws KeeperException, InterruptedException {
-    TimerContext time = stats.time(dir + "_poll");
+    Timer.Context time = stats.time(dir + "_poll");
     try {
       return removeFirst();
     } finally {
@@ -195,7 +195,7 @@ public class DistributedQueue {
    * @return The former head of the queue
    */
   public byte[] remove() throws NoSuchElementException, KeeperException, InterruptedException {
-    TimerContext time = stats.time(dir + "_remove");
+    Timer.Context time = stats.time(dir + "_remove");
     try {
       byte[] result = removeFirst();
       if (result == null) {
@@ -214,7 +214,7 @@ public class DistributedQueue {
    */
   public byte[] take() throws KeeperException, InterruptedException {
     // Same as for element. Should refactor this.
-    TimerContext timer = stats.time(dir + "_take");
+    Timer.Context timer = stats.time(dir + "_take");
     updateLock.lockInterruptibly();
     try {
       while (true) {
@@ -238,7 +238,7 @@ public class DistributedQueue {
    * element to become visible.
    */
   public void offer(byte[] data) throws KeeperException, InterruptedException {
-    TimerContext time = stats.time(dir + "_offer");
+    Timer.Context time = stats.time(dir + "_offer");
     try {
       while (true) {
         try {

--- a/solr/core/src/java/org/apache/solr/cloud/OverseerCollectionMessageHandler.java
+++ b/solr/core/src/java/org/apache/solr/cloud/OverseerCollectionMessageHandler.java
@@ -33,6 +33,8 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import com.codahale.metrics.Snapshot;
+import com.codahale.metrics.Timer;
 import org.apache.commons.lang.StringUtils;
 import org.apache.solr.client.solrj.SolrResponse;
 import org.apache.solr.client.solrj.SolrServerException;
@@ -82,8 +84,7 @@ import org.apache.solr.handler.component.ShardResponse;
 import org.apache.solr.update.SolrIndexSplitter;
 import org.apache.solr.util.RTimer;
 import org.apache.solr.util.TimeOut;
-import org.apache.solr.util.stats.Snapshot;
-import org.apache.solr.util.stats.Timer;
+import org.apache.solr.util.stats.Metrics;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.Stat;
@@ -429,17 +430,7 @@ public class OverseerCollectionMessageHandler implements OverseerMessageHandler 
         lst.add("errors", errors);
       }
       Timer timer = entry.getValue().requestTime;
-      Snapshot snapshot = timer.getSnapshot();
-      lst.add("totalTime", timer.getSum());
-      lst.add("avgRequestsPerMinute", timer.getMeanRate());
-      lst.add("5minRateRequestsPerMinute", timer.getFiveMinuteRate());
-      lst.add("15minRateRequestsPerMinute", timer.getFifteenMinuteRate());
-      lst.add("avgTimePerRequest", timer.getMean());
-      lst.add("medianRequestTime", snapshot.getMedian());
-      lst.add("75thPctlRequestTime", snapshot.get75thPercentile());
-      lst.add("95thPctlRequestTime", snapshot.get95thPercentile());
-      lst.add("99thPctlRequestTime", snapshot.get99thPercentile());
-      lst.add("999thPctlRequestTime", snapshot.get999thPercentile());
+      Metrics.addTimerMetrics(lst, timer);
     }
     results.add("overseer_operations", overseerStats);
     results.add("collection_operations", collectionStats);

--- a/solr/core/src/java/org/apache/solr/cloud/OverseerTaskProcessor.java
+++ b/solr/core/src/java/org/apache/solr/cloud/OverseerTaskProcessor.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.TimeUnit;
 
+import com.codahale.metrics.Timer;
 import org.apache.solr.client.solrj.SolrResponse;
 import org.apache.solr.cloud.OverseerTaskQueue.QueueEvent;
 import org.apache.solr.cloud.Overseer.LeaderStatus;
@@ -39,7 +40,6 @@ import org.apache.solr.common.util.ExecutorUtil;
 import org.apache.solr.common.util.Utils;
 import org.apache.solr.handler.component.ShardHandlerFactory;
 import org.apache.solr.util.DefaultSolrThreadFactory;
-import org.apache.solr.util.stats.TimerContext;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
@@ -352,7 +352,7 @@ public class OverseerTaskProcessor implements Runnable, Closeable {
 
   protected LeaderStatus amILeader() {
     String statsName = "collection_am_i_leader";
-    TimerContext timerContext = stats.time(statsName);
+    Timer.Context timerContext = stats.time(statsName);
     boolean success = true;
     try {
       ZkNodeProps props = ZkNodeProps.load(zkStateReader.getZkClient().getData(
@@ -425,7 +425,7 @@ public class OverseerTaskProcessor implements Runnable, Closeable {
 
     public void run() {
       String statsName = messageHandler.getTimerName(operation);
-      final TimerContext timerContext = stats.time(statsName);
+      final Timer.Context timerContext = stats.time(statsName);
 
       boolean success = false;
       final String asyncId = message.getStr(ASYNC);

--- a/solr/core/src/java/org/apache/solr/cloud/OverseerTaskQueue.java
+++ b/solr/core/src/java/org/apache/solr/cloud/OverseerTaskQueue.java
@@ -23,9 +23,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
+import com.codahale.metrics.Timer;
 import org.apache.solr.common.cloud.SolrZkClient;
 import org.apache.solr.common.cloud.ZkNodeProps;
-import org.apache.solr.util.stats.TimerContext;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
@@ -86,7 +86,7 @@ public class OverseerTaskQueue extends DistributedQueue {
    */
   public byte[] remove(QueueEvent event) throws KeeperException,
       InterruptedException {
-    TimerContext time = stats.time(dir + "_remove_event");
+    Timer.Context time = stats.time(dir + "_remove_event");
     try {
       String path = event.getId();
       String responsePath = dir + "/" + response_prefix
@@ -181,7 +181,7 @@ public class OverseerTaskQueue extends DistributedQueue {
    */
   public QueueEvent offer(byte[] data, long timeout) throws KeeperException,
       InterruptedException {
-    TimerContext time = stats.time(dir + "_offer");
+    Timer.Context time = stats.time(dir + "_offer");
     try {
       // Create and watch the response node before creating the request node;
       // otherwise we may miss the response.
@@ -218,7 +218,7 @@ public class OverseerTaskQueue extends DistributedQueue {
     ArrayList<QueueEvent> topN = new ArrayList<>();
 
     LOG.debug("Peeking for top {} elements. ExcludeSet: {}", n, excludeSet);
-    TimerContext time = null;
+    Timer.Context time = null;
     if (waitMillis == Long.MAX_VALUE) time = stats.time(dir + "_peekTopN_wait_forever");
     else time = stats.time(dir + "_peekTopN_wait" + waitMillis);
 

--- a/solr/core/src/java/org/apache/solr/cloud/overseer/ZkStateWriter.java
+++ b/solr/core/src/java/org/apache/solr/cloud/overseer/ZkStateWriter.java
@@ -21,12 +21,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import com.codahale.metrics.Timer;
 import org.apache.solr.cloud.Overseer;
 import org.apache.solr.common.cloud.ClusterState;
 import org.apache.solr.common.cloud.DocCollection;
 import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.common.util.Utils;
-import org.apache.solr.util.stats.TimerContext;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.Stat;
@@ -211,7 +211,7 @@ public class ZkStateWriter {
       throw new IllegalStateException("ZkStateWriter has seen a tragic error, this instance can no longer be used");
     }
     if (!hasPendingUpdates()) return clusterState;
-    TimerContext timerContext = stats.time("update_state");
+    Timer.Context timerContext = stats.time("update_state");
     boolean success = false;
     try {
       if (!updates.isEmpty()) {

--- a/solr/core/src/java/org/apache/solr/handler/RequestHandlerBase.java
+++ b/solr/core/src/java/org/apache/solr/handler/RequestHandlerBase.java
@@ -56,10 +56,11 @@ public abstract class RequestHandlerBase implements SolrRequestHandler, SolrInfo
   protected boolean httpCaching = true;
 
   // Statistics
+  public static final String REGISTRY_NAME = "requesthandler";
   private final AtomicLong numRequests = new AtomicLong();
   private final AtomicLong numErrors = new AtomicLong();
   private final AtomicLong numTimeouts = new AtomicLong();
-  private final Timer requestTimes = new Timer();
+  private Timer requestTimes = new Timer();
 
   private final long handlerStart;
 
@@ -250,7 +251,12 @@ public abstract class RequestHandlerBase implements SolrRequestHandler, SolrInfo
   }
 
   public void setPluginInfo(PluginInfo pluginInfo){
-    if(this.pluginInfo==null) this.pluginInfo = pluginInfo;
+    if(this.pluginInfo==null) {
+      // if a request handler has a name, use a persistent, reportable timer under that name
+      if (pluginInfo.name != null)
+        requestTimes = Metrics.namedTimer(Metrics.mkName(this.getClass(), pluginInfo.name), REGISTRY_NAME);
+      this.pluginInfo = pluginInfo;
+    }
   }
 
   public PluginInfo getPluginInfo(){

--- a/solr/core/src/java/org/apache/solr/util/stats/Clock.java
+++ b/solr/core/src/java/org/apache/solr/util/stats/Clock.java
@@ -27,7 +27,9 @@ import org.apache.solr.common.util.SuppressForbidden;
 
 /**
  * An abstraction for how time passes. It is passed to {@link Timer} to track timing.
+ * @deprecated Use the metrics-core library's classes instead
  */
+@Deprecated
 public abstract class Clock {
   /**
    * Returns the current time tick.

--- a/solr/core/src/java/org/apache/solr/util/stats/EWMA.java
+++ b/solr/core/src/java/org/apache/solr/util/stats/EWMA.java
@@ -32,7 +32,9 @@ import static java.lang.Math.exp;
  *      It Works</a>
  * @see <a href="http://www.teamquest.com/pdfs/whitepaper/ldavg2.pdf">UNIX Load Average Part 2: Not
  *      Your Average Average</a>
+ * @deprecated Use the metrics-core library's classes instead
  */
+@Deprecated
 public class EWMA {
   private static final int INTERVAL = 5;
   private static final double SECONDS_PER_MINUTE = 60.0;

--- a/solr/core/src/java/org/apache/solr/util/stats/ExponentiallyDecayingSample.java
+++ b/solr/core/src/java/org/apache/solr/util/stats/ExponentiallyDecayingSample.java
@@ -37,7 +37,9 @@ import static java.lang.Math.min;
  *
  * See <a href="http://www.research.att.com/people/Cormode_Graham/library/publications/CormodeShkapenyukSrivastavaXu09.pdf">
  *      Cormode et al. Forward Decay: A Practical Time Decay Model for Streaming Systems. ICDE '09: Proceedings of the 2009 IEEE International Conference on Data Engineering (2009)</a>
+ * @deprecated Use the metrics-core library's classes instead
  */
+@Deprecated
 public class ExponentiallyDecayingSample implements Sample {
 
   private static final long RESCALE_THRESHOLD = TimeUnit.HOURS.toNanos(1);

--- a/solr/core/src/java/org/apache/solr/util/stats/Histogram.java
+++ b/solr/core/src/java/org/apache/solr/util/stats/Histogram.java
@@ -30,7 +30,9 @@ import static java.lang.Math.sqrt;
  *
  * @see <a href="http://www.johndcook.com/standard_deviation.html">Accurately computing running
  *      variance</a>
+ * @deprecated Use the metrics-core library's classes instead
  */
+@Deprecated
 public class Histogram {
 
   private static final int DEFAULT_SAMPLE_SIZE = 1028;

--- a/solr/core/src/java/org/apache/solr/util/stats/Meter.java
+++ b/solr/core/src/java/org/apache/solr/util/stats/Meter.java
@@ -28,7 +28,10 @@ import java.util.concurrent.atomic.AtomicLong;
  * exponentially-weighted moving average throughputs.
  *
  * @see <a href="http://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average">EMA</a>
+ *
+ * @deprecated Use the metrics-core library's classes instead
  */
+@Deprecated
 public class Meter {
 
   private static final long TICK_INTERVAL = TimeUnit.SECONDS.toNanos(5);

--- a/solr/core/src/java/org/apache/solr/util/stats/Metrics.java
+++ b/solr/core/src/java/org/apache/solr/util/stats/Metrics.java
@@ -1,0 +1,108 @@
+package org.apache.solr.util.stats;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.SharedMetricRegistries;
+import com.codahale.metrics.Snapshot;
+import com.codahale.metrics.Timer;
+import org.apache.hadoop.metrics.util.MetricsRegistry;
+import org.apache.solr.common.util.NamedList;
+
+public enum Metrics {;   // empty enum, this is just a container for static methods
+
+  public static final String REGISTRY_NAME_PREFIX = "solr.registry";
+  public static final String DEFAULT_REGISTRY = MetricRegistry.name(REGISTRY_NAME_PREFIX, "default");
+
+  /**
+   * Use to get a Timer that you intend to use internally, and will never need to report metrics for.
+   * @return
+   */
+  public static Timer anonymousTimer() {
+    return new Timer();
+  }
+
+  /**
+   * Use to get a named (shared, persistent) Timer from the default shared registry.
+   * @param name A name that can be used to get this same Timer instance again
+   * @return
+   */
+  public static Timer namedTimer(String name) {
+    return namedTimer(name, DEFAULT_REGISTRY);
+  }
+
+  /**
+   * Use to get a named (shared, persistent) Timer from a specified registry.
+   * @param name A name that can be used to get this same Timer instance again
+   * @param registry The name of the registry to get this timer from
+   * @return
+   */
+  public static Timer namedTimer(String name, String registry) {
+    return SharedMetricRegistries.getOrCreate(overridableRegistryName(registry)).timer(name);
+  }
+
+  /**
+   * Allows named registries to be renamed using System properties.
+   * This would be mostly be useful if you want to combine the metrics from a few registries for a single
+   * reporter.
+   * @param registry The name of the registry
+   * @return A potentially overridden (via System properties) registry name
+   */
+  public static String overridableRegistryName(String registry) {
+    String fqRegistry = enforcePrefix(registry);
+    return enforcePrefix(System.getProperty(fqRegistry,fqRegistry));
+  }
+
+  private static String enforcePrefix(String name) {
+    if (name.startsWith(REGISTRY_NAME_PREFIX))
+      return name;
+    else
+      return MetricRegistry.name(REGISTRY_NAME_PREFIX, name);
+  }
+
+
+  /**
+   * Adds metrics from a Timer to a NamedList, using well-known names.
+   * @param lst The NamedList to add the metrics data to
+   * @param timer The Timer to extract the metrics from
+   */
+  public static void addTimerMetrics(NamedList<Object> lst, Timer timer) {
+    Snapshot snapshot = timer.getSnapshot();
+    lst.add("avgRequestsPerMinute", timer.getMeanRate());
+    lst.add("5minRateRequestsPerMinute", timer.getFiveMinuteRate());
+    lst.add("15minRateRequestsPerMinute", timer.getFifteenMinuteRate());
+    lst.add("avgTimePerRequest", nsToMs(snapshot.getMean()));
+    lst.add("medianRequestTime", nsToMs(snapshot.getMedian()));
+    lst.add("75thPctlRequestTime", nsToMs(snapshot.get75thPercentile()));
+    lst.add("95thPctlRequestTime", nsToMs(snapshot.get95thPercentile()));
+    lst.add("99thPctlRequestTime", nsToMs(snapshot.get99thPercentile()));
+    lst.add("999thPctlRequestTime", nsToMs(snapshot.get999thPercentile()));
+  }
+
+  /**
+   * Timers return measurements as a double representing nanos.
+   * This converts that to a double representing millis.
+   * @param ns Nanoseconds
+   * @return Milliseconds
+   */
+  public static double nsToMs(double ns) {
+    return ns / 1000000;  // Using TimeUnit involves casting to Long, so don't bother.
+  }
+
+}

--- a/solr/core/src/java/org/apache/solr/util/stats/Metrics.java
+++ b/solr/core/src/java/org/apache/solr/util/stats/Metrics.java
@@ -30,6 +30,8 @@ public enum Metrics {;   // empty enum, this is just a container for static meth
   public static final String REGISTRY_NAME_PREFIX = "solr.registry";
   public static final String DEFAULT_REGISTRY = MetricRegistry.name(REGISTRY_NAME_PREFIX, "default");
 
+  public static String mkName(String name, String... names) { return MetricRegistry.name(name, names); }
+  public static String mkName(Class<?> klass, String... names) { return MetricRegistry.name(klass, names); }
   /**
    * Use to get a Timer that you intend to use internally, and will never need to report metrics for.
    * @return
@@ -48,13 +50,22 @@ public enum Metrics {;   // empty enum, this is just a container for static meth
   }
 
   /**
-   * Use to get a named (shared, persistent) Timer from a specified registry.
+   * Use to get a named (shared, persistent) Timer from a specified shared registry.
    * @param name A name that can be used to get this same Timer instance again
    * @param registry The name of the registry to get this timer from
    * @return
    */
   public static Timer namedTimer(String name, String registry) {
     return SharedMetricRegistries.getOrCreate(overridableRegistryName(registry)).timer(name);
+  }
+
+  /**
+   * Gets a shared MetricRegistry by name, respecting overrides
+   * @param name
+   * @return
+   */
+  public static MetricRegistry registryFor(String name) {
+    return SharedMetricRegistries.getOrCreate(overridableRegistryName(name));
   }
 
   /**

--- a/solr/core/src/java/org/apache/solr/util/stats/Sample.java
+++ b/solr/core/src/java/org/apache/solr/util/stats/Sample.java
@@ -22,7 +22,9 @@ package org.apache.solr.util.stats;
 
 /**
  * A statistically representative sample of a data stream.
+ * @deprecated Use the metrics-core library's classes instead
  */
+@Deprecated
 public interface Sample {
   /**
    * Clears all recorded values.

--- a/solr/core/src/java/org/apache/solr/util/stats/Snapshot.java
+++ b/solr/core/src/java/org/apache/solr/util/stats/Snapshot.java
@@ -27,7 +27,9 @@ import static java.lang.Math.floor;
 
 /**
  * A statistical snapshot of a {@link Snapshot}.
+ * @deprecated Use the metrics-core library's classes instead
  */
+@Deprecated
 public class Snapshot {
   private static final double MEDIAN_Q = 0.5;
   private static final double P75_Q = 0.75;

--- a/solr/core/src/java/org/apache/solr/util/stats/Timer.java
+++ b/solr/core/src/java/org/apache/solr/util/stats/Timer.java
@@ -28,7 +28,9 @@ import java.util.concurrent.TimeUnit;
 /**
  * A timer metric which aggregates timing durations and provides duration statistics, plus
  * throughput statistics via {@link Meter}.
+ * @deprecated Use the metrics-core library's classes instead
  */
+@Deprecated
 public class Timer {
 
   private final TimeUnit durationUnit, rateUnit;

--- a/solr/core/src/java/org/apache/solr/util/stats/TimerContext.java
+++ b/solr/core/src/java/org/apache/solr/util/stats/TimerContext.java
@@ -26,7 +26,9 @@ import java.util.concurrent.TimeUnit;
  * A timing context.
  *
  * @see Timer#time()
+ * @deprecated Use the metrics-core library's classes instead
  */
+@Deprecated
 public class TimerContext {
   private final Timer timer;
   private final Clock clock;

--- a/solr/core/src/java/org/apache/solr/util/stats/UniformSample.java
+++ b/solr/core/src/java/org/apache/solr/util/stats/UniformSample.java
@@ -31,7 +31,9 @@ import java.util.concurrent.atomic.AtomicLongArray;
  * statistically representative sample.
  *
  * @see <a href="http://www.cs.umd.edu/~samir/498/vitter.pdf">Random Sampling with a Reservoir</a>
+ * @deprecated Use the metrics-core library's classes instead
  */
+@Deprecated
 public class UniformSample implements Sample {
 
   private static final int BITS_PER_LONG = 63;

--- a/solr/core/src/test/org/apache/solr/cloud/OverseerTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/OverseerTest.java
@@ -34,6 +34,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.codahale.metrics.Snapshot;
+import com.codahale.metrics.Timer;
 import org.apache.lucene.util.LuceneTestCase.Slow;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.cloud.overseer.OverseerAction;
@@ -52,9 +54,6 @@ import org.apache.solr.handler.component.HttpShardHandlerFactory;
 import org.apache.solr.update.UpdateShardHandler;
 import org.apache.solr.update.UpdateShardHandlerConfig;
 import org.apache.solr.util.DefaultSolrThreadFactory;
-import org.apache.solr.util.stats.Snapshot;
-import org.apache.solr.util.stats.Timer;
-import org.apache.solr.util.stats.TimerContext;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.NoNodeException;
@@ -1041,7 +1040,7 @@ public class OverseerTest extends SolrTestCaseJ4 {
       q.offer(Utils.toJSON(m));
 
       Timer t = new Timer();
-      TimerContext context = t.time();
+      Timer.Context context = t.time();
       try {
         overseerClient = electNewOverseer(server.getZkAddress());
         assertTrue(overseers.size() > 0);
@@ -1086,16 +1085,19 @@ public class OverseerTest extends SolrTestCaseJ4 {
 
   private void printTimingStats(Timer timer) {
     Snapshot snapshot = timer.getSnapshot();
-    log.info("\t totalTime: {}", timer.getSum());
     log.info("\t avgRequestsPerMinute: {}", timer.getMeanRate());
     log.info("\t 5minRateRequestsPerMinute: {}", timer.getFiveMinuteRate());
     log.info("\t 15minRateRequestsPerMinute: {}", timer.getFifteenMinuteRate());
-    log.info("\t avgTimePerRequest: {}", timer.getMean());
-    log.info("\t medianRequestTime: {}", snapshot.getMedian());
-    log.info("\t 75thPctlRequestTime: {}", snapshot.get75thPercentile());
-    log.info("\t 95thPctlRequestTime: {}", snapshot.get95thPercentile());
-    log.info("\t 99thPctlRequestTime: {}", snapshot.get99thPercentile());
-    log.info("\t 999thPctlRequestTime: {}", snapshot.get999thPercentile());
+    log.info("\t avgTimePerRequest: {}", nsToMs(snapshot.getMean()));
+    log.info("\t medianRequestTime: {}", nsToMs(snapshot.getMedian()));
+    log.info("\t 75thPctlRequestTime: {}", nsToMs(snapshot.get75thPercentile()));
+    log.info("\t 95thPctlRequestTime: {}", nsToMs(snapshot.get95thPercentile()));
+    log.info("\t 99thPctlRequestTime: {}", nsToMs(snapshot.get99thPercentile()));
+    log.info("\t 999thPctlRequestTime: {}", nsToMs(snapshot.get999thPercentile()));
+  }
+
+  private static long nsToMs(double ns) {
+    return TimeUnit.NANOSECONDS.convert((long)ns, TimeUnit.MILLISECONDS);
   }
 
   private void close(MockZKController mockController) {

--- a/solr/core/src/test/org/apache/solr/core/RequestHandlersTest.java
+++ b/solr/core/src/test/org/apache/solr/core/RequestHandlersTest.java
@@ -108,8 +108,8 @@ public class RequestHandlersTest extends SolrTestCaseJ4 {
     NamedList updateStats = updateHandler.getStatistics();
     NamedList termStats = termHandler.getStatistics();
 
-    Double updateTime = (Double) updateStats.get("totalTime");
-    Double termTime = (Double) termStats.get("totalTime");
+    Double updateTime = (Double) updateStats.get("avgTimePerRequest");
+    Double termTime = (Double) termStats.get("avgTimePerRequest");
 
     assertFalse("RequestHandlers should not share statistics!", updateTime.equals(termTime));
   }

--- a/solr/core/src/test/org/apache/solr/core/RequestHandlersTest.java
+++ b/solr/core/src/test/org/apache/solr/core/RequestHandlersTest.java
@@ -16,9 +16,12 @@
  */
 package org.apache.solr.core;
 
+import com.codahale.metrics.SharedMetricRegistries;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.util.NamedList;
+import org.apache.solr.handler.RequestHandlerBase;
 import org.apache.solr.request.SolrRequestHandler;
+import org.apache.solr.util.stats.Metrics;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -112,5 +115,8 @@ public class RequestHandlersTest extends SolrTestCaseJ4 {
     Double termTime = (Double) termStats.get("avgTimePerRequest");
 
     assertFalse("RequestHandlers should not share statistics!", updateTime.equals(termTime));
+
+    assertTrue("Named RequestHandlers should use a shared registry",
+        Metrics.registryFor(RequestHandlerBase.REGISTRY_NAME).getNames().contains(Metrics.mkName(updateHandler.getClass(), "/update")));
   }
 }

--- a/solr/core/src/test/org/apache/solr/util/stats/MetricsTest.java
+++ b/solr/core/src/test/org/apache/solr/util/stats/MetricsTest.java
@@ -1,0 +1,72 @@
+package org.apache.solr.util.stats;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.IOException;
+
+import com.codahale.metrics.SharedMetricRegistries;
+import org.apache.lucene.util.LuceneTestCase;
+import org.junit.Test;
+import com.codahale.metrics.Timer;
+
+public class MetricsTest   extends LuceneTestCase {
+
+  @Test
+  public void testSharedRegistryUse() throws IOException {
+
+    Timer t1 = Metrics.namedTimer("timer1");
+    assertTrue(SharedMetricRegistries.names().contains(Metrics.DEFAULT_REGISTRY));
+    assertTrue(SharedMetricRegistries.getOrCreate(Metrics.DEFAULT_REGISTRY).getNames().contains("timer1"));
+    SharedMetricRegistries.getOrCreate(Metrics.DEFAULT_REGISTRY).remove("timer1");
+
+    Timer t2 = Metrics.namedTimer("timer2", "test");
+    assertTrue(
+        SharedMetricRegistries.getOrCreate(Metrics.mkName(Metrics.REGISTRY_NAME_PREFIX, "test"))
+            .getNames().contains("timer2")
+    );
+    SharedMetricRegistries.getOrCreate(Metrics.mkName(Metrics.REGISTRY_NAME_PREFIX, "test")).remove("timer2");
+  }
+
+  @Test
+  public void testOverridableSharedRegistryNaming() throws IOException {
+     try {
+       System.setProperty("solr.registry.default", "override1");
+       System.setProperty("solr.registry.test", "solr.registry.override1");
+
+       Timer t1 = Metrics.namedTimer("timer10");
+       Timer t2 = Metrics.namedTimer("timer11", "test");
+
+       assertTrue(
+           SharedMetricRegistries.getOrCreate(Metrics.mkName(Metrics.REGISTRY_NAME_PREFIX, "override1"))
+               .getNames().contains("timer10")
+       );
+       assertTrue(
+           SharedMetricRegistries.getOrCreate(Metrics.mkName(Metrics.REGISTRY_NAME_PREFIX, "override1"))
+               .getNames().contains("timer11")
+       );
+       SharedMetricRegistries.getOrCreate(Metrics.mkName(Metrics.REGISTRY_NAME_PREFIX, "override1")).remove("timer10");
+       SharedMetricRegistries.getOrCreate(Metrics.mkName(Metrics.REGISTRY_NAME_PREFIX, "override1")).remove("timer11");
+
+     }
+     finally {
+       System.clearProperty("solr.registry.default");
+       System.clearProperty("solr.registry.test");
+     }
+  }
+
+}


### PR DESCRIPTION
There were three main areas that used the copied classes in org.apache.solr.util.stats:
- AnalyticsStatisticsCollector
- Overseer.Stats
- RequestHandlerBase

This patch adds depreciation tags to all the copied classes, and also replaces all usage of those classes with classes from the Metrics library.
I added one new class (org.apache.solr.util.stats.Metrics) to provide some common access patterns for metrics gathering.

This patch only adds Registry-based tracking to RequestHandlerBase, although all three areas are a fit for it. The effect is that all one needs to do is add a Reporter to the SharedMetricRegistry named “solr.registry.requesthandler” and all named request handler stats will be exported automatically.

Compatibility notes:
- The “totalTime” stat has been deleted from all three areas. This never seemed very useful, and Metrics didn’t support it in the Timer class, so it would have required some extra code to keep.
- RequestHandler stats are now persistent, and will no longer reset on reload.
