### PR TITLE
Add SolrConfig to SolrRequestParsers constructor in EmbeddedSolrServer

### DIFF
--- a/solr/core/src/java/org/apache/solr/client/solrj/embedded/EmbeddedSolrServer.java
+++ b/solr/core/src/java/org/apache/solr/client/solrj/embedded/EmbeddedSolrServer.java
@@ -109,7 +109,7 @@ public class EmbeddedSolrServer extends SolrClient {
       throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "Core name cannot be empty");
     this.coreContainer = coreContainer;
     this.coreName = coreName;
-    _parser = new SolrRequestParsers(null);
+    _parser = new SolrRequestParsers(coreContainer.getCores().getCore(coreName).getSolrConfig());
   }
 
   // TODO-- this implementation sends the response to XML and then parses it.


### PR DESCRIPTION
This commit allow users to use some settings in EmbeddedSolr mode, for example - stream.body in solrconfig