### PR TITLE
SOLR match mode change for the rouding off instead of taking floor

### DIFF
--- a/solr/core/src/java/org/apache/solr/util/SolrPluginUtils.java
+++ b/solr/core/src/java/org/apache/solr/util/SolrPluginUtils.java
@@ -698,7 +698,7 @@ public class SolrPluginUtils {
       spec = spec.substring(0,spec.length()-1);
       int percent = Integer.parseInt(spec);
       float calc = (result * percent) * (1/100f);
-      result = calc < 0 ? result + (int)calc : (int)calc;
+      result = calc < 0 ? result + (int)Math.round(calc) : (int)Math.round(calc);
     } else {
       int calc = Integer.parseInt(spec);
       result = calc < 0 ? result + calc : calc;


### PR DESCRIPTION
Instead of directly using the floor of  the mm %, we need to take the round of value, 
Ecample, 
When we have 5 boolean clauses and mm=75%, we get calc as 3.75 currently it took 3, so instead of 3 it should have taken 4. as Math.round() 