### PR TITLE
SOLR-8776: Support RankQuery in grouping

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/AbstractReRankQuery.java
+++ b/solr/core/src/java/org/apache/solr/search/AbstractReRankQuery.java
@@ -23,6 +23,7 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Rescorer;
+import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.TopDocsCollector;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.BytesRef;
@@ -54,6 +55,11 @@ public abstract class AbstractReRankQuery extends RankQuery {
   }
 
   public TopDocsCollector getTopDocsCollector(int len, QueryCommand cmd, IndexSearcher searcher) throws IOException {
+      return getTopDocsCollector(null, len, cmd.getSort(), searcher);
+  }
+
+
+  public TopDocsCollector getTopDocsCollector(TopDocsCollector previousCollector, int len, Sort sort, IndexSearcher searcher) throws IOException {
 
     if(this.boostedPriority == null) {
       SolrRequestInfo info = SolrRequestInfo.getRequestInfo();
@@ -63,7 +69,7 @@ public abstract class AbstractReRankQuery extends RankQuery {
       }
     }
 
-    return new ReRankCollector(reRankDocs, len, reRankQueryRescorer, cmd, searcher, boostedPriority);
+    return new ReRankCollector(previousCollector, reRankDocs, len, sort, reRankQueryRescorer, searcher, boostedPriority);
   }
 
   public Query rewrite(IndexReader reader) throws IOException {
@@ -81,3 +87,4 @@ public abstract class AbstractReRankQuery extends RankQuery {
     return new ReRankWeight(mainQuery, reRankQueryRescorer, searcher, mainWeight);
   }
 }
+

