### PR TITLE
SOLR-9513 A generic Solr authentication plugin to integrate with Hadoop

### DIFF
--- a/solr/core/src/java/org/apache/solr/security/AttributeOnlyServletContext.java
+++ b/solr/core/src/java/org/apache/solr/security/AttributeOnlyServletContext.java
@@ -1,0 +1,291 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.security;
+
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.EventListener;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterRegistration;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.Servlet;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRegistration;
+import javax.servlet.SessionCookieConfig;
+import javax.servlet.SessionTrackingMode;
+import javax.servlet.FilterRegistration.Dynamic;
+import javax.servlet.descriptor.JspConfigDescriptor;
+
+/**
+ * A concrete implementation of {@linkplain ServletContext} which support only attributes.
+ */
+class AttributeOnlyServletContext implements ServletContext {
+  private Map<String, Object> attributes = new HashMap<String, Object>();
+
+  @Override
+  public void setSessionTrackingModes(Set<SessionTrackingMode> sessionTrackingModes) {}
+
+  @Override
+  public boolean setInitParameter(String name, String value) {
+    return false;
+  }
+
+  @Override
+  public void setAttribute(String name, Object object) {
+    attributes.put(name, object);
+  }
+
+  @Override
+  public void removeAttribute(String name) {
+    attributes.remove(name);
+  }
+
+  @Override
+  public void log(String message, Throwable throwable) {}
+
+  @Override
+  public void log(Exception exception, String msg) {}
+
+  @Override
+  public void log(String msg) {}
+
+  @Override
+  public String getVirtualServerName() {
+    return null;
+  }
+
+  @Override
+  public SessionCookieConfig getSessionCookieConfig() {
+    return null;
+  }
+
+  @Override
+  public Enumeration<Servlet> getServlets() {
+    return null;
+  }
+
+  @Override
+  public Map<String,? extends ServletRegistration> getServletRegistrations() {
+    return null;
+  }
+
+  @Override
+  public ServletRegistration getServletRegistration(String servletName) {
+    return null;
+  }
+
+  @Override
+  public Enumeration<String> getServletNames() {
+    return null;
+  }
+
+  @Override
+  public String getServletContextName() {
+    return null;
+  }
+
+  @Override
+  public Servlet getServlet(String name) throws ServletException {
+    return null;
+  }
+
+  @Override
+  public String getServerInfo() {
+    return null;
+  }
+
+  @Override
+  public Set<String> getResourcePaths(String path) {
+    return null;
+  }
+
+  @Override
+  public InputStream getResourceAsStream(String path) {
+    return null;
+  }
+
+  @Override
+  public URL getResource(String path) throws MalformedURLException {
+    return null;
+  }
+
+  @Override
+  public RequestDispatcher getRequestDispatcher(String path) {
+    return null;
+  }
+
+  @Override
+  public String getRealPath(String path) {
+    return null;
+  }
+
+  @Override
+  public RequestDispatcher getNamedDispatcher(String name) {
+    return null;
+  }
+
+  @Override
+  public int getMinorVersion() {
+    return 0;
+  }
+
+  @Override
+  public String getMimeType(String file) {
+    return null;
+  }
+
+  @Override
+  public int getMajorVersion() {
+    return 0;
+  }
+
+  @Override
+  public JspConfigDescriptor getJspConfigDescriptor() {
+    return null;
+  }
+
+  @Override
+  public Enumeration<String> getInitParameterNames() {
+    return null;
+  }
+
+  @Override
+  public String getInitParameter(String name) {
+    return null;
+  }
+
+  @Override
+  public Map<String,? extends FilterRegistration> getFilterRegistrations() {
+    return null;
+  }
+
+  @Override
+  public FilterRegistration getFilterRegistration(String filterName) {
+    return null;
+  }
+
+  @Override
+  public Set<SessionTrackingMode> getEffectiveSessionTrackingModes() {
+    return null;
+  }
+
+  @Override
+  public int getEffectiveMinorVersion() {
+    return 0;
+  }
+
+  @Override
+  public int getEffectiveMajorVersion() {
+    return 0;
+  }
+
+  @Override
+  public Set<SessionTrackingMode> getDefaultSessionTrackingModes() {
+    return null;
+  }
+
+  @Override
+  public String getContextPath() {
+    return null;
+  }
+
+  @Override
+  public ServletContext getContext(String uripath) {
+    return null;
+  }
+
+  @Override
+  public ClassLoader getClassLoader() {
+    return null;
+  }
+
+  @Override
+  public Enumeration<String> getAttributeNames() {
+    return Collections.enumeration(attributes.keySet());
+  }
+
+  @Override
+  public Object getAttribute(String name) {
+    return attributes.get(name);
+  }
+
+  @Override
+  public void declareRoles(String... roleNames) {}
+
+  @Override
+  public <T extends Servlet> T createServlet(Class<T> clazz) throws ServletException {
+    return null;
+  }
+
+  @Override
+  public <T extends EventListener> T createListener(Class<T> clazz) throws ServletException {
+    return null;
+  }
+
+  @Override
+  public <T extends Filter> T createFilter(Class<T> clazz) throws ServletException {
+    return null;
+  }
+
+  @Override
+  public javax.servlet.ServletRegistration.Dynamic addServlet(String servletName, Class<? extends Servlet> servletClass) {
+    return null;
+  }
+
+  @Override
+  public javax.servlet.ServletRegistration.Dynamic addServlet(String servletName, Servlet servlet) {
+    return null;
+  }
+
+  @Override
+  public javax.servlet.ServletRegistration.Dynamic addServlet(String servletName, String className) {
+    return null;
+  }
+
+  @Override
+  public void addListener(Class<? extends EventListener> listenerClass) {}
+
+  @Override
+  public <T extends EventListener> void addListener(T t) {}
+
+  @Override
+  public void addListener(String className) {}
+
+  @Override
+  public Dynamic addFilter(String filterName, Class<? extends Filter> filterClass) {
+    return null;
+  }
+
+  @Override
+  public Dynamic addFilter(String filterName, Filter filter) {
+    return null;
+  }
+
+  @Override
+  public Dynamic addFilter(String filterName, String className) {
+    return null;
+  }
+}

--- a/solr/core/src/java/org/apache/solr/security/ConfigurableInternodeAuthHadoopPlugin.java
+++ b/solr/core/src/java/org/apache/solr/security/ConfigurableInternodeAuthHadoopPlugin.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.security;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.apache.solr.client.solrj.impl.HttpClientBuilderFactory;
+import org.apache.solr.client.solrj.impl.SolrHttpClientBuilder;
+import org.apache.solr.core.CoreContainer;
+
+/**
+ * This class extends {@linkplain HadoopAuthPlugin} by enabling configuration of
+ * authentication mechanism for Solr internal communication.
+ **/
+public class ConfigurableInternodeAuthHadoopPlugin extends HadoopAuthPlugin implements HttpClientBuilderPlugin {
+
+  /**
+   * A property specifying the {@linkplain HttpClientBuilderFactory} used for the Solr internal
+   * communication.
+   */
+  private static final String HTTPCLIENT_BUILDER_FACTORY = "clientBuilderFactory";
+
+  private HttpClientBuilderFactory factory = null;
+
+  public ConfigurableInternodeAuthHadoopPlugin(CoreContainer coreContainer) {
+    super(coreContainer);
+  }
+
+  @Override
+  public void init(Map<String,Object> pluginConfig) {
+    super.init(pluginConfig);
+
+    String httpClientBuilderFactory = (String)Objects.requireNonNull(pluginConfig.get(HTTPCLIENT_BUILDER_FACTORY),
+        "Please specify clientBuilderFactory to be used for Solr internal communication.");
+    factory = this.coreContainer.getResourceLoader().newInstance(httpClientBuilderFactory, HttpClientBuilderFactory.class);
+  }
+
+  @Override
+  public SolrHttpClientBuilder getHttpClientBuilder(SolrHttpClientBuilder builder) {
+    return factory.getHttpClientBuilder(Optional.ofNullable(builder));
+  }
+
+  @Override
+  public void close() throws IOException {
+    super.close();
+
+    if (factory != null) {
+      factory.close();
+    }
+  }
+}

