### PR TITLE
SOLR-8911: Angular Admin UI: Fix cut-off overflow strings on dashboard page

### DIFF
--- a/solr/webapp/web/css/angular/index.css
+++ b/solr/webapp/web/css/angular/index.css
@@ -110,6 +110,17 @@ limitations under the License.
   width: 40%;
 }
 
+#content #index .data
+{
+	padding-bottom: 12px;
+	overflow: hidden;
+}
+
+#content #index .data:hover
+{
+	overflow-x: auto;
+}
+
 #content #index .data li
 {
   padding-top: 3px;
@@ -127,7 +138,6 @@ limitations under the License.
 {
   float: right;
   text-overflow: ellipsis;
-  overflow: hidden;
   white-space: nowrap;
   width: 80%
 }

--- a/solr/webapp/web/js/angular/controllers/schema.js
+++ b/solr/webapp/web/js/angular/controllers/schema.js
@@ -475,6 +475,11 @@ var getFieldProperties = function(data, core, is, field) {
     // identify rows and cell values in field property table:
     for (var i in display.rows) {
         var row = display.rows[i];
+
+		if (!row.flags) {
+			continue; //Match the special case in the LukeRequestHandler
+		}
+
         row.cells = [];
 
         for (var j in display.columns) {


### PR DESCRIPTION
Fix too long value strings in the dashboard page (primarily versions and args sections) by adding overflow scrolling. The scrollbar appears when hovered or touched on the individual value area.

Tested on several browsers on Mac, Windows and Android. On Windows, the scrollbar makes the page jump a little bit for the args section, but is quite usable. On Mac and Android, the scrollbar is inside the area and does not cause a jump.