### PR TITLE
Debugging PriorityQueue.java

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/PriorityQueue.java
+++ b/lucene/core/src/java/org/apache/lucene/util/PriorityQueue.java
@@ -50,14 +50,15 @@ public abstract class PriorityQueue<T> implements Iterable<T> {
       // We allocate 1 extra to avoid if statement in top()
       heapSize = 2;
     } else {
+
+      if ((maxSize < 0) || (maxSize >= ArrayUtil.MAX_ARRAY_LENGTH)) {
+        // Throw exception to prevent confusing OOME:
+        throw new IllegalArgumentException("maxSize must be positive and < " + (ArrayUtil.MAX_ARRAY_LENGTH) + "; got: " + maxSize);
+      }
+
       // NOTE: we add +1 because all access to heap is
       // 1-based not 0-based.  heap[0] is unused.
       heapSize = maxSize + 1;
-
-      if (heapSize > ArrayUtil.MAX_ARRAY_LENGTH) {
-        // Throw exception to prevent confusing OOME:
-        throw new IllegalArgumentException("maxSize must be <= " + (ArrayUtil.MAX_ARRAY_LENGTH-1) + "; got: " + maxSize);
-      }
     }
     // T is unbounded type, so this unchecked cast works always:
     @SuppressWarnings("unchecked") final T[] h = (T[]) new Object[heapSize];

--- a/lucene/core/src/java/org/apache/lucene/util/PriorityQueue.java
+++ b/lucene/core/src/java/org/apache/lucene/util/PriorityQueue.java
@@ -53,7 +53,7 @@ public abstract class PriorityQueue<T> implements Iterable<T> {
 
       if ((maxSize < 0) || (maxSize >= ArrayUtil.MAX_ARRAY_LENGTH)) {
         // Throw exception to prevent confusing OOME:
-        throw new IllegalArgumentException("maxSize must be positive and < " + (ArrayUtil.MAX_ARRAY_LENGTH) + "; got: " + maxSize);
+        throw new IllegalArgumentException("maxSize must be >= 0 and < " + (ArrayUtil.MAX_ARRAY_LENGTH) + "; got: " + maxSize);
       }
 
       // NOTE: we add +1 because all access to heap is


### PR DESCRIPTION
The change I'm proposing eliminates a problem by properly checking the validity of maxSize itself, before even computing heapSize=maxSize+1.

In the constructor, when maxSize has a value == Integer.MAX_VALUE, then heapSize = maxSize+1 ends up being negative, more exactly -2147483648 (aka. Integer.MIN_VALUE.)  This is quite a bug because then the if statement checking whether heapSize is larger than ArrayUtil.MAX_ARRAY_LENGTH ends up false, so the IllegalArgumentException is never thrown. Yet the code in PriorityQueue.java fails immediately afterwards when reaching "new Object[heapSize]" because of heapSize being negative, causing a NegativeArraySize exception.

We saw this problem with our software which was using (correction--> ) Solr 6.6.1 in cloud mode.