### PR TITLE
Branch 5x small optimisations

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/store/RAMFile.java
+++ b/lucene/core/src/java/org/apache/lucene/store/RAMFile.java
@@ -29,6 +29,7 @@ import org.apache.lucene.util.Accountable;
  * @lucene.internal */
 public class RAMFile implements Accountable {
   protected final ArrayList<byte[]> buffers = new ArrayList<>();
+  private volatile int numBuffers;
   long length;
   RAMDirectory directory;
   protected long sizeInBytes;
@@ -53,6 +54,7 @@ public class RAMFile implements Accountable {
     byte[] buffer = newBuffer(size);
     synchronized(this) {
       buffers.add(buffer);
+      numBuffers = buffers.size();
       sizeInBytes += size;
     }
 
@@ -66,8 +68,8 @@ public class RAMFile implements Accountable {
     return buffers.get(index);
   }
 
-  protected final synchronized int numBuffers() {
-    return buffers.size();
+  protected final int numBuffers() {
+    return numBuffers;
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/store/RAMOutputStream.java
+++ b/lucene/core/src/java/org/apache/lucene/store/RAMOutputStream.java
@@ -32,7 +32,7 @@ import org.apache.lucene.util.Accountables;
  * @lucene.internal
  */
 public class RAMOutputStream extends IndexOutput implements Accountable {
-  static final int BUFFER_SIZE = 1024;
+  static final int BUFFER_SIZE = Integer.getInteger( "org.apache.lucene.store.RAMOutputStream.BUFFER_SIZE", 1024 );
 
   private final RAMFile file;
 


### PR DESCRIPTION
In a test with a high concurrency, high write workload on the NRTCachingDirectory, these changes gives me a ~10-15% throughput improvement. To get that, I had to increase the buffer size to 4 KiB. I have left it as is, and just allowed it to be tuned.