### PR TITLE
Lucene 8347

### DIFF
--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/analyzing/BlendedInfixSuggester.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/analyzing/BlendedInfixSuggester.java
@@ -224,8 +224,11 @@ public class BlendedInfixSuggester extends AnalyzingInfixSuggester {
       } else {
         coefficient = createCoefficient(searcher, fd.doc, matchedTokens, prefixToken);
       }
-
-      long score = (long) (weight * coefficient);
+      if (weight == 0) {
+        weight = 1;
+      }
+      long scaledCoefficient = (long) (coefficient * 10);
+      long score = weight * scaledCoefficient;
 
       LookupResult result;
       if (doHighlight) {


### PR DESCRIPTION
Introduced multi term management for the BlendedInfix suggester.
The score of each suggestion will be calculated based on : 

- the positional coefficient of each token matched
- the length of the suggestion ( minor)

This patch is supposed to go in after LUCENE-8343