### PR TITLE
docs(intelliJSetup): Mention the link related to project-setup in IDE

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,10 @@ Ant can be used to generate project files compatible with most common IDEs.
 Run the ant command corresponding to your IDE of choice before attempting to
 import Lucene/Solr.
 
-- *Eclipse* - `ant eclipse`
-- *IntelliJ* - `ant idea`
-- *Netbeans* - `ant netbeans`
+- *Eclipse* - `ant eclipse` (See [this](https://wiki.apache.org/solr/HowToConfigureEclipse) for details)
+- *IntelliJ* - `ant idea` (See [this](https://wiki.apache.org/lucene-java/HowtoConfigureIntelliJ) for details)
+- *Netbeans* - `ant netbeans` (See [this](https://wiki.apache.org/lucene-java/HowtoConfigureNetbeans) for details)
+
 
 ## Running Tests
 


### PR DESCRIPTION
This PR is to show some solr-wiki-page-links on the README.md page.
The instructions mentioned on the README.md page is not enough to set up the project in the IDEs.  
The wiki pages are very helpful, but are not easily accessible.
Having their references on the `README.md` page will be quite helpful for beginners.
  