### PR TITLE
SOLR-8645: managed-schema is XML type

### DIFF
--- a/solr/webapp/web/js/angular/controllers/cloud.js
+++ b/solr/webapp/web/js/angular/controllers/cloud.js
@@ -55,6 +55,11 @@ var treeSubController = function($scope, Zookeeper) {
             var path = data.znode.path.split( '.' );
             if(path.length >1) {
               $scope.lang = path.pop();
+            } else {
+              var lastPathElement = data.znode.path.split( '/' ).pop();
+              if (lastPathElement == "managed-schema") {
+                  $scope.lang = "xml";
+              }
             }
             $scope.showData = true;
         });


### PR DESCRIPTION
Cover the special case of no-extension known-name file. 
It was already done in the Files view, but missed in the Cloud/Tree one.