### PR TITLE
Make FacetField.TYPE public

### DIFF
--- a/lucene/facet/src/java/org/apache/lucene/facet/FacetField.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/FacetField.java
@@ -31,6 +31,8 @@ import org.apache.lucene.index.IndexOptions;
  * you add the document to IndexWriter.
  */
 public class FacetField extends Field {
+  
+  /** Field type used for storing facet values: docs, freqs, and positions. */
   public static final FieldType TYPE = new FieldType();
   static {
     TYPE.setIndexOptions(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS);

--- a/lucene/facet/src/java/org/apache/lucene/facet/FacetField.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/FacetField.java
@@ -31,7 +31,7 @@ import org.apache.lucene.index.IndexOptions;
  * you add the document to IndexWriter.
  */
 public class FacetField extends Field {
-  static final FieldType TYPE = new FieldType();
+  public static final FieldType TYPE = new FieldType();
   static {
     TYPE.setIndexOptions(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS);
     TYPE.freeze();


### PR DESCRIPTION
Everything else in the class is public, and all the other Field.TYPE constants are public. I want to use this in a field factory class.