### PR TITLE
SOLR-7798 ExpandComponent support for non-collapsed results

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -176,7 +176,7 @@ Bug Fixes
 * SOLR-12393: Compute score if requested even when expanded docs not sorted by score in ExpandComponent.
   (David Smiley, Munendra S N)
 
-* SOLR-13877: Fix NPE in expand component when matched docs have fewer unique values. (Munendra S N)
+* SOLR-13877, SOLR-7798: Robust support for ExpandComponent when used independently of CollapsingPostFilter. (Jörg Rathlev, Michael Gibney, Munendra S N)
 
 * SOLR-13823: Fix ClassCastEx when score is requested with group.query. This also fixes score not being generated
   for distributed group.query case. (Uwe Jäger, Munendra S N)

--- a/solr/core/src/test/org/apache/solr/handler/component/TestExpandComponent.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/TestExpandComponent.java
@@ -352,6 +352,19 @@ public class TestExpandComponent extends SolrTestCaseJ4 {
         "/response/lst[@name='expanded']/result[@name='2000.0']/doc[1]/str[@name='id'][.='7']",
         "count(//*[@name='score'])=0"
     );
+
+    // Support expand enabled without previous collapse
+    assertQ(req("q", "type_s:child", "sort", group+" asc, test_l desc", "defType", "edismax",
+        "expand", "true", "expand.q", "type_s:parent", "expand.field", group),
+        "*[count(/response/result/doc)=4]",
+        "*[count(/response/lst[@name='expanded']/result)=2]",
+        "/response/result/doc[1]/str[@name='id'][.='7']",
+        "/response/result/doc[2]/str[@name='id'][.='2']",
+        "/response/result/doc[3]/str[@name='id'][.='8']",
+        "/response/result/doc[4]/str[@name='id'][.='6']",
+        "/response/lst[@name='expanded']/result[@name='1"+floatAppend+"']/doc[1]/str[@name='id'][.='1']",
+        "/response/lst[@name='expanded']/result[@name='2"+floatAppend+"']/doc[1]/str[@name='id'][.='5']"
+    );
   }
 
   @Test


### PR DESCRIPTION
Applications of ExpandComponent that do not involve prior collapsing of results on the expand field had been throwing NPE in `getGroupQuery` due to different count/size tracking.