### PR TITLE
SOLR-8379: Text file extension is 'txt'

### DIFF
--- a/solr/webapp/web/js/angular/app.js
+++ b/solr/webapp/web/js/angular/app.js
@@ -148,7 +148,7 @@ solrAdminApp.config([
 })
 .filter('highlight', function($sce) {
   return function(input, lang) {
-    if (lang && input && lang!="text") return hljs.highlight(lang, input).value;
+    if (lang && input && lang!="txt") return hljs.highlight(lang, input).value;
     return input;
   }
 })


### PR DESCRIPTION
The do-not-highlight comparison was expecting type to be text, but it is based on extension, so was actually 'txt'. This was causing a stack trace and aborted population of the content box.