### PR TITLE
Solr snapshots

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/ShardRequestProcessor.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ShardRequestProcessor.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.cloud;
+
+import static org.apache.solr.common.params.CommonAdminParams.ASYNC;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.solr.client.solrj.SolrResponse;
+import org.apache.solr.client.solrj.impl.HttpSolrClient.RemoteSolrException;
+import org.apache.solr.common.SolrException;
+import org.apache.solr.common.SolrException.ErrorCode;
+import org.apache.solr.common.cloud.ZkStateReader;
+import org.apache.solr.common.params.CoreAdminParams;
+import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.common.params.CoreAdminParams.CoreAdminAction;
+import org.apache.solr.common.util.NamedList;
+import org.apache.solr.common.util.SimpleOrderedMap;
+import org.apache.solr.handler.component.ShardHandler;
+import org.apache.solr.handler.component.ShardRequest;
+import org.apache.solr.handler.component.ShardResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class provides functionality required to invoke operations for Solr collection replicas
+ * and process the results of those operations.
+ * TODO - Needs to cleanup this class as well as OverseerCollectionMessageHandler
+ */
+public class ShardRequestProcessor {
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private final ShardHandler shardHandler;
+  private final String adminPath;
+  private final ZkStateReader zkStateReader;
+  private final String asyncId;
+  private final Map<String, String> requestMap = new HashMap<>();
+
+  public ShardRequestProcessor(ShardHandler shardHandler, String adminPath, ZkStateReader zkStateReader, String asyncId) {
+    this.shardHandler = shardHandler;
+    this.adminPath = adminPath;
+    this.zkStateReader = zkStateReader;
+    this.asyncId = asyncId;
+  }
+
+  public ZkStateReader getZkStateReader() {
+    return zkStateReader;
+  }
+
+  public void sendShardRequest(String nodeName, ModifiableSolrParams params) {
+    if (asyncId != null) {
+      String coreAdminAsyncId = asyncId + Math.abs(System.nanoTime());
+      params.set(ASYNC, coreAdminAsyncId);
+      requestMap.put(nodeName, coreAdminAsyncId);
+    }
+
+    ShardRequest sreq = new ShardRequest();
+    params.set("qt", adminPath);
+    sreq.purpose = 1;
+    String replica = zkStateReader.getBaseUrlForNodeName(nodeName);
+    sreq.shards = new String[]{replica};
+    sreq.actualShards = sreq.shards;
+    sreq.nodeName = nodeName;
+    sreq.params = params;
+
+    shardHandler.submit(sreq, replica, sreq.params);
+  }
+
+  public NamedList processResponses(boolean abortOnError, String msgOnError, Set<String> okayExceptions) {
+    NamedList results = new NamedList<>();
+    // Processes all shard responses
+    ShardResponse srsp;
+    do {
+      srsp = shardHandler.takeCompletedOrError();
+      if (srsp != null) {
+        processResponse(results, srsp, okayExceptions);
+        Throwable exception = srsp.getException();
+        if (abortOnError && exception != null) {
+          // drain pending requests
+          while (srsp != null) {
+            srsp = shardHandler.takeCompletedOrError();
+          }
+          throw new SolrException(ErrorCode.SERVER_ERROR, msgOnError, exception);
+        }
+      }
+    } while (srsp != null);
+
+    // If request is async wait for the core admin to complete before returning
+    if (asyncId != null) {
+      waitForAsyncCallsToComplete(requestMap, results);
+      requestMap.clear();
+    }
+
+    return results;
+  }
+
+  private void processResponse(NamedList results, ShardResponse srsp, Set<String> okayExceptions) {
+    Throwable e = srsp.getException();
+    String nodeName = srsp.getNodeName();
+    SolrResponse solrResponse = srsp.getSolrResponse();
+    String shard = srsp.getShard();
+
+    processResponse(results, e, nodeName, solrResponse, shard, okayExceptions);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void processResponse(NamedList results, Throwable e, String nodeName, SolrResponse solrResponse, String shard, Set<String> okayExceptions) {
+    String rootThrowable = null;
+    if (e instanceof RemoteSolrException) {
+      rootThrowable = ((RemoteSolrException) e).getRootThrowable();
+    }
+
+    if (e != null && (rootThrowable == null || !okayExceptions.contains(rootThrowable))) {
+      log.error("Error from shard: " + shard, e);
+
+      SimpleOrderedMap failure = (SimpleOrderedMap) results.get("failure");
+      if (failure == null) {
+        failure = new SimpleOrderedMap();
+        results.add("failure", failure);
+      }
+
+      failure.add(nodeName, e.getClass().getName() + ":" + e.getMessage());
+
+    } else {
+
+      SimpleOrderedMap success = (SimpleOrderedMap) results.get("success");
+      if (success == null) {
+        success = new SimpleOrderedMap();
+        results.add("success", success);
+      }
+
+      success.add(nodeName, solrResponse.getResponse());
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private void waitForAsyncCallsToComplete(Map<String, String> requestMap, NamedList results) {
+    for (String k:requestMap.keySet()) {
+      log.debug("I am Waiting for :{}/{}", k, requestMap.get(k));
+      results.add(requestMap.get(k), waitForCoreAdminAsyncCallToComplete(k, requestMap.get(k)));
+    }
+  }
+
+  private NamedList waitForCoreAdminAsyncCallToComplete(String nodeName, String requestId) {
+    ModifiableSolrParams params = new ModifiableSolrParams();
+    params.set(CoreAdminParams.ACTION, CoreAdminAction.REQUESTSTATUS.toString());
+    params.set(CoreAdminParams.REQUESTID, requestId);
+    int counter = 0;
+    ShardRequest sreq;
+    do {
+      sreq = new ShardRequest();
+      params.set("qt", adminPath);
+      sreq.purpose = 1;
+      String replica = zkStateReader.getBaseUrlForNodeName(nodeName);
+      sreq.shards = new String[] {replica};
+      sreq.actualShards = sreq.shards;
+      sreq.params = params;
+
+      shardHandler.submit(sreq, replica, sreq.params);
+
+      ShardResponse srsp;
+      do {
+        srsp = shardHandler.takeCompletedOrError();
+        if (srsp != null) {
+          NamedList results = new NamedList();
+          processResponse(results, srsp, Collections.emptySet());
+          String r = (String) srsp.getSolrResponse().getResponse().get("STATUS");
+          if (r.equals("running")) {
+            log.debug("The task is still RUNNING, continuing to wait.");
+            try {
+              Thread.sleep(1000);
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+            }
+            continue;
+
+          } else if (r.equals("completed")) {
+            log.debug("The task is COMPLETED, returning");
+            return srsp.getSolrResponse().getResponse();
+          } else if (r.equals("failed")) {
+            // TODO: Improve this. Get more information.
+            log.debug("The task is FAILED, returning");
+            return srsp.getSolrResponse().getResponse();
+          } else if (r.equals("notfound")) {
+            log.debug("The task is notfound, retry");
+            if (counter++ < 5) {
+              try {
+                Thread.sleep(1000);
+              } catch (InterruptedException e) {
+              }
+              break;
+            }
+            throw new SolrException(ErrorCode.BAD_REQUEST, "Invalid status request for requestId: " + requestId + "" + srsp.getSolrResponse().getResponse().get("STATUS") +
+                "retried " + counter + "times");
+          } else {
+            throw new SolrException(ErrorCode.BAD_REQUEST, "Invalid status request " + srsp.getSolrResponse().getResponse().get("STATUS"));
+          }
+        }
+      } while (srsp != null);
+    } while(true);
+  }
+}

--- a/solr/core/src/java/org/apache/solr/core/backup/BackupManager.java
+++ b/solr/core/src/java/org/apache/solr/core/backup/BackupManager.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.core.backup;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.net.URI;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Properties;
+
+import org.apache.lucene.util.Version;
+import org.apache.solr.common.SolrException;
+import org.apache.solr.common.SolrException.ErrorCode;
+import org.apache.solr.common.cloud.DocCollection;
+import org.apache.solr.common.cloud.ZkStateReader;
+import org.apache.solr.common.util.Utils;
+import org.apache.solr.core.backup.repository.BackupRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * This class implements functionality to create a backup with extension points provided
+ * to integrate with different types of file-systems.
+ */
+public class BackupManager {
+  protected static Logger log = LoggerFactory.getLogger(BackupManager.class);
+  public static final String COLLECTION_PROPS_FILE = "collection_state.json";
+  public static final String BACKUP_PROPS_FILE = "backup.properties";
+  public static final String ZK_STATE_DIR = "zk_backup";
+  public static final String CONFIG_STATE_DIR = "configs";
+
+  // Backup properties
+  public static final String COLLECTION_NAME_PROP = "collection";
+  public static final String BACKUP_ID_PROP = "backupId";
+  public static final String COLLECTION_CONFIG_NAME_PROP = "collection.configName";
+  public static final String INDEX_VERSION_PROP = "index.version";
+  // version of the backup implementation. Defined to enable backwards compatibility
+  public static final String VERSION_PROP = "version";
+
+  protected final ZkStateReader zkStateReader;
+  protected final String collectionName;
+  protected final BackupRepository repository;
+  protected final IndexBackupStrategy strategy;
+
+  public BackupManager(BackupRepository repository, IndexBackupStrategy strategy, ZkStateReader zkStateReader,
+      String collectionName) {
+    this.repository = Preconditions.checkNotNull(repository);
+    this.strategy = Preconditions.checkNotNull(strategy);
+    this.zkStateReader = Preconditions.checkNotNull(zkStateReader);
+    this.collectionName = Preconditions.checkNotNull(collectionName);
+  }
+
+  /**
+   * @return The version of this backup implementation.
+   */
+  public final String getVersion() {
+    return "1.0";
+  }
+
+  /**
+   * This method implements the backup functionality.
+   *
+   * @param backupId The unique name for the backup to be created
+   * @throws IOException in case of errors
+   */
+  public final void createBackup(String backupId) throws IOException {
+    Preconditions.checkNotNull(backupId);
+
+    // Fetch the collection state (and validate its existence).
+    DocCollection collectionState = zkStateReader.getClusterState().getCollection(collectionName);
+
+    // Backup location
+    URI backupPath = repository.createURI(backupId);
+
+    if(repository.exists(backupPath)) {
+      throw new SolrException(ErrorCode.SERVER_ERROR, "The backup directory already exists " + backupPath);
+    }
+
+    // Create a directory to store backup details.
+    repository.createDirectory(backupPath);
+
+    try {
+      // Backup the index data.
+      log.info("Starting backup of collection={} with backupName={} at location={}", collectionName, backupId,
+          backupPath);
+      strategy.createBackup(backupPath, collectionName, backupId);
+
+      log.info("Starting to backup ZK data for backupName={}", backupId);
+
+      // Save the configset for the collection
+      String configName = zkStateReader.readConfigName(collectionName);
+      URI configPath = repository.createURI(backupId, ZK_STATE_DIR, CONFIG_STATE_DIR, configName);
+      downloadConfigDir(configName, configPath);
+
+      Properties props = new Properties();
+      props.setProperty(COLLECTION_NAME_PROP, collectionName);
+      props.setProperty(BACKUP_ID_PROP, backupId);
+      props.put(COLLECTION_CONFIG_NAME_PROP, configName);
+      props.put(INDEX_VERSION_PROP, Version.LATEST.toString());
+      props.put(VERSION_PROP, getVersion());
+
+      try ( Writer propsWriter = new OutputStreamWriter(repository.createOutput(repository.createURI(backupId, BACKUP_PROPS_FILE)));
+            OutputStream collectionStateOs = repository.createOutput(repository.createURI(backupId, ZK_STATE_DIR, COLLECTION_PROPS_FILE))) {
+        collectionStateOs.write(Utils.toJSON(Collections.singletonMap(collectionName, collectionState)));
+        props.store(propsWriter, null);
+      }
+
+      log.info("Completed backing up ZK data for backupName={}", backupId);
+    } catch (IOException ex) {
+      log.error("Unable to create a snapshot...", ex);
+      try {
+        log.info("Cleaning up the snapshot " + backupId + " for collection " + collectionName);
+        deleteBackup(backupId);
+      } catch (IOException e) {
+        log.error("Failed to cleanup a snapshot...", e);
+      }
+    }
+  }
+
+  /**
+   * @param backupId The name for the backup to be deleted
+   * @throws IOException in case of errors
+   */
+  public void deleteBackup(String backupId) throws IOException {
+    // Backup location
+    URI backupPath = repository.createURI(backupId);
+    repository.deleteDirectory(backupPath);
+  }
+
+  private void downloadConfigDir(String configName, URI dest) throws IOException {
+    // TODO - Enable copying ZK data to other file-systems too.
+    zkStateReader.getConfigManager().downloadConfigDir(configName, Paths.get(dest));
+  }
+}

--- a/solr/core/src/java/org/apache/solr/core/backup/CopyFilesStrategy.java
+++ b/solr/core/src/java/org/apache/solr/core/backup/CopyFilesStrategy.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.core.backup;
+
+import static org.apache.solr.common.cloud.ZkStateReader.CORE_NAME_PROP;
+import static org.apache.solr.common.params.CommonParams.NAME;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.Collections;
+
+import org.apache.solr.cloud.ShardRequestProcessor;
+import org.apache.solr.common.cloud.Replica;
+import org.apache.solr.common.cloud.Slice;
+import org.apache.solr.common.cloud.ZkStateReader;
+import org.apache.solr.common.params.CoreAdminParams;
+import org.apache.solr.common.params.CoreAdminParams.CoreAdminAction;
+import org.apache.solr.common.params.ModifiableSolrParams;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A concrete implementation of {@linkplain IndexBackupStrategy} which copies files associated
+ * with the index commit to the specified location.
+ */
+public class CopyFilesStrategy implements IndexBackupStrategy {
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private final ShardRequestProcessor processor;
+
+  public CopyFilesStrategy(ShardRequestProcessor processor) {
+    this.processor = processor;
+  }
+
+  @Override
+  public void createBackup(URI basePath, String collectionName, String backupName) {
+    ZkStateReader zkStateReader = processor.getZkStateReader();
+
+    for (Slice slice : zkStateReader.getClusterState().getCollection(collectionName).getActiveSlices()) {
+      Replica replica = slice.getLeader();
+      String coreName = replica.getStr(CORE_NAME_PROP);
+
+      ModifiableSolrParams params = new ModifiableSolrParams();
+      params.set(CoreAdminParams.ACTION, CoreAdminAction.BACKUPCORE.toString());
+      params.set(NAME, slice.getName());
+      // TODO - Fix the core level BACKUP operation to accept a URI so that it can also work with other file-systems.
+      params.set("location", basePath.getPath()); // note: index dir will be here then the "snapshot." + slice name
+      params.set(CORE_NAME_PROP, coreName);
+
+      processor.sendShardRequest(replica.getNodeName(), params);
+      log.debug("Sent backup request to core={} for backupname={}", coreName, backupName);
+    }
+
+    processor.processResponses( true, "Could not backup all replicas", Collections.emptySet());
+  }
+}

--- a/solr/core/src/java/org/apache/solr/core/backup/IndexBackupStrategy.java
+++ b/solr/core/src/java/org/apache/solr/core/backup/IndexBackupStrategy.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.core.backup;
+
+import java.net.URI;
+
+/**
+ * This interface defines the strategy used to backup the Solr collection index data.
+ */
+public interface IndexBackupStrategy {
+  /**
+   * Backups the index data for specified Solr collection at the given location.
+   *
+   * @param basePath The base location where the backup needs to be stored.
+   * @param collectionName The name of the collection which needs to be backed up.
+   * @param backupName The unique name of the backup.
+   */
+  public void createBackup(URI basePath, String collectionName, String backupName);
+}

--- a/solr/core/src/java/org/apache/solr/core/backup/repository/BackupRepository.java
+++ b/solr/core/src/java/org/apache/solr/core/backup/repository/BackupRepository.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.core.backup.repository;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+
+public interface BackupRepository {
+  /**
+   * This method creates a URI using the specified base location (during object creation) and the path
+   * components (as method arguments).
+   * @param pathComponents The directory (or file-name) to be included in the URI.
+   * @return A URI containing absolute path
+   */
+   URI createURI(String... pathComponents);
+
+   /**
+    * This method returns a {@linkplain OutputStream} instance for the specified <code>path</code>
+    *
+    * @param path The path for which {@linkplain OutputStream} needs to be created
+    * @return {@linkplain OutputStream} instance for the specified <code>path</code>
+    * @throws IOException in case of errors
+    */
+   OutputStream createOutput(URI path) throws IOException;
+
+  /**
+   * This method checks if the specified path exists in this repository.
+   *
+   * @param path The path whose existence needs to be checked.
+   * @return if the specified path exists in this repository.
+   * @throws IOException in case of errors
+   */
+  boolean exists(URI path) throws IOException;
+
+   /**
+    * This method creates a directory at the specified path.
+    *
+    * @param path The path where the directory needs to be created.
+    * @throws IOException in case of errors
+    */
+   void createDirectory(URI path) throws IOException;
+
+   /**
+    * This method deletes a directory at the specified path.
+    *
+    * @param path The path referring to the directory to be deleted.
+    * @throws IOException  in case of errors
+    */
+   void deleteDirectory(URI path) throws IOException;
+}

--- a/solr/core/src/java/org/apache/solr/core/backup/repository/BackupRepositoryFactory.java
+++ b/solr/core/src/java/org/apache/solr/core/backup/repository/BackupRepositoryFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.core.backup.repository;
+
+import java.net.URI;
+import com.google.common.base.Preconditions;
+
+public class BackupRepositoryFactory {
+  public static BackupRepository create(URI baseLocation) {
+    Preconditions.checkNotNull(baseLocation);
+
+    String scheme = baseLocation.getScheme();
+    if("file".equalsIgnoreCase(scheme)) {
+      return new LocalFileSystemRepository(baseLocation);
+    }
+    throw new UnsupportedOperationException("Backup operation is not supported for specified URI: " + baseLocation);
+  }
+
+}

--- a/solr/core/src/java/org/apache/solr/core/backup/repository/LocalFileSystemRepository.java
+++ b/solr/core/src/java/org/apache/solr/core/backup/repository/LocalFileSystemRepository.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.core.backup.repository;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+public class LocalFileSystemRepository implements BackupRepository {
+  private final URI baseLocation;
+
+  public LocalFileSystemRepository(URI baseLocation) {
+    this.baseLocation = baseLocation;
+  }
+
+  @Override
+  public URI createURI(String... pathComponents) {
+    Path result = Paths.get(baseLocation);
+    for(String path : pathComponents) {
+      result = result.resolve(path);
+    }
+    return result.toUri();
+  }
+
+  @Override
+  public void createDirectory(URI path) throws IOException {
+    Files.createDirectory(Paths.get(path));
+  }
+
+  @Override
+  public void deleteDirectory(URI path) throws IOException {
+    Files.walkFileTree(Paths.get(path), new SimpleFileVisitor<Path>() {
+      @Override
+      public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+          throws IOException {
+        Files.delete(file);
+        return FileVisitResult.CONTINUE;
+      }
+      @Override
+      public FileVisitResult postVisitDirectory(Path dir, IOException exc)
+          throws IOException {
+        Files.delete(dir);
+        return FileVisitResult.CONTINUE;
+      }
+    });
+  }
+
+  @Override
+  public boolean exists(URI path) throws IOException {
+    return Files.exists(Paths.get(path));
+  }
+
+  @Override
+  public OutputStream createOutput(URI path) throws IOException {
+    return Files.newOutputStream(Paths.get(path));
+  }
+}


### PR DESCRIPTION
Refactor the Solr collection backup implementation (refactoring "restore" implementation in progress).

Following changes introduced
- Added Solr/Lucene version to check the compatibility between the backup version and the version of Solr on which it is being restored.
- Similarly added a backup implementation version to check the compatibility between the "restore" implementation and backup format.
- Introduced a Strategy interface to define how the Solr index data is backed up (e.g. using file copy approach).
- Introduced a Repository interface to define the file-system used to store the backup data. (currently works only with local file system but can be extended).
