### PR TITLE
LUCENE-7778 Removed synchronized from RAMFile methods

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/store/RAMFile.java
+++ b/lucene/core/src/java/org/apache/lucene/store/RAMFile.java
@@ -60,11 +60,11 @@ public class RAMFile implements Accountable {
     return buffer;
   }
 
-  protected final synchronized byte[] getBuffer(int index) {
+  protected final byte[] getBuffer(int index) {
     return buffers.get(index);
   }
 
-  protected final synchronized int numBuffers() {
+  protected final int numBuffers() {
     return buffers.size();
   }
 


### PR DESCRIPTION
These methods don't seem to benefit from locking - the methods that mutate the underlying fields aren't synchronized themselves, for example

Removing these methods gives me a 2x throughput increase under concurrent load on internal benchmarks