### PR TITLE
[SOLR-10550] Improve FileFloatSource eviction // reduce FileFloatSource memory footprint

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/function/FileFloatSource.java
+++ b/solr/core/src/java/org/apache/solr/search/function/FileFloatSource.java
@@ -126,6 +126,14 @@ public class FileFloatSource extends ValueSource {
   }
 
   /**
+   * Remove all cached entries associated with the given index reader.  
+   * Values are lazily loaded next time getValues() is called.
+   */
+  public static void resetCacheFor(IndexReader reader){
+    floatCache.resetCacheFor(reader);
+  }
+
+  /**
    * Refresh the cache for an IndexReader.  The new values are loaded in the background
    * and then swapped in, so queries against the cache should not block while the reload
    * is happening.
@@ -207,8 +215,22 @@ public class FileFloatSource extends ValueSource {
         readerCache.clear();
       }
     }
-  }
 
+    /**
+     * Removes and clears the inner cache for the given index reader
+     */
+    public void resetCacheFor(IndexReader reader){
+      synchronized(readerCache){
+        Map innerCache = (Map) readerCache.remove(reader);
+        if (innerCache != null) {
+          // Map.clear() is optional and can throw UnsupportedOperationException,
+          // but readerCache is WeakHashMap and it supports clear().
+          innerCache.clear();
+        }
+      }
+    }
+  }
+  
   static Object onlyForTesting; // set to the last value
 
   static final class CreationPlaceholder {


### PR DESCRIPTION
As a follow up from `SOLR-10506` we found another possible memory leak in Solr. The values generated from an `ExternalFileField` are cached in a static cache inside the `FileFloatSource`. That cache caches both a `IndexReader` and `FileFloatSource`s loaded using that `IndexReader`.
Cache eviction is left to the internally used WeakHashMap or a full eviction can be triggered via url. We are dealing with large synonym files and word lists stored in managed resources. Those are tied to the SolrCore as described in `SOLR-10506`. We're also using `ExternalFileField`s whose `FileFloatSource` are cached in said static cache. The FileFloatSource hold strong (transitive) references to the SolrCore they have been created for.

After a couple of collection reloads, the cache eviction mechanism of the `WeakHashMap` gets activated pretty close to heap exhaustion. The patch attached adds a mechanism to evict cache entries created in the context of a `SolrCore` upon it's close using a close hook in the `ExternalFileFieldReloader`. It furthermore adds a static cache reset method for all entries bound to a given IndexReader. I'm not sure, if the added cache resets are too aggressive or executed too often, I'd like to leave that to the experts.

N.B.: I did this second PR for the same issue to separate code changes for both SOLR-10506 and SOLR-10550 which I maintained on the same fork branch :-/
