### PR TITLE
SOLR-9668 Support cursor paging in SolrEntityProcessor

### DIFF
--- a/solr/contrib/dataimporthandler/src/test/org/apache/solr/handler/dataimport/TestSolrEntityProcessorEndToEnd.java
+++ b/solr/contrib/dataimporthandler/src/test/org/apache/solr/handler/dataimport/TestSolrEntityProcessorEndToEnd.java
@@ -260,7 +260,36 @@ public class TestSolrEntityProcessorEndToEnd extends AbstractDataImportHandlerTe
     
     assertQ(req("*:*"), "//result[@numFound='0']");
   }
-    
+
+  public void testFullImportCursorPaging() {
+    assertQ(req("*:*"), "//result[@numFound='0']");
+
+    try {
+      addDocumentsToSolr(generateSolrDocuments(7));
+      runFullImport(generateDIHConfig("query='*:*' sort='id asc' rows='2'", false));
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      fail(e.getMessage());
+    }
+
+    assertQ(req("*:*"), "//result[@numFound='7']");
+    assertQ(req("id:3"), "//result[@numFound='1']", "//result/doc/arr[@name='desc'][.='Description3']");
+  }
+
+  public void testFullImportCursorPagingInvalidSort() {
+    assertQ(req("*:*"), "//result[@numFound='0']");
+    try {
+      addDocumentsToSolr(generateSolrDocuments(7));
+      // will throw 'Cursor functionality requires a sort containing a uniqueKey field tie breaker'
+      runFullImport(generateDIHConfig("query='*:*' sort='date asc' rows='2'", false));
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      fail(e.getMessage());
+    }
+
+    assertQ(req("*:*"), "//result[@numFound='0']");
+  }
+
   private static List<Map<String,Object>> generateSolrDocuments(int num) {
     List<Map<String,Object>> docList = new ArrayList<>();
     for (int i = 1; i <= num; i++) {


### PR DESCRIPTION
SolrEntityProcessor paginates using the start and rows parameters which can be very inefficient at large offsets. In fact, the current implementation is impracticable to import large amounts of data (10M+ documents) because the data import rate degrades from 1000docs/second to 10docs/second and the import gets stuck.
This patch introduces support for cursor paging which offers more or less predictable performance. In my tests the time to fetch the 1st and 1000th pages was about the same and the data import rate was stable throughout the entire import.

To enable cursor paging a user needs to add a "sort" attribute in the entity configuration:
```xml
<?xml version="1.0" encoding="UTF-8" ?>
<dataConfig>
  <document>
    <entity name="se" processor="SolrEntityProcessor" 
    query="*:*"
    rows="1000"
    sort="id asc"  <!-- turns on cursor paging. Must be a uniqueKey field tie breaker --> 
    url="http://localhost:8983/solr/collection1">
    </entity>
  </document>
</dataConfig>
```
If the "sort" attribute is missing then the default start/rows pagination is used.