### PR TITLE
[SOLR-9817] Make "working directory" for Solr server during startup c…

### DIFF
--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -1595,9 +1595,16 @@ function launch_solr() {
 
     echo -e "\n"
   fi
-    
-  # need to launch solr from the server dir
-  cd "$SOLR_SERVER_DIR"
+
+  if [ -z "$SOLR_CONFIG_DIR" ]; then
+    SOLR_CONFIG_DIR="$SOLR_SERVER_DIR"
+  else
+    # Copy the jetty configuration to conf directory (so that Jetty can pickup the webapp config)
+    cp -r "${SOLR_SERVER_DIR}/contexts" "${SOLR_CONFIG_DIR}"
+  fi
+
+  # need to launch solr from the solr config dir
+  cd "$SOLR_CONFIG_DIR"
   
   if [ ! -e "$SOLR_SERVER_DIR/start.jar" ]; then
     echo -e "\nERROR: start.jar file not found in $SOLR_SERVER_DIR!\nPlease check your -d parameter to set the correct Solr server directory.\n"
@@ -1632,12 +1639,12 @@ function launch_solr() {
   esac
 
   if [ "$run_in_foreground" == "true" ]; then
-    exec "$JAVA" "${SOLR_START_OPTS[@]}" $SOLR_ADDL_ARGS -jar start.jar "${SOLR_JETTY_CONFIG[@]}"
+    exec "$JAVA" "${SOLR_START_OPTS[@]}" $SOLR_ADDL_ARGS -jar "${SOLR_SERVER_DIR}"/start.jar "${SOLR_JETTY_CONFIG[@]}"
   else
     # run Solr in the background
     nohup "$JAVA" "${SOLR_START_OPTS[@]}" $SOLR_ADDL_ARGS -Dsolr.log.muteconsole \
 	"-XX:OnOutOfMemoryError=$SOLR_TIP/bin/oom_solr.sh $SOLR_PORT $SOLR_LOGS_DIR" \
-        -jar start.jar "${SOLR_JETTY_CONFIG[@]}" \
+        -jar "${SOLR_SERVER_DIR}"/start.jar "${SOLR_JETTY_CONFIG[@]}" \
 	1>"$SOLR_LOGS_DIR/solr-$SOLR_PORT-console.log" 2>&1 & echo $! > "$SOLR_PID_DIR/solr-$SOLR_PORT.pid"
 
     # no lsof on cygwin though

--- a/solr/server/contexts/solr-jetty-context.xml
+++ b/solr/server/contexts/solr-jetty-context.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_0.dtd">
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
   <Set name="contextPath"><Property name="hostContext" default="/solr"/></Set>
-  <Set name="war"><Property name="jetty.base"/>/solr-webapp/webapp</Set>
-  <Set name="defaultsDescriptor"><Property name="jetty.base"/>/etc/webdefault.xml</Set>
+  <Set name="war"><Property name="jetty.home"/>/solr-webapp/webapp</Set>
+  <Set name="defaultsDescriptor"><Property name="jetty.home"/>/etc/webdefault.xml</Set>
   <Set name="extractWAR">false</Set>
 </Configure>


### PR DESCRIPTION
…onfigurable

- Added an environment variable "SOLR_CONFIG_DIR" to specify the working directory.
  If this env variable is missing, then we use value of SOLR_SERVER_DIR as the default.
  This allows us to maintain backwards compatibility.
- Updated solr-jetty-context.xml to use the jetty.home system property (instead of jetty.base).
  This is required since the jetty.base would point to SOLR_CONFIG_DIR and we need the location
  specified by SOLR_SERVER_DIR variable.

Testing: Manual testing with (and without) specifying SOLR_CONFIG_DIR parameter. The server
         starts properly in both cases.