### PR TITLE
SOLR-12007 When a SolrCore is closed, cleanupOldIndexDirectories is c…

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -140,6 +140,8 @@ Bug Fixes
 
 * SOLR-2834: Fix SolrJ Field and Document analyzes for types that include CharacterFilter (Alexandre Rafalovitch)
 
+* SOLR-12007: When a SolrCore is closed, cleanupOldIndexDirectories is called in a background thread that will
+  race with DirectoryFactory close. (Mark Miller, Gabor Kaszab)
 
 Optimizations
 ----------------------

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -3093,16 +3093,12 @@ public final class SolrCore implements SolrInfoBean, SolrMetricProducer, Closeab
     final String myIndexDir = getNewIndexDir(); // ensure the latest replicated index is protected 
     final String coreName = getName();
     if (myDirFactory != null && myDataDir != null && myIndexDir != null) {
-      Thread cleanupThread = new Thread(() -> {
-        log.debug("Looking for old index directories to cleanup for core {} in {}", coreName, myDataDir);
-        try {
-          myDirFactory.cleanupOldIndexDirectories(myDataDir, myIndexDir, reload);
-        } catch (Exception exc) {
-          log.error("Failed to cleanup old index directories for core {}", coreName, exc);
-        }
-      }, "OldIndexDirectoryCleanupThreadForCore-"+coreName);
-      cleanupThread.setDaemon(true);
-      cleanupThread.start();
+      log.debug("Looking for old index directories to cleanup for core {} in {}", coreName, myDataDir);
+      try {
+        myDirFactory.cleanupOldIndexDirectories(myDataDir, myIndexDir, reload);
+      } catch (Exception exc) {
+        log.error("Failed to cleanup old index directories for core "+coreName, exc);
+      }
     }
   }
 


### PR DESCRIPTION
…alled in a background thread

that will race with DirectoryFactory close.

Change-Id: I8b77fd1469a956f20245835e6db2819294c2b58a