### PR TITLE
[SOLR-9242] Fix unit test failure on Windows platform.

### DIFF
--- a/solr/core/src/test/org/apache/solr/cloud/TestLocalFSCloudBackupRestore.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestLocalFSCloudBackupRestore.java
@@ -16,7 +16,6 @@
  */
 package org.apache.solr.cloud;
 
-import org.apache.lucene.util.Constants;
 import org.junit.BeforeClass;
 
 /**
@@ -28,7 +27,7 @@ public class TestLocalFSCloudBackupRestore extends AbstractCloudBackupRestoreTes
 
   @BeforeClass
   public static void setupClass() throws Exception {
-    assumeFalse("Backup/Restore is currently buggy on Windows. Tracking the fix on SOLR-9242", Constants.WINDOWS);
+    //assumeFalse("Backup/Restore is currently buggy on Windows. Tracking the fix on SOLR-9242", Constants.WINDOWS);
     configureCluster(NUM_SHARDS)// nodes
         .addConfig("conf1", TEST_PATH().resolve("configsets").resolve("cloud-minimal").resolve("conf"))
         .configure();


### PR DESCRIPTION
The root cause of the failure is the usage of URI::getPath() method in the backup/restore functionality (e.g. in BackupManager::downloadFromZK OR in the OverseerCollectionMessageHandler::processBackupAction methods). On the Windows platform, usage of URI.getPath() returns an invalid path string (e.g.  URI file:///C:/lucene-solr/solr
returns /C:/lucene-solr/solr as the result of getPath() method).

Refer to following discussion for more details,
http://stackoverflow.com/questions/9834776/java-nio-file-path-issue

Since the caller may have used this method to generate the string representation for the pathComponents, we implement a work-around specifically for Windows platform to remove the leading '/' character.