### PR TITLE
SOLR-12312: Change buf to not always use up 1 MB

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/IndexFetcher.java
+++ b/solr/core/src/java/org/apache/solr/handler/IndexFetcher.java
@@ -1530,9 +1530,6 @@ public class IndexFetcher {
    * @see org.apache.solr.handler.ReplicationHandler.DirectoryFileStream
    */
   private class FileFetcher {
-
-    static final int MAX_BUF_SIZE = 1024 * 1024;
-
     private final FileInterface file;
     private boolean includeChecksum = true;
     private final String fileName;
@@ -1552,7 +1549,7 @@ public class IndexFetcher {
       this.file = file;
       this.fileName = (String) fileDetails.get(NAME);
       this.size = (Long) fileDetails.get(SIZE);
-      buf = new byte[(int)Math.min(this.size, MAX_BUF_SIZE)];
+      buf = new byte[(int)Math.min(this.size, ReplicationHandler.PACKET_SZ)];
       this.solrParamOutput = solrParamOutput;
       this.saveAs = saveAs;
       indexGen = latestGen;
@@ -1633,8 +1630,6 @@ public class IndexFetcher {
             LOG.warn("No content received for file: {}", fileName);
             return NO_CONTENT;
           }
-          if (buf.length < packetSize)
-            buf = new byte[packetSize];
           if (checksum != null) {
             //read the checksum
             fis.readFully(longbytes);

--- a/solr/core/src/java/org/apache/solr/handler/IndexFetcher.java
+++ b/solr/core/src/java/org/apache/solr/handler/IndexFetcher.java
@@ -1530,6 +1530,9 @@ public class IndexFetcher {
    * @see org.apache.solr.handler.ReplicationHandler.DirectoryFileStream
    */
   private class FileFetcher {
+
+    int MAX_BUF_SIZE = 1024 * 1024;
+
     private final FileInterface file;
     private boolean includeChecksum = true;
     private final String fileName;
@@ -1549,8 +1552,7 @@ public class IndexFetcher {
       this.file = file;
       this.fileName = (String) fileDetails.get(NAME);
       this.size = (Long) fileDetails.get(SIZE);
-      //Max buf of 1 MB, but we should save memory if the file size is smaller
-      buf = this.size < 1048576 ? new byte[(int) this.size] : new byte[1024 * 1024];
+      buf = new byte[(int)Math.min(this.size, MAX_BUF_SIZE)];
       this.solrParamOutput = solrParamOutput;
       this.saveAs = saveAs;
       indexGen = latestGen;

--- a/solr/core/src/java/org/apache/solr/handler/IndexFetcher.java
+++ b/solr/core/src/java/org/apache/solr/handler/IndexFetcher.java
@@ -1539,7 +1539,7 @@ public class IndexFetcher {
 
     private final long size;
     private long bytesDownloaded = 0;
-    private byte[] buf = new byte[1024 * 1024];
+    private byte[] buf;
     private final Checksum checksum;
     private int errorCount = 0;
     private boolean aborted = false;
@@ -1549,6 +1549,8 @@ public class IndexFetcher {
       this.file = file;
       this.fileName = (String) fileDetails.get(NAME);
       this.size = (Long) fileDetails.get(SIZE);
+      //Max buf of 1 MB, but we should save memory if the file size is smaller
+      buf = this.size < 1048576 ? new byte[(int) this.size] : new byte[1024 * 1024];
       this.solrParamOutput = solrParamOutput;
       this.saveAs = saveAs;
       indexGen = latestGen;

--- a/solr/core/src/java/org/apache/solr/handler/IndexFetcher.java
+++ b/solr/core/src/java/org/apache/solr/handler/IndexFetcher.java
@@ -1630,6 +1630,10 @@ public class IndexFetcher {
             LOG.warn("No content received for file: {}", fileName);
             return NO_CONTENT;
           }
+          //This really shouldn't happen since we set the buf based on the handler PACKET_SZ, but it could be possible
+          //If that ever changes and both hosts aren't bounced at the same time for example..
+          if (buf.length < packetSize)
+            buf = new byte[packetSize];
           if (checksum != null) {
             //read the checksum
             fis.readFully(longbytes);

--- a/solr/core/src/java/org/apache/solr/handler/IndexFetcher.java
+++ b/solr/core/src/java/org/apache/solr/handler/IndexFetcher.java
@@ -1531,7 +1531,7 @@ public class IndexFetcher {
    */
   private class FileFetcher {
 
-    int MAX_BUF_SIZE = 1024 * 1024;
+    static final int MAX_BUF_SIZE = 1024 * 1024;
 
     private final FileInterface file;
     private boolean includeChecksum = true;


### PR DESCRIPTION
A lot of replicated files aren't 1 MB in size, this causes a lot of heap space waste when we create this for every file, instead create buffer based on the file size with a max of 1 MB