### PR TITLE
SOLR-11831: Skip second grouping step if group.limit is 1 (aka Las Vegas Patch)

### DIFF
--- a/lucene/grouping/src/java/org/apache/lucene/search/grouping/FirstPassGroupingCollector.java
+++ b/lucene/grouping/src/java/org/apache/lucene/search/grouping/FirstPassGroupingCollector.java
@@ -140,11 +140,21 @@ public class FirstPassGroupingCollector<T> extends SimpleCollector {
       // System.out.println("  group=" + (group.groupValue == null ? "null" : group.groupValue.toString()));
       SearchGroup<T> searchGroup = new SearchGroup<>();
       searchGroup.groupValue = group.groupValue;
+
+      // We pass this around so that we can get the corresponding solr id when serializing the search group to send to the federator
+      searchGroup.topDocLuceneId = group.topDoc;
+
       if (fillFields) {
         searchGroup.sortValues = new Object[sortFieldCount];
         for(int sortFieldIDX=0;sortFieldIDX<sortFieldCount;sortFieldIDX++) {
           searchGroup.sortValues[sortFieldIDX] = comparators[sortFieldIDX].value(group.comparatorSlot);
         }
+      }
+      // TODO: It should be possible to extend this to handle more than one FieldComparator and other types
+      if (sortFieldCount > 0 && comparators[0] instanceof FieldComparator.RelevanceComparator ){
+        searchGroup.topDocScore = (Float)comparators[0].value(group.comparatorSlot);
+      } else {
+        searchGroup.topDocScore = -1;
       }
       result.add(searchGroup);
     }

--- a/solr/contrib/analysis-extras/src/java/org/apache/solr/update/processor/OpenNLPExtractNamedEntitiesUpdateProcessorFactory.java
+++ b/solr/contrib/analysis-extras/src/java/org/apache/solr/update/processor/OpenNLPExtractNamedEntitiesUpdateProcessorFactory.java
@@ -73,7 +73,7 @@ import org.slf4j.LoggerFactory;
  *     &lt;/analyzer&gt;
  *   &lt;/fieldType&gt;
  * </pre>
- * 
+ *
  * <p>See the <a href="http://opennlp.apache.org/models.html">OpenNLP website</a>
  * for information on downloading pre-trained models.</p>
  *

