### PR TITLE
Add example schema settings for Korean analyzer.

### DIFF
--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/KoreanPartOfSpeechStopFilterFactory.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/KoreanPartOfSpeechStopFilterFactory.java
@@ -25,12 +25,21 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
 
 /**
  * Factory for {@link KoreanPartOfSpeechStopFilter}.
+ * <pre class="prettyprint">
+ * &lt;fieldType name="text_ko" class="solr.TextField"&gt;
+ *    &lt;analyzer&gt;
+ *      &lt;tokenizer class="solr.KoreanTokenizerFactory"/&gt;
+ *      &lt;filter class="solr.KoreanPartOfSpeechStopFilterFactory"
+ *              tags="E,J"/&gt;
+ *    &lt;/analyzer&gt;
+ * &lt;/fieldType&gt;
+ * </pre>
  * @lucene.experimental
  */
 public class KoreanPartOfSpeechStopFilterFactory extends TokenFilterFactory {
   private Set<POS.Tag> stopTags;
 
-  /** Creates a new JapanesePartOfSpeechStopFilterFactory */
+  /** Creates a new KoreanPartOfSpeechStopFilterFactory */
   public KoreanPartOfSpeechStopFilterFactory(Map<String,String> args) {
     super(args);
     Set<String> stopTagStr = getSet(args, "tags");

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/KoreanPartOfSpeechStopFilterFactory.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/KoreanPartOfSpeechStopFilterFactory.java
@@ -34,6 +34,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *    &lt;/analyzer&gt;
  * &lt;/fieldType&gt;
  * </pre>
+ *
+ * <p>
+ * Supports the following attributes:
+ * <ul>
+ *   <li>tags: List of stop tags. if not specified, {@link KoreanPartOfSpeechStopFilter#DEFAULT_STOP_TAGS} is used.</li>
+ * </ul>
  * @lucene.experimental
  */
 public class KoreanPartOfSpeechStopFilterFactory extends TokenFilterFactory {

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/KoreanReadingFormFilterFactory.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/KoreanReadingFormFilterFactory.java
@@ -23,6 +23,14 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
 
 /**
  * Factory for {@link KoreanReadingFormFilter}.
+ * <pre class="prettyprint">
+ * &lt;fieldType name="text_ko" class="solr.TextField"&gt;
+ *   &lt;analyzer&gt;
+ *     &lt;tokenizer class="solr.KoreanTokenizerFactory"/&gt;
+ *     &lt;filter class="solr.KoreanReadingFormFilterFactory"/&gt;
+ *   &lt;/analyzer&gt;
+ * &lt;/fieldType&gt;
+ * </pre>
  * @lucene.experimental
  */
 public class KoreanReadingFormFilterFactory extends TokenFilterFactory {

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/KoreanTokenizerFactory.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/KoreanTokenizerFactory.java
@@ -40,10 +40,10 @@ import org.apache.lucene.analysis.ko.KoreanTokenizer.DecompoundMode;
  * &lt;fieldType name="text_ko" class="solr.TextField"&gt;
  *   &lt;analyzer&gt;
  *     &lt;tokenizer class="solr.KoreanTokenizerFactory"
- *       decompoundMode="discard"
- *       userDictionary="user.txt"
- *       userDictionaryEncoding="UTF-8"
- *       outputUnknownUnigrams="false"
+ *                decompoundMode="discard"
+ *                userDictionary="user.txt"
+ *                userDictionaryEncoding="UTF-8"
+ *                outputUnknownUnigrams="false"
  *     /&gt;
  *  &lt;/analyzer&gt;
  * &lt;/fieldType&gt;

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/KoreanTokenizerFactory.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/KoreanTokenizerFactory.java
@@ -35,6 +35,18 @@ import org.apache.lucene.analysis.util.ResourceLoaderAware;
 
 /**
  * Factory for {@link KoreanTokenizer}.
+ * <pre class="prettyprint">
+ * &lt;fieldType name="text_ko" class="solr.TextField"&gt;
+ *   &lt;analyzer&gt;
+ *     &lt;tokenizer class="solr.KoreanTokenizerFactory"
+ *       decompoundMode="DISCARD"
+ *       userDictionary="user.txt"
+ *       userDictionaryEncoding="UTF-8"
+ *       outputUnknownUnigrams="true"
+ *     /&gt;
+ *  &lt;/analyzer&gt;
+ * &lt;/fieldType&gt;
+ </pre>
  * @lucene.experimental
  */
 public class KoreanTokenizerFactory extends TokenizerFactory implements ResourceLoaderAware {

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/KoreanTokenizerFactory.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/KoreanTokenizerFactory.java
@@ -32,6 +32,7 @@ import org.apache.lucene.util.AttributeFactory;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.analysis.util.ResourceLoader;
 import org.apache.lucene.analysis.util.ResourceLoaderAware;
+import org.apache.lucene.analysis.ko.KoreanTokenizer.DecompoundMode;
 
 /**
  * Factory for {@link KoreanTokenizer}.
@@ -46,7 +47,16 @@ import org.apache.lucene.analysis.util.ResourceLoaderAware;
  *     /&gt;
  *  &lt;/analyzer&gt;
  * &lt;/fieldType&gt;
- </pre>
+ * </pre>
+ *
+ * <p>
+ * Supports the following attributes:
+ * <ul>
+ *   <li>userDictionary: User dictionary path.</li>
+ *   <li>userDictionaryEncoding: User dictionary encoding.</li>
+ *   <li>decompoundMode: Decompound mode. Either 'none', 'discard', 'mixed'. Default is discard. See {@link DecompoundMode}</li>
+ *   <li>outputUnknownUnigrams: If true outputs unigrams for unknown words.</li>
+ * </ul>
  * @lucene.experimental
  */
 public class KoreanTokenizerFactory extends TokenizerFactory implements ResourceLoaderAware {

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/KoreanTokenizerFactory.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/KoreanTokenizerFactory.java
@@ -39,10 +39,10 @@ import org.apache.lucene.analysis.util.ResourceLoaderAware;
  * &lt;fieldType name="text_ko" class="solr.TextField"&gt;
  *   &lt;analyzer&gt;
  *     &lt;tokenizer class="solr.KoreanTokenizerFactory"
- *       decompoundMode="DISCARD"
+ *       decompoundMode="discard"
  *       userDictionary="user.txt"
  *       userDictionaryEncoding="UTF-8"
- *       outputUnknownUnigrams="true"
+ *       outputUnknownUnigrams="false"
  *     /&gt;
  *  &lt;/analyzer&gt;
  * &lt;/fieldType&gt;


### PR DESCRIPTION
Example schema settings for `KoreanTokenizerFactory`, `KoreanPartOfSpeechStopFilterFactory`, `KoreanReadingFormFilterFactory`.