### PR TITLE
SOLR-9876 Reuse CountSlotArrAcc internal array for same level subFacets

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/facet/FacetProcessor.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetProcessor.java
@@ -419,6 +419,7 @@ public abstract class FacetProcessor<FacetRequestT extends FacetRequest>  {
 
       // make a new context for each sub-facet since they can change the domain
       FacetContext subContext = fcontext.sub(filter, domain);
+      subContext.sequentialProcessing = true;
       FacetProcessor subProcessor = subRequest.createFacetProcessor(subContext);
 
       if (fcontext.getDebugInfo() != null) {   // if fcontext.debugInfo != null, it means rb.debug() == true

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetRequest.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetRequest.java
@@ -179,8 +179,9 @@ class FacetContext {
   int flags;
   FacetDebugInfo debugInfo;
   
-  int level; // level of the context
+  // Parameters for reusable
   boolean sequentialProcessing; // indicates if execution of facet processors happens sequentially 
+  int level; // level of facet processor
   private Map<String, Object> reusables;
   
   public FacetContext() {

--- a/solr/core/src/java/org/apache/solr/search/facet/SlotAcc.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/SlotAcc.java
@@ -394,7 +394,16 @@ class CountSlotArrAcc extends CountSlotAcc {
   int[] result;
   public CountSlotArrAcc(FacetContext fcontext, int numSlots) {
     super(fcontext);
-    result = new int[numSlots];
+    
+    String key = fcontext.level + this.getClass().getSimpleName();
+    result = (int[]) fcontext.getReusable(key);
+    if (result == null || result.length < numSlots) {
+      result = new int[numSlots];
+      fcontext.addReusable(key, result);
+    }
+    else {
+      Arrays.fill(result, 0);
+    }
   }
 
   @Override


### PR DESCRIPTION
All facet processors are processed sequentially. We can reuse CountSlotArrAcc internal array across same level facet processors instead of reallocating new array for each.
