### PR TITLE
SOLR-9399: Delete requests do not send credentials & fails for Basic Authentication

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/UpdateRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/UpdateRequest.java
@@ -321,6 +321,7 @@ public class UpdateRequest extends AbstractUpdateRequest {
           urequest.setParams(params);
           urequest.deleteById(deleteId, version);
           urequest.setCommitWithin(getCommitWithin());
+          urequest.setBasicAuthCredentials(getBasicAuthUser(), getBasicAuthPassword());
           request = new LBHttpSolrClient.Req(urequest, urls);
           routes.put(leaderUrl, request);
         }


### PR DESCRIPTION
This is a bug fix to set Authentication credential in case of delete requests.  

There is a duplicate code between update & delete requests which most likely has caused this issue and left to set credentials in case of delete requests.  I'll create a separate jira to refactor the code and also tests for authentication seems to be broken. 

The test class BasicAuthIntegrationTest doesn't have any test methods except the protected method doExtraTests which doesn't seems to be called from anywhere and delete tests needs to be added.
