### PR TITLE
Support spanQueries in CoreParser and SolrCoreParser

### DIFF
--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/xml/CoreParser.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/xml/CoreParser.java
@@ -20,6 +20,7 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.queryparser.xml.builders.*;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.spans.SpanQuery;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -31,7 +32,7 @@ import java.io.InputStream;
 /**
  * Assembles a QueryBuilder which uses only core Lucene Query objects
  */
-public class CoreParser implements QueryBuilder {
+public class CoreParser implements QueryBuilder, SpanQueryBuilder {
 
   protected String defaultField;
   protected Analyzer analyzer;
@@ -141,9 +142,13 @@ public class CoreParser implements QueryBuilder {
     return doc;
   }
 
-
   @Override
   public Query getQuery(Element e) throws ParserException {
     return queryFactory.getQuery(e);
+  }
+
+  @Override
+  public SpanQuery getSpanQuery(Element e) throws ParserException {
+    return spanFactory.getSpanQuery(e);
   }
 }

--- a/solr/core/src/java/org/apache/solr/search/SolrQueryBuilder.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrQueryBuilder.java
@@ -17,18 +17,35 @@
 package org.apache.solr.search;
 
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.queryparser.xml.ParserException;
 import org.apache.lucene.queryparser.xml.QueryBuilder;
+import org.apache.lucene.queryparser.xml.builders.SpanQueryBuilder;
+import org.apache.lucene.search.spans.SpanQuery;
 import org.apache.solr.request.SolrQueryRequest;
+import org.w3c.dom.Element;
 
-public abstract class SolrQueryBuilder implements QueryBuilder {
+public abstract class SolrQueryBuilder implements QueryBuilder, SpanQueryBuilder {
 
   protected final SolrQueryRequest req;
   protected final QueryBuilder queryFactory;
+  protected SpanQueryBuilder spanFactory;
 
+  @Deprecated
   public SolrQueryBuilder(String defaultField, Analyzer analyzer,
       SolrQueryRequest req, QueryBuilder queryFactory) {
     this.req = req;
     this.queryFactory = queryFactory;
+  }
+
+  public SolrQueryBuilder(String defaultField, Analyzer analyzer,
+      SolrQueryRequest req, QueryBuilder queryFactory, SpanQueryBuilder spanFactory) {
+    this(defaultField, analyzer, req, queryFactory);
+    this.spanFactory = spanFactory;
+  }
+
+  @Override
+  public SpanQuery getSpanQuery(Element e) throws ParserException {
+    return null;
   }
 
 }

--- a/solr/core/src/test/org/apache/solr/search/HandyQueryBuilder.java
+++ b/solr/core/src/test/org/apache/solr/search/HandyQueryBuilder.java
@@ -20,9 +20,12 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.queryparser.xml.DOMUtils;
 import org.apache.lucene.queryparser.xml.ParserException;
 import org.apache.lucene.queryparser.xml.QueryBuilder;
+import org.apache.lucene.queryparser.xml.builders.SpanQueryBuilder;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.spans.SpanOrQuery;
+import org.apache.lucene.search.spans.SpanQuery;
 import org.apache.solr.request.SolrQueryRequest;
 import org.w3c.dom.Element;
 
@@ -31,8 +34,8 @@ import org.w3c.dom.Element;
 public class HandyQueryBuilder extends SolrQueryBuilder {
 
   public HandyQueryBuilder(String defaultField, Analyzer analyzer,
-      SolrQueryRequest req, QueryBuilder queryFactory) {
-    super(defaultField, analyzer, req, queryFactory);
+      SolrQueryRequest req, QueryBuilder queryFactory, SpanQueryBuilder spanFactory) {
+    super(defaultField, analyzer, req, queryFactory, spanFactory);
   }
 
   @Override
@@ -45,9 +48,25 @@ public class HandyQueryBuilder extends SolrQueryBuilder {
     return bq.build();
   }
 
+  @Override
+  public SpanQuery getSpanQuery(Element e) throws ParserException {
+    SpanQuery subQueries[] = {
+        getSubSpanQuery(e, "Left"),
+        getSubSpanQuery(e, "Right"),
+    };
+
+    return new SpanOrQuery(subQueries);
+  }
+
   private Query getSubQuery(Element e, String name) throws ParserException {
     Element subE = DOMUtils.getChildByTagOrFail(e, name);
     subE = DOMUtils.getFirstChildOrFail(subE);
     return queryFactory.getQuery(subE);
+  }
+
+  private SpanQuery getSubSpanQuery(Element e, String name) throws ParserException {
+    Element subE = DOMUtils.getChildByTagOrFail(e, name);
+    subE = DOMUtils.getFirstChildOrFail(subE);
+    return spanFactory.getSpanQuery(subE);
   }
 }


### PR DESCRIPTION
@cpoerschke for consideration, I think this works.
I've kept HelloQueryBuilder and GoodbyeQueryBuilder as the "old" style, but HandyQueryBuilder has been updated to use the new API.

The tests pass, but in reality, we never call getSpanQuery() yet, maybe I could change HandyQueryBuilder, so it always returns a SpanQuery and never a normal one...