### PR TITLE
LUCENE-8484: Drop fully deleted reader in SubReaderWrapper

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/FilterDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FilterDirectoryReader.java
@@ -18,6 +18,7 @@ package org.apache.lucene.index;
 
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -51,11 +52,15 @@ public abstract class FilterDirectoryReader extends DirectoryReader {
   public static abstract class SubReaderWrapper {
 
     private LeafReader[] wrap(List<? extends LeafReader> readers) {
-      LeafReader[] wrapped = new LeafReader[readers.size()];
-      for (int i = 0; i < readers.size(); i++) {
-        wrapped[i] = wrap(readers.get(i));
+      List<LeafReader> wrapped = new ArrayList<>(readers.size());
+      for (LeafReader reader : readers) {
+        LeafReader wrap = wrap(reader);
+        assert wrap != null;
+        if (wrap.numDocs() > 0) {
+          wrapped.add(wrap);
+        }
       }
-      return wrapped;
+      return wrapped.toArray(new LeafReader[0]);
     }
 
     /** Constructor */

--- a/lucene/core/src/test/org/apache/lucene/index/TestSoftDeletesDirectoryReaderWrapper.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSoftDeletesDirectoryReaderWrapper.java
@@ -27,12 +27,63 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.LuceneTestCase;
 
 public class TestSoftDeletesDirectoryReaderWrapper extends LuceneTestCase {
+
+  public void testDropFullyDeletedSegments() throws IOException {
+    IndexWriterConfig indexWriterConfig = newIndexWriterConfig();
+    String softDeletesField = "soft_delete";
+    indexWriterConfig.setSoftDeletesField(softDeletesField);
+    indexWriterConfig.setMergePolicy(new SoftDeletesRetentionMergePolicy(softDeletesField, MatchAllDocsQuery::new,
+        NoMergePolicy.INSTANCE));
+    try (Directory dir = newDirectory();
+         IndexWriter writer = new IndexWriter(dir, indexWriterConfig)) {
+
+      Document doc = new Document();
+      doc.add(new StringField("id", "1", Field.Store.YES));
+      doc.add(new StringField("version", "1", Field.Store.YES));
+      writer.addDocument(doc);
+      writer.commit();
+      doc = new Document();
+      doc.add(new StringField("id", "2", Field.Store.YES));
+      doc.add(new StringField("version", "1", Field.Store.YES));
+      writer.addDocument(doc);
+      writer.commit();
+
+      try (DirectoryReader reader = new SoftDeletesDirectoryReaderWrapper(DirectoryReader.open(dir), softDeletesField)) {
+        assertEquals(2, reader.leaves().size());
+        assertEquals(2, reader.numDocs());
+        assertEquals(2, reader.maxDoc());
+        assertEquals(0, reader.numDeletedDocs());
+      }
+      writer.updateDocValues(new Term("id", "1"), new NumericDocValuesField(softDeletesField, 1));
+      writer.commit();
+      try (DirectoryReader reader = new SoftDeletesDirectoryReaderWrapper(DirectoryReader.open(writer), softDeletesField)) {
+        assertEquals(1, reader.numDocs());
+        assertEquals(1, reader.maxDoc());
+        assertEquals(0, reader.numDeletedDocs());
+        assertEquals(1, reader.leaves().size());
+      }
+      try (DirectoryReader reader = new SoftDeletesDirectoryReaderWrapper(DirectoryReader.open(dir), softDeletesField)) {
+        assertEquals(1, reader.numDocs());
+        assertEquals(1, reader.maxDoc());
+        assertEquals(0, reader.numDeletedDocs());
+        assertEquals(1, reader.leaves().size());
+      }
+
+      try (DirectoryReader reader = DirectoryReader.open(dir)) {
+        assertEquals(2, reader.numDocs());
+        assertEquals(2, reader.maxDoc());
+        assertEquals(0, reader.numDeletedDocs());
+        assertEquals(2, reader.leaves().size());
+      }
+    }
+  }
 
   public void testReuseUnchangedLeafReader() throws IOException {
     Directory dir = newDirectory();


### PR DESCRIPTION
Today we can only wrap readers in SubReaderWrapper but never filter them out
entirely. This causes a invariant for soft-deletes that exposes fully deleted
segments with SoftDeletesDirectoryReaderWrapper. This change drops fully deleted readers after they are wrapped.