### PR TITLE
[SOLR-12334] Improve detection of recreated lockfiles

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/store/FileID.java
+++ b/lucene/core/src/java/org/apache/lucene/store/FileID.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.store;
+
+import java.io.IOException;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * <p>A (hopefully) unique ID for a file</p>
+ *
+ * <p>This creates an ID for a file which can be compared to other IDs in order to attempt to
+ * verify that both are the same file. This comparison is done on an best-effort basis and is
+ * useful to ensure that a file has not been removed and recreated.</p>
+ *
+ * <p>Implementation details:</p>
+ *
+ * <ul>
+ *   <li>On plattforms that support {@link BasicFileAttributes#fileKey} this will be used to verify that
+ *   two {@link FileID}s refer to same file. On Unix-like systems, the key consists of the <em>device id</em>
+ *   and <em>inode</em> allowing detection of recreated files at a very low error rate.</li>
+ *   <li>On all other platforms, namely those that don't support {@link BasicFileAttributes#fileKey}, the
+ *   creation time or modification time, if available, is used in an attempt to ensure two {@link FileID}s
+ *   refer to the same file .</li>
+ * </ul>
+ */
+public class FileID {
+    private final FileTime creationTime;
+    private final Object fileKey;
+
+    public FileID(Path path) throws IOException {
+        BasicFileAttributes attributes = Files.readAttributes(path, BasicFileAttributes.class);
+        fileKey = attributes.fileKey();
+        creationTime = fileKey == null ? attributes.creationTime() : null;
+    }
+
+    public boolean isSameFileAs(FileID other) {
+        if (this.fileKey != null) {
+            if (other.fileKey == null) {
+                return false;
+            }
+            return this.fileKey.equals(other.fileKey);
+        } else {
+            return this.creationTime.equals(other.creationTime);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return String.format("FileID(fileKey=%s, creationTime=%s)", this.fileKey, this.creationTime);
+    }
+}


### PR DESCRIPTION
I've been running into issues with the detection of deleted and then
recreated files when using GlusterFS. Since, on most platforms, there
are more reliable ways to detect recreated files, I decided improved
the detection of such files.

Background:

As part of LUCENE-6508 [3] detection of recreated files was added.
In such a case, another instance may have obtained lock on the newly
created file. This isn't something that should happen on a properly
configured Solr instance but there is a good chance for this
happening when an index is shared by multiple instances that use a
different locking mechanism.

Implementation:

On platform that support it, fileKey() [1] is now used. On Unix-like
systems this key consists of the device ID and and inode. For locks
that keep the lock file open, this should ensure we detect recreation
since no two files can have the same device ID and inode even if the
last hard link has been removed already. Other locks, that don't keep
the file open, should still detect recreation at a low error rate.

Platforms without fileKey() support keep using the creation timestamp
or modification timestamp (subject to availability) [2].

[1]: https://docs.oracle.com/javase/8/docs/api/java/nio/file/attribute/BasicFileAttributes.html#fileKey--
[2]: https://docs.oracle.com/javase/8/docs/api/java/nio/file/attribute/BasicFileAttributes.html#creationTime--
[3]: https://issues.apache.org/jira/browse/LUCENE-6508