### PR TITLE
Small correction where windows path specified instead of linux

### DIFF
--- a/solr/solr-ref-guide/src/setting-up-an-external-zookeeper-ensemble.adoc
+++ b/solr/solr-ref-guide/src/setting-up-an-external-zookeeper-ensemble.adoc
@@ -138,7 +138,7 @@ The `<ZOOKEEPER_HOME>/conf/zoo2.cfg` file should have the content:
 [source,bash]
 ----
 tickTime=2000
-dataDir=c:/sw/zookeeperdata/2
+dataDir=/var/lib/zookeeperdata/2
 clientPort=2182
 initLimit=5
 syncLimit=2
@@ -152,7 +152,7 @@ You'll also need to create `<ZOOKEEPER_HOME>/conf/zoo3.cfg`:
 [source,bash]
 ----
 tickTime=2000
-dataDir=c:/sw/zookeeperdata/3
+dataDir=/var/lib/zookeeperdata/3
 clientPort=2183
 initLimit=5
 syncLimit=2


### PR DESCRIPTION
...For first zookeeper configuration, in the same doc page, path
specified is linux and suddently for second and third configuration it
seems somwhow changed to windows path which creates confusion. So
changed these windows path to linux path as given in first
configuration.