### PR TITLE
Fixing an edge case bug when overriding a default PostingsSolrHighligher

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/HighlightComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/HighlightComponent.java
@@ -189,7 +189,7 @@ public class HighlightComponent extends SearchComponent implements PluginInfoIni
 
     switch (method) {
       case UNIFIED:
-        if (solrConfigHighlighter instanceof UnifiedSolrHighlighter) {
+        if (solrConfigHighlighter.getClass() == UnifiedSolrHighlighter.class) {
           return solrConfigHighlighter;
         }
         return new UnifiedSolrHighlighter(); // TODO cache one?


### PR DESCRIPTION
Encountered this edge case issue. The impact of this should be limited but in our case (using a default PostingsSolrHighlighter) this was causing a weird issue.

The issue here is that, when passing the parameter hl.method=unified, we enter this switch, and end up in the UNIFIED case. But then we check whether the preconfigured highlighter is an instance of UnifiedSolrHighlighter. 
If the preconfigured highlighter is a PostingsSolrHighlighter, which is implemented for depracation reasons as a UnifiedSolrHighlighter, then that highlighter is used instead of a unified one (and effectively the hl.method parameter is ignored).

In our case, the additional parameters that the PostingsSolrHighlighter brings with it were causing an issue with highlighting down the line.

