### PR TITLE
Solr 12421

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/CoreDescriptor.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreDescriptor.java
@@ -195,8 +195,6 @@ public class CoreDescriptor {
                         Properties containerProperties, boolean isZooKeeperAware) {
     this.instanceDir = instanceDir;
 
-    originalCoreProperties.setProperty(CORE_NAME, name);
-
     name = PropertiesUtil.substituteProperty(checkPropertyIsNotEmpty(name, CORE_NAME),
                                              containerProperties);
 
@@ -216,6 +214,8 @@ public class CoreDescriptor {
         coreProperties.setProperty(propname,
             PropertiesUtil.substituteProperty(propvalue, containerProperties));
     }
+
+    originalCoreProperties.setProperty(CORE_NAME, name);
 
     loadExtraProperties();
     buildSubstitutableProperties();

--- a/solr/core/src/test/org/apache/solr/core/TestCoreDescriptor.java
+++ b/solr/core/src/test/org/apache/solr/core/TestCoreDescriptor.java
@@ -17,12 +17,15 @@
 
 package org.apache.solr.core;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
 import com.google.common.io.Files;
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,6 +37,11 @@ public class TestCoreDescriptor extends Assert {
   @Before
   public void setup() {
     instanceDir = Files.createTempDir().toPath();
+  }
+
+  @After
+  public void teardown() throws IOException {
+    FileUtils.deleteDirectory(instanceDir.toFile());
   }
 
 

--- a/solr/core/src/test/org/apache/solr/core/TestCoreDescriptor.java
+++ b/solr/core/src/test/org/apache/solr/core/TestCoreDescriptor.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.core;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import com.google.common.io.Files;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestCoreDescriptor extends Assert {
+
+  Path instanceDir;
+
+  @Before
+  public void setup() {
+    instanceDir = Files.createTempDir().toPath();
+  }
+
+
+  @Test
+  public void testNameIsNotOverrriddenByPropertiesMap() {
+    Map<String, String> map = new HashMap();
+    Properties properties = new Properties();
+    properties.put(CoreDescriptor.CORE_NAME, "BadName");
+    map.put(CoreDescriptor.CORE_NAME, "BadName");
+    CoreDescriptor cd = new CoreDescriptor("GoodName", instanceDir, map, properties, false);
+    assertTrue("Should not of allowed name to be overridden by properties",
+        cd.getPersistableStandardProperties().getProperty(CoreDescriptor.CORE_NAME).equals("GoodName"));
+  }
+}


### PR DESCRIPTION
If we allow the passed in properties object to override the name written to originalCoreProperties then the core.properties file gets written with the wrong name in it.