### PR TITLE
SOLR-8984 Add field name to exception message.

### DIFF
--- a/solr/core/src/java/org/apache/solr/schema/EnumField.java
+++ b/solr/core/src/java/org/apache/solr/schema/EnumField.java
@@ -386,8 +386,11 @@ public class EnumField extends PrimitiveFieldType {
       return null;
     }
     final Integer intValue = stringValueToIntValue(value.toString());
-    if (intValue == null || intValue.equals(DEFAULT_VALUE))
-      throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "Unknown value for enum field: " + value.toString());
+    if (intValue == null || intValue.equals(DEFAULT_VALUE)) {
+      String exceptionMessage = String.format(Locale.ENGLISH, "Unknown value for enum field: %s, value: %s",
+          field.getName(), value.toString());
+      throw new SolrException(SolrException.ErrorCode.SERVER_ERROR,  exceptionMessage);
+    }
 
     final LegacyFieldType newType = new LegacyFieldType();
 

--- a/solr/core/src/test/org/apache/solr/schema/EnumFieldTest.java
+++ b/solr/core/src/test/org/apache/solr/schema/EnumFieldTest.java
@@ -152,9 +152,9 @@ public class EnumFieldTest extends SolrTestCaseJ4 {
   @Test
   public void testBogusEnumIndexing() throws Exception {
 
-    ignoreException("Unknown value for enum field: blabla");
-    ignoreException("Unknown value for enum field: 10");
-    ignoreException("Unknown value for enum field: -4");
+    ignoreException("Unknown value for enum field: " + FIELD_NAME + ", value: blabla");
+    ignoreException("Unknown value for enum field: " + FIELD_NAME + ", value: 10");
+    ignoreException("Unknown value for enum field: " + FIELD_NAME + ", value: -4");
 
     clearIndex();
 


### PR DESCRIPTION
This is an old issue, but I figured it was something simple to start learning your codebase.  I added the field name to the exception message and used the syntax used in another exception then updated the tests.