### PR TITLE
SOLR-10703 Add prepare and finish in DocTrasformer

### DIFF
--- a/solr/contrib/ltr/src/java/org/apache/solr/ltr/response/transform/LTRFeatureLoggerTransformerFactory.java
+++ b/solr/contrib/ltr/src/java/org/apache/solr/ltr/response/transform/LTRFeatureLoggerTransformerFactory.java
@@ -187,8 +187,8 @@ public class LTRFeatureLoggerTransformerFactory extends TransformerFactory {
     }
 
     @Override
-    public void setContext(ResultContext context) {
-      super.setContext(context);
+    public void prepare(ResultContext context) {
+      super.prepare(context);
       if (context == null) {
         return;
       }

--- a/solr/core/src/java/org/apache/solr/handler/component/RealTimeGetComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/RealTimeGetComponent.java
@@ -61,6 +61,7 @@ import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.StrUtils;
 import org.apache.solr.core.SolrCore;
 import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.response.DocsStreamer;
 import org.apache.solr.response.ResultContext;
 import org.apache.solr.response.SolrQueryResponse;
 import org.apache.solr.response.transform.DocTransformer;
@@ -296,13 +297,13 @@ public class RealTimeGetComponent extends SearchComponent
          if (null == resultContext) {
            // either first pass, or we've re-opened searcher - either way now we setContext
            resultContext = new RTGResultContext(rsp.getReturnFields(), searcherInfo.getSearcher(), req);
-           transformer.setContext(resultContext);
+           transformer.prepare(resultContext);
          }
          transformer.transform(doc, docid, 0);
        }
        docList.add(doc);
      }
-
+     if ( null != transformer) transformer.finish();
    } finally {
      searcherInfo.clear();
    }
@@ -1210,7 +1211,7 @@ public class RealTimeGetComponent extends SearchComponent
     }
     
     /** @returns null */
-    public Iterator<SolrDocument> getProcessedDocuments() {
+    public DocsStreamer getProcessedDocuments() {
       return null;
     }
   }

--- a/solr/core/src/java/org/apache/solr/response/BinaryResponseWriter.java
+++ b/solr/core/src/java/org/apache/solr/response/BinaryResponseWriter.java
@@ -33,6 +33,7 @@ import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.util.JavaBinCodec;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.response.transform.DocTransformer;
 import org.apache.solr.schema.IndexSchema;
 import org.apache.solr.schema.SchemaField;
 import org.apache.solr.search.DocList;
