### PR TITLE
SOLR-9769 solr stop on a stopped service should be success

### DIFF
--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -1774,7 +1774,7 @@ else
   else
     if [ "$SCRIPT_CMD" == "stop" ]; then
       echo -e "No process found for Solr node running on port $SOLR_PORT"
-      exit 1
+      exit 0
     fi
   fi
 fi


### PR DESCRIPTION
According to the LSB specification:
In addition to straightforward success, the following situations are
also to be considered successful:

- running stop on a service already stopped or not running