### PR TITLE
SOLR-12416 Add autoDeleteAge to optional router params

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/TimeRoutedAlias.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/TimeRoutedAlias.java
@@ -82,6 +82,7 @@ public class TimeRoutedAlias {
    */
   public static final List<String> OPTIONAL_ROUTER_PARAMS = Collections.unmodifiableList(Arrays.asList(
       ROUTER_MAX_FUTURE,
+      ROUTER_AUTO_DELETE_AGE,
       TZ)); // kinda special
 
   static Predicate<String> PARAM_IS_PROP =


### PR DESCRIPTION
Since autoDeleteAge is not in either REQUIRED_ROUTER_PARAMS or OPTIONAL_ROUTER_PARAMS the CollectionsHandler will not pass it on and it will be ignored in the CREATEALIAS command.