### PR TITLE
SOLR-11800: Improve error message when parsing RankQuery

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -167,8 +167,8 @@ public class QueryComponent extends SearchComponent
 
       String rankQueryString = rb.req.getParams().get(CommonParams.RQ);
       if(rankQueryString != null) {
-        QParser rqparser = QParser.getParser(rankQueryString, defType, req);
-        Query rq = rqparser.getQuery();
+        final QParser rqparser =  QParser.getParser(rankQueryString, defType, req);
+        final Query rq = (rqparser != null) ? rqparser.getQuery() : null;
         if(rq instanceof RankQuery) {
           RankQuery rankQuery = (RankQuery)rq;
           rb.setRankQuery(rankQuery);
@@ -180,7 +180,15 @@ public class QueryComponent extends SearchComponent
             }
           }
         } else {
-          throw new SolrException(SolrException.ErrorCode.BAD_REQUEST,"rq parameter must be a RankQuery");
+          final String error;
+          if (rqparser == null){
+            error = "rq parser is null for rankquery string "+rankQueryString;
+          } else if (rq == null){
+            error = "rq parameter is null ( rq parser is " + rqparser.getClass() + " )";
+          } else {
+            error = "rq parameter must be a RankQuery, but it is "+rq.getClass().getName() + " ( rqP parser is "+rqparser.getClass() +" )";
+          }
+          throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, error);
         }
       }
 

--- a/solr/core/src/java/org/apache/solr/search/QParser.java
+++ b/solr/core/src/java/org/apache/solr/search/QParser.java
@@ -360,6 +360,10 @@ public abstract class QParser {
     }
 
     QParserPlugin qplug = req.getCore().getQueryPlugin(parserName);
+    if (qplug == null){
+      // error: log ?
+      return null;
+    }
     QParser parser =  qplug.createParser(qstr, localParams, req.getParams(), req);
 
     parser.stringIncludingLocalParams = stringIncludingLocalParams;

--- a/solr/core/src/test/org/apache/solr/search/TestReRankQParserPlugin.java
+++ b/solr/core/src/test/org/apache/solr/search/TestReRankQParserPlugin.java
@@ -596,10 +596,38 @@ public class TestReRankQParserPlugin extends SolrTestCaseJ4 {
     params.add("q", "term_s:YYYY");
     params.add("start", "0");
     params.add("rows", "2");
+    ignoreException("reRankQuery parameter is mandatory");
 
     try {
       h.query(req(params));
       fail("A syntax error should be thrown when "+ReRankQParserPlugin.RERANK_QUERY+" parameter is not specified");
+    } catch (SolrException e) {
+      assertTrue(e.code() == SolrException.ErrorCode.BAD_REQUEST.code);
+    }
+  }
+
+  @Test
+  public void testInvalidRqParam() throws Exception {
+    assertU(delQ("*:*"));
+    assertU(commit());
+
+    String[] doc = {"id", "1", "term_s", "YYYY", "group_s", "group1", "test_ti", "5", "test_tl", "10", "test_tf", "2000"};
+    assertU(adoc(doc));
+    assertU(commit());
+    String[] doc1 = {"id", "2", "term_s", "YYYY", "group_s", "group1", "test_ti", "50", "test_tl", "100", "test_tf", "200"};
+    assertU(adoc(doc1));
+    assertU(commit());
+
+    ModifiableSolrParams params = new ModifiableSolrParams();
+
+    params.add("rq", "{!invalidrq" + " " + ReRankQParserPlugin.RERANK_QUERY + "=$rqq " + ReRankQParserPlugin.RERANK_DOCS + "=200}");
+    params.add("q", "term_s:YYYY");
+    params.add("start", "0");
+    params.add("rows", "2");
+    ignoreException("rq parser is null for rankquery string");
+    try {
+      h.query(req(params));
+      fail("h.query should raise an exception if rq does not exist");
     } catch (SolrException e) {
       assertTrue(e.code() == SolrException.ErrorCode.BAD_REQUEST.code);
     }


### PR DESCRIPTION
When a user specifies something wrong for the parameter `rq` sometimes it is hard to understand where is the problem, this patch attempts to improve the error message returned in the response.