### PR TITLE
[SOLR-9341] GC logs go to SOLR_LOGS_DIR on Windows

### DIFF
--- a/solr/bin/solr.cmd
+++ b/solr/bin/solr.cmd
@@ -714,7 +714,7 @@ IF "%STOP_KEY%"=="" set STOP_KEY=solrrocks
 
 @REM This is quite hacky, but examples rely on a different log4j.properties
 @REM so that we can write logs for examples to %SOLR_HOME%\..\logs
-set "SOLR_LOGS_DIR=%SOLR_SERVER_DIR%\logs"
+if not defined SOLR_LOGS_DIR set "SOLR_LOGS_DIR=%SOLR_SERVER_DIR%\logs"
 set "EXAMPLE_DIR=%SOLR_TIP%\example"
 set TMP=!SOLR_HOME:%EXAMPLE_DIR%=!
 IF NOT "%TMP%"=="%SOLR_HOME%" (


### PR DESCRIPTION
Don't override the SOLR_LOGS_DIR environment variable when it has already been set.  This brings the windows behaviour in line with the bash script.