### PR TITLE
LUCENE-7436: Changes MinHashFilter to have public constructor/defaults

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/minhash/MinHashFilter.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/minhash/MinHashFilter.java
@@ -49,11 +49,11 @@ public class MinHashFilter extends TokenFilter {
 
   private static final LongPair[] cachedIntHashes = new LongPair[HASH_CACHE_SIZE];
 
-  static final int DEFAULT_HASH_COUNT = 1;
+  public static final int DEFAULT_HASH_COUNT = 1;
 
-  static final int DEFAULT_HASH_SET_SIZE = 1;
+  public static final int DEFAULT_HASH_SET_SIZE = 1;
 
-  static final int DEFAULT_BUCKET_COUNT = 512;
+  public static final int DEFAULT_BUCKET_COUNT = 512;
 
   static final String MIN_HASH_TYPE = "MIN_HASH";
 
@@ -112,7 +112,7 @@ public class MinHashFilter extends TokenFilter {
    * @param hashSetSize the no. of min hashes to keep
    * @param withRotation whether rotate or not hashes while incrementing tokens
    */
-  MinHashFilter(TokenStream input, int hashCount, int bucketCount, int hashSetSize, boolean withRotation) {
+  public MinHashFilter(TokenStream input, int hashCount, int bucketCount, int hashSetSize, boolean withRotation) {
     super(input);
     this.hashCount = hashCount;
     this.bucketCount = bucketCount;


### PR DESCRIPTION
To use MinHashFilter directly, made constructor & defaults public
