### PR TITLE
SOLR-12162: Fixes typo in CorePropertiesLocator

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/CorePropertiesLocator.java
+++ b/solr/core/src/java/org/apache/solr/core/CorePropertiesLocator.java
@@ -66,7 +66,7 @@ public class CorePropertiesLocator implements CoresLocator {
       if (Files.exists(propertiesFile))
         throw new SolrException(SolrException.ErrorCode.BAD_REQUEST,
                                 "Could not create a new core in " + cd.getInstanceDir()
-                              + "as another core is already defined there");
+                              + " as another core is already defined there");
       writePropertiesFile(cd, propertiesFile);
     }
   }


### PR DESCRIPTION
Fixes a simple typo in the CorePropertiesLocator

https://issues.apache.org/jira/browse/SOLR-12162