--- a/solr/core/src/java/org/apache/solr/security/GenericHadoopAuthPlugin.java
+++ b/solr/core/src/java/org/apache/solr/security/GenericHadoopAuthPlugin.java
@@ -1,0 +1,266 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.security;
+
+import static org.apache.solr.security.RequestContinuesRecorderAuthenticationHandler.REQUEST_CONTINUES_ATTR;
+import static org.apache.solr.security.HadoopAuthFilter.DELEGATION_TOKEN_ZK_CLIENT;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.lang.invoke.MethodHandles;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
+
+import org.apache.commons.collections.iterators.IteratorEnumeration;
+import org.apache.hadoop.security.authentication.server.AuthenticationFilter;
+import org.apache.solr.client.solrj.impl.HttpClientBuilderFactory;
+import org.apache.solr.client.solrj.impl.Krb5HttpClientBuilder;
+import org.apache.solr.client.solrj.impl.SolrHttpClientBuilder;
+import org.apache.solr.cloud.ZkController;
+import org.apache.solr.common.SolrException;
+import org.apache.solr.common.SolrException.ErrorCode;
+import org.apache.solr.common.util.SuppressForbidden;
+import org.apache.solr.core.CoreContainer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class implements a generic plugin which can use authentication schemes exposed by the
+ * Hadoop framework. This plugin supports following features
+ * - integration with authentication mehcanisms (e.g. kerberos)
+ * - Delegation token support
+ * - Proxy users (or secure impersonation) support
+ *
+ * This plugin enables defining configuration parameters required by the undelying Hadoop authentication
+ * mechanism. These configuration parameters can either be specified as a Java system property or the default
+ * value can be specified as part of the plugin configuration.
+ *
+ * The proxy users are configured by specifying relevant Hadoop configuration parameters. Please note that
+ * the delegation token support must be enabled for using the proxy users support.
+ *
+ * For Solr internal communication, this plugin enables configuring {@linkplain HttpClientBuilderFactory}
+ * implementation (e.g. based on kerberos).
+ */
+public class GenericHadoopAuthPlugin extends AuthenticationPlugin implements HttpClientBuilderPlugin {
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  /**
+   * A property specifying the type of authentication scheme to be configured.
+   */
+  private static final String HADOOP_AUTH_TYPE = "type";
+
+  /**
+   * A property specifies the value of the prefix to be used to define Java system property
+   * for configuring the authentication mechanism. The name of the Java system property is
+   * defined by appending the configuration parmeter namne to this prefix value e.g. if prefix
+   * is 'solr' then the Java system property 'solr.kerberos.principal' defines the value of
+   * configuration parameter 'kerberos.principal'.
+   */
+  private static final String SYSPROP_PREFIX_PROPERTY = "sysPropPrefix";
+
+  /**
+   * A property specifying the configuration parameters required by the authentication scheme
+   * defined by {@linkplain #HADOOP_AUTH_TYPE} property.
+   */
+  private static final String AUTH_CONFIG_NAMES_PROPERTY = "authConfigs";
+
+  /**
+   * A property specifying the {@linkplain HttpClientBuilderFactory} used for the Solr internal
+   * communication.
+   */
+  private static final String HTTPCLIENT_BUILDER_FACTORY = "clientBuilderFactory";
+
+  /**
+   * A property specifying the default values for the configuration parameters specified by the
+   * {@linkplain #AUTH_CONFIG_NAMES_PROPERTY} property. The default values are specified as a
+   * collection of key-value pairs (i.e. property-name : default_value).
+   */
+  private static final String DEFAULT_AUTH_CONFIGS_PROPERTY = "defaultConfigs";
+
+  /**
+   * A property which enable (or disable) the delegation tokens functionality.
+   */
+  private static final String DELEGATION_TOKEN_ENABLED_PROPERTY = "enableDelegationToken";
+
+  /**
+   * A property which enables initialization of kerberos before connecting to Zookeeper.
+   */
+  private static final String INIT_KERBEROS_ZK = "initKerberosZk";
+
+  /**
+   * A property which configures proxy users for the underlying Hadoop authentication mechanism.
+   * This configuration is expressed as a collection of key-value pairs  (i.e. property-name : value).
+   */
+  public static final String PROXY_USER_CONFIGS = "proxyUserConfigs";
+
+  private AuthenticationFilter authFilter;
+  private HttpClientBuilderFactory factory = null;
+  private final CoreContainer coreContainer;
+
+  public GenericHadoopAuthPlugin(CoreContainer coreContainer) {
+    this.coreContainer = coreContainer;
+  }
+
+  @SuppressWarnings("rawtypes")
+  @Override
+  public void init(Map<String,Object> pluginConfig) {
+    try {
+      String delegationTokenEnabled = (String)pluginConfig.getOrDefault(DELEGATION_TOKEN_ENABLED_PROPERTY, "false");
+      authFilter = (Boolean.parseBoolean(delegationTokenEnabled)) ? new HadoopAuthFilter() : new AuthenticationFilter();
+
+      // Initialize kerberos before initializing curator instance.
+      boolean initKerberosZk = Boolean.parseBoolean((String)pluginConfig.getOrDefault(INIT_KERBEROS_ZK, "false"));
+      if (initKerberosZk) {
+        (new Krb5HttpClientBuilder()).getBuilder();
+      }
+
+      FilterConfig conf = getInitFilterConfig(pluginConfig);
+      authFilter.init(conf);
+
+      String httpClientBuilderFactory = (String)pluginConfig.get(HTTPCLIENT_BUILDER_FACTORY);
+      if (httpClientBuilderFactory != null) {
+        Class c = Class.forName(httpClientBuilderFactory);
+        factory = (HttpClientBuilderFactory)c.newInstance();
+      }
+
+    } catch (ServletException | ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+      throw new SolrException(ErrorCode.SERVER_ERROR, "Error initializing kerberos authentication plugin: "+e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  protected FilterConfig getInitFilterConfig(Map<String, Object> pluginConfig) {
+    Map<String, String> params = new HashMap<>();
+
+    String type = (String) Objects.requireNonNull(pluginConfig.get(HADOOP_AUTH_TYPE));
+    params.put(HADOOP_AUTH_TYPE, type);
+
+    String sysPropPrefix = (String) pluginConfig.getOrDefault(SYSPROP_PREFIX_PROPERTY, "solr.");
+    Collection<String> authConfigNames = (Collection<String>) pluginConfig.
+        getOrDefault(AUTH_CONFIG_NAMES_PROPERTY, Collections.emptyList());
+    Map<String,String> authConfigDefaults = (Map<String,String>) pluginConfig
+        .getOrDefault(DEFAULT_AUTH_CONFIGS_PROPERTY, Collections.emptyMap());
+    Map<String,String> proxyUserConfigs = (Map<String,String>) pluginConfig
+        .getOrDefault(PROXY_USER_CONFIGS, Collections.emptyMap());
+
+    for ( String configName : authConfigNames) {
+      String systemProperty = sysPropPrefix + configName;
+      String defaultConfigVal = authConfigDefaults.get(configName);
+      String configVal = System.getProperty(systemProperty, defaultConfigVal);
+      if (configVal != null) {
+        params.put(configName, configVal);
+      }
+    }
+
+    // Configure proxy user settings.
+    params.putAll(proxyUserConfigs);
+
+    final ServletContext servletContext = new AttributeOnlyServletContext();
+    log.info("Params: "+params);
+
+    ZkController controller = coreContainer.getZkController();
+    if (controller != null) {
+      servletContext.setAttribute(DELEGATION_TOKEN_ZK_CLIENT, controller.getZkClient());
+    }
+
+    FilterConfig conf = new FilterConfig() {
+      @Override
+      public ServletContext getServletContext() {
+        return servletContext;
+      }
+
+      @Override
+      public Enumeration<String> getInitParameterNames() {
+        return new IteratorEnumeration(params.keySet().iterator());
+      }
+
+      @Override
+      public String getInitParameter(String param) {
+        return params.get(param);
+      }
+
+      @Override
+      public String getFilterName() {
+        return "HadoopAuthFilter";
+      }
+    };
+
+    return conf;
+  }
+
+  @Override
+  public boolean doAuthenticate(ServletRequest request, ServletResponse response, FilterChain filterChain)
+      throws Exception {
+    final HttpServletResponse frsp = (HttpServletResponse)response;
+
+    // Workaround until HADOOP-13346 is fixed.
+    HttpServletResponse rspCloseShield = new HttpServletResponseWrapper(frsp) {
+      @SuppressForbidden(reason = "Hadoop DelegationTokenAuthenticationFilter uses response writer, this" +
+          "is providing a CloseShield on top of that")
+      @Override
+      public PrintWriter getWriter() throws IOException {
+        final PrintWriter pw = new PrintWriterWrapper(frsp.getWriter()) {
+          @Override
+          public void close() {};
+        };
+        return pw;
+      }
+    };
+    authFilter.doFilter(request, rspCloseShield, filterChain);
+
+    if (authFilter instanceof HadoopAuthFilter) { // delegation token mgmt.
+      String requestContinuesAttr = (String)request.getAttribute(REQUEST_CONTINUES_ATTR);
+      if (requestContinuesAttr == null) {
+        log.warn("Could not find " + REQUEST_CONTINUES_ATTR);
+        return false;
+      } else {
+        return Boolean.parseBoolean(requestContinuesAttr);
+      }
+    }
+
+    return true;
+  }
+
+  @Override
+  public SolrHttpClientBuilder getHttpClientBuilder(SolrHttpClientBuilder builder) {
+    return (factory != null) ? factory.getHttpClientBuilder(Optional.ofNullable(builder)) : builder;
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (authFilter != null) {
+      authFilter.destroy();
+    }
+    if (factory != null) {
+      factory.close();
+    }
+  }
+}

--- a/solr/core/src/java/org/apache/solr/security/KerberosFilter.java
+++ b/solr/core/src/java/org/apache/solr/security/KerberosFilter.java
@@ -42,9 +42,9 @@ public class KerberosFilter extends AuthenticationFilter {
     super.initializeAuthHandler(authHandlerClassName, filterConfig);
     AuthenticationHandler authHandler = getAuthenticationHandler();
     super.initializeAuthHandler(
-        KerberosPlugin.RequestContinuesRecorderAuthenticationHandler.class.getName(), filterConfig);
-    KerberosPlugin.RequestContinuesRecorderAuthenticationHandler newAuthHandler =
-        (KerberosPlugin.RequestContinuesRecorderAuthenticationHandler)getAuthenticationHandler();
+        RequestContinuesRecorderAuthenticationHandler.class.getName(), filterConfig);
+    RequestContinuesRecorderAuthenticationHandler newAuthHandler =
+        (RequestContinuesRecorderAuthenticationHandler)getAuthenticationHandler();
     newAuthHandler.setAuthHandler(authHandler);
   }
 

--- a/solr/core/src/java/org/apache/solr/security/KerberosPlugin.java
+++ b/solr/core/src/java/org/apache/solr/security/KerberosPlugin.java
@@ -17,43 +17,24 @@
 package org.apache.solr.security;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.PrintWriter;
 import java.lang.invoke.MethodHandles;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.Collections;
 import java.util.Enumeration;
-import java.util.EventListener;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
-import javax.servlet.FilterRegistration;
-import javax.servlet.FilterRegistration.Dynamic;
-import javax.servlet.RequestDispatcher;
-import javax.servlet.Servlet;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
-import javax.servlet.ServletRegistration;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
-import javax.servlet.SessionCookieConfig;
-import javax.servlet.SessionTrackingMode;
-import javax.servlet.descriptor.JspConfigDescriptor;
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpServletResponseWrapper;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.collections.iterators.IteratorEnumeration;
-import org.apache.hadoop.security.authentication.client.AuthenticationException;
-import org.apache.hadoop.security.authentication.server.AuthenticationHandler;
-import org.apache.hadoop.security.authentication.server.AuthenticationToken;
 import org.apache.solr.client.solrj.impl.Krb5HttpClientBuilder;
 import org.apache.solr.client.solrj.impl.SolrHttpClientBuilder;
 import org.apache.solr.cloud.ZkController;
@@ -92,9 +73,6 @@ public class KerberosPlugin extends AuthenticationPlugin implements HttpClientBu
   public static final String IMPERSONATOR_DO_AS_HTTP_PARAM = "doAs";
   public static final String IMPERSONATOR_USER_NAME = "solr.impersonator.user.name";
 
-  // filled in by Plugin/Filter
-  static final String REQUEST_CONTINUES_ATTR =
-      "org.apache.solr.security.kerberosplugin.requestcontinues";
   static final String DELEGATION_TOKEN_ZK_CLIENT =
       "solr.kerberos.delegation.token.zk.client";
 
@@ -263,9 +241,9 @@ public class KerberosPlugin extends AuthenticationPlugin implements HttpClientBu
       }
     };
     kerberosFilter.doFilter(req, rspCloseShield, chain);
