### PR TITLE
SOLR-11508: core.properties should be stored $solr.data.home/core_name

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -64,6 +64,10 @@ Upgrade Notes
   If you want to allow power-users to do this, set uf=*,_query_ or some other value that includes _query_.
   If you must have full backwards compatibility, use luceneMatchVersion=7.1.0 or something earlier. (David Smiley)
 
+* SOLR-11508: coreRootDirectory now defaults to $SOLR_DATA_HOME, if defined. If you have configured $SOLR_DATA_HOME and
+  have not configured an explicit value for coreRootDirectory in solr.xml, you may need to manually migrate the
+  core.properties files stored in server/solr to $SOLR_DATA_HOME or core discovery for pre-7.2 cores will fail.
+
 New Features
 ----------------------
 * SOLR-11448: Implement an option in collection commands to wait for final results. (ab)
@@ -149,6 +153,9 @@ Bug Fixes
 * SOLR-11645: When the java commandline had exact duplicate arguments, the
   admin UI dashboard would not display any commandline arguments.
   (Webster Homer via Shawn Heisey)
+
+* SOLR-11508: core.properties files are now stored in solr.data.home along with the rest of the core data.
+  (Marc Morissette)
 
 Optimizations
 ----------------------

--- a/solr/core/src/java/org/apache/solr/core/NodeConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/NodeConfig.java
@@ -262,7 +262,7 @@ public class NodeConfig {
       // always init from sysprop because <solrDataHome> config element may be missing
       String dataHomeProperty = System.getProperty(SolrXmlConfig.SOLR_DATA_HOME);
       if (dataHomeProperty != null && !dataHomeProperty.isEmpty()) {
-        solrDataHome = loader.getInstancePath().resolve(dataHomeProperty);
+        coreRootDirectory = solrDataHome = loader.getInstancePath().resolve(dataHomeProperty);
       }
       this.configSetBaseDirectory = loader.getInstancePath().resolve("configsets");
       this.metricsConfig = new MetricsConfig.MetricsConfigBuilder().build();

--- a/solr/core/src/test/org/apache/solr/core/TestCoreDiscovery.java
+++ b/solr/core/src/test/org/apache/solr/core/TestCoreDiscovery.java
@@ -385,6 +385,25 @@ public class TestCoreDiscovery extends SolrTestCaseJ4 {
   }
 
   @Test
+  public void testAlternateCoreViaSolrDataHome() throws Exception {
+    File alt = createTempDir().toFile();
+    System.setProperty("solr.data.home", alt.getAbsolutePath());
+    setMeUp(null);
+    addCoreWithProps(makeCoreProperties("core1", false, true, "dataDir=core1"),
+        new File(alt, "core1" + File.separator + CorePropertiesLocator.PROPERTIES_FILENAME));
+    addCoreWithProps(makeCoreProperties("core2", false, false, "dataDir=core2"),
+        new File(alt, "core2" + File.separator + CorePropertiesLocator.PROPERTIES_FILENAME));
+    CoreContainer cc = init();
+    try (SolrCore core1 = cc.getCore("core1");
+         SolrCore core2 = cc.getCore("core2")) {
+      assertNotNull(core1);
+      assertNotNull(core2);
+    } finally {
+      cc.shutdown();
+    }
+  }
+
+  @Test
   public void testAlternateRelativeCoreDir() throws Exception {
 
     String relative = "relativeCoreDir";

--- a/solr/solr-ref-guide/src/format-of-solr-xml.adoc
+++ b/solr/solr-ref-guide/src/format-of-solr-xml.adoc
@@ -70,7 +70,7 @@ As above, for custom InfoHandler implementations.
 Specifies the number of threads that will be assigned to load cores in parallel.
 
 `coreRootDirectory`::
-The root of the core discovery tree, defaults to `$SOLR_HOME` (by default, `server/solr`).
+The root of the core discovery tree. Defaults to `$SOLR_DATA_HOME` if it is defined, or `$SOLR_HOME` otherwise (if $SOLR_HOME is undefined, it defaults to `server/solr`.)
 
 `managementPath`::
 Currently non-operational.


### PR DESCRIPTION
I ended up simply defaulting coreRootDirectory to solr.data.home, if it is defined, and solr.home.home otherwise.  

Both values seem somewhat redundant but comments in SOLR-6671 indicate that others have reasons to keep them separate. This patch simply makes Solr behave in a way that is more intuitive by default. 

Those who need to revert to the old way can define coreRootDirectory in solr.xml, if they hadn't already. 