--- a/solr/core/src/java/org/apache/solr/search/grouping/GroupingSpecification.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/GroupingSpecification.java
@@ -37,6 +37,12 @@ public class GroupingSpecification {
   private Grouping.Format responseFormat;
   private boolean needScore;
   private boolean truncateGroups;
+  /* This is an optimization to skip the second grouping step when groupLimit is 1. The second
+  * grouping step retrieves the top K documents for each group. This is not necessary when only one
+  * document per group is required because in the first step every shard sends back the group score given
+  * by its top document.
+  */
+  private boolean skipSecondGroupingStep;
 
   public String[] getFields() {
     return fields;
@@ -173,5 +179,9 @@ public class GroupingSpecification {
   public void setWithinGroupSortSpec(SortSpec withinGroupSortSpec) {
     this.withinGroupSortSpec = withinGroupSortSpec;
   }
+
+  public boolean isSkipSecondGroupingStep() { return skipSecondGroupingStep; }
+
+  public void setSkipSecondGroupingStep(boolean skipSecondGroupingStep) { this.skipSecondGroupingStep = skipSecondGroupingStep; }
 
 }

--- a/solr/core/src/java/org/apache/solr/search/grouping/distributed/command/GroupConverter.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/distributed/command/GroupConverter.java
@@ -52,6 +52,8 @@ class GroupConverter {
     for (SearchGroup<MutableValue> original : values) {
       SearchGroup<BytesRef> converted = new SearchGroup<BytesRef>();
       converted.sortValues = original.sortValues;
+      converted.topDocLuceneId = original.topDocLuceneId;
+      converted.topDocScore = original.topDocScore;
       if (original.groupValue.exists) {
         BytesRefBuilder binary = new BytesRefBuilder();
         fieldType.readableToIndexed(original.groupValue.toString(), binary);

--- a/solr/core/src/java/org/apache/solr/search/grouping/distributed/responseprocessor/SearchGroupShardResponseProcessor.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/distributed/responseprocessor/SearchGroupShardResponseProcessor.java
@@ -27,13 +27,16 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.grouping.GroupDocs;
 import org.apache.lucene.search.grouping.SearchGroup;
+import org.apache.lucene.search.grouping.TopGroups;
 import org.apache.lucene.util.BytesRef;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.common.params.ShardParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
 import org.apache.solr.handler.component.ResponseBuilder;
+import org.apache.solr.handler.component.ShardDoc;
 import org.apache.solr.handler.component.ShardRequest;
 import org.apache.solr.handler.component.ShardResponse;
 import org.apache.solr.response.SolrQueryResponse;
@@ -68,7 +71,9 @@ public class SearchGroupShardResponseProcessor implements ShardResponseProcessor
       }
     }
 
-    SearchGroupsResultTransformer serializer = new SearchGroupsResultTransformer(rb.req.getSearcher());
+    final SearchGroupsResultTransformer serializer = SearchGroupsResultTransformer.getInstance(rb.req.getSearcher(), rb.getGroupingSpec().isSkipSecondGroupingStep());
+    final Map<Object, String> docIdToShard = new HashMap<>();
+
     int maxElapsedTime = 0;
     int hitCountDuringFirstPhase = 0;
 
@@ -135,6 +140,8 @@ public class SearchGroupShardResponseProcessor implements ShardResponseProcessor
             shards = new HashSet<>();
             map.put(searchGroup, shards);
           }
+          assert(srsp.getShard() != null);
+          docIdToShard.put(searchGroup.topDocSolrId, srsp.getShard());
           shards.add(srsp.getShard());
         }
       }
@@ -148,12 +155,61 @@ public class SearchGroupShardResponseProcessor implements ShardResponseProcessor
       if (mergedTopGroups == null) {
         continue;
       }
-
-      rb.mergedSearchGroups.put(groupField, mergedTopGroups);
-      for (SearchGroup<BytesRef> mergedTopGroup : mergedTopGroups) {
-        rb.searchGroupToShards.get(groupField).put(mergedTopGroup, tempSearchGroupToShards.get(groupField).get(mergedTopGroup));
+      if (rb.getGroupingSpec().isSkipSecondGroupingStep()){
+          /* If we are skipping the second grouping step we want to translate the response of the
+           * first step in the response of the second step and send it to the get_fields step.
+           */
+          processSkipSecondGroupingStep(rb, mergedTopGroups, tempSearchGroupToShards, docIdToShard, groupSort, fields,  groupField);
+      }
+      else {
+        rb.mergedSearchGroups.put(groupField, mergedTopGroups);
+        for (SearchGroup<BytesRef> mergedTopGroup : mergedTopGroups) {
+          rb.searchGroupToShards.get(groupField).put(mergedTopGroup, tempSearchGroupToShards.get(groupField).get(mergedTopGroup));
+        }
       }
     }