-    String requestContinuesAttr = (String)req.getAttribute(REQUEST_CONTINUES_ATTR);
+    String requestContinuesAttr = (String)req.getAttribute(RequestContinuesRecorderAuthenticationHandler.REQUEST_CONTINUES_ATTR);
     if (requestContinuesAttr == null) {
-      log.warn("Could not find " + REQUEST_CONTINUES_ATTR);
+      log.warn("Could not find " + RequestContinuesRecorderAuthenticationHandler.REQUEST_CONTINUES_ATTR);
       return false;
     } else {
       return Boolean.parseBoolean(requestContinuesAttr);
@@ -286,292 +264,4 @@ public class KerberosPlugin extends AuthenticationPlugin implements HttpClientBu
   protected Filter getKerberosFilter() { return kerberosFilter; }
 
   protected void setKerberosFilter(Filter kerberosFilter) { this.kerberosFilter = kerberosFilter; }
-
-  protected static class AttributeOnlyServletContext implements ServletContext {
-    private Map<String, Object> attributes = new HashMap<String, Object>();
-
-    @Override
-    public void setSessionTrackingModes(Set<SessionTrackingMode> sessionTrackingModes) {}
-    
-    @Override
-    public boolean setInitParameter(String name, String value) {
-      return false;
-    }
-
-    @Override
-    public void setAttribute(String name, Object object) {
-      attributes.put(name, object);
-    }
-
-    @Override
-    public void removeAttribute(String name) {
-      attributes.remove(name);
-    }
-    
-    @Override
-    public void log(String message, Throwable throwable) {}
-    
-    @Override
-    public void log(Exception exception, String msg) {}
-    
-    @Override
-    public void log(String msg) {}
-    
-    @Override
-    public String getVirtualServerName() {
-      return null;
-    }
-    
-    @Override
-    public SessionCookieConfig getSessionCookieConfig() {
-      return null;
-    }
-    
-    @Override
-    public Enumeration<Servlet> getServlets() {
-      return null;
-    }
-    
-    @Override
-    public Map<String,? extends ServletRegistration> getServletRegistrations() {
-      return null;
-    }
-    
-    @Override
-    public ServletRegistration getServletRegistration(String servletName) {
-      return null;
-    }
-    
-    @Override
-    public Enumeration<String> getServletNames() {
-      return null;
-    }
-    
-    @Override
-    public String getServletContextName() {
-      return null;
-    }
-    
-    @Override
-    public Servlet getServlet(String name) throws ServletException {
-      return null;
-    }
-    
-    @Override
-    public String getServerInfo() {
-      return null;
-    }
-    
-    @Override
-    public Set<String> getResourcePaths(String path) {
-      return null;
-    }
-    
-    @Override
-    public InputStream getResourceAsStream(String path) {
-      return null;
-    }
-    
-    @Override
-    public URL getResource(String path) throws MalformedURLException {
-      return null;
-    }
-    
-    @Override
-    public RequestDispatcher getRequestDispatcher(String path) {
-      return null;
-    }
-    
-    @Override
-    public String getRealPath(String path) {
-      return null;
-    }
-    
-    @Override
-    public RequestDispatcher getNamedDispatcher(String name) {
-      return null;
-    }
-    
-    @Override
-    public int getMinorVersion() {
-      return 0;
-    }
-    
-    @Override
-    public String getMimeType(String file) {
-      return null;
-    }
-    
-    @Override
-    public int getMajorVersion() {
-      return 0;
-    }
-    
-    @Override
-    public JspConfigDescriptor getJspConfigDescriptor() {
-      return null;
-    }
-    
-    @Override
-    public Enumeration<String> getInitParameterNames() {
-      return null;
-    }
-    
-    @Override
-    public String getInitParameter(String name) {
-      return null;
-    }
-    
-    @Override
-    public Map<String,? extends FilterRegistration> getFilterRegistrations() {
-      return null;
-    }
-    
-    @Override
-    public FilterRegistration getFilterRegistration(String filterName) {
-      return null;
-    }
-    
-    @Override
-    public Set<SessionTrackingMode> getEffectiveSessionTrackingModes() {
-      return null;
-    }
-    
-    @Override
-    public int getEffectiveMinorVersion() {
-      return 0;
-    }
-    
-    @Override
-    public int getEffectiveMajorVersion() {
-      return 0;
-    }
-    
-    @Override
-    public Set<SessionTrackingMode> getDefaultSessionTrackingModes() {
-      return null;
-    }
-    
-    @Override
-    public String getContextPath() {
-      return null;
-    }
-    
-    @Override
-    public ServletContext getContext(String uripath) {
-      return null;
-    }
-    
-    @Override
-    public ClassLoader getClassLoader() {
-      return null;
-    }
-
-    @Override
-    public Enumeration<String> getAttributeNames() {
-      return Collections.enumeration(attributes.keySet());
-    }
-
-    @Override
-    public Object getAttribute(String name) {
-      return attributes.get(name);
-    }
-    
-    @Override
-    public void declareRoles(String... roleNames) {}
-    
-    @Override
-    public <T extends Servlet> T createServlet(Class<T> clazz) throws ServletException {
-      return null;
-    }
-    
-    @Override
-    public <T extends EventListener> T createListener(Class<T> clazz) throws ServletException {
-      return null;
-    }
-    
-    @Override
-    public <T extends Filter> T createFilter(Class<T> clazz) throws ServletException {
-      return null;
-    }
-    
-    @Override
-    public javax.servlet.ServletRegistration.Dynamic addServlet(String servletName, Class<? extends Servlet> servletClass) {
-      return null;
-    }
-    
-    @Override
-    public javax.servlet.ServletRegistration.Dynamic addServlet(String servletName, Servlet servlet) {
-      return null;
-    }
-    
-    @Override
-    public javax.servlet.ServletRegistration.Dynamic addServlet(String servletName, String className) {
-      return null;
-    }
-    
-    @Override
-    public void addListener(Class<? extends EventListener> listenerClass) {}
-    
-    @Override
-    public <T extends EventListener> void addListener(T t) {}
-    
-    @Override
-    public void addListener(String className) {}
-    
-    @Override
-    public Dynamic addFilter(String filterName, Class<? extends Filter> filterClass) {
-      return null;
-    }
-    
-    @Override
-    public Dynamic addFilter(String filterName, Filter filter) {
-      return null;
-    }
-    
-    @Override
-    public Dynamic addFilter(String filterName, String className) {
-      return null;
-    }
-  };
-
-  /*
-   * {@link AuthenticationHandler} that delegates to another {@link AuthenticationHandler}
-   * and records the response of managementOperation (which indicates whether the request
-   * should continue or not).
-   */
-  public static class RequestContinuesRecorderAuthenticationHandler implements AuthenticationHandler {
-    private AuthenticationHandler authHandler;
-
-    public void setAuthHandler(AuthenticationHandler authHandler) {
-      this.authHandler = authHandler;
-    }
-
-    public String getType() {
-      return authHandler.getType();
-    }
-
-    public void init(Properties config) throws ServletException {
-      // authHandler has already been init'ed, nothing to do here
-    }
-
-    public void destroy() {
-      authHandler.destroy();
-    }
-
-    public boolean managementOperation(AuthenticationToken token,
-                                       HttpServletRequest request,
-                                       HttpServletResponse response)
-        throws IOException, AuthenticationException {
-      boolean result = authHandler.managementOperation(token, request, response);
-      request.setAttribute(KerberosPlugin.REQUEST_CONTINUES_ATTR, new Boolean(result).toString());
-      return result;
-    }
-
-
-    public AuthenticationToken authenticate(HttpServletRequest request, HttpServletResponse response)
-        throws IOException, AuthenticationException {
-      return authHandler.authenticate(request, response);
-    }
-  }
 }

