### PR TITLE
Fix invalid javadoc example in SpellChecker

### DIFF
--- a/lucene/suggest/src/java/org/apache/lucene/search/spell/SpellChecker.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/spell/SpellChecker.java
@@ -57,10 +57,11 @@ import org.apache.lucene.util.BytesRefIterator;
  * 
  * <pre class="prettyprint">
  *  SpellChecker spellchecker = new SpellChecker(spellIndexDirectory);
+ *  IndexWriterConfig config = new IndexWriterConfig();
  *  // To index a field of a user index:
- *  spellchecker.indexDictionary(new LuceneDictionary(my_lucene_reader, a_field));
+ *  spellchecker.indexDictionary(new LuceneDictionary(my_lucene_reader, a_field), config, true);
  *  // To index a file containing words:
- *  spellchecker.indexDictionary(new PlainTextDictionary(new File("myfile.txt")));
+ *  spellchecker.indexDictionary(new PlainTextDictionary(new File("myfile.txt")), config, true);
  *  String[] suggestions = spellchecker.suggestSimilar("misspelt", 5);
  * </pre>
  * 


### PR DESCRIPTION
Hello Lucene team.

This pull request is to address [LUCENE-7971](https://issues.apache.org/jira/browse/LUCENE-7971) bug from JIRA.

It is a fix for invalid example in ```SpellChecker``` javadoc. Index dictionary can be done by invoking ```checker.indexDictionary(dictionary, config, true)``` but in javadoc example the ```checker.indexDictionary(dictionary)``` method is used instead, which is wrong, because such method does not exist.

