### PR TITLE
[LUCENE-8051] Typo in LevensHtein distance

### DIFF
--- a/lucene/suggest/src/java/org/apache/lucene/search/spell/LevenshteinDistance.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/spell/LevenshteinDistance.java
@@ -19,13 +19,13 @@ package org.apache.lucene.search.spell;
 /**
  * Levenstein edit distance class.
  */
-public final class LevensteinDistance implements StringDistance {
+public final class LevenshteinDistance implements StringDistance {
 
     /**
      * Optimized to run a bit faster than the static getDistance().
      * In one benchmark times were 5.3sec using ctr vs 8.5sec w/ static method, thus 37% faster.
      */
-    public LevensteinDistance () {
+    public LevenshteinDistance () {
     }
 
 

--- a/lucene/suggest/src/java/org/apache/lucene/search/spell/SpellChecker.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/spell/SpellChecker.java
@@ -126,7 +126,7 @@ public class SpellChecker implements java.io.Closeable {
   }
   /**
    * Use the given directory as a spell checker index with a
-   * {@link LevensteinDistance} as the default {@link StringDistance}. The
+   * {@link LevenshteinDistance} as the default {@link StringDistance}. The
    * directory is created if it doesn't exist yet.
    * 
    * @param spellIndex
@@ -135,7 +135,7 @@ public class SpellChecker implements java.io.Closeable {
    *           if spellchecker can not open the directory
    */
   public SpellChecker(Directory spellIndex) throws IOException {
-    this(spellIndex, new LevensteinDistance());
+    this(spellIndex, new LevenshteinDistance());
   }
 
   /**

--- a/lucene/suggest/src/test/org/apache/lucene/search/spell/TestLevenshteinDistance.java
+++ b/lucene/suggest/src/test/org/apache/lucene/search/spell/TestLevenshteinDistance.java
@@ -20,7 +20,7 @@ import org.apache.lucene.util.LuceneTestCase;
 
 public class TestLevenshteinDistance extends LuceneTestCase {
 
-  private StringDistance sd = new LevensteinDistance();
+  private StringDistance sd = new LevenshteinDistance();
   
   public void testGetDistance() {
     float d = sd.getDistance("al", "al");

--- a/lucene/suggest/src/test/org/apache/lucene/search/spell/TestSpellChecker.java
+++ b/lucene/suggest/src/test/org/apache/lucene/search/spell/TestSpellChecker.java
@@ -149,7 +149,7 @@ public class TestSpellChecker extends LuceneTestCase {
   public void testComparator() throws Exception {
     IndexReader r = DirectoryReader.open(userindex);
     Directory compIdx = newDirectory();
-    SpellChecker compareSP = new SpellCheckerMock(compIdx, new LevensteinDistance(), new SuggestWordFrequencyComparator());
+    SpellChecker compareSP = new SpellCheckerMock(compIdx, new LevenshteinDistance(), new SuggestWordFrequencyComparator());
     addwords(r, compareSP, "field3");
 
     String[] similar = compareSP.suggestSimilar("fvie", 2, r, "field3",
@@ -167,7 +167,7 @@ public class TestSpellChecker extends LuceneTestCase {
   public void testBogusField() throws Exception {
     IndexReader r = DirectoryReader.open(userindex);
     Directory compIdx = newDirectory();
-    SpellChecker compareSP = new SpellCheckerMock(compIdx, new LevensteinDistance(), new SuggestWordFrequencyComparator());
+    SpellChecker compareSP = new SpellCheckerMock(compIdx, new LevenshteinDistance(), new SuggestWordFrequencyComparator());
     addwords(r, compareSP, "field3");
 
     String[] similar = compareSP.suggestSimilar("fvie", 2, r,

--- a/solr/core/src/java/org/apache/solr/search/ValueSourceParser.java
+++ b/solr/core/src/java/org/apache/solr/search/ValueSourceParser.java
@@ -41,7 +41,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.spell.JaroWinklerDistance;
-import org.apache.lucene.search.spell.LevensteinDistance;
+import org.apache.lucene.search.spell.LevenshteinDistance;
 import org.apache.lucene.search.spell.NGramDistance;
 import org.apache.lucene.search.spell.StringDistance;
 import org.apache.lucene.util.BytesRefBuilder;
@@ -406,7 +406,7 @@ public abstract class ValueSourceParser implements NamedListInitializedPlugin {
         if (distClass.equalsIgnoreCase("jw")) {
           dist = new JaroWinklerDistance();
         } else if (distClass.equalsIgnoreCase("edit")) {
-          dist = new LevensteinDistance();
+          dist = new LevenshteinDistance();
         } else if (distClass.equalsIgnoreCase("ngram")) {
           int ngram = 2;
           if (fp.hasMoreArguments()) {

--- a/solr/core/src/java/org/apache/solr/spelling/AbstractLuceneSpellChecker.java
+++ b/solr/core/src/java/org/apache/solr/spelling/AbstractLuceneSpellChecker.java
@@ -26,7 +26,7 @@ import java.util.List;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.spell.Dictionary;
-import org.apache.lucene.search.spell.LevensteinDistance;
+import org.apache.lucene.search.spell.LevenshteinDistance;
 import org.apache.lucene.search.spell.SpellChecker;
 import org.apache.lucene.search.spell.StringDistance;
 import org.apache.lucene.search.spell.SuggestWord;
@@ -109,7 +109,7 @@ public abstract class AbstractLuceneSpellChecker extends SolrSpellChecker {
       sd = core.getResourceLoader().newInstance(strDistanceName, StringDistance.class);
       //TODO: Figure out how to configure options.  Where's Spring when you need it?  Or at least BeanUtils...
     } else {
-      sd = new LevensteinDistance();
+      sd = new LevenshteinDistance();
     }
     try {
       initIndex();

--- a/solr/core/src/java/org/apache/solr/spelling/SolrSpellChecker.java
+++ b/solr/core/src/java/org/apache/solr/spelling/SolrSpellChecker.java
@@ -23,7 +23,7 @@ import java.util.Map;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.core.WhitespaceAnalyzer;
-import org.apache.lucene.search.spell.LevensteinDistance;
+import org.apache.lucene.search.spell.LevenshteinDistance;
 import org.apache.lucene.search.spell.StringDistance;
 import org.apache.lucene.search.spell.SuggestWord;
 import org.apache.lucene.search.spell.SuggestWordQueue;
@@ -89,9 +89,9 @@ public abstract class SolrSpellChecker {
     
     StringDistance sd = null;
     try {
-      sd = getStringDistance() == null ? new LevensteinDistance() : getStringDistance();    
+      sd = getStringDistance() == null ? new LevenshteinDistance() : getStringDistance();    
     } catch(UnsupportedOperationException uoe) {
-      sd = new LevensteinDistance();
+      sd = new LevenshteinDistance();
     }
     
     SpellingResult result = new SpellingResult();

--- a/solr/core/src/test/org/apache/solr/spelling/ConjunctionSolrSpellCheckerTest.java
+++ b/solr/core/src/test/org/apache/solr/spelling/ConjunctionSolrSpellCheckerTest.java
@@ -18,7 +18,7 @@ package org.apache.solr.spelling;
 
 import java.io.IOException;
 
-import org.apache.lucene.search.spell.LevensteinDistance;
+import org.apache.lucene.search.spell.LevenshteinDistance;
 import org.apache.lucene.search.spell.NGramDistance;
 import org.apache.lucene.search.spell.StringDistance;
 import org.apache.lucene.util.LuceneTestCase;
@@ -31,8 +31,8 @@ public class ConjunctionSolrSpellCheckerTest extends LuceneTestCase {
   @Test
   public void test() throws Exception {
     ConjunctionSolrSpellChecker cssc = new ConjunctionSolrSpellChecker();
-    MockSolrSpellChecker levenstein1 = new MockSolrSpellChecker(new LevensteinDistance());
-    MockSolrSpellChecker levenstein2 = new MockSolrSpellChecker(new LevensteinDistance());
+    MockSolrSpellChecker levenstein1 = new MockSolrSpellChecker(new LevenshteinDistance());
+    MockSolrSpellChecker levenstein2 = new MockSolrSpellChecker(new LevenshteinDistance());
     MockSolrSpellChecker ngram = new MockSolrSpellChecker(new NGramDistance());
     
     cssc.addChecker(levenstein1);

--- a/solr/solr-ref-guide/src/spell-checking.adoc
+++ b/solr/solr-ref-guide/src/spell-checking.adoc
@@ -39,7 +39,7 @@ The `IndexBasedSpellChecker` uses a Solr index as the basis for a parallel index
     <str name="field">content</str>
     <str name="buildOnCommit">true</str>
     <!-- optional elements with defaults
-    <str name="distanceMeasure">org.apache.lucene.search.spell.LevensteinDistance</str>
+    <str name="distanceMeasure">org.apache.lucene.search.spell.LevenshteinDistance</str>
     <str name="accuracy">0.5</str>
     -->
  </lst>
@@ -99,7 +99,7 @@ The `FileBasedSpellChecker` uses an external file as a spelling dictionary. This
     <str name="characterEncoding">UTF-8</str>
     <str name="spellcheckIndexDir">./spellcheckerFile</str>
     <!-- optional elements with defaults
-    <str name="distanceMeasure">org.apache.lucene.search.spell.LevensteinDistance</str>
+    <str name="distanceMeasure">org.apache.lucene.search.spell.LevenshteinDistance</str>
     <str name="accuracy">0.5</str>
     -->
  </lst>


### PR DESCRIPTION
Fixed a type:
"Looking into an issue in elasticsearch I notices that the Levenshtein distance in lucene is called LevensteinDistance instead of LevenshteinDistance.
The algorithm name contains an H and in the rest of the code the Levenshtein name is spelled correctly with an H."