--- a/solr/core/src/java/org/apache/solr/security/RequestContinuesRecorderAuthenticationHandler.java
+++ b/solr/core/src/java/org/apache/solr/security/RequestContinuesRecorderAuthenticationHandler.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.security;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.hadoop.security.authentication.client.AuthenticationException;
+import org.apache.hadoop.security.authentication.server.AuthenticationHandler;
+import org.apache.hadoop.security.authentication.server.AuthenticationToken;
+
+/*
+ * {@link AuthenticationHandler} that delegates to another {@link AuthenticationHandler}
+ * and records the response of managementOperation (which indicates whether the request
+ * should continue or not).
+ */
+public class RequestContinuesRecorderAuthenticationHandler implements AuthenticationHandler {
+  // filled in by Plugin/Filter
+  static final String REQUEST_CONTINUES_ATTR =
+      "org.apache.solr.security.authentication.requestcontinues";
+
+  private AuthenticationHandler authHandler;
+
+  public void setAuthHandler(AuthenticationHandler authHandler) {
+    this.authHandler = authHandler;
+  }
+
+  public String getType() {
+    return authHandler.getType();
+  }
+
+  public void init(Properties config) throws ServletException {
+    // authHandler has already been init'ed, nothing to do here
+  }
+
+  public void destroy() {
+    authHandler.destroy();
+  }
+
+  public boolean managementOperation(AuthenticationToken token,
+                                     HttpServletRequest request,
+                                     HttpServletResponse response)
+      throws IOException, AuthenticationException {
+    boolean result = authHandler.managementOperation(token, request, response);
+    request.setAttribute(RequestContinuesRecorderAuthenticationHandler.REQUEST_CONTINUES_ATTR, new Boolean(result).toString());
+    return result;
+  }
+
+  public AuthenticationToken authenticate(HttpServletRequest request, HttpServletResponse response)
+      throws IOException, AuthenticationException {
+    return authHandler.authenticate(request, response);
+  }
+}