+  }
+
+  private void processSkipSecondGroupingStep(final ResponseBuilder rb, final Collection<SearchGroup<BytesRef>> mergedTopGroups, final Map<String, Map<SearchGroup<BytesRef>, Set<String>>> tempSearchGroupToShards, Map<Object, String> docIdToShard, Sort groupSort, final String[] fields, final String groupField){
+    GroupDocs<BytesRef>[] groups = new GroupDocs[mergedTopGroups.size()];
+    Map<Object, ShardDoc> resultsId = new HashMap<>(mergedTopGroups.size());
+
+    // This is the max score found in any document on any group
+    float maxScore = 0;
+    int index = 0;
+
+    for (SearchGroup<BytesRef> group : mergedTopGroups) {
+      maxScore = Math.max(maxScore, group.topDocScore);
+      rb.searchGroupToShards.get(groupField).put(group, tempSearchGroupToShards.get(groupField).get(group));
+      final String shard = docIdToShard.get(group.topDocSolrId);
+      assert(shard != null);
+      ShardDoc sdoc = new ShardDoc(group.topDocScore,
+          fields,
+          group.topDocSolrId,
+          shard );
+      sdoc.positionInResponse = index;
+
+      resultsId.put(sdoc.id, sdoc);
+      groups[index++] = new GroupDocs<BytesRef>(group.topDocScore,
+          group.topDocScore,
+          1, /* we don't know the actual number of hits in the group- we set it to 1 as we only keep track of the top doc */
+          new ShardDoc[] { sdoc }, /* only top doc */
+          group.groupValue,
+          group.sortValues);
+    }
+    TopGroups<BytesRef> topMergedGroups = new TopGroups<BytesRef>(groupSort.getSort(),
+        rb.getGroupingSpec().getSortWithinGroup().getSort(),
+        0, /*Set totalHitCount to 0 as we can't computed it as is */
+        0, /*Set totalGroupedHitCount to 0 as we can't computed it as is*/
+        groups,
+        maxScore);
+    rb.mergedTopGroups.put(groupField, topMergedGroups);
+
+    if(rb.resultIds == null) {
+      rb.resultIds = new HashMap<>();
+    }
+
+    rb.resultIds.putAll(resultsId);
   }
 
 }

--- a/solr/core/src/java/org/apache/solr/search/grouping/distributed/shardresultserializer/SearchGroupsResultTransformer.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/distributed/shardresultserializer/SearchGroupsResultTransformer.java
@@ -16,12 +16,19 @@
  */
 package org.apache.solr.search.grouping.distributed.shardresultserializer;
 
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.DocumentStoredFieldVisitor;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.grouping.SearchGroup;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.CharsRefBuilder;
+import org.apache.solr.common.SolrException;
 import org.apache.solr.common.util.NamedList;
+import org.apache.solr.schema.FieldType;
+import org.apache.solr.schema.IndexSchema;
 import org.apache.solr.schema.SchemaField;
 import org.apache.solr.search.SolrIndexSearcher;
 import org.apache.solr.search.grouping.Command;
@@ -34,15 +41,35 @@ import java.util.*;
 /**
  * Implementation for transforming {@link SearchGroup} into a {@link NamedList} structure and visa versa.
  */
