### PR TITLE
SOLR-9616 Return empty result, when expand component is used with empty result set.

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/ExpandComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/ExpandComponent.java
@@ -265,6 +265,12 @@ public class ExpandComponent extends SearchComponent implements PluginInfoInitia
     * This code gathers the group information for the current page.
     */
     List<LeafReaderContext> contexts = searcher.getTopReaderContext().leaves();
+
+    if(contexts.size() == 0) {
+      //When no context is available we can skip the expanding
+      return;
+    }
+
     int currentContext = 0;
     int currentDocBase = contexts.get(currentContext).docBase;
     int nextDocBase = (currentContext+1)<contexts.size() ? contexts.get(currentContext+1).docBase : Integer.MAX_VALUE;

--- a/solr/core/src/test/org/apache/solr/handler/component/TestExpandComponent.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/TestExpandComponent.java
@@ -314,4 +314,19 @@ public class TestExpandComponent extends SolrTestCaseJ4 {
     );
   }
 
+  @Test
+  public void testExpandWithEmptyIndexReturnsZeroResults() {
+    //We make sure the index is cleared
+
+    clearIndex();
+    assertU(commit());
+
+    ModifiableSolrParams params = new ModifiableSolrParams();
+    params.add("q", "*:*");
+    params.add("fq", "{!collapse field=group_s}");
+    params.add("expand" ,"true");
+    params.add("expand.rows", "10");
+
+    assertQ(req(params), "*[count(//doc)=0]");
+  }
 }


### PR DESCRIPTION
This pull request:

* Add's early return in expand component, when there is nothing to expand
* Add's a regression test for SOLR-9616

Since i am very new to the code i am not sure if this has any other side effects, by checking the other tests it looks good for me, but help is appreciated.