### PR TITLE
SOLR-11932 Retry ZkOperation on SessionExpired

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/Overseer.java
+++ b/solr/core/src/java/org/apache/solr/cloud/Overseer.java
@@ -303,7 +303,7 @@ public class Overseer implements SolrCloseable {
       String path = OVERSEER_ELECT + "/leader";
       byte[] data;
       try {
-        data = zkClient.getData(path, null, stat, true);
+        data = zkClient.getData(path, null, stat, false);
       } catch (Exception e) {
         log.error("could not read the data" ,e);
         return;
@@ -314,7 +314,7 @@ public class Overseer implements SolrCloseable {
         if(overseerCollectionConfigSetProcessor.getId().equals(id)){
           try {
             log.warn("I'm exiting, but I'm still the leader");
-            zkClient.delete(path,stat.getVersion(),true);
+            zkClient.delete(path,stat.getVersion(),false);
           } catch (KeeperException.BadVersionException e) {
             //no problem ignore it some other Overseer has already taken over
           } catch (Exception e) {

--- a/solr/core/src/test/org/apache/solr/cloud/ZkSolrClientTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ZkSolrClientTest.java
@@ -188,7 +188,7 @@ public class ZkSolrClientTest extends SolrTestCaseJ4 {
     }
   }
   
-  public void testZkCmdExectutor() throws Exception {
+  public void testZkCmdExecutor() throws Exception {
     String zkDir = createTempDir("zkData").toFile().getAbsolutePath();
     ZkTestServer server = null;
 
@@ -205,14 +205,14 @@ public class ZkSolrClientTest extends SolrTestCaseJ4 {
       try {
       zkCmdExecutor.retryOperation(() -> {
         if (System.nanoTime() - start > TimeUnit.NANOSECONDS.convert(timeout, TimeUnit.MILLISECONDS)) {
-          throw new KeeperException.SessionExpiredException();
+          throw new KeeperException.AuthFailedException();
         }
         throw new KeeperException.ConnectionLossException();
       });
-      } catch(KeeperException.SessionExpiredException e) {
+      } catch(KeeperException.AuthFailedException e) {
         
       } catch (Exception e) {
-        fail("Expected " + KeeperException.SessionExpiredException.class.getSimpleName() + " but got " + e.getClass().getSimpleName());
+        fail("Expected " + KeeperException.AuthFailedException.class.getSimpleName() + " but got " + e.getClass().getSimpleName());
       }
     } finally {
       if (server != null) {

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/SolrZkClient.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/SolrZkClient.java
@@ -241,7 +241,7 @@ public class SolrZkClient implements Closeable {
       throws InterruptedException, KeeperException {
     if (retryOnConnLoss) {
       zkCmdExecutor.retryOperation(() -> {
-        keeper.delete(path, version);
+        getSolrZooKeeper().delete(path, version);
         return null;
       });
     } else {
@@ -301,7 +301,7 @@ public class SolrZkClient implements Closeable {
   public Stat exists(final String path, final Watcher watcher, boolean retryOnConnLoss)
       throws KeeperException, InterruptedException {
     if (retryOnConnLoss) {
-      return zkCmdExecutor.retryOperation(() -> keeper.exists(path, wrapWatcher(watcher)));
+      return zkCmdExecutor.retryOperation(() -> getSolrZooKeeper().exists(path, wrapWatcher(watcher)));
     } else {
       return keeper.exists(path, wrapWatcher(watcher));
     }
@@ -313,7 +313,7 @@ public class SolrZkClient implements Closeable {
   public Boolean exists(final String path, boolean retryOnConnLoss)
       throws KeeperException, InterruptedException {
     if (retryOnConnLoss) {
-      return zkCmdExecutor.retryOperation(() -> keeper.exists(path, null) != null);
+      return zkCmdExecutor.retryOperation(() -> getSolrZooKeeper().exists(path, null) != null);
     } else {
       return keeper.exists(path, null) != null;
     }
@@ -325,7 +325,7 @@ public class SolrZkClient implements Closeable {
   public List<String> getChildren(final String path, final Watcher watcher, boolean retryOnConnLoss)
       throws KeeperException, InterruptedException {
     if (retryOnConnLoss) {
-      return zkCmdExecutor.retryOperation(() -> keeper.getChildren(path, wrapWatcher(watcher)));
+      return zkCmdExecutor.retryOperation(() -> getSolrZooKeeper().getChildren(path, wrapWatcher(watcher)));
     } else {
       return keeper.getChildren(path, wrapWatcher(watcher));
     }
@@ -337,7 +337,7 @@ public class SolrZkClient implements Closeable {
   public byte[] getData(final String path, final Watcher watcher, final Stat stat, boolean retryOnConnLoss)
       throws KeeperException, InterruptedException {
     if (retryOnConnLoss) {
-      return zkCmdExecutor.retryOperation(() -> keeper.getData(path, wrapWatcher(watcher), stat));
+      return zkCmdExecutor.retryOperation(() -> getSolrZooKeeper().getData(path, wrapWatcher(watcher), stat));
     } else {
       return keeper.getData(path, wrapWatcher(watcher), stat);
     }
@@ -349,7 +349,7 @@ public class SolrZkClient implements Closeable {
   public Stat setData(final String path, final byte data[], final int version, boolean retryOnConnLoss)
       throws KeeperException, InterruptedException {
     if (retryOnConnLoss) {
-      return zkCmdExecutor.retryOperation(() -> keeper.setData(path, data, version));
+      return zkCmdExecutor.retryOperation(() -> getSolrZooKeeper().setData(path, data, version));
     } else {
       return keeper.setData(path, data, version);
     }
@@ -362,7 +362,7 @@ public class SolrZkClient implements Closeable {
       final CreateMode createMode, boolean retryOnConnLoss) throws KeeperException,
       InterruptedException {
     if (retryOnConnLoss) {
-      return zkCmdExecutor.retryOperation(() -> keeper.create(path, data, zkACLProvider.getACLsToAdd(path),
+      return zkCmdExecutor.retryOperation(() -> getSolrZooKeeper().create(path, data, zkACLProvider.getACLsToAdd(path),
           createMode));
     } else {
       List<ACL> acls = zkACLProvider.getACLsToAdd(path);
@@ -493,7 +493,7 @@ public class SolrZkClient implements Closeable {
             final CreateMode finalMode = mode;
             final byte[] finalBytes = bytes;
             zkCmdExecutor.retryOperation(() -> {
-              keeper.create(currentPath, finalBytes, zkACLProvider.getACLsToAdd(currentPath), finalMode);
+              getSolrZooKeeper().create(currentPath, finalBytes, zkACLProvider.getACLsToAdd(currentPath), finalMode);
               return null;
             });
           } else {
@@ -555,7 +555,7 @@ public class SolrZkClient implements Closeable {
 
   public List<OpResult> multi(final Iterable<Op> ops, boolean retryOnConnLoss) throws InterruptedException, KeeperException  {
     if (retryOnConnLoss) {
-      return zkCmdExecutor.retryOperation(() -> keeper.multi(ops));
+      return zkCmdExecutor.retryOperation(() -> getSolrZooKeeper().multi(ops));
     } else {
       return keeper.multi(ops);
     }
@@ -735,7 +735,7 @@ public class SolrZkClient implements Closeable {
    */
   public Stat setACL(String path, List<ACL> acls, boolean retryOnConnLoss) throws InterruptedException, KeeperException  {
     if (retryOnConnLoss) {
-      return zkCmdExecutor.retryOperation(() -> keeper.setACL(path, acls, -1));
+      return zkCmdExecutor.retryOperation(() -> getSolrZooKeeper().setACL(path, acls, -1));
     } else {
       return keeper.setACL(path, acls, -1);
     }

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/ZkCmdExecutor.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/ZkCmdExecutor.java
@@ -58,7 +58,7 @@ public class ZkCmdExecutor {
     for (int i = 0; i < retryCount; i++) {
       try {
         return (T) operation.execute();
-      } catch (KeeperException.ConnectionLossException e) {
+      } catch (KeeperException.ConnectionLossException | KeeperException.SessionExpiredException e) {
         if (exception == null) {
           exception = e;
         }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-11932

We are seeing situations where an operation, such as changing a replica's state to active after a recovery, fails because the zk session has expired.

However, these operations seem like they are retryable, because the ZookeeperConnect receives an event that the session expired and tries to reconnect.

That makes the SessionExpired handling scenario seem very similar to the ConnectionLoss handling scenario, so the ZkCmdExecutor seems like it could handle them in the same way.
