### PR TITLE
Fix NPE on connection failure

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudSolrClient.java
@@ -909,10 +909,12 @@ public class CloudSolrClient extends SolrClient {
         // so that the next attempt would fetch the fresh state
         // just re-read state for all of them, if it has not been retired
         // in retryExpiryTime time
-        for (DocCollection ext : requestedCollections) {
-          ExpiringCachedDocCollection cacheEntry = collectionStateCache.get(ext.getName());
-          if (cacheEntry == null) continue;
-          cacheEntry.maybeStale = true;
+        if (requestedCollections != null) {
+          for (DocCollection ext : requestedCollections) {
+            ExpiringCachedDocCollection cacheEntry = collectionStateCache.get(ext.getName());
+            if (cacheEntry == null) continue;
+            cacheEntry.maybeStale = true;
+          }
         }
         if (retryCount < MAX_STALE_RETRIES) {//if it is a communication error , we must try again
           //may be, we have a stale version of the collection state


### PR DESCRIPTION
We're using ZK for node discovery. During rare evens of when some nodes are unavailable, we observe NPEs. I'm not quite familiar with the solr client logic but by looking at the code further, I concluded that the iteration misses a null check. 

```java
java.lang.NullPointerException: null
    at org.apache.solr.client.solrj.impl.CloudSolrClient.requestWithRetryOnStaleState(CloudSolrClient.java:1143)
    at org.apache.solr.client.solrj.impl.CloudSolrClient.request(CloudSolrClient.java:1037)
    at org.apache.solr.client.solrj.SolrRequest.process(SolrRequest.java:149)
    at org.apache.solr.client.solrj.SolrClient.query(SolrClient.java:974)
    at org.apache.solr.client.solrj.SolrClient.query(SolrClient.java:990)
    at com.company.search.SolrQueryServiceImpl.query(SolrQueryServiceImpl.java:65)
    at com.company.search.SolrQueryServiceImpl.query(SolrQueryServiceImpl.java:50)
    at com.company.search.server.ServiceServer.searchMedia(ServiceServer.java:358)
    at com.company.search.server.SearchServer.searchMedia(SearchServer.java:97)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
    at java.lang.Thread.run(Thread.java:748)
```