### PR TITLE
LUCENE-8502: Allow access to delegate in FilterCodecReader

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/FilterCodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FilterCodecReader.java
@@ -39,6 +39,15 @@ import org.apache.lucene.util.Bits;
  * {@link #getCoreCacheHelper()} and {@link #getReaderCacheHelper()}.
  */
 public abstract class FilterCodecReader extends CodecReader {
+
+  /** Get the wrapped instance by <code>reader</code> as long as this reader is
+   *  an instance of {@link FilterCodecReader}.  */
+  public static CodecReader unwrap(CodecReader reader) {
+    while (reader instanceof FilterCodecReader) {
+      reader = ((FilterCodecReader) reader).getDelegate();
+    }
+    return reader;
+  }
   /** 
    * The underlying CodecReader instance. 
    */
@@ -125,6 +134,11 @@ public abstract class FilterCodecReader extends CodecReader {
   @Override
   public void checkIntegrity() throws IOException {
     in.checkIntegrity();
+  }
+
+  /** Returns the wrapped {@link CodecReader}. */
+  public CodecReader getDelegate() {
+    return in;
   }
 
   /**

--- a/lucene/core/src/test/org/apache/lucene/index/TestFilterCodecReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestFilterCodecReader.java
@@ -16,8 +16,12 @@
  */
 package org.apache.lucene.index;
 
+import java.io.IOException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.LuceneTestCase;
 
 public class TestFilterCodecReader extends LuceneTestCase {
@@ -25,6 +29,20 @@ public class TestFilterCodecReader extends LuceneTestCase {
   public void testDeclaredMethodsOverridden() throws Exception {
     final Class<?> subClass = FilterCodecReader.class;
     implTestDeclaredMethodsOverridden(subClass.getSuperclass(), subClass);
+  }
+
+  public void testGetDelegate() throws IOException {
+    try (Directory dir = newDirectory();
+         IndexWriter w = new IndexWriter(dir,newIndexWriterConfig())) {
+      w.addDocument(new Document());
+      try (DirectoryReader reader = w.getReader()) {
+        FilterCodecReader r = FilterCodecReader.wrapLiveDocs((CodecReader) reader.getSequentialSubReaders().get(0),
+            null, 1);
+
+        assertSame(FilterCodecReader.unwrap(r), reader.getSequentialSubReaders().get(0));
+        assertSame(r.getDelegate(), reader.getSequentialSubReaders().get(0));
+      }
+    }
   }
 
   private void implTestDeclaredMethodsOverridden(Class<?> superClass, Class<?> subClass) throws Exception {


### PR DESCRIPTION
FilterCodecReader doesn't allow access to it's delegate like other
filter readers. This adds a new getDelegate method to access the
wrapped reader.