### PR TITLE
fix small issue in solr shell script

### DIFF
--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -73,6 +73,10 @@ while [ -h "$SOLR_SCRIPT" ] ; do
   fi
 done
 
+# if you are using cdpath, almost all "cd somedir" command (if you don't use absolute path) print path where it go
+# thus if SOLR_TIP is /home/user/solr, SOLR_TIP=`cd "$SOLR_TIP"; pwd` will return "/home/user/solr\n/home/user/solr" 
+# and you will see "file or directory not found"
+CDPATH=''
 SOLR_TIP=`dirname "$SOLR_SCRIPT"`/..
 SOLR_TIP=`cd "$SOLR_TIP"; pwd`
 DEFAULT_SERVER_DIR="$SOLR_TIP/server"


### PR DESCRIPTION
if you are using CDPATH  (and it is really userful OTB function of bash shell), this script will not work.
Finally you will see, that $SOLR_SERVER_DIR not found
CDPATH is not necessary inside any scripts and we must to break it like 
CDPATH='' # empty 
