### PR TITLE
SOLR-12233

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -955,7 +955,7 @@ public final class SolrCore implements SolrInfoBean, SolrMetricProducer, Closeab
       initIndex(prev != null, reload);
 
       initWriters();
-      qParserPlugins.init(createInstances(QParserPlugin.standardPlugins), this);
+      qParserPlugins.init(QParserPlugin.standardPlugins, this);
       valueSourceParsers.init(ValueSourceParser.standardValueSourceParsers, this);
       transformerFactories.init(TransformerFactory.defaultFactories, this);
       loadSearchComponents();

--- a/solr/core/src/java/org/apache/solr/search/QParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/search/QParserPlugin.java
@@ -43,47 +43,46 @@ public abstract class QParserPlugin implements NamedListInitializedPlugin, SolrI
    * This result to NPE during initialization.
    * For every plugin, listed here, NAME field has to be final and static.
    */
-  public static final Map<String, Class<? extends QParserPlugin>> standardPlugins;
+  public static final Map<String, QParserPlugin> standardPlugins;
 
   static {
-    HashMap<String, Class<? extends QParserPlugin>> map = new HashMap<>(30, 1);
-    map.put(LuceneQParserPlugin.NAME, LuceneQParserPlugin.class);
-    map.put(FunctionQParserPlugin.NAME, FunctionQParserPlugin.class);
-    map.put(PrefixQParserPlugin.NAME, PrefixQParserPlugin.class);
-    map.put(BoostQParserPlugin.NAME, BoostQParserPlugin.class);
-    map.put(DisMaxQParserPlugin.NAME, DisMaxQParserPlugin.class);
-    map.put(ExtendedDismaxQParserPlugin.NAME, ExtendedDismaxQParserPlugin.class);
-    map.put(FieldQParserPlugin.NAME, FieldQParserPlugin.class);
-    map.put(RawQParserPlugin.NAME, RawQParserPlugin.class);
-    map.put(TermQParserPlugin.NAME, TermQParserPlugin.class);
-    map.put(TermsQParserPlugin.NAME, TermsQParserPlugin.class);
-    map.put(NestedQParserPlugin.NAME, NestedQParserPlugin.class);
-    map.put(FunctionRangeQParserPlugin.NAME, FunctionRangeQParserPlugin.class);
-    map.put(SpatialFilterQParserPlugin.NAME, SpatialFilterQParserPlugin.class);
-    map.put(SpatialBoxQParserPlugin.NAME, SpatialBoxQParserPlugin.class);
-    map.put(JoinQParserPlugin.NAME, JoinQParserPlugin.class);
-    map.put(SurroundQParserPlugin.NAME, SurroundQParserPlugin.class);
-    map.put(SwitchQParserPlugin.NAME, SwitchQParserPlugin.class);
-    map.put(MaxScoreQParserPlugin.NAME, MaxScoreQParserPlugin.class);
-    map.put(BlockJoinParentQParserPlugin.NAME, BlockJoinParentQParserPlugin.class);
-    map.put(BlockJoinChildQParserPlugin.NAME, BlockJoinChildQParserPlugin.class);
-    map.put(FiltersQParserPlugin.NAME, FiltersQParserPlugin.class);
-    map.put(CollapsingQParserPlugin.NAME, CollapsingQParserPlugin.class);
-    map.put(SimpleQParserPlugin.NAME, SimpleQParserPlugin.class);
-    map.put(ComplexPhraseQParserPlugin.NAME, ComplexPhraseQParserPlugin.class);
-    map.put(ReRankQParserPlugin.NAME, ReRankQParserPlugin.class);
-    map.put(ExportQParserPlugin.NAME, ExportQParserPlugin.class);
-    map.put(MLTQParserPlugin.NAME, MLTQParserPlugin.class);
-    map.put(HashQParserPlugin.NAME, HashQParserPlugin.class);
-    map.put(GraphQParserPlugin.NAME, GraphQParserPlugin.class);
-    map.put(XmlQParserPlugin.NAME, XmlQParserPlugin.class);
-    map.put(GraphTermsQParserPlugin.NAME, GraphTermsQParserPlugin.class);
-    map.put(IGainTermsQParserPlugin.NAME, IGainTermsQParserPlugin.class);
-    map.put(TextLogisticRegressionQParserPlugin.NAME, TextLogisticRegressionQParserPlugin.class);
-    map.put(SignificantTermsQParserPlugin.NAME, SignificantTermsQParserPlugin.class);
-    map.put(PayloadScoreQParserPlugin.NAME, PayloadScoreQParserPlugin.class);
-    map.put(PayloadCheckQParserPlugin.NAME, PayloadCheckQParserPlugin.class);
-    map.put(BoolQParserPlugin.NAME, BoolQParserPlugin.class);
+    HashMap<String, QParserPlugin> map = new HashMap<>(30, 1);
+    map.put(LuceneQParserPlugin.NAME, new LuceneQParserPlugin());
+    map.put(FunctionQParserPlugin.NAME, new FunctionQParserPlugin());
+    map.put(PrefixQParserPlugin.NAME, new PrefixQParserPlugin());
+    map.put(BoostQParserPlugin.NAME, new BoostQParserPlugin());
+    map.put(DisMaxQParserPlugin.NAME, new DisMaxQParserPlugin());
+    map.put(ExtendedDismaxQParserPlugin.NAME, new ExtendedDismaxQParserPlugin());
+    map.put(FieldQParserPlugin.NAME, new FieldQParserPlugin());
+    map.put(RawQParserPlugin.NAME, new RawQParserPlugin());
+    map.put(TermQParserPlugin.NAME, new TermQParserPlugin());
+    map.put(TermsQParserPlugin.NAME, new TermsQParserPlugin());
+    map.put(NestedQParserPlugin.NAME, new NestedQParserPlugin());
+    map.put(FunctionRangeQParserPlugin.NAME, new FunctionRangeQParserPlugin());
+    map.put(SpatialFilterQParserPlugin.NAME, new SpatialFilterQParserPlugin());
+    map.put(SpatialBoxQParserPlugin.NAME, new SpatialBoxQParserPlugin());
+    map.put(JoinQParserPlugin.NAME, new JoinQParserPlugin());
+    map.put(SurroundQParserPlugin.NAME, new SurroundQParserPlugin());
+    map.put(SwitchQParserPlugin.NAME, new SwitchQParserPlugin());
+    map.put(MaxScoreQParserPlugin.NAME, new MaxScoreQParserPlugin());
+    map.put(BlockJoinParentQParserPlugin.NAME, new BlockJoinParentQParserPlugin());
+    map.put(BlockJoinChildQParserPlugin.NAME, new BlockJoinChildQParserPlugin());
+    map.put(CollapsingQParserPlugin.NAME, new CollapsingQParserPlugin());
+    map.put(SimpleQParserPlugin.NAME, new SimpleQParserPlugin());
+    map.put(ComplexPhraseQParserPlugin.NAME, new ComplexPhraseQParserPlugin());
+    map.put(ReRankQParserPlugin.NAME, new ReRankQParserPlugin());
+    map.put(ExportQParserPlugin.NAME, new ExportQParserPlugin());
+    map.put(MLTQParserPlugin.NAME, new MLTQParserPlugin());
+    map.put(HashQParserPlugin.NAME, new HashQParserPlugin());
+    map.put(GraphQParserPlugin.NAME, new GraphQParserPlugin());
+    map.put(XmlQParserPlugin.NAME, new XmlQParserPlugin());
+    map.put(GraphTermsQParserPlugin.NAME, new GraphTermsQParserPlugin());
+    map.put(IGainTermsQParserPlugin.NAME, new IGainTermsQParserPlugin());
+    map.put(TextLogisticRegressionQParserPlugin.NAME, new TextLogisticRegressionQParserPlugin());
+    map.put(SignificantTermsQParserPlugin.NAME, new SignificantTermsQParserPlugin());
+    map.put(PayloadScoreQParserPlugin.NAME, new PayloadScoreQParserPlugin());
+    map.put(PayloadCheckQParserPlugin.NAME, new PayloadCheckQParserPlugin());
+    map.put(BoolQParserPlugin.NAME, new BoolQParserPlugin());
 
     standardPlugins = Collections.unmodifiableMap(map);
   }

--- a/solr/core/src/test/org/apache/solr/search/TestStandardQParsers.java
+++ b/solr/core/src/test/org/apache/solr/search/TestStandardQParsers.java
@@ -50,9 +50,9 @@ public class TestStandardQParsers extends LuceneTestCase {
     List<String> notFinal = new ArrayList<>(QParserPlugin.standardPlugins.size());
     List<String> mismatch = new ArrayList<>(QParserPlugin.standardPlugins.size());
 
-    for (Map.Entry<String, Class<? extends QParserPlugin>> pair : QParserPlugin.standardPlugins.entrySet()) {
+    for (Map.Entry<String, QParserPlugin> pair : QParserPlugin.standardPlugins.entrySet()) {
       String regName = pair.getKey();
-      Class<? extends QParserPlugin> clazz = pair.getValue();
+      Class<? extends QParserPlugin> clazz = pair.getValue().getClass();;
 
       Field nameField = clazz.getField(FIELD_NAME);
       int modifiers = nameField.getModifiers();


### PR DESCRIPTION
Instead of recreating the classes every time we reload a solr core, just create them once.  The same is done in other classes such as TransformerFactory