### PR TITLE
SOLR-12477 - Return server error(500) for AlreadyClosedException instead of client Errors(400)

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -1806,7 +1806,11 @@ public class CoreContainer {
     return false;
   }
 
-  public void checkTragicException(SolrCore solrCore) {
+  /**
+   * @param solrCore
+   * @return whether this solr core has tragic exception
+   */
+  public boolean checkTragicException(SolrCore solrCore) {
     Throwable tragicException = null;
     try {
       tragicException = solrCore.getSolrCoreState().getTragicException();
@@ -1820,6 +1824,8 @@ public class CoreContainer {
         getZkController().giveupLeadership(solrCore.getCoreDescriptor(), tragicException);
       }
     }
+    
+    return tragicException != null;
   }
 
 }

--- a/solr/core/src/test/org/apache/solr/cloud/LeaderTragicEventTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/LeaderTragicEventTest.java
@@ -17,18 +17,23 @@
 
 package org.apache.solr.cloud;
 
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.is;
+
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
+import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.MockDirectoryWrapper;
 import org.apache.solr.client.solrj.embedded.JettySolrRunner;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
+import org.apache.solr.client.solrj.impl.HttpSolrClient.RemoteSolrException;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.UpdateRequest;
+import org.apache.solr.common.SolrException;
 import org.apache.solr.common.cloud.ClusterStateUtil;
 import org.apache.solr.common.cloud.DocCollection;
 import org.apache.solr.common.cloud.Replica;
@@ -133,8 +138,17 @@ public class LeaderTragicEventTest extends SolrCloudTestCase {
         }
       }
     } catch (Exception e) {
-      log.info("Corrupt leader ex: ",e);
-      // Expected
+      log.info("Corrupt leader ex: ", e);
+      
+      // solrClient.add/commit would throw RemoteSolrException with error code 500 or 
+      // 404(when the leader replica is already deleted by giveupLeadership)
+      if (e instanceof RemoteSolrException) {
+        SolrException se = (SolrException) e;
+        assertThat(se.code(), anyOf(is(500), is(404)));
+      } else if (!(e instanceof AlreadyClosedException)) {
+        throw new RuntimeException("Unexpected exception", e);
+      }
+      //else expected
     }
     return oldLeader;
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-12477

In some cases(for example: corrupt index), addDoc0 throws AlreadyClosedException, but solr server returns client error 400 to client

This will confuse customers and especially monitoring tool.