### PR TITLE
LUCENE-8033: FieldInfos always use dense encoding

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
@@ -28,6 +28,8 @@ import java.util.Set;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.lucene.util.ArrayUtil;
+
 /** 
  * Collection of {@link FieldInfo}s (accessible by number or by name).
  *  @lucene.experimental
@@ -70,8 +72,8 @@ public class FieldInfos implements Iterable<FieldInfo> {
       }
       size = info.number >= size ? info.number+1 : size;
       if (info.number >= capacity){ //grow array
-        capacity = info.number + 1;
-        byNumberTemp = Arrays.copyOf(byNumberTemp, capacity);
+        byNumberTemp = ArrayUtil.grow(byNumberTemp, info.number + 1);
+        capacity = byNumberTemp.length;
       }
       FieldInfo previous = byNumberTemp[info.number];
       if (previous != null) {
@@ -104,17 +106,14 @@ public class FieldInfos implements Iterable<FieldInfo> {
     this.hasPointValues = hasPointValues;
 
     List<FieldInfo> valuesTemp = new ArrayList<>();
-    if (size > 0){
-      byNumber = new FieldInfo[size];
-      for(int i=0; i<size; i++){
-        byNumber[i] = byNumberTemp[i];
-        if (byNumberTemp[i] != null)
-          valuesTemp.add(byNumberTemp[i]);
+    byNumber = new FieldInfo[size];
+    for(int i=0; i<size; i++){
+      byNumber[i] = byNumberTemp[i];
+      if (byNumberTemp[i] != null) {
+        valuesTemp.add(byNumberTemp[i]);
       }
-    } else {
-      byNumber = null;
     }
-    values = Collections.unmodifiableCollection(valuesTemp);
+    values = Collections.unmodifiableCollection(Arrays.asList(valuesTemp.toArray(new FieldInfo[0])));
   }
   
   /** Returns true if any fields have freqs */

--- a/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
@@ -45,7 +45,7 @@ public class FieldInfos implements Iterable<FieldInfo> {
   private final boolean hasPointValues;
   
   // used only by fieldInfo(int)
-  private final FieldInfo[] byNumber; // contiguous
+  private final FieldInfo[] byNumber;
   
   private final HashMap<String,FieldInfo> byName = new HashMap<>();
   private final Collection<FieldInfo> values; // for an unmodifiable iterator
@@ -63,17 +63,15 @@ public class FieldInfos implements Iterable<FieldInfo> {
     boolean hasDocValues = false;
     boolean hasPointValues = false;
 
-    int size = 0; // number of elements in byNumberTemp
-    int capacity = 10; // byNumberTemp's capacity
-    FieldInfo[] byNumberTemp = new FieldInfo[capacity];
+    int size = 0; // number of elements in byNumberTemp, number of used array slots
+    FieldInfo[] byNumberTemp = new FieldInfo[10]; // initial array capacity of 10
     for (FieldInfo info : infos) {
       if (info.number < 0) {
         throw new IllegalArgumentException("illegal field number: " + info.number + " for field " + info.name);
       }
       size = info.number >= size ? info.number+1 : size;
-      if (info.number >= capacity){ //grow array
+      if (info.number >= byNumberTemp.length){ //grow array
         byNumberTemp = ArrayUtil.grow(byNumberTemp, info.number + 1);
-        capacity = byNumberTemp.length;
       }
       FieldInfo previous = byNumberTemp[info.number];
       if (previous != null) {

--- a/lucene/core/src/test/org/apache/lucene/index/TestFieldInfos.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestFieldInfos.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.index;
+
+
+import java.util.Iterator;
+
+import org.apache.lucene.analysis.MockAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.LuceneTestCase;
+import org.junit.Test;
+
+public class TestFieldInfos extends LuceneTestCase {
+
+  @Test
+  public void testFieldInfosSparse() throws Exception{
+    Directory dir = newDirectory();
+    IndexWriter writer = new IndexWriter(dir, newIndexWriterConfig(new MockAnalyzer(random()))
+        .setMergePolicy(NoMergePolicy.INSTANCE));
+
+    Document d1 = new Document();
+    for (int i = 0; i < 15; i++) {
+      d1.add(new StringField("f" + i, "v" + i, Field.Store.YES));
+    }
+    writer.addDocument(d1);
+    writer.commit();
+
+    Document d2 = new Document();
+    d2.add(new StringField("f0", "v0", Field.Store.YES));
+    d2.add(new StringField("f15", "v15", Field.Store.YES));
+    d2.add(new StringField("f16", "v16", Field.Store.YES));
+    writer.addDocument(d2);
+    writer.close();
+
+    SegmentInfos sis = SegmentInfos.readLatestCommit(dir);
+    assertEquals(2, sis.size());
+
+    FieldInfos fis1 = IndexWriter.readFieldInfos(sis.info(0));
+    FieldInfos fis2 = IndexWriter.readFieldInfos(sis.info(1));
+
+    Iterator<FieldInfo>  it = fis1.iterator();
+    int i = 0;
+    while(it.hasNext()) {
+      FieldInfo fi = it.next();
+      assertEquals(i, fi.number);
+      assertEquals("f" + i , fi.name);
+      i++;
+    }
+
+    assertEquals("f0", fis2.fieldInfo(0).name);
+    assertNull(fis2.fieldInfo(1));
+    assertEquals("f15", fis2.fieldInfo(15).name);
+    assertEquals("f16", fis2.fieldInfo(16).name);
+    dir.close();
+  }
+
+}

--- a/lucene/core/src/test/org/apache/lucene/index/TestFieldInfos.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestFieldInfos.java
@@ -58,7 +58,6 @@ public class TestFieldInfos extends LuceneTestCase {
     FieldInfos fis2 = IndexWriter.readFieldInfos(sis.info(1));
     FieldInfos fis3 = IndexWriter.readFieldInfos(sis.info(2));
 
-
     // testing dense FieldInfos
     Iterator<FieldInfo>  it = fis1.iterator();
     int i = 0;
@@ -66,17 +65,24 @@ public class TestFieldInfos extends LuceneTestCase {
       FieldInfo fi = it.next();
       assertEquals(i, fi.number);
       assertEquals("f" + i , fi.name);
+      assertEquals("f" + i, fis1.fieldInfo(i).name); //lookup by number
+      assertEquals("f" + i, fis1.fieldInfo("f" + i).name); //lookup by name
       i++;
     }
 
     // testing sparse FieldInfos
-    assertEquals("f0", fis2.fieldInfo(0).name);
+    assertEquals("f0", fis2.fieldInfo(0).name); //lookup by number
+    assertEquals("f0", fis2.fieldInfo("f0").name); //lookup by name
     assertNull(fis2.fieldInfo(1));
+    assertNull(fis2.fieldInfo("f1"));
     assertEquals("f15", fis2.fieldInfo(15).name);
+    assertEquals("f15", fis2.fieldInfo("f15").name);
     assertEquals("f16", fis2.fieldInfo(16).name);
+    assertEquals("f16", fis2.fieldInfo("f16").name);
 
     // testing empty FieldInfos
-    assertNull(fis3.fieldInfo(0));
+    assertNull(fis3.fieldInfo(0)); //lookup by number
+    assertNull(fis3.fieldInfo("f0")); //lookup by name
     assertEquals(0, fis3.size());
     Iterator<FieldInfo> it3 = fis3.iterator();
     assertFalse(it3.hasNext());


### PR DESCRIPTION
FieldInfos always to use an array to store FieldInfo byNumber