### PR TITLE
SOLR-11853: Make check for used tool "service" compatible with SuSE Linux

### DIFF
--- a/solr/bin/install_solr_service.sh
+++ b/solr/bin/install_solr_service.sh
@@ -193,7 +193,7 @@ else
   unzip -hh &>/dev/null         || print_error "Script requires the 'unzip' command"
 fi
 if [[ $SOLR_START == "true" ]] ; then
-  service --version &>/dev/null || print_error "Script requires the 'service' command"
+  service --version &>/dev/null || service --help &>/dev/null || print_error "Script requires the 'service' command"
   java -version &>/dev/null     || print_error "Solr requires java, please install or set JAVA_HOME properly"
 fi
 lsof -h &>/dev/null             || echo "We recommend installing the 'lsof' command for more stable start/stop of Solr"


### PR DESCRIPTION
On current SuSE Linux releases like SLES or OpenSuSE the Solr installer stops with the error message "Script requires the 'service' command".

This happens because before installation the installer checks if the used command "service" exists by its option "service --version".

The command line option "--version" doesn't exist for "service" on current SuSE Linux stable releases.

Since the command "service" is there and has an option "--help", this option can be used as additional fallback.

So in the pull request i extended the check with "service --help" as second check / fallback before printing this error and exiting.