### PR TITLE
LUCENE-8503: Call #getDelegate instead of direct member access during unwrap

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/FilterCodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FilterCodecReader.java
@@ -48,8 +48,8 @@ public abstract class FilterCodecReader extends CodecReader {
     }
     return reader;
   }
-  /** 
-   * The underlying CodecReader instance. 
+  /**
+   * The underlying CodecReader instance.
    */
   protected final CodecReader in;
   

--- a/lucene/core/src/java/org/apache/lucene/index/FilterDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FilterDirectoryReader.java
@@ -37,7 +37,7 @@ public abstract class FilterDirectoryReader extends DirectoryReader {
    *  an instance of {@link FilterDirectoryReader}.  */
   public static DirectoryReader unwrap(DirectoryReader reader) {
     while (reader instanceof FilterDirectoryReader) {
-      reader = ((FilterDirectoryReader) reader).in;
+      reader = ((FilterDirectoryReader) reader).getDelegate();
     }
     return reader;
   }

--- a/lucene/core/src/java/org/apache/lucene/index/FilterLeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FilterLeafReader.java
@@ -44,7 +44,7 @@ public abstract class FilterLeafReader extends LeafReader {
    *  an instance of {@link FilterLeafReader}.  */
   public static LeafReader unwrap(LeafReader reader) {
     while (reader instanceof FilterLeafReader) {
-      reader = ((FilterLeafReader) reader).in;
+      reader = ((FilterLeafReader) reader).getDelegate();
     }
     return reader;
   }


### PR DESCRIPTION
Filter*Reader instances access the member or the delegate directly instead of
calling getDelegate(). In order to track access of the delegate these methods
should call #getDelegat()
