### PR TITLE
LUCENE-8086

### DIFF
--- a/lucene/spatial-extras/src/java/org/apache/lucene/spatial/spatial4j/Geo3dCircleShape.java
+++ b/lucene/spatial-extras/src/java/org/apache/lucene/spatial/spatial4j/Geo3dCircleShape.java
@@ -20,13 +20,10 @@ package org.apache.lucene.spatial.spatial4j;
 import org.apache.lucene.spatial3d.geom.GeoCircle;
 import org.apache.lucene.spatial3d.geom.GeoCircleFactory;
 import org.apache.lucene.spatial3d.geom.GeoPointShapeFactory;
-import org.apache.lucene.spatial3d.geom.PlanetModel;
 import org.locationtech.spatial4j.context.SpatialContext;
 import org.locationtech.spatial4j.distance.DistanceUtils;
 import org.locationtech.spatial4j.shape.Circle;
 import org.locationtech.spatial4j.shape.Point;
-import org.locationtech.spatial4j.shape.Shape;
-import org.locationtech.spatial4j.shape.SpatialRelation;
 
 /**
  * Specialization of a {@link Geo3dShape} which represents a {@link Circle}.
@@ -66,17 +63,5 @@ public class Geo3dCircleShape extends Geo3dShape<GeoCircle> implements Circle {
       this.center = center;
     }
     return center;
-  }
-
-  //TODO Improve GeoCircle to properly relate a point with WGS84 model -- LUCENE-7970
-  @Override
-  public SpatialRelation relate(Shape other) {
-    if (shape.getPlanetModel() != PlanetModel.SPHERE && other instanceof Point) {
-      if (spatialcontext.getDistCalc().distance((Point) other, getCenter()) <= getRadius()) {
-        return SpatialRelation.CONTAINS;
-      }
-      return SpatialRelation.DISJOINT;
-    }
-    return super.relate(other);
   }
 }

--- a/lucene/spatial-extras/src/java/org/apache/lucene/spatial/spatial4j/Geo3dDistanceCalculator.java
+++ b/lucene/spatial-extras/src/java/org/apache/lucene/spatial/spatial4j/Geo3dDistanceCalculator.java
@@ -19,7 +19,6 @@ package org.apache.lucene.spatial.spatial4j;
 
 import org.apache.lucene.spatial3d.geom.GeoPoint;
 import org.apache.lucene.spatial3d.geom.GeoPointShape;
-import org.apache.lucene.spatial3d.geom.GeoPointShapeFactory;
 import org.apache.lucene.spatial3d.geom.PlanetModel;
 import org.locationtech.spatial4j.context.SpatialContext;
 import org.locationtech.spatial4j.distance.DistanceCalculator;

--- a/lucene/spatial-extras/src/java/org/apache/lucene/spatial/spatial4j/Geo3dDistanceCalculator.java
+++ b/lucene/spatial-extras/src/java/org/apache/lucene/spatial/spatial4j/Geo3dDistanceCalculator.java
@@ -19,6 +19,7 @@ package org.apache.lucene.spatial.spatial4j;
 
 import org.apache.lucene.spatial3d.geom.GeoPoint;
 import org.apache.lucene.spatial3d.geom.GeoPointShape;
+import org.apache.lucene.spatial3d.geom.GeoPointShapeFactory;
 import org.apache.lucene.spatial3d.geom.PlanetModel;
 import org.locationtech.spatial4j.context.SpatialContext;
 import org.locationtech.spatial4j.distance.DistanceCalculator;
@@ -73,62 +74,20 @@ public class Geo3dDistanceCalculator implements DistanceCalculator {
 
   @Override
   public Point pointOnBearing(Point from, double distDEG, double bearingDEG, SpatialContext ctx, Point reuse) {
-    // Algorithm using Vincenty's formulae (https://en.wikipedia.org/wiki/Vincenty%27s_formulae)
-    // which takes into account that planets may not be spherical.
-    //Code adaptation from http://www.movable-type.co.uk/scripts/latlong-vincenty.html
     Geo3dPointShape geoFrom = (Geo3dPointShape) from;
     GeoPoint point = (GeoPoint) geoFrom.shape;
-    double lat = point.getLatitude();
-    double lon = point.getLongitude();
     double dist = DistanceUtils.DEGREES_TO_RADIANS * distDEG;
     double bearing = DistanceUtils.DEGREES_TO_RADIANS * bearingDEG;
-
-    double sinα1 = Math.sin(bearing);
-    double cosα1 = Math.cos(bearing);
-
-    double tanU1 = (1 - planetModel.flattening) * Math.tan(lat);
-    double cosU1 = 1 / Math.sqrt((1 + tanU1 * tanU1));
-    double sinU1 = tanU1 * cosU1;
-
-    double σ1 = Math.atan2(tanU1, cosα1);
-    double sinα = cosU1 * sinα1;
-    double cosSqα = 1 - sinα * sinα;
-    double uSq = cosSqα * planetModel.squareRatio;// (planetModel.ab* planetModel.ab - planetModel.c*planetModel.c) / (planetModel.c*planetModel.c);
-    double A = 1 + uSq / 16384 * (4096 + uSq * (-768 + uSq * (320 - 175 * uSq)));
-    double B = uSq / 1024 * (256 + uSq * (-128 + uSq * (74 - 47 * uSq)));
-
-    double cos2σM;
-    double sinσ;
-    double cosσ;
-    double Δσ;
-
-    double σ = dist / (planetModel.c * A);
-    double σʹ;
-    double iterations = 0;
-    do {
-      cos2σM = Math.cos(2 * σ1 + σ);
-      sinσ = Math.sin(σ);
-      cosσ = Math.cos(σ);
-      Δσ = B * sinσ * (cos2σM + B / 4 * (cosσ * (-1 + 2 * cos2σM * cos2σM) -
-          B / 6 * cos2σM * (-3 + 4 * sinσ * sinσ) * (-3 + 4 * cos2σM * cos2σM)));
-      σʹ = σ;
-      σ = dist / (planetModel.c * A) + Δσ;
-    } while (Math.abs(σ - σʹ) > 1e-12 && ++iterations < 200);
-
-    if (iterations >= 200) {
-      throw new RuntimeException("Formula failed to converge");
+    GeoPoint newPoint = planetModel.surfacePointOnBearing(point, dist, bearing);
+    double newLat = newPoint.getLatitude() * DistanceUtils.RADIANS_TO_DEGREES;
+    double newLon = newPoint.getLongitude() * DistanceUtils.RADIANS_TO_DEGREES;
+    if (reuse != null) {
+      reuse.reset(newLon, newLat);
+      return reuse;
     }
-
-    double x = sinU1 * sinσ - cosU1 * cosσ * cosα1;
-    double φ2 = Math.atan2(sinU1 * cosσ + cosU1 * sinσ * cosα1, (1 - planetModel.flattening) * Math.sqrt(sinα * sinα + x * x));
-    double λ = Math.atan2(sinσ * sinα1, cosU1 * cosσ - sinU1 * sinσ * cosα1);
-    double C = planetModel.flattening / 16 * cosSqα * (4 + planetModel.flattening * (4 - 3 * cosSqα));
-    double L = λ - (1 - C) * planetModel.flattening * sinα *
-        (σ + C * sinσ * (cos2σM + C * cosσ * (-1 + 2 * cos2σM * cos2σM)));
-    double λ2 = (lon + L + 3 * Math.PI) % (2 * Math.PI) - Math.PI;  // normalise to -180..+180
-
-    return ctx.getShapeFactory().pointXY(λ2 * DistanceUtils.RADIANS_TO_DEGREES,
-        φ2 * DistanceUtils.RADIANS_TO_DEGREES);
+    else {
+      return ctx.getShapeFactory().pointXY(newLon, newLat);
+    }
   }
 
   @Override

--- a/lucene/spatial-extras/src/java/org/apache/lucene/spatial/spatial4j/Geo3dShape.java
+++ b/lucene/spatial-extras/src/java/org/apache/lucene/spatial/spatial4j/Geo3dShape.java
@@ -112,11 +112,7 @@ public class Geo3dShape<T extends GeoAreaShape> implements Shape {
     if (bbox == null) {
       LatLonBounds bounds = new LatLonBounds();
       shape.getBounds(bounds);
-      double leftLon = bounds.checkNoLongitudeBound() ? -Math.PI : bounds.getLeftLongitude();
-      double rightLon = bounds.checkNoLongitudeBound() ? Math.PI : bounds.getRightLongitude();
-      double minLat = bounds.checkNoBottomLatitudeBound() ? -Math.PI * 0.5 : bounds.getMinLatitude();
-      double maxLat = bounds.checkNoTopLatitudeBound() ? Math.PI * 0.5 : bounds.getMaxLatitude();
-      GeoBBox geoBBox = GeoBBoxFactory.makeGeoBBox(shape.getPlanetModel(), maxLat, minLat, leftLon, rightLon);
+      GeoBBox geoBBox = GeoBBoxFactory.makeGeoBBox(shape.getPlanetModel(), bounds);
       bbox = new Geo3dRectangleShape(geoBBox, spatialcontext);
       this.boundingBox = bbox;
     }

--- a/lucene/spatial-extras/src/java/org/apache/lucene/spatial/spatial4j/Geo3dShapeFactory.java
+++ b/lucene/spatial-extras/src/java/org/apache/lucene/spatial/spatial4j/Geo3dShapeFactory.java
@@ -59,7 +59,7 @@ public class Geo3dShapeFactory implements ShapeFactory {
    * Default accuracy for circles when not using the unit sphere.
    * It is equivalent to 10m on the surface of the earth.
    */