@@ -119,10 +120,14 @@ public class BinaryResponseWriter implements BinaryQueryResponseWriter {
 
     protected void writeResultsBody( ResultContext res, JavaBinCodec codec ) throws IOException {
       codec.writeTag(JavaBinCodec.ARR, res.getDocList().size());
-      Iterator<SolrDocument> docStreamer = res.getProcessedDocuments();
-      while (docStreamer.hasNext()) {
-        SolrDocument doc = docStreamer.next();
+
+      Iterator<SolrDocument> docsStreamer = res.getProcessedDocuments();
+      while (docsStreamer.hasNext()) {
+        SolrDocument doc = docsStreamer.next();
         codec.writeSolrDocument(doc);
+      }
+      if (docsStreamer instanceof DocsStreamer){
+        ((DocsStreamer)docsStreamer).finish();
       }
     }
 

--- a/solr/core/src/java/org/apache/solr/response/DocsStreamer.java
+++ b/solr/core/src/java/org/apache/solr/response/DocsStreamer.java
@@ -142,6 +142,11 @@ public class DocsStreamer implements Iterator<SolrDocument> {
     return docIterator.hasNext();
   }
 
+  // called at the end of the stream
+  public void finish(){
+    if (transformer != null) transformer.finish();
+  }
+
   public SolrDocument next() {
     int id = docIterator.nextDoc();
     idx++;

--- a/solr/core/src/java/org/apache/solr/response/TextResponseWriter.java
+++ b/solr/core/src/java/org/apache/solr/response/TextResponseWriter.java
@@ -266,6 +266,9 @@ public abstract class TextResponseWriter implements PushWriter {
       writeSolrDocument(null, docsStreamer.next(), res.getReturnFields(), idx);
       idx++;
     }
+    if (docsStreamer instanceof DocsStreamer){
+      ((DocsStreamer)docsStreamer).finish();
+    }
     writeEndDocumentList();
   }
   

--- a/solr/core/src/java/org/apache/solr/response/transform/DocTransformer.java
+++ b/solr/core/src/java/org/apache/solr/response/transform/DocTransformer.java
@@ -41,12 +41,26 @@ public abstract class DocTransformer {
    */
   public abstract String getName();
 
+
   /**
    * This is called before {@link #transform} to provide context for any subsequent transformations.
    *
    * @param context The {@link ResultContext} stores information about how the documents were produced.
    * @see #needsSolrIndexSearcher
    */
+  public void prepare( ResultContext context ) {
+    this.context = context;
+
+  }
+
+
+  /**
+   * This is called before {@link #transform} to provide context for any subsequent transformations.
+   *
+   * @param context The {@link ResultContext} stores information about how the documents were produced.
+   * @see #needsSolrIndexSearcher
+   */
+  @Deprecated
   public void setContext( ResultContext context ) {
     this.context = context;
 
@@ -55,7 +69,7 @@ public abstract class DocTransformer {
   /**
    * Indicates if this transformer requires access to the underlying index to perform it's functions.
    *
-   * In some situations (notably RealTimeGet) this method <i>may</i> be called before {@link #setContext} 
+   * In some situations (notably RealTimeGet) this method <i>may</i> be called before {@link #prepare}
    * to determine if the transformer must be given a "full" ResultContext and accurate docIds 
    * that can be looked up using {@link ResultContext#getSearcher}, or if optimizations can be taken 
    * advantage of such that {@link ResultContext#getSearcher} <i>may</i> return null, and docIds passed to 
@@ -92,6 +106,12 @@ public abstract class DocTransformer {
    */
   public String[] getExtraRequestFields() {
     return null;
+  }
+
+  /**
+   * This is called after a transformer has been applied to all the documents in the results set
+   */
+  public void finish(){
   }
   
   @Override

--- a/solr/core/src/java/org/apache/solr/response/transform/DocTransformers.java
+++ b/solr/core/src/java/org/apache/solr/response/transform/DocTransformers.java
@@ -63,10 +63,11 @@ public class DocTransformers extends DocTransformer
     return children.get( idx );
   }
 
+
   @Override
-  public void setContext( ResultContext context ) {
+  public void prepare( ResultContext context ) {
     for( DocTransformer a : children ) {
-      a.setContext( context );
+      a.prepare( context );
     }
   }
 
@@ -86,6 +87,13 @@ public class DocTransformers extends DocTransformer
       }
     }
     return false;
+  }
+
+  @Override
+  public void finish() {
+    for( DocTransformer a : children ) {
+      a.finish();
+    }
   }
 
 }

--- a/solr/core/src/java/org/apache/solr/response/transform/ValueSourceAugmenter.java
+++ b/solr/core/src/java/org/apache/solr/response/transform/ValueSourceAugmenter.java
@@ -60,8 +60,8 @@ public class ValueSourceAugmenter extends DocTransformer
   }
 
   @Override
-  public void setContext( ResultContext context ) {
-    super.setContext(context);
+  public void prepare( ResultContext context ) {
+    super.prepare(context);
     try {
       searcher = context.getSearcher();
       readerContexts = searcher.getIndexReader().leaves();

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-doctransformers.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-doctransformers.xml
@@ -36,6 +36,7 @@
   </updateHandler>
 
   <transformer name="custom" class="org.apache.solr.response.TestCustomDocTransformer$CustomTransformerFactory" />
+  <transformer name="customFinish" class="org.apache.solr.response.TestCustomDocTransformer$CustomFinishTransformerFactory" />
 
   <requestHandler name="/select" class="solr.StandardRequestHandler"/>
 


### PR DESCRIPTION
This patch adds a prepare and a finish method to the interface of DocTransformer allowing a developer to perform actions before/after a doc transformer is applied to a result set. My use case was to benchmark the performance of a transformer, since transformer time is not part of QTime.