### PR TITLE
SOLR-1384 minShouldMatch parameter is supported for boolean query

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -67,6 +67,8 @@ Upgrading from Solr 6.x
 
 New Features
 ----------------------
+* SOLR-1384: minShouldMatch parameter is supported for boolean query.
+
 * SOLR-9857, SOLR-9858: Collect aggregated metrics from nodes and shard leaders in overseer. (ab)
 
 * SOLR-9835: Create another replication mode for SolrCloud

--- a/solr/core/src/java/org/apache/solr/search/LuceneQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/LuceneQParser.java
@@ -18,6 +18,7 @@ package org.apache.solr.search;
 
 import org.apache.lucene.search.Query;
 import org.apache.solr.common.params.CommonParams;
+import org.apache.solr.common.params.DisMaxParams;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.StrUtils;
 import org.apache.solr.request.SolrQueryRequest;
@@ -49,6 +50,8 @@ public class LuceneQParser extends QParser {
                                                   getParam(QueryParsing.OP)));
     lparser.setSplitOnWhitespace(StrUtils.parseBool
       (getParam(QueryParsing.SPLIT_ON_WHITESPACE), SolrQueryParser.DEFAULT_SPLIT_ON_WHITESPACE));
+
+    lparser.setDefaultMinShouldMatchSpec(getParam(DisMaxParams.MM));
 
     return lparser.parse(qstr);
   }

--- a/solr/core/src/test/org/apache/solr/search/TestMinShouldMatchForBooleanQuery.java
+++ b/solr/core/src/test/org/apache/solr/search/TestMinShouldMatchForBooleanQuery.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.search;
+
+import org.apache.solr.util.AbstractSolrTestCase;
+import org.junit.BeforeClass;
+
+/**
+ *
+ */
+public class TestMinShouldMatchForBooleanQuery extends AbstractSolrTestCase {
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    initCore("solrconfig.xml", "schema.xml");
+  }
+
+  public void testMinShouldMatchForBooleanQuery() {
+    String f = "name";  // name is whitespace tokenized
+
+    assertU(adoc("id", "1",  f, "A B C D"));
+    assertU(adoc("id", "2",  f, "A B C"));
+    assertU(adoc("id", "3",  f, "A B"));
+    assertU(commit());
+
+    assertQ("without mm we expect 3 documents to match",
+        req("name:(A B C D)"),
+        "//result[@numFound='3']"
+    );
+
+    assertQ("with mm=3 we expect 2 documents to match",
+        req("{!mm=3}name:(A B C D)"),
+        "//result[@numFound='2']"
+    );
+
+    assertQ("with mm=80% in q we expect 2 documents to match",
+        req("{!mm=80%}name:(A B C D)"),
+        "//result[@numFound='2']"
+    );
+
+    assertQ("with mm=80% in fq we expect 2 documents to match",
+        req("q", "*:*",
+            "fq","{!mm=80%}name:(A B C D)"),
+        "//result[@numFound='2']"
+    );
+
+    assertQ("with mm<50% 6<70% we expect 2 documents to match",
+        req("q", "*:*",
+            "fq","{!mm='3<50% 6<70%'}name:(A B C D E F)"),
+        "//result[@numFound='2']"
+    );
+
+  }
+
+}


### PR DESCRIPTION
Please consider adding min-should-match support to boolean query. We need it and can't switch to eDisMax because of it's restriction. (eDisMax stops min-should-match processing if it finds boolean operators in subqueries.)