### PR TITLE
Update ZkConfigManager.java

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/common/cloud/ZkConfigManager.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/ZkConfigManager.java
@@ -162,7 +162,7 @@ public class ZkConfigManager {
    * @throws IOException if an I/O error occurs
    */
   public void copyConfigDir(String fromConfig, String toConfig) throws IOException {
-    copyConfigDir(CONFIGS_ZKNODE + "/" + fromConfig, CONFIGS_ZKNODE + "/" + toConfig, null);
+    copyConfigDir(fromConfig, toConfig, null);
   }
 
   /**


### PR DESCRIPTION
fix copyConfigDir(String fromConfig, String toConfig)
When i call copyConfigDir(String fromConfig, String toConfig),the 'CONFIGS_ZKNODE + "/"' will be appended to parameter twice.Once in copyConfigDir(String fromConfig, String toConfig),once in copyConfigDir(String fromConfig, String toConfig, Set<String> copiedToZkPaths).
Then the 'fromZkPath' will become likes this:"/configs//configs/conf0",which cause a "empty node name" exception