-  private static double DEFAULT_CIRCLE_ACCURACY = 1.6e-6;
+  private static final double DEFAULT_CIRCLE_ACCURACY = 1.6e-6;
   private double circleAccuracy = DEFAULT_CIRCLE_ACCURACY;
 
   @SuppressWarnings("unchecked")
@@ -177,7 +177,7 @@ public class Geo3dShapeFactory implements ShapeFactory {
   @Override
   public Circle circle(double x, double y, double distance) {
     GeoCircle circle;
-    if (planetModel.ab == planetModel.c) {
+    if (planetModel.isSphere()) {
       circle = GeoCircleFactory.makeGeoCircle(planetModel,
           y * DistanceUtils.DEGREES_TO_RADIANS,
           x * DistanceUtils.DEGREES_TO_RADIANS,

--- a/lucene/spatial-extras/src/java/org/apache/lucene/spatial/spatial4j/Geo3dShapeFactory.java
+++ b/lucene/spatial-extras/src/java/org/apache/lucene/spatial/spatial4j/Geo3dShapeFactory.java
@@ -57,9 +57,9 @@ public class Geo3dShapeFactory implements ShapeFactory {
 
   /**
    * Default accuracy for circles when not using the unit sphere.
-   * It is equivalent to 10m on the surface of the earth.
+   * It is equivalent to ~10m on the surface of the earth.
    */
-  private static final double DEFAULT_CIRCLE_ACCURACY = 1.6e-6;
+  private static final double DEFAULT_CIRCLE_ACCURACY = 1e-4;
   private double circleAccuracy = DEFAULT_CIRCLE_ACCURACY;
 
   @SuppressWarnings("unchecked")
@@ -75,19 +75,10 @@ public class Geo3dShapeFactory implements ShapeFactory {
   }
 
   /**
-   * Set the accuracy for circles.
+   * Set the accuracy for circles in decimal degrees. Note that accuracy has no effect
+   * when the planet model is a sphere. In that case, circles are always fully precise.
    *
-   * "Accuracy" is defined as the maximum linear distance between any point on the
-   * surface circle and planes that describe the circle. Therefore on WSG84, since the
-   * radius of earth is 6,371,000 meters, an accuracy of 1e-6 corresponds to 6.3 meters.
-   * For an accuracy of 1.0 meters, the value of 1.6e-7.
-   *
-   * The default value is set to 10m (1.6e-6).
-   *
-   * Note that accuracy has no effect when the planet model is a sphere. In that case circles
-   * are always fully precise.
-   *
-   * @param circleAccuracy the provided accuracy as a linear distance.
+   * @param circleAccuracy the provided accuracy in decimal degrees.
    */
   public void setCircleAccuracy(double circleAccuracy) {
     this.circleAccuracy = circleAccuracy;
@@ -184,11 +175,13 @@ public class Geo3dShapeFactory implements ShapeFactory {
           distance * DistanceUtils.DEGREES_TO_RADIANS);
     }
     else {
+      //accuracy is defined as a linear distance in this class. At tiny distances, linear distance
+      //can be approximated to surface distance in radians.
       circle = GeoCircleFactory.makeExactGeoCircle(planetModel,
           y * DistanceUtils.DEGREES_TO_RADIANS,
           x * DistanceUtils.DEGREES_TO_RADIANS,
           distance * DistanceUtils.DEGREES_TO_RADIANS,
-          circleAccuracy);
+          circleAccuracy * DistanceUtils.DEGREES_TO_RADIANS);
 
     }
     return new Geo3dCircleShape(circle, context);
@@ -275,8 +268,7 @@ public class Geo3dShapeFactory implements ShapeFactory {
 
   /**
    * Geo3d implementation of {@link org.locationtech.spatial4j.shape.ShapeFactory.LineStringBuilder} to generate
-   * nine Strings. Note that GeoPath needs a buffer so we set the
-   * buffer to 1e-10.
+   * line strings.
    */
   private class Geo3dLineStringBuilder extends Geo3dPointBuilder<LineStringBuilder> implements LineStringBuilder {
 
@@ -410,7 +402,7 @@ public class Geo3dShapeFactory implements ShapeFactory {
 
   /**
    * Geo3d implementation of {@link org.locationtech.spatial4j.shape.ShapeFactory.MultiShapeBuilder} to generate
-   * geometry collections
+   * geometry collections.
    *
    * @param <T> is the type of shapes.
    */

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/spatial4j/Geo3dShapeSphereModelRectRelationTest.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/spatial4j/Geo3dShapeSphereModelRectRelationTest.java
@@ -36,11 +36,12 @@ import org.locationtech.spatial4j.shape.SpatialRelation;
 
 public class Geo3dShapeSphereModelRectRelationTest extends Geo3dShapeRectRelationTestCase {
 
+  PlanetModel planetModel = PlanetModel.SPHERE;
+
   public Geo3dShapeSphereModelRectRelationTest() {
-    super(PlanetModel.SPHERE);
+    super();
     Geo3dSpatialContextFactory factory = new Geo3dSpatialContextFactory();
-    factory.planetModel = PlanetModel.SPHERE;
-    //factory.distCalc = new GeodesicSphereDistCalc.Haversine();
+    factory.planetModel = planetModel;
     this.ctx = factory.newSpatialContext();
   }
 

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/spatial4j/Geo3dShapeSphereModelRectRelationTest.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/spatial4j/Geo3dShapeSphereModelRectRelationTest.java
@@ -34,7 +34,7 @@ import org.locationtech.spatial4j.shape.Point;
 import org.locationtech.spatial4j.shape.Rectangle;
 import org.locationtech.spatial4j.shape.SpatialRelation;
 
-public class Geo3dShapeSphereModelRectRelationTest extends Geo3dShapeRectRelationTestCase {
+public class Geo3dShapeSphereModelRectRelationTest extends ShapeRectRelationTestCase {
 
   PlanetModel planetModel = PlanetModel.SPHERE;
 

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/spatial4j/Geo3dShapeWGS84ModelRectRelationTest.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/spatial4j/Geo3dShapeWGS84ModelRectRelationTest.java
@@ -32,12 +32,15 @@ import org.locationtech.spatial4j.shape.SpatialRelation;
 
 public class Geo3dShapeWGS84ModelRectRelationTest extends Geo3dShapeRectRelationTestCase {
 
+  PlanetModel planetModel = PlanetModel.WGS84;
+
   public Geo3dShapeWGS84ModelRectRelationTest() {
-    super(PlanetModel.WGS84);
+    super();
     Geo3dSpatialContextFactory factory = new Geo3dSpatialContextFactory();
-    factory.planetModel = PlanetModel.WGS84;
-    //factory.distCalc = new GeodesicSphereDistCalc.Haversine();
+    factory.planetModel = planetModel;
     this.ctx = factory.newSpatialContext();
+    this.maxRadius = 178;
+    ((Geo3dShapeFactory)ctx.getShapeFactory()).setCircleAccuracy(1e-10);
   }
 
   @Test

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/spatial4j/Geo3dShapeWGS84ModelRectRelationTest.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/spatial4j/Geo3dShapeWGS84ModelRectRelationTest.java
@@ -30,7 +30,7 @@ import org.locationtech.spatial4j.shape.Circle;
 import org.locationtech.spatial4j.shape.Point;
 import org.locationtech.spatial4j.shape.SpatialRelation;
 
-public class Geo3dShapeWGS84ModelRectRelationTest extends Geo3dShapeRectRelationTestCase {
+public class Geo3dShapeWGS84ModelRectRelationTest extends ShapeRectRelationTestCase {
 
   PlanetModel planetModel = PlanetModel.WGS84;
 

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/spatial4j/Geo3dShapeWGS84ModelRectRelationTest.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/spatial4j/Geo3dShapeWGS84ModelRectRelationTest.java
@@ -40,7 +40,7 @@ public class Geo3dShapeWGS84ModelRectRelationTest extends ShapeRectRelationTestC
     factory.planetModel = planetModel;
     this.ctx = factory.newSpatialContext();
     this.maxRadius = 178;
-    ((Geo3dShapeFactory)ctx.getShapeFactory()).setCircleAccuracy(1e-10);
+    ((Geo3dShapeFactory)ctx.getShapeFactory()).setCircleAccuracy(1e-6);
   }
 
   @Test

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/spatial4j/ShapeRectRelationTestCase.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/spatial4j/ShapeRectRelationTestCase.java
@@ -28,7 +28,7 @@ import org.locationtech.spatial4j.shape.ShapeFactory;
 
 import static org.locationtech.spatial4j.distance.DistanceUtils.DEGREES_TO_RADIANS;
 
-public abstract class Geo3dShapeRectRelationTestCase extends RandomizedShapeTestCase {
+public abstract class ShapeRectRelationTestCase extends RandomizedShapeTestCase {
   protected final static double RADIANS_PER_DEGREE = Math.PI/180.0;
 
   @Rule
@@ -36,7 +36,7 @@ public abstract class Geo3dShapeRectRelationTestCase extends RandomizedShapeTest
 
   protected int maxRadius = 180;
 
-  public Geo3dShapeRectRelationTestCase() {
+  public ShapeRectRelationTestCase() {
     super(SpatialContext.GEO);
   }
 
@@ -75,9 +75,9 @@ public abstract class Geo3dShapeRectRelationTestCase extends RandomizedShapeTest
     new Geo3dRectIntersectionTestHelper(ctx) {
 
       @Override
-      protected Geo3dShape generateRandomShape(Point nearP) {
+      protected Shape generateRandomShape(Point nearP) {
         final int circleRadius = maxRadius - random().nextInt(maxRadius);//no 0-radius
-        return (Geo3dShape<?>) ctx.getShapeFactory().circle(nearP, circleRadius);
+        return ctx.getShapeFactory().circle(nearP, circleRadius);
       }
 
       @Override
@@ -98,16 +98,16 @@ public abstract class Geo3dShapeRectRelationTestCase extends RandomizedShapeTest
       }
 
       @Override
-      protected Geo3dShape generateRandomShape(Point nearP) {
-        Point ulhcPoint = randomPoint();
-        Point lrhcPoint = randomPoint();
-        if (ulhcPoint.getY() < lrhcPoint.getY()) {
+      protected Shape generateRandomShape(Point nearP) {
+        Point upperRight = randomPoint();
+        Point lowerLeft = randomPoint();
+        if (upperRight.getY() < lowerLeft.getY()) {
           //swap
-          Point temp = ulhcPoint;
-          ulhcPoint = lrhcPoint;
-          lrhcPoint = temp;
+          Point temp = upperRight;
+          upperRight = lowerLeft;
+          lowerLeft = temp;
         }
-        return (Geo3dShape<?>) ctx.getShapeFactory().rect(lrhcPoint, ulhcPoint);
+        return ctx.getShapeFactory().rect(lowerLeft, upperRight);
       }
 
       @Override

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/spatial4j/ShapeRectRelationTestCase.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/spatial4j/ShapeRectRelationTestCase.java
@@ -40,9 +40,9 @@ public abstract class ShapeRectRelationTestCase extends RandomizedShapeTestCase 
     super(SpatialContext.GEO);
   }
 
-  public abstract class Geo3dRectIntersectionTestHelper extends RectIntersectionTestHelper<Shape> {
+  public abstract class AbstractRectIntersectionTestHelper extends RectIntersectionTestHelper<Shape> {
 
-    public Geo3dRectIntersectionTestHelper(SpatialContext ctx) {
+    public AbstractRectIntersectionTestHelper(SpatialContext ctx) {
       super(ctx);
     }
 
@@ -72,7 +72,7 @@ public abstract class ShapeRectRelationTestCase extends RandomizedShapeTestCase 
 
   @Test
   public void testGeoCircleRect() {
-    new Geo3dRectIntersectionTestHelper(ctx) {
+    new AbstractRectIntersectionTestHelper(ctx) {
 
       @Override
       protected Shape generateRandomShape(Point nearP) {
@@ -90,7 +90,7 @@ public abstract class ShapeRectRelationTestCase extends RandomizedShapeTestCase 
 
   @Test
   public void testGeoBBoxRect() {
-    new Geo3dRectIntersectionTestHelper(ctx) {
+    new AbstractRectIntersectionTestHelper(ctx) {
 
       @Override
       protected boolean isRandomShapeRectangular() {
@@ -119,7 +119,7 @@ public abstract class ShapeRectRelationTestCase extends RandomizedShapeTestCase 
 
   @Test
   public void testGeoPolygonRect() {
-    new Geo3dRectIntersectionTestHelper(ctx) {
+    new AbstractRectIntersectionTestHelper(ctx) {
 
       @Override
       protected Shape generateRandomShape(Point nearP) {
@@ -159,7 +159,7 @@ public abstract class ShapeRectRelationTestCase extends RandomizedShapeTestCase 
 
   @Test
   public void testGeoPathRect() {
-    new Geo3dRectIntersectionTestHelper(ctx) {
+    new AbstractRectIntersectionTestHelper(ctx) {
 
       @Override
       protected Shape generateRandomShape(Point nearP) {


### PR DESCRIPTION
Here are the changes, in particular:

- Geo3dFactory: Use GeoExactCircle for non-spherical planets.
- Geo3dCircleShape: Remove method relate.
- Geo3DShape: Use new factory method for building GeoBbox from bounds object.
- Geo3dDistanceCalculator: use pointonbearing from planet model.
- Test refactoring

