### PR TITLE
SOLR-9772 FieldSortValues should reuse comparator and only invalidate leafComparator

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -616,7 +616,7 @@ public class QueryComponent extends SearchComponent
         // :TODO: would be simpler to always serialize every position of SortField[]
         if (type==SortField.Type.SCORE || type==SortField.Type.DOC) continue;
 
-        FieldComparator<?> comparator = null;
+        FieldComparator<?> comparator = sortField.getComparator(1,0);
         LeafFieldComparator leafComparator = null;
         Object[] vals = new Object[nDocs];
 
@@ -633,13 +633,13 @@ public class QueryComponent extends SearchComponent
             idx = ReaderUtil.subIndex(doc, leaves);
             currentLeaf = leaves.get(idx);
             if (idx != lastIdx) {
-              // we switched segments.  invalidate comparator.
-              comparator = null;
+              // we switched segments.  invalidate leafComparator.
+              lastIdx = idx;
+              leafComparator = null;
             }
           }
 
-          if (comparator == null) {
-            comparator = sortField.getComparator(1,0);
+          if (leafComparator == null) {
             leafComparator = comparator.getLeafComparator(currentLeaf);
           }
 


### PR DESCRIPTION
No need to recreate the comparator as leaf changes. There was a bug where lastIdx was not set and was recreating the comparator and re-initializing the leafComparator for each document.