### PR TITLE
Allocate ArrayList with exact size

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/ExactPhraseScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ExactPhraseScorer.java
@@ -53,8 +53,8 @@ final class ExactPhraseScorer extends Scorer {
     this.docScorer = docScorer;
     this.needsScores = needsScores;
 
-    List<DocIdSetIterator> iterators = new ArrayList<>();
-    List<PostingsAndPosition> postingsAndPositions = new ArrayList<>();
+    List<DocIdSetIterator> iterators = new ArrayList<>(postings.size());
+    List<PostingsAndPosition> postingsAndPositions = new ArrayList<>(postings.size());
     for(PhraseQuery.PostingsAndFreq posting : postings) {
       iterators.add(posting.postings);
       postingsAndPositions.add(new PostingsAndPosition(posting.postings, posting.position));


### PR DESCRIPTION
For more than 10 terms in a phrase (the default size of an array list), this may save reallocations, and for fewer terms it may save a little bit of memory.