### PR TITLE
WIP: SOLR-12361

### DIFF
--- a/solr/core/src/java/org/apache/solr/response/GeoJSONResponseWriter.java
+++ b/solr/core/src/java/org/apache/solr/response/GeoJSONResponseWriter.java
@@ -175,21 +175,6 @@ class GeoJSONWriter extends JSONWriter {
       }
     }
 
-    // GeoJSON does not really support nested FeatureCollections
-    if(doc.hasChildDocuments()) {
-      if(first == false) {
-        writeMapSeparator();
-        indent();
-      }
-      writeKey("_childDocuments_", true);
-      writeArrayOpener(doc.getChildDocumentCount());
-      List<SolrDocument> childDocs = doc.getChildDocuments();
-      for(int i=0; i<childDocs.size(); i++) {
-        writeSolrDocument(null, childDocs.get(i), null, i);
-      }
-      writeArrayCloser();
-    }
-
     // check that we added any properties
     if(!first) {
       decLevel();

--- a/solr/core/src/java/org/apache/solr/response/JSONResponseWriter.java
+++ b/solr/core/src/java/org/apache/solr/response/JSONResponseWriter.java
@@ -376,20 +376,6 @@ class JSONWriter extends TextResponseWriter {
         writeVal(fname, val);
       }
     }
-
-    if(doc.hasChildDocuments()) {
-      if(first == false) {
-        writeMapSeparator();
-        indent();
-      }
-      writeKey("_childDocuments_", true);
-      writeArrayOpener(doc.getChildDocumentCount());
-      List<SolrDocument> childDocs = doc.getChildDocuments();
-      for(int i=0; i<childDocs.size(); i++) {
-        writeSolrDocument(null, childDocs.get(i), null, i);
-      }
-      writeArrayCloser();
-    }
     
     decLevel();
     writeMapCloser();

