### PR TITLE
SOLR-12595: CloudSolrClient.Builder accepts ZK connection strings

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudSolrClient.java
@@ -1412,6 +1412,25 @@ public class CloudSolrClient extends SolrClient {
     }
 
     /**
+     * Provide a ZK connection string which will be used when configuring {@link CloudSolrClient} instances.
+     *
+     * Usage example:
+     *
+     * <pre>
+     *   final SolrClient client = new CloudSolrClient.Builder("zk1:2181,zk2:2181/solr").build();
+     * </pre>
+     *
+     * @param zkHost a String containing zookeeper hosts and possibly chroot (e.g. "zk1:2181,zk2:2181/solr")
+     */
+    public Builder(String zkHost) {
+      this(new ZkClientClusterStateProvider(zkHost));
+    }
+
+    private Builder(ClusterStateProvider stateProvider) {
+      this.stateProvider = stateProvider;
+    }
+
+    /**
      * Provide a ZooKeeper client endpoint to be used when configuring {@link CloudSolrClient} instances.
      * 
      * Method may be called multiple times.  All provided values will be used.
@@ -1566,8 +1585,7 @@ public class CloudSolrClient extends SolrClient {
       if (stateProvider == null) {
         if (!zkHosts.isEmpty()) {
           stateProvider = new ZkClientClusterStateProvider(zkHosts, zkChroot);
-        }
-        else if (!this.solrUrls.isEmpty()) {
+        } else if (!this.solrUrls.isEmpty()) {
           try {
             stateProvider = new HttpClusterStateProvider(solrUrls, httpClient);
           } catch (Exception e) {

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/CloudSolrClientBuilderTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/CloudSolrClientBuilderTest.java
@@ -31,6 +31,9 @@ public class CloudSolrClientBuilderTest extends LuceneTestCase {
   private static final String ANY_CHROOT = "/ANY_CHROOT";
   private static final String ANY_ZK_HOST = "ANY_ZK_HOST";
   private static final String ANY_OTHER_ZK_HOST = "ANY_OTHER_ZK_HOST";
+  private static final String ANY_ZK_CONNECTION_STRING =
+      String.format("%s,%s%s", ANY_ZK_HOST, ANY_OTHER_ZK_HOST, ANY_CHROOT);
+
 
   @Test(expected = IllegalArgumentException.class)
   public void testNoZkHostSpecified() {
@@ -52,9 +55,9 @@ public class CloudSolrClientBuilderTest extends LuceneTestCase {
   @Test
   public void testSeveralZkHostsSpecifiedSingly() throws IOException {
     final List<String> zkHostList = new ArrayList<>();
-    zkHostList.add(ANY_ZK_HOST); zkHostList.add(ANY_OTHER_ZK_HOST);
-    try (CloudSolrClient createdClient = new Builder(zkHostList, Optional.of(ANY_CHROOT))
-        .build()) {
+    zkHostList.add(ANY_ZK_HOST);
+    zkHostList.add(ANY_OTHER_ZK_HOST);
+    try (CloudSolrClient createdClient = new Builder(zkHostList, Optional.of(ANY_CHROOT)).build()) {
       final String clientZkHost = createdClient.getZkHost();
     
       assertTrue(clientZkHost.contains(ANY_ZK_HOST));
@@ -63,22 +66,20 @@ public class CloudSolrClientBuilderTest extends LuceneTestCase {
   }
   
   @Test
-  public void testSeveralZkHostsSpecifiedTogether() throws IOException {
-    final ArrayList<String> zkHosts = new ArrayList<String>();
-    zkHosts.add(ANY_ZK_HOST);
-    zkHosts.add(ANY_OTHER_ZK_HOST);
-    try(CloudSolrClient createdClient = new Builder(zkHosts, Optional.of(ANY_CHROOT)).build()) {
+  public void testZkConnectionString() throws IOException {
+    try(CloudSolrClient createdClient = new Builder(ANY_ZK_CONNECTION_STRING).build()) {
       final String clientZkHost = createdClient.getZkHost();
     
       assertTrue(clientZkHost.contains(ANY_ZK_HOST));
       assertTrue(clientZkHost.contains(ANY_OTHER_ZK_HOST));
+      assertTrue(clientZkHost.contains(ANY_CHROOT));
     }
   }
   
   @Test
   public void testByDefaultConfiguresClientToSendUpdatesOnlyToShardLeaders() throws IOException {
     try(CloudSolrClient createdClient = new Builder(Collections.singletonList(ANY_ZK_HOST), Optional.of(ANY_CHROOT)).build()) {
-      assertTrue(createdClient.isUpdatesToLeaders() == true);
+      assertTrue(createdClient.isUpdatesToLeaders());
     }
   }
 


### PR DESCRIPTION
Added additional constructor to `CloudSolrClient.Builder` which accepts ZooKeeper connection strings.