### PR TITLE
SOLR-6246 - Fix core reload if suggester has been built.

### DIFF
--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/analyzing/AnalyzingInfixSuggester.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/analyzing/AnalyzingInfixSuggester.java
@@ -281,6 +281,8 @@ public class AnalyzingInfixSuggester extends Lookup implements Closeable {
       }
       searcherMgr = new SearcherManager(writer, null);
       success = true;
+      writer.close();
+      writer = null;
     } finally {
       if (success == false && writer != null) {
         writer.rollback();
@@ -293,10 +295,9 @@ public class AnalyzingInfixSuggester extends Lookup implements Closeable {
    *
    *  @see IndexWriter#commit */
   public void commit() throws IOException {
-    if (writer == null) {
-      throw new IllegalStateException("Cannot commit on an closed writer. Add documents first");
+    if (writer != null) {
+      writer.commit();
     }
-    writer.commit();
   }
 
   private Analyzer getGramAnalyzer() {


### PR DESCRIPTION
In my testing, it is not required to keep the writer open for the suggester to keep working.
Add and Update call ensureOpen, which will open a new writer if it has been set = null.
This change closes it at the end of a build and sets the reference = null such that
Add and Update will continue to work correctly. Additionally, commit is updated to not
throw if the writer is null. This is correct because nothing has been added or updated
since the last build.
The only thing I'm left with uncertainty about is reloading a core with NRT updates
pending. This would appear to still cause the issue to appear again. The difference being that
a rebuild would alleviate the issue. This requires additional thought.