### PR TITLE
[SOLR-10506] Fixes a memory leak in zk schema watching

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/function/FileFloatSource.java
+++ b/solr/core/src/java/org/apache/solr/search/function/FileFloatSource.java
@@ -126,6 +126,14 @@ public class FileFloatSource extends ValueSource {
   }
 
   /**
+   * Remove all cached entries associated with the given index reader.  
+   * Values are lazily loaded next time getValues() is called.
+   */
+  public static void resetCacheFor(IndexReader reader){
+    floatCache.resetCacheFor(reader);
+  }
+
+  /**
    * Refresh the cache for an IndexReader.  The new values are loaded in the background
    * and then swapped in, so queries against the cache should not block while the reload
    * is happening.
@@ -207,8 +215,22 @@ public class FileFloatSource extends ValueSource {
         readerCache.clear();
       }
     }
-  }
 
+    /**
+     * Removes and clears the inner cache for the given index reader
+     */
+    public void resetCacheFor(IndexReader reader){
+      synchronized(readerCache){
+        Map innerCache = (Map) readerCache.remove(reader);
+        if (innerCache != null) {
+          // Map.clear() is optional and can throw UnsupportedOperationException,
+          // but readerCache is WeakHashMap and it supports clear().
+          innerCache.clear();
+        }
+      }
+    }
+  }
+  
   static Object onlyForTesting; // set to the last value
 
   static final class CreationPlaceholder {


### PR DESCRIPTION
Upon manual Solr Collection reloading, references to the closed `SolrCore` are not fully removed by the garbage collector as a strong reference to the `ZkIndexSchemaReader` is held in a ZooKeeper `Watcher` that watches for schema changes.

In our case, this leads to a massive memory leak as managed resources are still referenced by the closed `SolrCore`. Our Solr cloud environment utilizes rather large managed resources (synonyms, stopwords). To reproduce, we fired out environment up and reloaded the collection 13 times. As a result we fully exhausted our heap. A closer look with the Yourkit profiler revealed 13 `SolrCore` instances, still holding strong references to the garbage collection root.

Each `SolrCore` instance holds a single path with strong references to the gc root via a `Watcher` in `ZkIndexSchemaReader`. The `ZkIndexSchemaReader` registers a close hook in the `SolrCore` but the Zookeeper is not removed upon core close.

We supplied this Github Pull Request that extracts the zookeeper `Watcher` as a static inner class. To eliminate the memory leak, the schema reader is held inside a `WeakReference` and the reference is explicitly removed on core close.

Initially I wanted to supply a test case but unfortunately did not find a good starting point ...