-public class SearchGroupsResultTransformer implements ShardResultTransformer<List<Command>, Map<String, SearchGroupsFieldCommandResult>> {
+public abstract class SearchGroupsResultTransformer implements ShardResultTransformer<List<Command>, Map<String, SearchGroupsFieldCommandResult>> {
 
   private static final String TOP_GROUPS = "topGroups";
   private static final String GROUP_COUNT = "groupCount";
 
-  private final SolrIndexSearcher searcher;
+  protected final SolrIndexSearcher searcher;
 
-  public SearchGroupsResultTransformer(SolrIndexSearcher searcher) {
+  private SearchGroupsResultTransformer(SolrIndexSearcher searcher) {
     this.searcher = searcher;
+  }
+
+  public static SearchGroupsResultTransformer getInstance(SolrIndexSearcher searcher, boolean skipSecondStep){
+    return (skipSecondStep) ? new SkipSecondStepSearchResultResultTransformer(searcher) : new DefaultSearchResultResultTransformer(searcher);
+  }
+
+  final protected Object[] getConvertedSortValues(final Object[] sortValues, final SortField[] sortFields) {
+    Object[] convertedSortValues = new Object[sortValues.length];
+    for (int i = 0; i < sortValues.length; i++) {
+      Object sortValue = sortValues[i];
+      SchemaField field = sortFields[i].getField() != null ? searcher.getSchema().getFieldOrNull(sortFields[i].getField()) : null;
+      if (field != null) {
+        FieldType fieldType = field.getType();
+        if (sortValue != null) {
+          sortValue = fieldType.marshalSortValue(sortValue);
+        }
+      }
+      convertedSortValues[i] = sortValue;
+    }
+    return convertedSortValues;
   }
 
   /**
@@ -73,63 +100,178 @@ public class SearchGroupsResultTransformer implements ShardResultTransformer<Lis
     return result;
   }
 
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public Map<String, SearchGroupsFieldCommandResult> transformToNative(NamedList<NamedList> shardResponse, Sort groupSort, Sort withinGroupSort, String shard) {
-    final Map<String, SearchGroupsFieldCommandResult> result = new HashMap<>(shardResponse.size());
-    for (Map.Entry<String, NamedList> command : shardResponse) {
-      List<SearchGroup<BytesRef>> searchGroups = new ArrayList<>();
-      NamedList topGroupsAndGroupCount = command.getValue();
-      @SuppressWarnings("unchecked")
-      final NamedList<List<Comparable>> rawSearchGroups = (NamedList<List<Comparable>>) topGroupsAndGroupCount.get(TOP_GROUPS);
-      if (rawSearchGroups != null) {
-        for (Map.Entry<String, List<Comparable>> rawSearchGroup : rawSearchGroups){
-          SearchGroup<BytesRef> searchGroup = new SearchGroup<>();
-          SchemaField groupField = rawSearchGroup.getKey() != null? searcher.getSchema().getFieldOrNull(command.getKey()) : null;
-          searchGroup.groupValue = null;
-          if (rawSearchGroup.getKey() != null) {
-            if (groupField != null) {
-              BytesRefBuilder builder = new BytesRefBuilder();
-              groupField.getType().readableToIndexed(rawSearchGroup.getKey(), builder);
-              searchGroup.groupValue = builder.get();
-            } else {
-              searchGroup.groupValue = new BytesRef(rawSearchGroup.getKey());
+  protected abstract NamedList serializeSearchGroup(Collection<SearchGroup<BytesRef>> data, SearchGroupsFieldCommand command);
+
+  private static class DefaultSearchResultResultTransformer extends SearchGroupsResultTransformer {
+
+    private DefaultSearchResultResultTransformer(SolrIndexSearcher searcher) {
+      super(searcher);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<String, SearchGroupsFieldCommandResult> transformToNative(NamedList<NamedList> shardResponse, Sort groupSort, Sort withinGroupSort, String shard) {
+      final Map<String, SearchGroupsFieldCommandResult> result = new HashMap<>(shardResponse.size());
+      for (Map.Entry<String, NamedList> command : shardResponse) {
+        List<SearchGroup<BytesRef>> searchGroups = new ArrayList<>();
+        NamedList topGroupsAndGroupCount = command.getValue();
+        @SuppressWarnings("unchecked")
+        final NamedList<List<Comparable>> rawSearchGroups = (NamedList<List<Comparable>>) topGroupsAndGroupCount.get(TOP_GROUPS);
+        if (rawSearchGroups != null) {
+          for (Map.Entry<String, List<Comparable>> rawSearchGroup : rawSearchGroups){
+            SearchGroup<BytesRef> searchGroup = new SearchGroup<>();
+            SchemaField groupField = rawSearchGroup.getKey() != null? searcher.getSchema().getFieldOrNull(command.getKey()) : null;
+            searchGroup.groupValue = null;
+            if (rawSearchGroup.getKey() != null) {
+              if (groupField != null) {
+                BytesRefBuilder builder = new BytesRefBuilder();
+                groupField.getType().readableToIndexed(rawSearchGroup.getKey(), builder);
+                searchGroup.groupValue = builder.get();
+              } else {
+                searchGroup.groupValue = new BytesRef(rawSearchGroup.getKey());
+              }
             }
+            searchGroup.sortValues = rawSearchGroup.getValue().toArray(new Comparable[rawSearchGroup.getValue().size()]);
+            for (int i = 0; i < searchGroup.sortValues.length; i++) {
+              SchemaField field = groupSort.getSort()[i].getField() != null ? searcher.getSchema().getFieldOrNull(groupSort.getSort()[i].getField()) : null;
+              searchGroup.sortValues[i] = ShardResultTransformerUtils.unmarshalSortValue(searchGroup.sortValues[i], field);
+            }
+            searchGroups.add(searchGroup);
           }
-          searchGroup.sortValues = rawSearchGroup.getValue().toArray(new Comparable[rawSearchGroup.getValue().size()]);
-          for (int i = 0; i < searchGroup.sortValues.length; i++) {
-            SchemaField field = groupSort.getSort()[i].getField() != null ? searcher.getSchema().getFieldOrNull(groupSort.getSort()[i].getField()) : null;
-            searchGroup.sortValues[i] = ShardResultTransformerUtils.unmarshalSortValue(searchGroup.sortValues[i], field);
-          }
-          searchGroups.add(searchGroup);
         }
+
+        final Integer groupCount = (Integer) topGroupsAndGroupCount.get(GROUP_COUNT);
+        result.put(command.getKey(), new SearchGroupsFieldCommandResult(groupCount, searchGroups));
       }
-
-      final Integer groupCount = (Integer) topGroupsAndGroupCount.get(GROUP_COUNT);
-      result.put(command.getKey(), new SearchGroupsFieldCommandResult(groupCount, searchGroups));
-    }
-    return result;
-  }
-
-  private NamedList serializeSearchGroup(Collection<SearchGroup<BytesRef>> data, SearchGroupsFieldCommand command) {
-    final NamedList<Object[]> result = new NamedList<>(data.size());
-
-    for (SearchGroup<BytesRef> searchGroup : data) {
-      Object[] convertedSortValues = new Object[searchGroup.sortValues.length];
-      for (int i = 0; i < searchGroup.sortValues.length; i++) {
-        Object sortValue = searchGroup.sortValues[i];
-        SchemaField field = command.getGroupSort().getSort()[i].getField() != null ?
-            searcher.getSchema().getFieldOrNull(command.getGroupSort().getSort()[i].getField()) : null;
-        convertedSortValues[i] = ShardResultTransformerUtils.marshalSortValue(sortValue, field);
-      }
-      SchemaField field = searcher.getSchema().getFieldOrNull(command.getKey());
-      String groupValue = searchGroup.groupValue != null ? field.getType().indexedToReadable(searchGroup.groupValue, new CharsRefBuilder()).toString() : null;
-      result.add(groupValue, convertedSortValues);
+      return result;
     }
 
-    return result;
+    @Override
+    protected NamedList serializeSearchGroup(Collection<SearchGroup<BytesRef>> data, SearchGroupsFieldCommand command) {
+      final NamedList<Object[]> result = new NamedList<>(data.size());
+
+      for (SearchGroup<BytesRef> searchGroup : data) {
+        Object[] convertedSortValues = new Object[searchGroup.sortValues.length];
+        for (int i = 0; i < searchGroup.sortValues.length; i++) {
+          Object sortValue = searchGroup.sortValues[i];
+          SchemaField field = command.getGroupSort().getSort()[i].getField() != null ?
+              searcher.getSchema().getFieldOrNull(command.getGroupSort().getSort()[i].getField()) : null;
+          convertedSortValues[i] = ShardResultTransformerUtils.marshalSortValue(sortValue, field);
+        }
+        SchemaField field = searcher.getSchema().getFieldOrNull(command.getKey());
+        String groupValue = searchGroup.groupValue != null ? field.getType().indexedToReadable(searchGroup.groupValue, new CharsRefBuilder()).toString() : null;
+        result.add(groupValue, convertedSortValues);
+      }
+
+      return result;
+    }
   }
 
+  private static class SkipSecondStepSearchResultResultTransformer extends SearchGroupsResultTransformer {
+
+    private static final String TOP_DOC_SOLR_ID_KEY = "topDocSolrId";
+    private static final String TOP_DOC_SCORE_KEY = "topDocScore";
+    private static final String SORTVALUES_KEY  = "sortValues";
+
+    private SkipSecondStepSearchResultResultTransformer(SolrIndexSearcher searcher) {
+      super(searcher);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<String, SearchGroupsFieldCommandResult> transformToNative(NamedList<NamedList> shardResponse, Sort groupSort, Sort withinGroupSort, String shard) {
+      final Map<String, SearchGroupsFieldCommandResult> result = new HashMap<>(shardResponse.size());
+      for (Map.Entry<String, NamedList> command : shardResponse) {
+        List<SearchGroup<BytesRef>> searchGroups = new ArrayList<>();
+        NamedList topGroupsAndGroupCount = command.getValue();
+        @SuppressWarnings("unchecked")
+        final NamedList<List<Comparable>> rawSearchGroups = (NamedList<List<Comparable>>) topGroupsAndGroupCount.get(TOP_GROUPS);
+        if (rawSearchGroups != null) {
+          for (Map.Entry<String, List<Comparable>> rawSearchGroup : rawSearchGroups){
+            SearchGroup<BytesRef> searchGroup = new SearchGroup<>();
+            SchemaField groupField = rawSearchGroup.getKey() != null? searcher.getSchema().getFieldOrNull(command.getKey()) :    null;
+            searchGroup.groupValue = null;
+            if (rawSearchGroup.getKey() != null) {
+              if (groupField != null) {
+                BytesRefBuilder builder = new BytesRefBuilder();
+                groupField.getType().readableToIndexed(rawSearchGroup.getKey(), builder);
+                searchGroup.groupValue = builder.get();
+              } else {
+                searchGroup.groupValue = new BytesRef(rawSearchGroup.getKey());
+              }
+            }
+            // I don't think we need this for upstream
+            //
+            // If we don't recognize this serialization throw an exception
+            // if (!isSerializationCompatible(rawSearchGroups)) {
+            //   logger.warn("Incompatible serialization/deserialization. Falling back to the default method");
+            //   throw new UnsupportedOperationException("Incompatible serialization/deserialization. Falling back to the default method");
+            // }
+            NamedList<Object> groupInfo = (NamedList) rawSearchGroup.getValue();
+            searchGroup.topDocLuceneId = DocIdSetIterator.NO_MORE_DOCS;
+            searchGroup.topDocScore = (float) groupInfo.get(TOP_DOC_SCORE_KEY);
+            searchGroup.topDocSolrId = groupInfo.get(TOP_DOC_SOLR_ID_KEY);
+            final ArrayList<?> sortValues = (ArrayList<?>)groupInfo.get(SORTVALUES_KEY);
+            searchGroup.sortValues = sortValues.toArray(new Comparable[sortValues.size()]);
+
+            final IndexSchema schema = searcher.getSchema();
+            for (int i = 0; i < searchGroup.sortValues.length; i++) {
+              final String sortField = groupSort.getSort()[i].getField();
+              final SchemaField field = (sortField != null) ? schema.getFieldOrNull(sortField) : null;
+              searchGroup.sortValues[i] = ShardResultTransformerUtils.unmarshalSortValue(searchGroup.sortValues[i], field);
+            }
+            searchGroups.add(searchGroup);
+          }
+        }
+
+        final Integer groupCount = (Integer) topGroupsAndGroupCount.get(GROUP_COUNT);
+        result.put(command.getKey(), new SearchGroupsFieldCommandResult(groupCount, searchGroups));
+      }
+      return result;
+    }
+
+    @Override
+    protected NamedList serializeSearchGroup(Collection<SearchGroup<BytesRef>> data, SearchGroupsFieldCommand command) {
+      final NamedList<NamedList> result = new NamedList<>(data.size());
+      for (SearchGroup<BytesRef> searchGroup : data) {
+
+        final IndexSchema schema = searcher.getSchema();
+        SchemaField uniqueField = schema.getUniqueKeyField();
+
+        Document luceneDoc = null;
+        /** Use the lucene id to get the unique solr id so that it can be sent to the federator.
+         * The lucene id of a document is not unique across all shards i.e. different documents
+         * in different shards could have the same lucene id, whereas the solr id is guaranteed
+         * to be unique so this is what we need to return to the federator
+        **/
+        try {
+          luceneDoc = retrieveDocument(uniqueField, searchGroup.topDocLuceneId);
+        } catch (IOException e) {
+          throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "Cannot retrieve document for unique field " + uniqueField + " ("+e.toString()+")");
+        }
+        Object topDocSolrId = uniqueField.getType().toExternal(luceneDoc.getField(uniqueField.getName()));
+        NamedList<Object> groupInfo = new NamedList<>(5);
+        groupInfo.add(TOP_DOC_SCORE_KEY, searchGroup.topDocScore);
+        groupInfo.add(TOP_DOC_SOLR_ID_KEY, topDocSolrId);
+
+        Object[] convertedSortValues = getConvertedSortValues(searchGroup.sortValues, command.getGroupSort().getSort());
+        groupInfo.add(SORTVALUES_KEY, convertedSortValues);
+
+        SchemaField field = searcher.getSchema().getFieldOrNull(command.getKey());
+        final String groupValue = searchGroup.groupValue != null ? field.getType().indexedToReadable(searchGroup.groupValue, new CharsRefBuilder()).toString() : null;
+        result.add(groupValue, groupInfo);
+      }
+      return result;
+    }
+
+    private Document retrieveDocument(final SchemaField uniqueField, int doc) throws IOException {
+      DocumentStoredFieldVisitor visitor = new DocumentStoredFieldVisitor(uniqueField.getName());
+      searcher.doc(doc, visitor);
+      return visitor.getDocument();
+    }
+  }
 }

