### PR TITLE
Guide update: Grouping XML commands and curl description extension

### DIFF
--- a/solr/solr-ref-guide/src/uploading-data-with-index-handlers.adoc
+++ b/solr/solr-ref-guide/src/uploading-data-with-index-handlers.adoc
@@ -136,6 +136,26 @@ When using the Join query parser in a Delete By Query, you should use the `score
 
 The rollback command rolls back all add and deletes made to the index since the last commit. It neither calls any event listeners nor creates a new searcher. Its syntax is simple: `<rollback/>`.
 
+=== Grouping operations
+
+There may be several commands posted in a single XML file, by grouping them with the surrounding `<update>` element.
+
+[source,xml]
+----
+<update>
+  <add>
+    <doc><!-- doc 1 content --></doc>
+  </add>
+  <add>
+    <doc><!-- doc 2 content --></doc>
+  </add>
+  <delete>
+    <id>0002166313</id>
+  </delete>
+</update>
+----
+
+
 === Using curl to Perform Updates
 
 You can use the `curl` utility to perform any of the above commands, using its `--data-binary` option to append the XML message to the `curl` command, and generating a HTTP POST request. For example:
@@ -160,6 +180,13 @@ For posting XML messages contained in a file, you can use the alternative form:
 [source,bash]
 ----
 curl http://localhost:8983/solr/my_collection/update -H "Content-Type: text/xml" --data-binary @myfile.xml
+----
+
+The approach above works perfectly, but using the `--data-binary` causes `curl` to load the whole `myfile.xml` into memory before posting it to server. This may be problematical when dealing with multi gigabyte files. Alternative `curl` command, performing equivalent operation but with constant minimal `curl` memory usage:
+
+[source,bash]
+----
+curl http://localhost:8983/solr/my_collection/update -H "Content-Type: text/xml" -T "myfile.xml" -X POST
 ----
 
 Short requests can also be sent using a HTTP GET command, if enabled in <<requestdispatcher-in-solrconfig.adoc#requestparsers-element,RequestDispatcher in SolrConfig>> element, URL-encoding the request, as in the following. Note the escaping of "<" and ">":


### PR DESCRIPTION
The guide does not say anything about grouping XML commands with the <update> element, I =found it only once in some wiki.
In addition I have faced problems myself wuth curl when dealing with multi gigabyte XML files. The solution I describe here works nicely. Tested with SOLR 7.1.