### PR TITLE
SOLR-10078: Handle MatchNoDocsQuery in BooleanQuery nested in ComplexPhraseQuery

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -407,6 +407,8 @@ New Features
 * LUCENE-7982: A new NormsFieldExistsQuery matches documents that have
   norms in a specified field (Colin Goodheart-Smithe via Mike McCandless)
 
+* SOLR-10078: Handle MatchNoDocsQuery in BooleanQuery nested in ComplexPhraseQuery
+
 Optimizations
 
 * LUCENE-7905: Optimize how OrdinalMap (used by

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/complexPhrase/ComplexPhraseQueryParser.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/complexPhrase/ComplexPhraseQueryParser.java
@@ -398,6 +398,13 @@ public class ComplexPhraseQueryParser extends QueryParser {
         } else if (childQuery instanceof BooleanQuery) {
           BooleanQuery cbq = (BooleanQuery) childQuery;
           addComplexPhraseClause(chosenList, cbq);
+        } else if (childQuery instanceof MatchNoDocsQuery) {
+          // Insert fake term e.g. phrase query was for "Fred Smithe*" and
+          // there were no "Smithe*" terms - need to
+          // prevent match on just "Fred".
+          SpanQuery stq = new SpanTermQuery(new Term(field,
+                                                     "Dummy clause because no terms found - must match nothing"));
+          chosenList.add(stq);
         } else {
           // TODO alternatively could call extract terms here?
           throw new IllegalArgumentException("Unknown query type:"

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/complexPhrase/TestComplexPhraseQuery.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/complexPhrase/TestComplexPhraseQuery.java
@@ -64,6 +64,8 @@ public class TestComplexPhraseQuery extends LuceneTestCase {
     checkMatches("\"john\"", "1,3"); // Simple single-term still works
     checkMatches("\"(john OR johathon)  smith\"", "1,2"); // boolean logic with
     // brackets works.
+    checkMatches("\"(john OR nosuchword*)  smith\"", "1"); // boolean logic with
+    // brackets works when one of the terms in BooleanQuery does not exist (SOLR-10078).
     checkMatches("\"(jo* -john) smyth~\"", "2"); // boolean logic with
     // brackets works.
 


### PR DESCRIPTION
When a BooleanQuery is nested inside a ComplexPhrase, and one of the terms returns a MatchNoDocsQuery (which was introduced in LUCENE-7337), ComplexPhraseQuery.addComplexPhraseClause throws an exception "Unknown query type:org.apache.lucene.search.MatchNoDocsQuery"

Example: "(john OR nosuchword*) smith"

The fix is to handle MatchNoDocsQuery the same way as it is done in ComplexPhraseQuery.rewrite