--- a/solr/core/src/java/org/apache/solr/update/AddUpdateCommand.java
+++ b/solr/core/src/java/org/apache/solr/update/AddUpdateCommand.java
@@ -19,6 +19,7 @@ package org.apache.solr.update;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.Term;
@@ -231,10 +232,13 @@ public class AddUpdateCommand extends UpdateCommand implements Iterable<Document
   }
 
   private void recUnwrapp(List<SolrInputDocument> unwrappedDocs, SolrInputDocument currentDoc) {
-    List<SolrInputDocument> children = currentDoc.getChildDocuments();
+    Map<String, Object> children = currentDoc.getChildDocumentsMap();
     if (children != null) {
-      for (SolrInputDocument child : children) {
-        recUnwrapp(unwrappedDocs, child);
+      for (Map.Entry<String, Object> childEntry : children.entrySet()) {
+        List<SolrInputDocument> childrenList = ((List<SolrInputDocument>) childEntry.getValue());
+        for(SolrInputDocument child: childrenList) {
+          recUnwrapp(unwrappedDocs, child);
+        }
       }
     }
     unwrappedDocs.add(currentDoc);

--- a/solr/core/src/java/org/apache/solr/update/DocumentBuilder.java
+++ b/solr/core/src/java/org/apache/solr/update/DocumentBuilder.java
@@ -25,6 +25,7 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.BytesRef;
+import org.apache.solr.common.SolrDocumentBase;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.SolrInputField;
@@ -132,6 +133,9 @@ public class DocumentBuilder {
     
     // Load fields from SolrDocument to Document
     for( SolrInputField field : doc ) {
+      if (field.getFirstValue() instanceof SolrDocumentBase) {
+        continue;
+      }
       String name = field.getName();
       SchemaField sfield = schema.getFieldOrNull(name);
       boolean used = false;

--- a/solr/core/src/test-files/solr/collection1/conf/schema_latest.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/schema_latest.xml
@@ -382,6 +382,7 @@
   <fieldType name="float" class="${solr.tests.FloatFieldType}" docValues="${solr.tests.numeric.dv}" precisionStep="0" positionIncrementGap="0"/>
   <fieldType name="long" class="${solr.tests.LongFieldType}" docValues="${solr.tests.numeric.dv}" precisionStep="0" positionIncrementGap="0"/>
   <fieldType name="double" class="${solr.tests.DoubleFieldType}" docValues="${solr.tests.numeric.dv}" precisionStep="0" positionIncrementGap="0"/>
+  <fieldType name="date" class="${solr.tests.DateFieldType}" docValues="${solr.tests.numeric.dv}" precisionStep="0" positionIncrementGap="0"/>
 
   <!--
    Numeric field types that index each value at various levels of precision
@@ -420,7 +421,6 @@
 
        Note: For faster range queries, consider the tdate type
     -->
-  <fieldType name="date" class="${solr.tests.DateFieldType}" precisionStep="0" positionIncrementGap="0"/>
 
   <!-- A Trie based date field for faster date range queries and date faceting. -->
   <fieldType name="tdate" class="${solr.tests.DateFieldType}" precisionStep="6" positionIncrementGap="0"/>

--- a/solr/core/src/test/org/apache/solr/update/AddBlockUpdateTest.java
+++ b/solr/core/src/test/org/apache/solr/update/AddBlockUpdateTest.java
@@ -421,7 +421,7 @@ public class AddBlockUpdateTest extends SolrTestCaseJ4 {
     try (JavaBinCodec jbc = new JavaBinCodec(); InputStream is = new ByteArrayInputStream(buffer)) {
       result = (SolrInputDocument) jbc.unmarshal(is);
     }
-    assertEquals(2, result.size());
+    assertEquals(3, result.size());
     assertEquals("v1", result.getFieldValue("parent_f1"));
     assertEquals("v2", result.getFieldValue("parent_f2"));
     

--- a/solr/core/src/test/org/apache/solr/update/processor/IgnoreLargeDocumentProcessorFactoryTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/IgnoreLargeDocumentProcessorFactoryTest.java
@@ -31,6 +31,7 @@ import org.apache.solr.common.util.NamedList;
 import org.apache.solr.update.AddUpdateCommand;
 import org.junit.Test;
 
+import static org.apache.solr.handler.loader.JsonLoader.CHILD_DOC_KEY;
 import static org.apache.solr.update.processor.IgnoreLargeDocumentProcessorFactory.ObjectSizeEstimator.fastEstimate;
 
 public class IgnoreLargeDocumentProcessorFactoryTest extends LuceneTestCase {
@@ -97,6 +98,8 @@ public class IgnoreLargeDocumentProcessorFactoryTest extends LuceneTestCase {
       childDocument.addField(entry.getKey(), entry.getValue());
     }
     document.addChildDocument(childDocument);
-    assertEquals(fastEstimate(document), fastEstimate(map) * 2);
+    Map<String, Object> mapWChild = new HashMap<>(map);
+    mapWChild.put(CHILD_DOC_KEY, map);
+    assertEquals(fastEstimate(document), fastEstimate(mapWChild));
   }
 }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/util/ClientUtils.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/util/ClientUtils.java
@@ -72,7 +72,9 @@ public class ClientUtils
       for( Object v : field ) {
         String update = null;
 
-        if (v instanceof Map) {
+        if(v instanceof SolrInputDocument) {
+          continue;
+        } else if (v instanceof Map) {
           // currently only supports a single value
           for (Entry<Object,Object> entry : ((Map<Object,Object>)v).entrySet()) {
             update = entry.getKey().toString();

--- a/solr/solrj/src/java/org/apache/solr/common/SolrDocument.java
+++ b/solr/solrj/src/java/org/apache/solr/common/SolrDocument.java
@@ -16,7 +16,6 @@
  */
 package org.apache.solr.common;
 
-import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -26,7 +25,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import org.apache.solr.common.util.NamedList;
 
@@ -401,12 +399,20 @@ public class SolrDocument extends SolrDocumentBase<Object, SolrDocument> impleme
    /** Returns the list of child documents, or null if none. */
    @Override
    public List<SolrDocument> getChildDocuments() {
-     List<SolrDocument> childDocs = new ArrayList<>();
-     Stream<AbstractMap.SimpleEntry<String, SolrDocument>> fields = _fields.entrySet().stream()
-         .filter(value -> value.getValue() instanceof SolrInputDocument)
-         .map(value -> new AbstractMap.SimpleEntry<>(value.getKey(), (SolrDocument) value.getValue()));
-     fields.forEach(e -> childDocs.add(e.getValue()));
-     return childDocs.size() > 0 ? childDocs: null;
+     Map<String, Object> childDocMap = getChildDocumentsMap();
+     if (childDocMap == null) {
+       return null;
+     }
+     List<SolrDocument> children = new ArrayList<>();
+     for(Entry<String, Object> entry: childDocMap.entrySet()) {
+       Object value = entry.getValue();
+       if(value instanceof Collection) {
+         children.addAll(((Collection<SolrDocument>) value));
+         continue;
+       }
+       children.add(((SolrDocument) value));
+     }
+     return children;
    }
    
    @Override

--- a/solr/solrj/src/java/org/apache/solr/common/SolrDocumentBase.java
+++ b/solr/solrj/src/java/org/apache/solr/common/SolrDocumentBase.java
@@ -23,6 +23,20 @@ import java.util.Map;
 
 public abstract class SolrDocumentBase<T, K> implements Map<String, T>, Serializable {
 
+  protected boolean objIsDocument(Object obj) {
+    if (obj instanceof SolrDocumentBase) {
+      return true;
+    } else if (obj instanceof Collection) {
+      Collection objCol = ((Collection) obj);
+      if(objCol.size() > 0) {
+        return objCol.iterator().next() instanceof SolrDocumentBase;
+      }
+    }
+    return false;
+  }
+
+  public static final String CHILD_DOC_KEY = "_childDocuments_";
+
   /** Get all field names.
   */
   public abstract Collection<String> getFieldNames();
@@ -55,6 +69,8 @@ public abstract class SolrDocumentBase<T, K> implements Map<String, T>, Serializ
   public abstract void addChildDocuments(Collection<K> children);
 
   public abstract List<K> getChildDocuments();
+
+  public abstract Map<String, Object> getChildDocumentsMap();
 
   public abstract boolean hasChildDocuments();
 

--- a/solr/solrj/src/java/org/apache/solr/common/util/JavaBinCodec.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/JavaBinCodec.java
@@ -607,18 +607,11 @@ public class JavaBinCodec implements PushWriter {
   }
 
   public void writeSolrInputDocument(SolrInputDocument sdoc) throws IOException {
-    List<SolrInputDocument> children = sdoc.getChildDocuments();
-    int sz = sdoc.size() + (children==null ? 0 : children.size());
-    writeTag(SOLRINPUTDOC, sz);
+    writeTag(SOLRINPUTDOC, sdoc.size());
     writeFloat(1f); // document boost
     for (SolrInputField inputField : sdoc.values()) {
       writeExternString(inputField.getName());
       writeVal(inputField.getValue());
-    }
-    if (children != null) {
-      for (SolrInputDocument child : children) {
-        writeSolrInputDocument(child);
-      }
     }
   }
 

--- a/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
+++ b/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
@@ -45,6 +45,7 @@ import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
@@ -1351,30 +1352,27 @@ public abstract class SolrTestCaseJ4 extends LuceneTestCase {
         JSONUtil.writeString(sfield.getName(), 0, sfield.getName().length(), out);
         out.append(':');
 
-        if (sfield.getValueCount() > 1) {
+        if (sfield.getValue() instanceof Collection) {
           out.append('[');
           boolean firstVal = true;
           for (Object val : sfield) {
             if (firstVal) firstVal=false;
             else out.append(',');
+            if(val instanceof SolrInputDocument) {
+              json((SolrInputDocument) val, out);
+              continue;
+            }
             out.append(JSONUtil.toJSON(val));
           }
           out.append(']');
         } else {
-          out.append(JSONUtil.toJSON(sfield.getValue()));
+          Object val = sfield.getValue();
+          if (val instanceof SolrInputDocument) {
+            json(((SolrInputDocument) val), out);
+            continue;
+          }
+          out.append(JSONUtil.toJSON(val));
         }
-      }
-
-      boolean firstChildDoc = true;
-      if(doc.hasChildDocuments()) {
-        out.append(",\"_childDocuments_\": [");
-        List<SolrInputDocument> childDocuments = doc.getChildDocuments();
-        for(SolrInputDocument childDocument : childDocuments) {
-          if (firstChildDoc) firstChildDoc=false;
-          else out.append(',');
-          json(childDocument, out);
-        }
-        out.append(']');
       }
       out.append('}');
     } catch (IOException e) {


### PR DESCRIPTION
pass tests but the TestChildDocTransformer.
We have to think of a how we want to change the transformer, which should probably be discussed in another issue.
Currently it does not add the _childDocuments_ field to fl, causing the childDocuments to be ommited from the response.