--- a/solr/core/src/java/org/apache/solr/search/grouping/endresulttransformer/GroupedEndResultTransformer.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/endresulttransformer/GroupedEndResultTransformer.java
@@ -68,8 +68,14 @@ public class GroupedEndResultTransformer implements EndResultTransformer {
         for (GroupDocs<BytesRef> group : topGroups.groups) {
           SimpleOrderedMap<Object> groupResult = new SimpleOrderedMap<>();
           if (group.groupValue != null) {
+            final String groupValue;
+            if (rb.getGroupingSpec().isSkipSecondGroupingStep()) {
+              groupValue = groupField.getType().indexedToReadable(group.groupValue.utf8ToString());
+            } else {
+              groupValue = group.groupValue.utf8ToString();
+            }
             groupResult.add(
-                "groupValue", groupFieldType.toObject(groupField.createField(group.groupValue.utf8ToString()))
+                "groupValue", groupFieldType.toObject(groupField.createField(groupValue))
             );
           } else {
             groupResult.add("groupValue", null);

--- a/solr/core/src/test/org/apache/solr/TestDistributedGrouping.java
+++ b/solr/core/src/test/org/apache/solr/TestDistributedGrouping.java
@@ -310,6 +310,32 @@ public class TestDistributedGrouping extends BaseDistributedSearchTestCase {
     
     //Debug
     simpleQuery("q", "*:*", "rows", 10, "fl", "id," + i1, "group", "true", "group.field", i1, "debug", "true");
+
+    // Ignore numFound if group.skip.second.step is enabled because the number of documents per group will not be computed (will default to 1)
+    handle.put("numFound", SKIP);
+    query("q", "{!func}id_i1", "rows", 3, "group.skip.second.step", true, "group.limit", 1,  "fl",  "id," + i1, "group", "true",
+               "group.field", i1);
+    query("q", "kings", "group.skip.second.step", true, "fl", "id," + i1, "group", "true", "group.field", i1);
+    query("q", "{!func}id_i1", "rows", 3, "group.skip.second.step", true,  "fl",  "id," + i1, "group", "true",
+          "group.field", i1);
+    query("q", "1234doesnotmatchanything1234", "group.skip.second.step", true, "fl", "id," + i1, "group", "true", "group.field", i1);
+
+    ignoreException("Illegal grouping specification");
+    assertSimpleQueryThrows("q", "{!func}id_i1", "group.skip.second.step", true, "fl", "id," + i1, "group", "true", "group.field", i1, "group.ngroups", true);
+    assertSimpleQueryThrows("q", "{!func}id", "group.skip.second.step", true, "fl", "id," + i1, "group", "true", "group.field", i1, "group.limit", 5);
+    assertSimpleQueryThrows("q", "{!func}id_i1", "group.skip.second.step", true, "fl", "id," + i1, "group", "true", "group.field", i1, "group.limit", 0);
+    handle.remove("numFound");
+
+  }
+
+  private void assertSimpleQueryThrows(Object... queryParams) {
+    boolean requestFailed = false;
+    try {
+      simpleQuery(queryParams);
+    } catch (Exception e) {
+      requestFailed = true;
+    }
+    assertTrue(requestFailed);
   }
 
   private void simpleQuery(Object... queryParams) throws SolrServerException, IOException {

--- a/solr/solrj/src/java/org/apache/solr/common/params/GroupParams.java
+++ b/solr/solrj/src/java/org/apache/solr/common/params/GroupParams.java
@@ -66,5 +66,10 @@ public interface GroupParams {
   public static final String GROUP_DISTRIBUTED_SECOND = GROUP + ".distributed.second";
 
   public static final String GROUP_DISTRIBUTED_TOPGROUPS_PREFIX = GROUP + ".topgroups.";
+
+  /** activates optimization in case only one document per group.
+   * Setting this to true is only compatible with group.limit = 1
+   */
+  public static final String GROUP_SKIP_DISTRIBUTED_SECOND = GROUP + ".skip.second.step";
 }
 

--- a/solr/test-framework/src/java/org/apache/solr/BaseDistributedSearchTestCase.java
+++ b/solr/test-framework/src/java/org/apache/solr/BaseDistributedSearchTestCase.java
@@ -785,9 +785,13 @@ public abstract class BaseDistributedSearchTestCase extends SolrTestCaseJ4 {
         }
       }
     }
-
-    cmp = compare(a.getNumFound(), b.getNumFound(), 0, handle);
-    if (cmp != null) return ".numFound" + cmp;
+    final int checkNumFound = flags(handle, "numFound");
+    if (checkNumFound == 0){
+      cmp = compare(a.getNumFound(), b.getNumFound(), 0, handle);
+      if (cmp != null) return ".numFound" + cmp;
+    } else if (checkNumFound != SKIP) {
+        assert (f & SKIPVAL) != 0;
+    }
 
     cmp = compare(a.getStart(), b.getStart(), 0, handle);
     if (cmp != null) return ".start" + cmp;


### PR DESCRIPTION
Summary:
In cases where we do grouping and ask for  {{group.limit=1}} only it is possible to skip the second grouping step. In our test datasets it improved speed by around 40%.

Essentially, in the first grouping step each shard returns the top K groups based on the highest scoring document in each group. The top K groups from each shard are merged in the federator and in the second step we ask all the shards to return the top documents from each of the top ranking groups.

If we only want to return the highest scoring document per group we can return the top document id in the first step, merge results in the federator to retain the top K groups and then skip the second grouping step entirely.