--- a/solr/core/src/java/org/apache/solr/search/ExportQParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/search/ExportQParserPlugin.java
@@ -87,6 +87,15 @@ public class ExportQParserPlugin extends QParserPlugin {
     public TopDocsCollector getTopDocsCollector(int len,
                                                 QueryCommand cmd,
                                                 IndexSearcher searcher) throws IOException {
+
+      return getTopDocsCollector(null, len, cmd.getSort(), searcher);
+    }
+
+    @Override
+    public TopDocsCollector getTopDocsCollector(TopDocsCollector previousCollector,
+                                                int len,
+                                                Sort sort,
+                                                IndexSearcher searcher) throws IOException {
       int leafCount = searcher.getTopReaderContext().leaves().size();
       FixedBitSet[] sets = new FixedBitSet[leafCount];
       return new ExportCollector(sets);

--- a/solr/core/src/java/org/apache/solr/search/RankQuery.java
+++ b/solr/core/src/java/org/apache/solr/search/RankQuery.java
@@ -17,8 +17,9 @@
 package org.apache.solr.search;
 
 import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.TopDocsCollector;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.TopDocsCollector;
 import org.apache.solr.handler.component.MergeStrategy;
 
 import java.io.IOException;
@@ -29,7 +30,9 @@ import java.io.IOException;
 
 public abstract class RankQuery extends ExtendedQueryBase {
 
+  @Deprecated
   public abstract TopDocsCollector getTopDocsCollector(int len, QueryCommand cmd, IndexSearcher searcher) throws IOException;
+  public abstract TopDocsCollector getTopDocsCollector(TopDocsCollector previousCollector, int len, Sort sort, IndexSearcher searcher) throws IOException;
   public abstract MergeStrategy getMergeStrategy();
   public abstract RankQuery wrap(Query mainQuery);
 

--- a/solr/core/src/java/org/apache/solr/search/ReRankCollector.java
+++ b/solr/core/src/java/org/apache/solr/search/ReRankCollector.java
@@ -47,21 +47,32 @@ public class ReRankCollector extends TopDocsCollector {
   final private int length;
   final private Map<BytesRef, Integer> boostedPriority;
   final private Rescorer reRankQueryRescorer;
+  final private TopDocsCollector previousCollector;
 
-
+  @Deprecated
   public ReRankCollector(int reRankDocs,
       int length,
       Rescorer reRankQueryRescorer,
       QueryCommand cmd,
       IndexSearcher searcher,
       Map<BytesRef, Integer> boostedPriority) throws IOException {
+    this(null, reRankDocs, length, cmd.getSort(), reRankQueryRescorer, searcher, boostedPriority);
+  }
+
+  public ReRankCollector(TopDocsCollector previousCollector,
+                         int reRankDocs,
+                         int length,
+                         Sort sort,
+                         Rescorer reRankQueryRescorer,
+                         IndexSearcher searcher,
+                         Map<BytesRef, Integer> boostedPriority) throws IOException {
     super(null);
-    this.reRankDocs = reRankDocs;
     this.length = length;
+    this.reRankDocs = reRankDocs;
     this.boostedPriority = boostedPriority;
-    Sort sort = cmd.getSort();
+    this.previousCollector = previousCollector;
     if(sort == null) {
-      this.mainCollector = TopScoreDocCollector.create(Math.max(this.reRankDocs, length));
+      this.mainCollector = TopScoreDocCollector.create( Math.max(this.reRankDocs, length));
     } else {
       sort = sort.rewrite(searcher);
       this.mainCollector = TopFieldCollector.create(sort, Math.max(this.reRankDocs, length), false, true, true);

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -1858,7 +1858,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     Query q = cmd.getQuery();
     if (q instanceof RankQuery) {
       RankQuery rq = (RankQuery) q;
-      return rq.getTopDocsCollector(len, cmd, this);
+      return rq.getTopDocsCollector(TopScoreDocCollector.create(len), len, cmd.getSort(), this);
     }
 
     if (null == cmd.getSort()) {

--- a/solr/core/src/java/org/apache/solr/search/grouping/collector/RerankTermSecondPassGroupingCollector.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/collector/RerankTermSecondPassGroupingCollector.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.search.grouping.collector;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.Collection;
+
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.TopDocsCollector;
+import org.apache.lucene.search.grouping.SearchGroup;
+import org.apache.lucene.search.grouping.term.TermSecondPassGroupingCollector;
+import org.apache.lucene.util.BytesRef;
+import org.apache.solr.search.RankQuery;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RerankTermSecondPassGroupingCollector extends TermSecondPassGroupingCollector {
+
+  private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final int DEFAULT_GROUPING_RERANKING = 10;
+
+
+  public RerankTermSecondPassGroupingCollector(String groupField, Collection<SearchGroup<BytesRef>> groups,
+      Sort groupSort, Sort withinGroupSort, IndexSearcher searcher, RankQuery query, int maxDocsPerGroup, boolean getScores, boolean getMaxScores,
+      boolean fillSortFields) throws IOException {
+    super(groupField, groups, groupSort, withinGroupSort, maxDocsPerGroup, getScores, getMaxScores, fillSortFields);
+
+
+    for (SearchGroup<BytesRef> group : groups) {
+      TopDocsCollector<?> collector;
+      if (query != null) {
+        collector = groupMap.get(group.groupValue).collector;
+        collector = query.getTopDocsCollector(collector, DEFAULT_GROUPING_RERANKING, groupSort, searcher);
+        groupMap.put(group.groupValue, new SearchGroupDocs<BytesRef>(group.groupValue, collector));
+      }
+    }
+  }
+}

--- a/solr/core/src/test/org/apache/solr/search/TestRankQueryPlugin.java
+++ b/solr/core/src/test/org/apache/solr/search/TestRankQueryPlugin.java
@@ -128,12 +128,6 @@ public class TestRankQueryPlugin extends QParserPlugin {
       this.mergeStrategy = mergeStrategy;
     }
 
-    public TopDocsCollector getTopDocsCollector(int len, QueryCommand cmd, IndexSearcher searcher) {
-      if(collector == 0)
-        return new TestCollector(null);
-      else
-        return new TestCollector1(null);
-    }
 
     public MergeStrategy getMergeStrategy() {
       if(mergeStrategy == 0)
@@ -141,6 +135,21 @@ public class TestRankQueryPlugin extends QParserPlugin {
       else
         return new TestMergeStrategy1();
     }
+
+    @Override
+    public TopDocsCollector getTopDocsCollector(int len, QueryCommand cmd, IndexSearcher searcher) throws IOException {
+      return getTopDocsCollector(null, len, cmd.getSort(), searcher);
+    }
+
+    @Override
+    public TopDocsCollector getTopDocsCollector(TopDocsCollector previousCollector, int length, Sort sort, IndexSearcher searcher)
+        throws IOException {
+      if(collector == 0)
+        return new TestCollector(null);
+      else
+        return new TestCollector1(null);
+    }
+
   }
 
   class TestMergeStrategy implements MergeStrategy {


### PR DESCRIPTION
Update SOLR-8776 to current master
  - Reranking and grouping work together in non-distributed setting when grouping is done by field
  - Still have to fix for distribute setting and for grouping based on the unique values of a function query. 