### PR TITLE
LUCENE-8287: In ContextQuery, use a more comprehensive check for an empty prefix automaton

### DIFF
--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/ContextQuery.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/ContextQuery.java
@@ -187,8 +187,8 @@ public class ContextQuery extends CompletionQuery implements Accountable {
 
     // If the inner automaton matches nothing, then we return an empty weight to avoid
     // traversing all contexts during scoring.
-    if (innerAutomaton.getNumStates() == 0) {
-      return new CompletionWeight(this, innerAutomaton);
+    if (Operations.isEmpty(innerAutomaton)) {
+      return new CompletionWeight(this, Automata.makeEmpty());
     }
 
     // if separators are preserved the fst contains a SEP_LABEL

--- a/lucene/suggest/src/test/org/apache/lucene/search/suggest/document/TestPrefixCompletionQuery.java
+++ b/lucene/suggest/src/test/org/apache/lucene/search/suggest/document/TestPrefixCompletionQuery.java
@@ -34,6 +34,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.suggest.BitsProducer;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.Bits;
@@ -432,6 +433,12 @@ public class TestPrefixCompletionQuery extends LuceneTestCase {
     ContextQuery query = new ContextQuery(new PrefixCompletionQuery(analyzer, new Term("suggest_field", "")));
     query.addContext("type", 1);
 
+    // Ensure that context queries optimize an empty prefix to a fully empty automaton.
+    CompletionWeight weight = (CompletionWeight) query.createWeight(
+        suggestIndexSearcher, ScoreMode.COMPLETE, 1.0F);
+    assertEquals(0, weight.getAutomaton().getNumStates());
+
+    // Check that there are no suggestions.
     TopSuggestDocs suggest = suggestIndexSearcher.suggest(query, 5, false);
     assertEquals(0, suggest.scoreDocs.length);
 

--- a/lucene/suggest/src/test/org/apache/lucene/search/suggest/document/TestRegexCompletionQuery.java
+++ b/lucene/suggest/src/test/org/apache/lucene/search/suggest/document/TestRegexCompletionQuery.java
@@ -22,6 +22,7 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.LuceneTestCase;
 import org.junit.After;
@@ -188,6 +189,12 @@ public class TestRegexCompletionQuery extends LuceneTestCase {
     ContextQuery query = new ContextQuery(new RegexCompletionQuery(new Term("suggest_field", "")));
     query.addContext("type", 1);
 
+    // Ensure that context queries optimize an empty regex to a fully empty automaton.
+    CompletionWeight weight = (CompletionWeight) query.createWeight(
+        suggestIndexSearcher, ScoreMode.COMPLETE, 1.0F);
+    assertEquals(0, weight.getAutomaton().getNumStates());
+
+    // Check that there are no suggestions.
     TopSuggestDocs suggest = suggestIndexSearcher.suggest(query, 5, false);
     assertEquals(0, suggest.scoreDocs.length);
 


### PR DESCRIPTION
Follow-up to https://github.com/apache/lucene-solr/pull/375.