### PR TITLE
SOLR-12194: Deprecate SolrRequest#setBasicAuthCredentials

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -66,6 +66,10 @@ Upgrade Notes
   To return the previous behavior pass false to skipCommitOnMasterVersionZero in slave section of replication
   handler configuration, or pass it to the fetchindex command.
 
+* SOLR-12194: If using SolrRequest#setBasicAuthCredentials in SolrJ this way of specifying Basic Authentication is now
+  deprecated and will be removed in 8.0. You should move to specifying your basic authentication credentials through
+  a SolrClientBuilderFactory (janhoy)
+ 
 New Features
 ----------------------
 
@@ -170,6 +174,9 @@ Other Changes
 
 * SOLR-12134: ref-guide 'bare-bones html' validation is now part of 'ant documentation' and validates
   javadoc links locally. (hossman)
+
+* SOLR-12194: Deprecate SolrRequest#setBasicAuthCredentials and promote ClientBuilderFactory for basic auth in Solrj
+  (janhoy)
 
 ==================  7.3.0 ==================
 

--- a/solr/core/src/test/org/apache/solr/security/BasicAuthIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/security/BasicAuthIntegrationTest.java
@@ -67,6 +67,9 @@ import org.slf4j.LoggerFactory;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonMap;
 
+/**
+ * TODO: Migrate to {@link org.apache.solr.client.solrj.impl.PreemptiveBasicAuthClientBuilderFactory} or similar
+ */
 public class BasicAuthIntegrationTest extends SolrCloudTestCase {
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/SolrRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/SolrRequest.java
@@ -77,15 +77,28 @@ public abstract class SolrRequest<T extends SolrResponse> implements Serializabl
 
   private String basicAuthUser, basicAuthPwd;
 
+  /**
+   * @deprecated use a {@link org.apache.solr.client.solrj.impl.SolrHttpClientBuilder} instead 
+   */
+  @Deprecated
   public SolrRequest setBasicAuthCredentials(String user, String password) {
     this.basicAuthUser = user;
     this.basicAuthPwd = password;
     return this;
   }
 
+  /**
+   * @deprecated use a {@link org.apache.solr.client.solrj.impl.SolrHttpClientBuilder} instead 
+   */
+  @Deprecated
   public String getBasicAuthUser(){
     return basicAuthUser;
   }
+
+  /**
+   * @deprecated use a {@link org.apache.solr.client.solrj.impl.SolrHttpClientBuilder} instead 
+   */
+  @Deprecated
   public String getBasicAuthPassword(){
     return basicAuthPwd;
   }


### PR DESCRIPTION
First step
Still need to modify `BasicAuthIntegrationTest` and document in ref-guide, but that could also be done in separate issues.