--- a/solr/core/src/test-files/solr/security/hadoop_kerberos_config.json
+++ b/solr/core/src/test-files/solr/security/hadoop_kerberos_config.json
@@ -1,6 +1,6 @@
 {
     "authentication": {
-        "class": "org.apache.solr.security.GenericHadoopAuthPlugin",
+        "class": "org.apache.solr.security.ConfigurableInternodeAuthHadoopPlugin",
         "sysPropPrefix": "solr.",
         "type": "kerberos",
         "clientBuilderFactory": "org.apache.solr.client.solrj.impl.Krb5HttpClientBuilder",

--- a/solr/core/src/test-files/solr/security/hadoop_kerberos_config.json
+++ b/solr/core/src/test-files/solr/security/hadoop_kerberos_config.json
@@ -1,0 +1,16 @@
+{
+    "authentication": {
+        "class": "org.apache.solr.security.GenericHadoopAuthPlugin",
+        "sysPropPrefix": "solr.",
+        "type": "kerberos",
+        "clientBuilderFactory": "org.apache.solr.client.solrj.impl.Krb5HttpClientBuilder",
+        "initKerberosZk": "true",
+        "authConfigs": [
+            "kerberos.principal",
+            "kerberos.keytab",
+            "kerberos.name.rules"
+        ],
+        "defaultConfigs": {
+        }
+    }
+}

--- a/solr/core/src/test-files/solr/security/hadoop_simple_auth_with_delegation.json
+++ b/solr/core/src/test-files/solr/security/hadoop_simple_auth_with_delegation.json
@@ -1,0 +1,29 @@
+{
+    "authentication": {
+        "class": "org.apache.solr.security.GenericHadoopAuthPlugin",
+        "sysPropPrefix": "solr.",
+        "type": "simple",
+        "enableDelegationToken":"true",
+        "authConfigs": [
+            "delegation-token.token-kind",
+            "delegation-token.update-interval.sec",
+            "delegation-token.max-lifetime.sec",
+            "delegation-token.renewal-interval.sec",
+            "delegation-token.removal-scan-interval.sec",
+            "cookie.domain",
+            "signer.secret.provider",
+            "zk-dt-secret-manager.enable",
+            "zk-dt-secret-manager.znodeWorkingPath",
+            "signer.secret.provider.zookeeper.path"
+        ],
+        "defaultConfigs": {
+            "delegation-token.token-kind": "solr-dt",
+            "signer.secret.provider": "zookeeper",
+            "zk-dt-secret-manager.enable": "true",
+            "token.validity": "36000",
+            "zk-dt-secret-manager.znodeWorkingPath": "solr/security/zkdtsm",
+            "signer.secret.provider.zookeeper.path": "/token",
+            "cookie.domain": "127.0.0.1"
+        }
+    }
+}

--- a/solr/core/src/test-files/solr/security/hadoop_simple_auth_with_delegation.json
+++ b/solr/core/src/test-files/solr/security/hadoop_simple_auth_with_delegation.json
@@ -1,6 +1,6 @@
 {
     "authentication": {
-        "class": "org.apache.solr.security.GenericHadoopAuthPlugin",
+        "class": "org.apache.solr.security.HadoopAuthPlugin",
         "sysPropPrefix": "solr.",
         "type": "simple",
         "enableDelegationToken":"true",

--- a/solr/core/src/test/org/apache/solr/cloud/TestSolrCloudWithSecureImpersonation.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestSolrCloudWithSecureImpersonation.java
@@ -108,11 +108,9 @@ public class TestSolrCloudWithSecureImpersonation extends SolrTestCaseJ4 {
     System.setProperty("solr.test.sys.prop2", "proptwo");
 
     SolrRequestParsers.DEFAULT.setAddRequestHeadersToContext(true);
-    String solrXml = MiniSolrCloudCluster.DEFAULT_CLOUD_SOLR_XML.replace("</solr>",
-        " <str name=\"collectionsHandler\">" + ImpersonatorCollectionsHandler.class.getName() + "</str>\n" +
-            "</solr>");
+    System.setProperty("collectionsHandler", ImpersonatorCollectionsHandler.class.getName());
 
-    miniCluster = new MiniSolrCloudCluster(NUM_SERVERS, createTempDir(), solrXml, buildJettyConfig("/solr"));
+    miniCluster = new MiniSolrCloudCluster(NUM_SERVERS, createTempDir(), buildJettyConfig("/solr"));
     JettySolrRunner runner = miniCluster.getJettySolrRunners().get(0);
     solrClient = new HttpSolrClient.Builder(runner.getBaseUrl().toString()).build();
   }
@@ -168,6 +166,8 @@ public class TestSolrCloudWithSecureImpersonation extends SolrTestCaseJ4 {
     }
     System.clearProperty("solr.test.sys.prop1");
     System.clearProperty("solr.test.sys.prop2");
+    System.clearProperty("collectionsHandler");
+
     SolrRequestParsers.DEFAULT.setAddRequestHeadersToContext(false);
   }
 

--- a/solr/core/src/test/org/apache/solr/security/hadoop/ImpersonationUtil.java
+++ b/solr/core/src/test/org/apache/solr/security/hadoop/ImpersonationUtil.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.security.hadoop;
+
+import java.util.List;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.authentication.client.PseudoAuthenticator;
+import org.apache.lucene.util.Constants;
+import org.apache.solr.client.solrj.SolrRequest;
+import org.apache.solr.client.solrj.request.CollectionAdminRequest;
+import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.common.params.SolrParams;
+import org.apache.solr.security.GenericHadoopAuthPlugin;
+import org.apache.solr.security.KerberosPlugin;
+
+/**
+ * This class implements utility functions required to test the secure impersonation feature for {@linkplain GenericHadoopAuthPlugin}
+ */
+public class ImpersonationUtil {
+
+  static String getUsersFirstGroup() throws Exception {
+    String group = "*"; // accept any group if a group can't be found
+    if (!Constants.WINDOWS) { // does not work on Windows!
+      org.apache.hadoop.security.Groups hGroups =
+          new org.apache.hadoop.security.Groups(new Configuration());
+      try {
+        List<String> g = hGroups.getGroups(System.getProperty("user.name"));
+        if (g != null && g.size() > 0) {
+          group = g.get(0);
+        }
+      } catch (NullPointerException npe) {
+        // if user/group doesn't exist on test box
+      }
+    }
+    return group;
+  }
+
+  static SolrRequest getProxyRequest(String user, String doAs) {
+    return new CollectionAdminRequest.List() {
+      @Override
+      public SolrParams getParams() {
+        ModifiableSolrParams params = new ModifiableSolrParams(super.getParams());
+        params.set(PseudoAuthenticator.USER_NAME, user);
+        params.set(KerberosPlugin.IMPERSONATOR_DO_AS_HTTP_PARAM, doAs);
+        return params;
+      }
+    };
+  }
+
+  static String getExpectedGroupExMsg(String user, String doAs) {
+    return "User: " + user + " is not allowed to impersonate " + doAs;
+  }
+
+  static String getExpectedHostExMsg(String user) {
+    return "Unauthorized connection for super-user: " + user;
+  }
+
+}

--- a/solr/core/src/test/org/apache/solr/security/hadoop/ImpersonationUtil.java
+++ b/solr/core/src/test/org/apache/solr/security/hadoop/ImpersonationUtil.java
@@ -25,11 +25,11 @@ import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.SolrParams;
-import org.apache.solr.security.GenericHadoopAuthPlugin;
+import org.apache.solr.security.HadoopAuthPlugin;
 import org.apache.solr.security.KerberosPlugin;
 
 /**
- * This class implements utility functions required to test the secure impersonation feature for {@linkplain GenericHadoopAuthPlugin}
+ * This class implements utility functions required to test the secure impersonation feature for {@linkplain HadoopAuthPlugin}
  */
 public class ImpersonationUtil {
 

--- a/solr/core/src/test/org/apache/solr/security/hadoop/ImpersonatorCollectionsHandler.java
+++ b/solr/core/src/test/org/apache/solr/security/hadoop/ImpersonatorCollectionsHandler.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.security.hadoop;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.hadoop.security.authentication.client.PseudoAuthenticator;
+import org.apache.solr.core.CoreContainer;
+import org.apache.solr.handler.admin.CollectionsHandler;
+import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.response.SolrQueryResponse;
+import org.apache.solr.security.GenericHadoopAuthPlugin;
+import org.apache.solr.security.KerberosPlugin;
+import org.junit.Assert;
+
+/**
+ * This class extends {@linkplain CollectionsHandler} and implements extra validations
+ * for verifying proxy users support in {@linkplain GenericHadoopAuthPlugin}
+ */
+public class ImpersonatorCollectionsHandler extends CollectionsHandler {
+  static AtomicBoolean called = new AtomicBoolean(false);
+
+  public ImpersonatorCollectionsHandler() {
+    super();
+  }
+
+  public ImpersonatorCollectionsHandler(final CoreContainer coreContainer) {
+    super(coreContainer);
+  }
+
+  @Override
+  public void handleRequestBody(SolrQueryRequest req, SolrQueryResponse rsp) throws Exception {
+    called.set(true);
+    super.handleRequestBody(req, rsp);
+    String doAs = req.getParams().get(KerberosPlugin.IMPERSONATOR_DO_AS_HTTP_PARAM);
+    if (doAs != null) {
+      HttpServletRequest httpRequest = (HttpServletRequest)req.getContext().get("httpRequest");
+      Assert.assertNotNull(httpRequest);
+      String user = req.getParams().get(PseudoAuthenticator.USER_NAME);
+      Assert.assertNotNull(user);
+      Assert.assertEquals(user, httpRequest.getAttribute(KerberosPlugin.IMPERSONATOR_USER_NAME));
+    }
+  }
+}

--- a/solr/core/src/test/org/apache/solr/security/hadoop/ImpersonatorCollectionsHandler.java
+++ b/solr/core/src/test/org/apache/solr/security/hadoop/ImpersonatorCollectionsHandler.java
@@ -25,13 +25,13 @@ import org.apache.solr.core.CoreContainer;
 import org.apache.solr.handler.admin.CollectionsHandler;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.response.SolrQueryResponse;
-import org.apache.solr.security.GenericHadoopAuthPlugin;
+import org.apache.solr.security.HadoopAuthPlugin;
 import org.apache.solr.security.KerberosPlugin;
 import org.junit.Assert;
 
 /**
  * This class extends {@linkplain CollectionsHandler} and implements extra validations
- * for verifying proxy users support in {@linkplain GenericHadoopAuthPlugin}
+ * for verifying proxy users support in {@linkplain HadoopAuthPlugin}
  */
 public class ImpersonatorCollectionsHandler extends CollectionsHandler {
   static AtomicBoolean called = new AtomicBoolean(false);

--- a/solr/core/src/test/org/apache/solr/security/hadoop/TestDelegationWithHadoopAuth.java
+++ b/solr/core/src/test/org/apache/solr/security/hadoop/TestDelegationWithHadoopAuth.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import org.apache.hadoop.security.authentication.client.PseudoAuthenticator;
 import org.apache.hadoop.util.Time;
 import org.apache.http.HttpStatus;
+import org.apache.lucene.util.Constants;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.embedded.JettySolrRunner;
@@ -50,6 +51,8 @@ public class TestDelegationWithHadoopAuth extends SolrCloudTestCase {
 
   @BeforeClass
   public static void setupClass() throws Exception {
+    assumeFalse("Hadoop does not work on Windows", Constants.WINDOWS);
+
     configureCluster(NUM_SERVERS)// nodes
         .withSecurityJson(TEST_PATH().resolve("security").resolve("hadoop_simple_auth_with_delegation.json"))
         .configure();

--- a/solr/core/src/test/org/apache/solr/security/hadoop/TestDelegationWithHadoopAuth.java
+++ b/solr/core/src/test/org/apache/solr/security/hadoop/TestDelegationWithHadoopAuth.java
@@ -1,0 +1,397 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.security.hadoop;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.hadoop.security.authentication.client.PseudoAuthenticator;
+import org.apache.hadoop.util.Time;
+import org.apache.http.HttpStatus;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrRequest;
+import org.apache.solr.client.solrj.embedded.JettySolrRunner;
+import org.apache.solr.client.solrj.impl.CloudSolrClient;
+import org.apache.solr.client.solrj.impl.HttpSolrClient;
+import org.apache.solr.client.solrj.impl.LBHttpSolrClient;
+import org.apache.solr.client.solrj.request.CollectionAdminRequest;
+import org.apache.solr.client.solrj.request.DelegationTokenRequest;
+import org.apache.solr.client.solrj.response.DelegationTokenResponse;
+import org.apache.solr.cloud.SolrCloudTestCase;
+import org.apache.solr.common.SolrException.ErrorCode;
+import org.apache.solr.common.cloud.SolrZkClient;
+import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.common.params.SolrParams;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import junit.framework.Assert;
+
+public class TestDelegationWithHadoopAuth extends SolrCloudTestCase {
+  protected static final int NUM_SERVERS = 2;
+  protected static final String USER_1 = "foo";
+  protected static final String USER_2 = "bar";
+  private static HttpSolrClient primarySolrClient, secondarySolrClient;
+
+  @BeforeClass
+  public static void setupClass() throws Exception {
+    configureCluster(NUM_SERVERS)// nodes
+        .withSecurityJson(TEST_PATH().resolve("security").resolve("hadoop_simple_auth_with_delegation.json"))
+        .configure();
+
+    JettySolrRunner runnerPrimary = cluster.getJettySolrRunners().get(0);
+    primarySolrClient =
+        new HttpSolrClient.Builder(runnerPrimary.getBaseUrl().toString())
+            .build();
+    JettySolrRunner runnerSecondary = cluster.getJettySolrRunners().get(1);
+    secondarySolrClient =
+        new HttpSolrClient.Builder(runnerSecondary.getBaseUrl().toString())
+            .build();
+  }
+
+  @AfterClass
+  public static void tearDownClass() throws Exception {
+    if (primarySolrClient != null) {
+      primarySolrClient.close();
+      primarySolrClient = null;
+    }
+
+    if (secondarySolrClient != null) {
+      secondarySolrClient.close();
+      secondarySolrClient = null;
+    }
+  }
+
+  private String getDelegationToken(final String renewer, final String user, HttpSolrClient solrClient) throws Exception {
+    DelegationTokenRequest.Get get = new DelegationTokenRequest.Get(renewer) {
+      @Override
+      public SolrParams getParams() {
+        ModifiableSolrParams params = new ModifiableSolrParams(super.getParams());
+        params.set(PseudoAuthenticator.USER_NAME, user);
+        return params;
+      }
+    };
+    DelegationTokenResponse.Get getResponse = get.process(solrClient);
+    return getResponse.getDelegationToken();
+  }
+
+  private long renewDelegationToken(final String token, final int expectedStatusCode,
+      final String user, HttpSolrClient client) throws Exception {
+    DelegationTokenRequest.Renew renew = new DelegationTokenRequest.Renew(token) {
+      @Override
+      public SolrParams getParams() {
+        ModifiableSolrParams params = new ModifiableSolrParams(super.getParams());
+        params.set(PseudoAuthenticator.USER_NAME, user);
+        return params;
+      }
+
+      @Override
+      public Set<String> getQueryParams() {
+        Set<String> queryParams = super.getQueryParams();
+        queryParams.add(PseudoAuthenticator.USER_NAME);
+        return queryParams;
+      }
+    };
+    try {
+      DelegationTokenResponse.Renew renewResponse = renew.process(client);
+      assertEquals(HttpStatus.SC_OK, expectedStatusCode);
+      return renewResponse.getExpirationTime();
+    } catch (HttpSolrClient.RemoteSolrException ex) {
+      assertEquals(expectedStatusCode, ex.code());
+      return -1;
+    }
+  }
+
+  private void cancelDelegationToken(String token, int expectedStatusCode, HttpSolrClient client)
+  throws Exception {
+    DelegationTokenRequest.Cancel cancel = new DelegationTokenRequest.Cancel(token);
+    try {
+      cancel.process(client);
+      assertEquals(HttpStatus.SC_OK, expectedStatusCode);
+    } catch (HttpSolrClient.RemoteSolrException ex) {
+      assertEquals(expectedStatusCode, ex.code());
+    }
+  }
+
+  private void doSolrRequest(String token, int expectedStatusCode, HttpSolrClient client)
+  throws Exception {
+    doSolrRequest(token, expectedStatusCode, client, 1);
+  }
+
+  private void doSolrRequest(String token, int expectedStatusCode, HttpSolrClient client, int trials)
+  throws Exception {
+    int lastStatusCode = 0;
+    for (int i = 0; i < trials; ++i) {
+      lastStatusCode = getStatusCode(token, null, null, client);
+      if (lastStatusCode == expectedStatusCode) {
+        return;
+      }
+      Thread.sleep(1000);
+    }
+    assertEquals("Did not receieve excepted status code", expectedStatusCode, lastStatusCode);
+  }
+
+  private SolrRequest getAdminRequest(final SolrParams params) {
+    return new CollectionAdminRequest.List() {
+      @Override
+      public SolrParams getParams() {
+        ModifiableSolrParams p = new ModifiableSolrParams(super.getParams());
+        p.add(params);
+        return p;
+      }
+    };
+  }
+
+  private int getStatusCode(String token, final String user, final String op, HttpSolrClient client)
+  throws Exception {
+    SolrClient delegationTokenClient;
+    if (random().nextBoolean()) delegationTokenClient = new HttpSolrClient.Builder(client.getBaseURL().toString())
+        .withKerberosDelegationToken(token)
+        .withResponseParser(client.getParser())
+        .build();
+    else delegationTokenClient = new CloudSolrClient.Builder()
+        .withZkHost((cluster.getZkServer().getZkAddress()))
+        .withLBHttpSolrClientBuilder(new LBHttpSolrClient.Builder()
+            .withResponseParser(client.getParser())
+            .withHttpSolrClientBuilder(
+                new HttpSolrClient.Builder()
+                    .withKerberosDelegationToken(token)
+            ))
+        .build();
+    try {
+      ModifiableSolrParams p = new ModifiableSolrParams();
+      if (user != null) p.set(PseudoAuthenticator.USER_NAME, user);
+      if (op != null) p.set("op", op);
+      SolrRequest req = getAdminRequest(p);
+      if (user != null || op != null) {
+        Set<String> queryParams = new HashSet<>();
+        if (user != null) queryParams.add(PseudoAuthenticator.USER_NAME);
+        if (op != null) queryParams.add("op");
+        req.setQueryParams(queryParams);
+      }
+      try {
+        delegationTokenClient.request(req, null);
+        return HttpStatus.SC_OK;
+      } catch (HttpSolrClient.RemoteSolrException re) {
+        return re.code();
+      }
+    } finally {
+      delegationTokenClient.close();
+    }
+  }
+
+  private void doSolrRequest(SolrClient client, SolrRequest request,
+      int expectedStatusCode) throws Exception {
+    try {
+      client.request(request);
+      assertEquals(HttpStatus.SC_OK, expectedStatusCode);
+    } catch (HttpSolrClient.RemoteSolrException ex) {
+      assertEquals(expectedStatusCode, ex.code());
+    }
+  }
+
+  private void verifyTokenValid(String token) throws Exception {
+     // pass with token
+    doSolrRequest(token, HttpStatus.SC_OK, primarySolrClient);
+
+    // fail without token
+    doSolrRequest(null, ErrorCode.UNAUTHORIZED.code, primarySolrClient);
+
+    // pass with token on other server
+    doSolrRequest(token, HttpStatus.SC_OK, secondarySolrClient);
+
+    // fail without token on other server
+    doSolrRequest(null, ErrorCode.UNAUTHORIZED.code, secondarySolrClient);
+  }
+
+  /**
+   * Test basic Delegation Token get/verify
+   */
+  @Test
+  public void testDelegationTokenVerify() throws Exception {
+    // Get token
+    String token = getDelegationToken(null, USER_1, primarySolrClient);
+    assertNotNull(token);
+    verifyTokenValid(token);
+  }
+
+  private void verifyTokenCancelled(String token, HttpSolrClient client) throws Exception {
+    // fail with token on both servers.  If cancelToOtherURL is true,
+    // the request went to other url, so FORBIDDEN should be returned immediately.
+    // The cancelled token may take awhile to propogate to the standard url (via ZK).
+    // This is of course the opposite if cancelToOtherURL is false.
+    doSolrRequest(token, ErrorCode.FORBIDDEN.code, client, 10);
+
+    // fail without token on both servers
+    doSolrRequest(null, ErrorCode.UNAUTHORIZED.code, primarySolrClient);
+    doSolrRequest(null, ErrorCode.UNAUTHORIZED.code, secondarySolrClient);
+  }
+
+  @Test
+  public void testDelegationTokenCancel() throws Exception {
+    {
+      // Get token
+      String token = getDelegationToken(null, USER_1, primarySolrClient);
+      assertNotNull(token);
+
+      // cancel token, note don't need to be authenticated to cancel (no user specified)
+      cancelDelegationToken(token, HttpStatus.SC_OK, primarySolrClient);
+      verifyTokenCancelled(token, primarySolrClient);
+    }
+
+    {
+      // cancel token on different server from where we got it
+      String token = getDelegationToken(null, USER_1, primarySolrClient);
+      assertNotNull(token);
+
+      cancelDelegationToken(token, HttpStatus.SC_OK, secondarySolrClient);
+      verifyTokenCancelled(token, secondarySolrClient);
+    }
+  }
+
+  @Test
+  public void testDelegationTokenCancelFail() throws Exception {
+    // cancel a bogus token
+    cancelDelegationToken("BOGUS", ErrorCode.NOT_FOUND.code, primarySolrClient);
+
+    {
+      // cancel twice, first on same server
+      String token = getDelegationToken(null, USER_1, primarySolrClient);
+      assertNotNull(token);
+      cancelDelegationToken(token, HttpStatus.SC_OK, primarySolrClient);
+      cancelDelegationToken(token, ErrorCode.NOT_FOUND.code, secondarySolrClient);
+      cancelDelegationToken(token, ErrorCode.NOT_FOUND.code, primarySolrClient);
+    }
+
+    {
+      // cancel twice, first on other server
+      String token = getDelegationToken(null, USER_1, primarySolrClient);
+      assertNotNull(token);
+      cancelDelegationToken(token, HttpStatus.SC_OK, secondarySolrClient);
+      cancelDelegationToken(token, ErrorCode.NOT_FOUND.code, secondarySolrClient);
+      cancelDelegationToken(token, ErrorCode.NOT_FOUND.code, primarySolrClient);
+    }
+  }
+
+  private void verifyDelegationTokenRenew(String renewer, String user)
+  throws Exception {
+    {
+      // renew on same server
+      String token = getDelegationToken(renewer, user, primarySolrClient);
+      assertNotNull(token);
+      long now = Time.now();
+      assertTrue(renewDelegationToken(token, HttpStatus.SC_OK, user, primarySolrClient) > now);
+      verifyTokenValid(token);
+    }
+
+    {
+      // renew on different server
+      String token = getDelegationToken(renewer, user, primarySolrClient);
+      assertNotNull(token);
+      long now = Time.now();
+      assertTrue(renewDelegationToken(token, HttpStatus.SC_OK, user, secondarySolrClient) > now);
+      verifyTokenValid(token);
+    }
+  }
+
+  @Test
+  public void testDelegationTokenRenew() throws Exception {
+    // test with specifying renewer
+    verifyDelegationTokenRenew(USER_1, USER_1);
+
+    // test without specifying renewer
+    verifyDelegationTokenRenew(null, USER_1);
+  }
+
+  @Test
+  public void testDelegationTokenRenewFail() throws Exception {
+    // don't set renewer and try to renew as an a different user
+    String token = getDelegationToken(null, USER_1, primarySolrClient);
+    assertNotNull(token);
+    renewDelegationToken(token, ErrorCode.FORBIDDEN.code, USER_2, primarySolrClient);
+    renewDelegationToken(token, ErrorCode.FORBIDDEN.code, USER_2, secondarySolrClient);
+
+    // set renewer and try to renew as different user
+    token = getDelegationToken("renewUser", USER_1, primarySolrClient);
+    assertNotNull(token);
+    renewDelegationToken(token, ErrorCode.FORBIDDEN.code, "notRenewUser", primarySolrClient);
+    renewDelegationToken(token, ErrorCode.FORBIDDEN.code, "notRenewUser", secondarySolrClient);
+  }
+
+  /**
+   * Test that a non-delegation-token "op" http param is handled correctly
+   */
+  @Test
+  public void testDelegationOtherOp() throws Exception {
+    assertEquals(HttpStatus.SC_OK, getStatusCode(null, USER_1, "someSolrOperation", primarySolrClient));
+  }
+
+  @Test
+  public void testZNodePaths() throws Exception {
+    getDelegationToken(null, USER_1, primarySolrClient);
+    SolrZkClient zkClient = new SolrZkClient(cluster.getZkServer().getZkAddress(), 1000);
+    try {
+      assertTrue(zkClient.exists("/security/zkdtsm", true));
+      assertTrue(zkClient.exists("/security/token", true));
+    } finally {
+      zkClient.close();
+    }
+  }
+
+  /**
+   * Test HttpSolrServer's delegation token support
+   */
+  @Test
+  public void testDelegationTokenSolrClient() throws Exception {
+    // Get token
+    String token = getDelegationToken(null, USER_1, primarySolrClient);
+    assertNotNull(token);
+
+    SolrRequest request = getAdminRequest(new ModifiableSolrParams());
+
+    // test without token
+    HttpSolrClient ss =
+        new HttpSolrClient.Builder(primarySolrClient.getBaseURL().toString())
+            .withResponseParser(primarySolrClient.getParser())
+            .build();
+    try {
+      doSolrRequest(ss, request, ErrorCode.UNAUTHORIZED.code);
+    } finally {
+      ss.close();
+    }
+
+    ss = new HttpSolrClient.Builder(primarySolrClient.getBaseURL().toString())
+        .withDelegationToken(token)
+        .withResponseParser(primarySolrClient.getParser())
+        .build();
+    try {
+      // test with token via property
+      doSolrRequest(ss, request, HttpStatus.SC_OK);
+
+      // test with param -- should throw an exception
+      ModifiableSolrParams tokenParam = new ModifiableSolrParams();
+      tokenParam.set("delegation", "invalidToken");
+      try {
+        doSolrRequest(ss, getAdminRequest(tokenParam), ErrorCode.FORBIDDEN.code);
+        Assert.fail("Expected exception");
+      } catch (IllegalArgumentException ex) {}
+    } finally {
+      ss.close();
+    }
+  }
+}

--- a/solr/core/src/test/org/apache/solr/security/hadoop/TestImpersonationWithHadoopAuth.java
+++ b/solr/core/src/test/org/apache/solr/security/hadoop/TestImpersonationWithHadoopAuth.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.security.hadoop;
+
+import static org.apache.solr.security.HttpParamDelegationTokenPlugin.USER_PARAM;
+import static org.apache.solr.security.hadoop.ImpersonationUtil.*;
+
+import java.net.InetAddress;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.lucene.util.Constants;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.embedded.JettySolrRunner;
+import org.apache.solr.client.solrj.impl.HttpSolrClient;
+import org.apache.solr.client.solrj.request.CollectionAdminRequest;
+import org.apache.solr.cloud.SolrCloudTestCase;
+import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.common.util.Utils;
+import org.apache.solr.security.GenericHadoopAuthPlugin;
+import org.apache.solr.servlet.SolrRequestParsers;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TestImpersonationWithHadoopAuth  extends SolrCloudTestCase {
+  protected static final int NUM_SERVERS = 2;
+  private static SolrClient solrClient;
+  private static final boolean defaultAddRequestHeadersToContext =
+      SolrRequestParsers.DEFAULT.isAddRequestHeadersToContext();
+
+  @SuppressWarnings("unchecked")
+  @BeforeClass
+  public static void setupClass() throws Exception {
+    assumeFalse("Hadoop does not work on Windows", Constants.WINDOWS);
+
+    InetAddress loopback = InetAddress.getLoopbackAddress();
+    Path securityJsonPath = TEST_PATH().resolve("security").resolve("hadoop_simple_auth_with_delegation.json");
+    String securityJson = new String(Files.readAllBytes(securityJsonPath), Charset.defaultCharset());
+
+    Map<String, Object> securityConfig = (Map<String, Object>)Utils.fromJSONString(securityJson);
+    Map<String, Object> authConfig = (Map<String, Object>)securityConfig.get("authentication");
+    Map<String,String> proxyUserConfigs = (Map<String,String>) authConfig
+        .getOrDefault(GenericHadoopAuthPlugin.PROXY_USER_CONFIGS, new HashMap<>());
+    proxyUserConfigs.put("proxyuser.noGroups.hosts", "*");
+    proxyUserConfigs.put("proxyuser.anyHostAnyUser.hosts", "*");
+    proxyUserConfigs.put("proxyuser.anyHostAnyUser.groups", "*");
+    proxyUserConfigs.put("proxyuser.wrongHost.hosts", "1.1.1.1.1.1");
+    proxyUserConfigs.put("proxyuser.wrongHost.groups", "*");
+    proxyUserConfigs.put("proxyuser.noHosts.groups", "*");
+    proxyUserConfigs.put("proxyuser.localHostAnyGroup.hosts",
+        loopback.getCanonicalHostName() + "," + loopback.getHostName() + "," + loopback.getHostAddress());
+    proxyUserConfigs.put("proxyuser.localHostAnyGroup.groups", "*");
+    proxyUserConfigs.put("proxyuser.bogusGroup.hosts", "*");
+    proxyUserConfigs.put("proxyuser.bogusGroup.groups", "__some_bogus_group");
+    proxyUserConfigs.put("proxyuser.anyHostUsersGroup.groups", ImpersonationUtil.getUsersFirstGroup());
+    proxyUserConfigs.put("proxyuser.anyHostUsersGroup.hosts", "*");
+
+    authConfig.put(GenericHadoopAuthPlugin.PROXY_USER_CONFIGS, proxyUserConfigs);
+
+    SolrRequestParsers.DEFAULT.setAddRequestHeadersToContext(true);
+    System.setProperty("collectionsHandler", ImpersonatorCollectionsHandler.class.getName());
+
+    configureCluster(NUM_SERVERS)// nodes
+        .withSecurityJson(Utils.toJSONString(securityConfig))
+        .addConfig("conf1", TEST_PATH().resolve("configsets").resolve("cloud-minimal").resolve("conf"))
+        .configure();
+    solrClient = new HttpSolrClient.Builder(
+        cluster.getJettySolrRunner(0).getBaseUrl().toString()).build();
+  }
+
+  @AfterClass
+  public static void tearDownClass() throws Exception {
+    if (solrClient != null) {
+      solrClient.close();
+      solrClient = null;
+    }
+    SolrRequestParsers.DEFAULT.setAddRequestHeadersToContext(defaultAddRequestHeadersToContext);
+    System.clearProperty("collectionsHandler");
+  }
+
+  @Test
+  public void testProxyNoConfigGroups() throws Exception {
+    try {
+      solrClient.request(getProxyRequest("noGroups","bar"));
+      fail("Expected RemoteSolrException");
+    }
+    catch (HttpSolrClient.RemoteSolrException ex) {
+      assertTrue(ex.getLocalizedMessage(), ex.getMessage().contains(getExpectedGroupExMsg("noGroups", "bar")));
+    }
+  }
+
+  @Test
+  public void testProxyWrongHost() throws Exception {
+    try {
+      solrClient.request(getProxyRequest("wrongHost","bar"));
+      fail("Expected RemoteSolrException");
+    }
+    catch (HttpSolrClient.RemoteSolrException ex) {
+      assertTrue(ex.getMessage().contains(getExpectedHostExMsg("wrongHost")));
+    }
+  }
+
+  @Test
+  public void testProxyNoConfigHosts() throws Exception {
+    try {
+      solrClient.request(getProxyRequest("noHosts","bar"));
+      fail("Expected RemoteSolrException");
+    }
+    catch (HttpSolrClient.RemoteSolrException ex) {
+      assertTrue(ex.getMessage().contains(getExpectedHostExMsg("noHosts")));
+    }
+  }
+
+  @Test
+  public void testProxyValidateAnyHostAnyUser() throws Exception {
+    solrClient.request(getProxyRequest("anyHostAnyUser", "bar"));
+    assertTrue(ImpersonatorCollectionsHandler.called.get());
+  }
+
+  @Test
+  public void testProxyInvalidProxyUser() throws Exception {
+    try {
+      // wrong direction, should fail
+      solrClient.request(getProxyRequest("bar","anyHostAnyUser"));
+      fail("Expected RemoteSolrException");
+    }
+    catch (HttpSolrClient.RemoteSolrException ex) {
+      assertTrue(ex.getMessage().contains(getExpectedGroupExMsg("bar", "anyHostAnyUser")));
+    }
+  }
+
+  @Test
+  public void testProxyValidateHost() throws Exception {
+    solrClient.request(getProxyRequest("localHostAnyGroup", "bar"));
+    assertTrue(ImpersonatorCollectionsHandler.called.get());
+  }
+
+  @Test
+  public void testProxyValidateGroup() throws Exception {
+    solrClient.request(getProxyRequest("anyHostUsersGroup", System.getProperty("user.name")));
+    assertTrue(ImpersonatorCollectionsHandler.called.get());
+  }
+
+  @Test
+  public void testProxyInvalidGroup() throws Exception {
+    try {
+      solrClient.request(getProxyRequest("bogusGroup","bar"));
+      fail("Expected RemoteSolrException");
+    }
+    catch (HttpSolrClient.RemoteSolrException ex) {
+      assertTrue(ex.getMessage().contains(getExpectedGroupExMsg("bogusGroup", "bar")));
+    }
+  }
+
+  @Test
+  public void testProxyNullProxyUser() throws Exception {
+    try {
+      solrClient.request(getProxyRequest("","bar"));
+      fail("Expected RemoteSolrException");
+    }
+    catch (HttpSolrClient.RemoteSolrException ex) {
+      // this exception is specific to our implementation, don't check a specific message.
+    }
+  }
+
+  @Test
+  @AwaitsFix(bugUrl="https://issues.apache.org/jira/browse/HADOOP-9893")
+  public void testForwarding() throws Exception {
+    String collectionName = "forwardingCollection";
+
+    // create collection
+    CollectionAdminRequest.Create create = CollectionAdminRequest.createCollection(collectionName, "conf1",
+        1, 1);
+    create.process(solrClient);
+
+    // try a command to each node, one of them must be forwarded
+    for (JettySolrRunner jetty : cluster.getJettySolrRunners()) {
+      HttpSolrClient client =
+          new HttpSolrClient.Builder(jetty.getBaseUrl().toString() + "/" + collectionName).build();
+      try {
+        ModifiableSolrParams params = new ModifiableSolrParams();
+        params.set("q", "*:*");
+        params.set(USER_PARAM, "user");
+        client.query(params);
+      } finally {
+        client.close();
+      }
+    }
+  }
+
+}

--- a/solr/core/src/test/org/apache/solr/security/hadoop/TestSolrCloudWithHadoopAuthPlugin.java
+++ b/solr/core/src/test/org/apache/solr/security/hadoop/TestSolrCloudWithHadoopAuthPlugin.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.security.hadoop;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.lucene.util.Constants;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.impl.CloudSolrClient;
+import org.apache.solr.client.solrj.request.CollectionAdminRequest;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.cloud.AbstractDistribZkTestBase;
+import org.apache.solr.cloud.KerberosTestServices;
+import org.apache.solr.cloud.SolrCloudTestCase;
+import org.apache.solr.common.SolrInputDocument;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TestSolrCloudWithHadoopAuthPlugin extends SolrCloudTestCase {
+  protected static final int NUM_SERVERS = 1;
+  protected static final int NUM_SHARDS = 1;
+  protected static final int REPLICATION_FACTOR = 1;
+  private static KerberosTestServices kerberosTestServices;
+
+  @BeforeClass
+  public static void setupClass() throws Exception {
+    assumeFalse("FIXME: SOLR-8182: This test fails under Java 9", Constants.JRE_IS_MINIMUM_JAVA9);
+
+    setupMiniKdc();
+
+    configureCluster(NUM_SERVERS)// nodes
+        .withSecurityJson(TEST_PATH().resolve("security").resolve("hadoop_kerberos_config.json"))
+        .addConfig("conf1", TEST_PATH().resolve("configsets").resolve("cloud-minimal").resolve("conf"))
+        .configure();
+  }
+
+  @AfterClass
+  public static void tearDownClass() throws Exception {
+    System.clearProperty("java.security.auth.login.config");
+    System.clearProperty("solr.kerberos.principal");
+    System.clearProperty("solr.kerberos.keytab");
+    System.clearProperty("solr.kerberos.name.rules");
+    System.clearProperty("solr.jaas.debug");
+    kerberosTestServices.stop();
+    kerberosTestServices = null;
+  }
+
+  private static void setupMiniKdc() throws Exception {
+    System.setProperty("solr.jaas.debug", "true");
+    String kdcDir = createTempDir()+File.separator+"minikdc";
+    String solrClientPrincipal = "solr";
+    File keytabFile = new File(kdcDir, "keytabs");
+    kerberosTestServices = KerberosTestServices.builder()
+        .withKdc(new File(kdcDir))
+        .withJaasConfiguration(solrClientPrincipal, keytabFile, "SolrClient")
+        .build();
+    String solrServerPrincipal = "HTTP/127.0.0.1";
+    kerberosTestServices.start();
+    kerberosTestServices.getKdc().createPrincipal(keytabFile, solrServerPrincipal, solrClientPrincipal);
+
+    String jaas = "SolrClient {\n"
+        + " com.sun.security.auth.module.Krb5LoginModule required\n"
+        + " useKeyTab=true\n"
+        + " keyTab=\"" + keytabFile.getAbsolutePath() + "\"\n"
+        + " storeKey=true\n"
+        + " useTicketCache=false\n"
+        + " doNotPrompt=true\n"
+        + " debug=true\n"
+        + " principal=\"" + solrClientPrincipal + "\";\n"
+        + "};";
+
+    String jaasFilePath = kdcDir+File.separator+"jaas-client.conf";
+    FileUtils.write(new File(jaasFilePath), jaas, StandardCharsets.UTF_8);
+    System.setProperty("java.security.auth.login.config", jaasFilePath);
+    System.setProperty("solr.kerberos.jaas.appname", "SolrClient"); // Get this app name from the jaas file
+
+    System.setProperty("solr.kerberos.principal", solrServerPrincipal);
+    System.setProperty("solr.kerberos.keytab", keytabFile.getAbsolutePath());
+    // Extracts 127.0.0.1 from HTTP/127.0.0.1@EXAMPLE.COM
+    System.setProperty("solr.kerberos.name.rules", "RULE:[1:$1@$0](.*EXAMPLE.COM)s/@.*//"
+        + "\nRULE:[2:$2@$0](.*EXAMPLE.COM)s/@.*//"
+        + "\nDEFAULT"
+        );
+  }
+
+  @Test
+  public void testBasics() throws Exception {
+    testCollectionCreateSearchDelete();
+    // sometimes run a second test e.g. to test collection create-delete-create scenario
+    if (random().nextBoolean()) testCollectionCreateSearchDelete();
+  }
+
+  protected void testCollectionCreateSearchDelete() throws Exception {
+    CloudSolrClient solrClient = cluster.getSolrClient();
+    String collectionName = "testkerberoscollection";
+
+    // create collection
+    CollectionAdminRequest.Create create = CollectionAdminRequest.createCollection(collectionName, "conf1",
+        NUM_SHARDS, REPLICATION_FACTOR);
+    create.process(solrClient);
+
+    SolrInputDocument doc = new SolrInputDocument();
+    doc.setField("id", "1");
+    solrClient.add(collectionName, doc);
+    solrClient.commit(collectionName);
+
+    SolrQuery query = new SolrQuery();
+    query.setQuery("*:*");
+    QueryResponse rsp = solrClient.query(collectionName, query);
+    assertEquals(1, rsp.getResults().getNumFound());
+
+    CollectionAdminRequest.Delete deleteReq = CollectionAdminRequest.deleteCollection(collectionName);
+    deleteReq.process(solrClient);
+    AbstractDistribZkTestBase.waitForCollectionToDisappear(collectionName,
+        solrClient.getZkStateReader(), true, true, 330);
+  }
+
+}

--- a/solr/core/src/test/org/apache/solr/security/hadoop/TestSolrCloudWithHadoopAuthPlugin.java
+++ b/solr/core/src/test/org/apache/solr/security/hadoop/TestSolrCloudWithHadoopAuthPlugin.java
@@ -41,6 +41,7 @@ public class TestSolrCloudWithHadoopAuthPlugin extends SolrCloudTestCase {
 
   @BeforeClass
   public static void setupClass() throws Exception {
+    assumeFalse("Hadoop does not work on Windows", Constants.WINDOWS);
     assumeFalse("FIXME: SOLR-8182: This test fails under Java 9", Constants.JRE_IS_MINIMUM_JAVA9);
 
     setupMiniKdc();

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpClientBuilderFactory.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpClientBuilderFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.client.solrj.impl;
+
+import java.io.Closeable;
+import java.util.Optional;
+
+/**
+ * Factory interface for configuring {@linkplain SolrHttpClientBuilder}. This
+ * relies on the internal HttpClient implementation and is subject to
+ * change.
+ *
+ * @lucene.experimental
+ **/
+public interface HttpClientBuilderFactory extends Closeable {
+
+  /**
+   * This method configures the {@linkplain SolrHttpClientBuilder} by overriding the
+   * configuration of passed SolrHttpClientBuilder or as a new instance.
+   *
+   * @param builder The instance of the {@linkplain SolrHttpClientBuilder} which should
+   *                by configured (optional).
+   * @return the {@linkplain SolrHttpClientBuilder}
+   */
+  public SolrHttpClientBuilder getHttpClientBuilder(Optional<SolrHttpClientBuilder> builder);
+
+}

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Krb5HttpClientBuilder.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Krb5HttpClientBuilder.java
@@ -21,6 +21,7 @@ import java.security.Principal;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.security.auth.login.AppConfigurationEntry;
@@ -46,7 +47,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Kerberos-enabled SolrHttpClientBuilder
  */
-public class Krb5HttpClientBuilder  {
+public class Krb5HttpClientBuilder implements HttpClientBuilderFactory {
   
   public static final String LOGIN_CONFIG_PROP = "java.security.auth.login.config";
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -73,7 +74,12 @@ public class Krb5HttpClientBuilder  {
   public void close() {
     HttpClientUtil.removeRequestInterceptor(bufferedEntityInterceptor);
   }
-  
+
+  @Override
+  public SolrHttpClientBuilder getHttpClientBuilder(Optional<SolrHttpClientBuilder> builder) {
+    return builder.isPresent() ? getBuilder(builder.get()) : getBuilder();
+  }
+
   public SolrHttpClientBuilder getBuilder(SolrHttpClientBuilder builder) {
     if (System.getProperty(LOGIN_CONFIG_PROP) != null) {
       String configValue = System.getProperty(LOGIN_CONFIG_PROP);


### PR DESCRIPTION
- Added a generic Solr authentication plugin to integrate with Hadoop
- Added delegation tokens support
- Added proxy users support

Currently the unit tests are using kerberos authentication handler in
Hadoop. After Solr is updated to use Hadoop 3, these tests will be
modified to use multi-auth support in Hadoop.