### PR TITLE
SpanishLightStemmer fix for plural words like casas

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/es/SpanishLightStemmer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/es/SpanishLightStemmer.java
@@ -1,26 +1,9 @@
+package com.infuy.elpais.searchengine.search;
+
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-package org.apache.lucene.analysis.es;
-
-
-/* 
  * This algorithm is updated based on code located at:
  * http://members.unine.ch/jacques.savoy/clef/
- * 
+ *
  * Full copyright for that code follows:
  */
 
@@ -28,26 +11,26 @@ package org.apache.lucene.analysis.es;
  * Copyright (c) 2005, Jacques Savoy
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without 
+ * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *
- * Redistributions of source code must retain the above copyright notice, this 
- * list of conditions and the following disclaimer. Redistributions in binary 
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer. Redistributions in binary
  * form must reproduce the above copyright notice, this list of conditions and
- * the following disclaimer in the documentation and/or other materials 
- * provided with the distribution. Neither the name of the author nor the names 
- * of its contributors may be used to endorse or promote products derived from 
+ * the following disclaimer in the documentation and/or other materials
+ * provided with the distribution. Neither the name of the author nor the names
+ * of its contributors may be used to endorse or promote products derived from
  * this software without specific prior written permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
@@ -60,50 +43,80 @@ package org.apache.lucene.analysis.es;
  * Jacques Savoy
  */
 public class SpanishLightStemmer {
-  
-  public int stem(char s[], int len) {
-    if (len < 5)
-      return len;
-    
-    for (int i = 0; i < len; i++)
-      switch(s[i]) {
-        case 'à': 
-        case 'á':
-        case 'â':
-        case 'ä': s[i] = 'a'; break;
-        case 'ò':
-        case 'ó':
-        case 'ô':
-        case 'ö': s[i] = 'o'; break;
-        case 'è':
-        case 'é':
-        case 'ê':
-        case 'ë': s[i] = 'e'; break;
-        case 'ù':
-        case 'ú':
-        case 'û':
-        case 'ü': s[i] = 'u'; break;
-        case 'ì':
-        case 'í':
-        case 'î':
-        case 'ï': s[i] = 'i'; break;
-      }
-    
-    switch(s[len-1]) {
-      case 'o':
-      case 'a':
-      case 'e': return len - 1;
-      case 's':
-        if (s[len-2] == 'e' && s[len-3] == 's' && s[len-4] == 'e')
-          return len-2;
-        if (s[len-2] == 'e' && s[len-3] == 'c') {
-          s[len-3] = 'z';
-          return len - 2;
+
+    public int stem(final char[] s, final int len) {
+        if (len < 5)
+            return len;
+
+        for (int i = 0; i < len; i++)
+            switch (s[i]) {
+                case 'à':
+                case 'á':
+                case 'â':
+                case 'ä':
+                    s[i] = 'a';
+                    break;
+                case 'ò':
+                case 'ó':
+                case 'ô':
+                case 'ö':
+                    s[i] = 'o';
+                    break;
+                case 'è':
+                case 'é':
+                case 'ê':
+                case 'ë':
+                    s[i] = 'e';
+                    break;
+                case 'ù':
+                case 'ú':
+                case 'û':
+                case 'ü':
+                    s[i] = 'u';
+                    break;
+                case 'ì':
+                case 'í':
+                case 'î':
+                case 'ï':
+                    s[i] = 'i';
+                    break;
+            }
+
+        switch (s[len - 1]) {
+            case 'o':
+            case 'a':
+            case 'e':
+                return len - 1;
+            case 's':
+                if (s[len - 2] == 'e' && s[len - 3] == 's' && s[len - 4] == 'e')
+                    return checkMinLen(len);
+                if (s[len - 2] == 'e' && s[len - 3] == 'c') {
+                    s[len - 3] = 'z';
+                    return checkMinLen(len);
+                }
+                if (s[len - 2] == 'o' || s[len - 2] == 'a' || s[len - 2] == 'e') {
+                    return checkMinLen(len);
+                }
         }
-        if (s[len-2] == 'o' || s[len-2] == 'a' || s[len-2] == 'e')
-          return len - 2;
+
+        return len;
     }
-    
-    return len;
-  }
+
+    /**
+     * This is for check the final len before return the result, singular words in spanish has a minimum len of 4 so if the final len is lower the final word is not a valid word,
+     * this fix the stemmer for stem words like "casas".
+     * The plural of casa is casas, before this, casas was stemmed like cas, now is casa. The same thing happens for other words like
+     * casos, pasos, etc.
+     *
+     * @param len
+     * @return
+     */
+    private int checkMinLen(final int len) {
+        if ((len - 2) < 4) {
+            return len - 1;
+        } else {
+            return len - 2;
+        }
+    }
 }
+


### PR DESCRIPTION
This is for check the final len before return the result, singular words in spanish has a minimum len of 4 so if the final len is lower the final word is not a valid word, this fix the stemmer for stem words like "casas".
The plural of casa is casas, before this, casas was stemmed like cas, now is casa. The same thing happens for other words like casos, pasos, etc.