### PR TITLE
SOLR-8146: Allowing SolrJ CloudSolrClient to have preferred replica for query/read

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/common/cloud/rule/ClientSnitchContext.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/rule/ClientSnitchContext.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.common.cloud.rule;
+
+import java.util.Map;
+
+import org.apache.solr.common.params.ModifiableSolrParams;
+
+public class ClientSnitchContext extends SnitchContext {
+
+  public ClientSnitchContext(SnitchInfo perSnitch, String node, Map<String,Object> session) {
+    super(perSnitch, node, session);
+  }
+
+  @Override
+  public Map getZkJson(String path) {
+    return null;
+  }
+
+  @Override
+  public void invokeRemote(String node, ModifiableSolrParams params, String klas, RemoteCallback callback) {}
+
+  
+  
+}

--- a/solr/solrj/src/java/org/apache/solr/common/params/CommonParams.java
+++ b/solr/solrj/src/java/org/apache/solr/common/params/CommonParams.java
@@ -257,5 +257,7 @@ public interface CommonParams {
 
   String NAME = "name";
   String VALUE_LONG = "val";
+
+  String ROUTING_RULE = "routingRule";
 }
 

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/CloudSolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/CloudSolrClientTest.java
@@ -607,6 +607,26 @@ public class CloudSolrClientTest extends SolrCloudTestCase {
       HttpClientUtil.close(client);
     }
   }
+  
+  @Test
+  public void routingRuleTest() throws Exception {
+
+    
+    
+    //TBD to look into mocking / create a cluster with some shards matching 
+    //routing rule and other do not. 
+  //  String collectionName = "CollectionWithSomeReplicasMatchingRoutingRules";
+  //  CloudSolrClient solrClient = cluster.getSolrClient();
+    
+  //  SolrQuery query = new SolrQuery("*:*");
+  //  query.add("routingRule","ip_4:11");
+  //  query.add("routingRule","ip_3:16");
+  //  QueryResponse response = solrClient.query(collectionName,query);
+    
+    //TBD to add assertions to check only matching shards gets added to 
+    // urlList for LoadBalancer to query
+    
+  }
 
   private static void checkSingleServer(NamedList<Object> response) {
     final CloudSolrClient.RouteResponse rr = (CloudSolrClient.RouteResponse) response;
@@ -619,5 +639,6 @@ public class CloudSolrClientTest extends SolrCloudTestCase {
             1, entry.getValue().getServers().size());
     }
   }
+  
 
 }


### PR DESCRIPTION
This pull request is to get feedback on the approach of implementing routingRule. 

The unit test is not ready yet as facing challenges on how to mock/ inject dependency to simulate a cluster with different IP addresses machines and only matching one gets added to urlList which ultimately gets passed to LBHttpSolrClient.
