### PR TITLE
LUCENE-8497: refactor multi-term analysis handling

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/ar/ArabicNormalizationFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/ar/ArabicNormalizationFilterFactory.java
@@ -20,8 +20,6 @@ package org.apache.lucene.analysis.ar;
 import java.util.Map;
 
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.ar.ArabicNormalizationFilter;
-import org.apache.lucene.analysis.util.AbstractAnalysisFactory;
 import org.apache.lucene.analysis.util.MultiTermAwareComponent;
 import org.apache.lucene.analysis.util.TokenFilterFactory;
 
@@ -51,7 +49,7 @@ public class ArabicNormalizationFilterFactory extends TokenFilterFactory impleme
   }
 
   @Override
-  public AbstractAnalysisFactory getMultiTermComponent() {
-    return this;
+  public ArabicNormalizationFilter normalize(TokenStream input) {
+    return create(input);
   }
 }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/bn/BengaliNormalizationFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/bn/BengaliNormalizationFilterFactory.java
@@ -18,7 +18,6 @@ package org.apache.lucene.analysis.bn;
 
 
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.util.AbstractAnalysisFactory;
 import org.apache.lucene.analysis.util.MultiTermAwareComponent;
 import org.apache.lucene.analysis.util.TokenFilterFactory;
 
@@ -48,9 +47,9 @@ public class BengaliNormalizationFilterFactory extends TokenFilterFactory implem
   public TokenStream create(TokenStream input) {
     return new BengaliNormalizationFilter(input);
   }
-  
+
   @Override
-  public AbstractAnalysisFactory getMultiTermComponent() {
-    return this;
+  public TokenStream normalize(TokenStream input) {
+    return create(input);
   }
 }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/charfilter/MappingCharFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/charfilter/MappingCharFilterFactory.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.lucene.analysis.util.AbstractAnalysisFactory;
 import org.apache.lucene.analysis.util.CharFilterFactory;
 import org.apache.lucene.analysis.util.MultiTermAwareComponent;
 import org.apache.lucene.analysis.util.ResourceLoader;
@@ -86,6 +85,11 @@ public class MappingCharFilterFactory extends CharFilterFactory implements
     return normMap == null ? input : new MappingCharFilter(normMap,input);
   }
 
+  @Override
+  public Reader normalize(Reader input) {
+    return create(input);
+  }
+
   // "source" => "target"
   static Pattern p = Pattern.compile( "\"(.*)\"\\s*=>\\s*\"(.*)\"\\s*$" );
 
@@ -131,8 +135,4 @@ public class MappingCharFilterFactory extends CharFilterFactory implements
     return new String( out, 0, writePos );
   }
 
-  @Override
-  public AbstractAnalysisFactory getMultiTermComponent() {
-    return this;
-  }
 }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/cjk/CJKWidthFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/cjk/CJKWidthFilterFactory.java
@@ -20,8 +20,6 @@ package org.apache.lucene.analysis.cjk;
 import java.util.Map;
 
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.cjk.CJKWidthFilter;
-import org.apache.lucene.analysis.util.AbstractAnalysisFactory;
 import org.apache.lucene.analysis.util.MultiTermAwareComponent;
 import org.apache.lucene.analysis.util.TokenFilterFactory;
 
@@ -52,9 +50,9 @@ public class CJKWidthFilterFactory extends TokenFilterFactory implements MultiTe
   public TokenStream create(TokenStream input) {
     return new CJKWidthFilter(input);
   }
-  
+
   @Override
-  public AbstractAnalysisFactory getMultiTermComponent() {
-    return this;
+  public TokenStream normalize(TokenStream input) {
+    return create(input);
   }
 }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/ckb/SoraniNormalizationFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/ckb/SoraniNormalizationFilterFactory.java
@@ -20,7 +20,6 @@ package org.apache.lucene.analysis.ckb;
 import java.util.Map;
 
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.util.AbstractAnalysisFactory;
 import org.apache.lucene.analysis.util.MultiTermAwareComponent;
 import org.apache.lucene.analysis.util.TokenFilterFactory;
 
@@ -51,7 +50,7 @@ public class SoraniNormalizationFilterFactory extends TokenFilterFactory impleme
   }
 
   @Override
-  public AbstractAnalysisFactory getMultiTermComponent() {
-    return this;
+  public SoraniNormalizationFilter normalize(TokenStream input) {
+    return create(input);
   }
 }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/core/DecimalDigitFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/core/DecimalDigitFilterFactory.java
@@ -20,7 +20,6 @@ package org.apache.lucene.analysis.core;
 import java.util.Map;
 
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.util.AbstractAnalysisFactory;
 import org.apache.lucene.analysis.util.MultiTermAwareComponent;
 import org.apache.lucene.analysis.util.TokenFilterFactory;
 
@@ -51,7 +50,7 @@ public class DecimalDigitFilterFactory extends TokenFilterFactory implements Mul
   }
 
   @Override
-  public AbstractAnalysisFactory getMultiTermComponent() {
-    return this;
+  public DecimalDigitFilter normalize(TokenStream input) {
+    return create(input);
   }
 }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/core/LowerCaseFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/core/LowerCaseFilterFactory.java
@@ -20,7 +20,6 @@ package org.apache.lucene.analysis.core;
 import java.util.Map;
 
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.util.AbstractAnalysisFactory;
 import org.apache.lucene.analysis.util.MultiTermAwareComponent;
 import org.apache.lucene.analysis.util.TokenFilterFactory;
 
@@ -50,7 +49,7 @@ public class LowerCaseFilterFactory extends TokenFilterFactory implements MultiT
   }
 
   @Override
-  public AbstractAnalysisFactory getMultiTermComponent() {
-    return this;
+  public LowerCaseFilter normalize(TokenStream input) {
+    return create(input);
   }
 }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/core/UpperCaseFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/core/UpperCaseFilterFactory.java
@@ -20,8 +20,6 @@ package org.apache.lucene.analysis.core;
 import java.util.Map;
 
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.core.UpperCaseFilter;
-import org.apache.lucene.analysis.util.AbstractAnalysisFactory;
 import org.apache.lucene.analysis.util.MultiTermAwareComponent;
 import org.apache.lucene.analysis.util.TokenFilterFactory;
 
@@ -57,7 +55,7 @@ public class UpperCaseFilterFactory extends TokenFilterFactory implements MultiT
   }
 
   @Override
-  public AbstractAnalysisFactory getMultiTermComponent() {
-    return this;
+  public UpperCaseFilter normalize(TokenStream input) {
+    return create(input);
   }
 }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/custom/CustomAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/custom/CustomAnalyzer.java
@@ -40,7 +40,6 @@ import org.apache.lucene.analysis.util.AbstractAnalysisFactory;
 import org.apache.lucene.analysis.util.CharFilterFactory;
 import org.apache.lucene.analysis.util.ClasspathResourceLoader;
 import org.apache.lucene.analysis.util.FilesystemResourceLoader;
-import org.apache.lucene.analysis.util.MultiTermAwareComponent;
 import org.apache.lucene.analysis.util.ResourceLoader;
 import org.apache.lucene.analysis.util.ResourceLoaderAware;
 import org.apache.lucene.analysis.util.TokenFilterFactory;
@@ -141,10 +140,7 @@ public final class CustomAnalyzer extends Analyzer {
   @Override
   protected Reader initReaderForNormalization(String fieldName, Reader reader) {
     for (CharFilterFactory charFilter : charFilters) {
-      if (charFilter instanceof MultiTermAwareComponent) {
-        charFilter = (CharFilterFactory) ((MultiTermAwareComponent) charFilter).getMultiTermComponent();
-        reader = charFilter.create(reader);
-      }
+      reader = charFilter.normalize(reader);
     }
     return reader;
   }
@@ -162,17 +158,8 @@ public final class CustomAnalyzer extends Analyzer {
   @Override
   protected TokenStream normalize(String fieldName, TokenStream in) {
     TokenStream result = in;
-    // tokenizers can return a tokenfilter if the tokenizer does normalization,
-    // although this is really bogus/abstraction violation...
-    if (tokenizer instanceof MultiTermAwareComponent) {
-      TokenFilterFactory filter = (TokenFilterFactory) ((MultiTermAwareComponent) tokenizer).getMultiTermComponent();
-      result = filter.create(result);
-    }
     for (TokenFilterFactory filter : tokenFilters) {
-      if (filter instanceof MultiTermAwareComponent) {
-        filter = (TokenFilterFactory) ((MultiTermAwareComponent) filter).getMultiTermComponent();
-        result = filter.create(result);
-      }
+      result = filter.normalize(result);
     }
     return result;
   }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/de/GermanNormalizationFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/de/GermanNormalizationFilterFactory.java
@@ -20,8 +20,6 @@ package org.apache.lucene.analysis.de;
 import java.util.Map;
 
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.de.GermanNormalizationFilter;
-import org.apache.lucene.analysis.util.AbstractAnalysisFactory;
 import org.apache.lucene.analysis.util.MultiTermAwareComponent;
 import org.apache.lucene.analysis.util.TokenFilterFactory;
 
@@ -51,9 +49,9 @@ public class GermanNormalizationFilterFactory extends TokenFilterFactory impleme
   public TokenStream create(TokenStream input) {
     return new GermanNormalizationFilter(input);
   }
-  
+
   @Override
-  public AbstractAnalysisFactory getMultiTermComponent() {
-    return this;
+  public TokenStream normalize(TokenStream input) {
+    return create(input);
   }
 }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/el/GreekLowerCaseFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/el/GreekLowerCaseFilterFactory.java
@@ -20,8 +20,6 @@ package org.apache.lucene.analysis.el;
 import java.util.Map;
 
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.el.GreekLowerCaseFilter;
-import org.apache.lucene.analysis.util.AbstractAnalysisFactory;
 import org.apache.lucene.analysis.util.MultiTermAwareComponent;
 import org.apache.lucene.analysis.util.TokenFilterFactory;
 
@@ -51,8 +49,8 @@ public class GreekLowerCaseFilterFactory extends TokenFilterFactory implements M
   }
 
   @Override
-  public AbstractAnalysisFactory getMultiTermComponent() {
-    return this;
+  public GreekLowerCaseFilter normalize(TokenStream input) {
+    return create(input);
   }
 }
 

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/fa/PersianCharFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/fa/PersianCharFilterFactory.java
@@ -21,8 +21,6 @@ import java.io.Reader;
 import java.util.Map;
 
 import org.apache.lucene.analysis.CharFilter;
-import org.apache.lucene.analysis.fa.PersianCharFilter;
-import org.apache.lucene.analysis.util.AbstractAnalysisFactory;
 import org.apache.lucene.analysis.util.CharFilterFactory;
 import org.apache.lucene.analysis.util.MultiTermAwareComponent;
 
@@ -52,7 +50,7 @@ public class PersianCharFilterFactory extends CharFilterFactory implements Multi
   }
 
   @Override
-  public AbstractAnalysisFactory getMultiTermComponent() {
-    return this;
+  public CharFilter normalize(Reader input) {
+    return create(input);
   }
 }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/fa/PersianNormalizationFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/fa/PersianNormalizationFilterFactory.java
@@ -19,9 +19,7 @@ package org.apache.lucene.analysis.fa;
 
 import java.util.Map;
 
-import org.apache.lucene.analysis.fa.PersianNormalizationFilter;
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.util.AbstractAnalysisFactory;
 import org.apache.lucene.analysis.util.MultiTermAwareComponent;
 import org.apache.lucene.analysis.util.TokenFilterFactory;
 
@@ -50,10 +48,10 @@ public class PersianNormalizationFilterFactory extends TokenFilterFactory implem
   public PersianNormalizationFilter create(TokenStream input) {
     return new PersianNormalizationFilter(input);
   }
-  
+
   @Override
-  public AbstractAnalysisFactory getMultiTermComponent() {
-    return this;
+  public PersianNormalizationFilter normalize(TokenStream input) {
+    return create(input);
   }
 }
 

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/ga/IrishLowerCaseFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/ga/IrishLowerCaseFilterFactory.java
@@ -20,8 +20,6 @@ package org.apache.lucene.analysis.ga;
 import java.util.Map;
 
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.ga.IrishLowerCaseFilter;
-import org.apache.lucene.analysis.util.AbstractAnalysisFactory;
 import org.apache.lucene.analysis.util.MultiTermAwareComponent;
 import org.apache.lucene.analysis.util.TokenFilterFactory;
 
@@ -53,7 +51,7 @@ public class IrishLowerCaseFilterFactory extends TokenFilterFactory implements M
 
   // this will 'mostly work', except for special cases, just like most other filters
   @Override
-  public AbstractAnalysisFactory getMultiTermComponent() {
-    return this;
+  public TokenStream normalize(TokenStream input) {
+    return create(input);
   }
 }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hi/HindiNormalizationFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hi/HindiNormalizationFilterFactory.java
@@ -20,8 +20,6 @@ package org.apache.lucene.analysis.hi;
 import java.util.Map;
 
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.hi.HindiNormalizationFilter;
-import org.apache.lucene.analysis.util.AbstractAnalysisFactory;
 import org.apache.lucene.analysis.util.MultiTermAwareComponent;
 import org.apache.lucene.analysis.util.TokenFilterFactory;
 
@@ -50,9 +48,9 @@ public class HindiNormalizationFilterFactory extends TokenFilterFactory implemen
   public TokenStream create(TokenStream input) {
     return new HindiNormalizationFilter(input);
   }
-  
+
   @Override
-  public AbstractAnalysisFactory getMultiTermComponent() {
-    return this;
+  public TokenStream normalize(TokenStream input) {
+    return create(input);
   }
 }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/in/IndicNormalizationFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/in/IndicNormalizationFilterFactory.java
@@ -20,8 +20,6 @@ package org.apache.lucene.analysis.in;
 import java.util.Map;
 
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.in.IndicNormalizationFilter;
-import org.apache.lucene.analysis.util.AbstractAnalysisFactory;
 import org.apache.lucene.analysis.util.MultiTermAwareComponent;
 import org.apache.lucene.analysis.util.TokenFilterFactory;
 
@@ -50,9 +48,9 @@ public class IndicNormalizationFilterFactory extends TokenFilterFactory implemen
   public TokenStream create(TokenStream input) {
     return new IndicNormalizationFilter(input);
   }
-  
+
   @Override
-  public AbstractAnalysisFactory getMultiTermComponent() {
-    return this;
+  public TokenStream normalize(TokenStream input) {
+    return create(input);
   }
 }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/ASCIIFoldingFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/ASCIIFoldingFilterFactory.java
@@ -17,13 +17,10 @@
 package org.apache.lucene.analysis.miscellaneous;
 
 
-import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.lucene.analysis.util.AbstractAnalysisFactory;
 import org.apache.lucene.analysis.util.MultiTermAwareComponent;
 import org.apache.lucene.analysis.util.TokenFilterFactory;
-import org.apache.lucene.analysis.miscellaneous.ASCIIFoldingFilter;
 import org.apache.lucene.analysis.TokenStream;
 
 /** 
@@ -56,18 +53,13 @@ public class ASCIIFoldingFilterFactory extends TokenFilterFactory implements Mul
   }
 
   @Override
-  public AbstractAnalysisFactory getMultiTermComponent() {
-    if (preserveOriginal) {
-      // The main use-case for using preserveOriginal is to match regardless of
-      // case but to give better scores to exact matches. Since most multi-term
-      // queries return constant scores anyway, the multi-term component only
-      // emits the folded token
-      Map<String, String> args = new HashMap<>(getOriginalArgs());
-      args.remove(PRESERVE_ORIGINAL);
-      return new ASCIIFoldingFilterFactory(args);
-    } else {
-      return this;
-    }
+  public ASCIIFoldingFilter normalize(TokenStream input) {
+    // The main use-case for using preserveOriginal is to match regardless of
+    // case and to give better scores to exact matches. Since most multi-term
+    // queries return constant scores anyway, for normalization we
+    // emit only the folded token
+    return new ASCIIFoldingFilter(input, false);
   }
+
 }
 

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/ScandinavianFoldingFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/ScandinavianFoldingFilterFactory.java
@@ -18,7 +18,6 @@ package org.apache.lucene.analysis.miscellaneous;
 
 
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.util.AbstractAnalysisFactory;
 import org.apache.lucene.analysis.util.MultiTermAwareComponent;
 import org.apache.lucene.analysis.util.TokenFilterFactory;
 
@@ -35,8 +34,7 @@ import java.util.Map;
  * &lt;/fieldType&gt;</pre>
  * @since 4.4.0
  */
-public class ScandinavianFoldingFilterFactory extends TokenFilterFactory
-    implements MultiTermAwareComponent {
+public class ScandinavianFoldingFilterFactory extends TokenFilterFactory implements MultiTermAwareComponent {
 
   public ScandinavianFoldingFilterFactory(Map<String,String> args) {
     super(args);
@@ -51,7 +49,7 @@ public class ScandinavianFoldingFilterFactory extends TokenFilterFactory
   }
 
   @Override
-  public AbstractAnalysisFactory getMultiTermComponent() {
-    return this;
+  public ScandinavianFoldingFilter normalize(TokenStream input) {
+    return create(input);
   }
 }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/ScandinavianNormalizationFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/ScandinavianNormalizationFilterFactory.java
@@ -18,7 +18,6 @@ package org.apache.lucene.analysis.miscellaneous;
 
 
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.util.AbstractAnalysisFactory;
 import org.apache.lucene.analysis.util.MultiTermAwareComponent;
 import org.apache.lucene.analysis.util.TokenFilterFactory;
 
@@ -35,8 +34,7 @@ import java.util.Map;
  * &lt;/fieldType&gt;</pre>
  * @since 4.4.0
  */
-public class ScandinavianNormalizationFilterFactory extends TokenFilterFactory
-    implements MultiTermAwareComponent {
+public class ScandinavianNormalizationFilterFactory extends TokenFilterFactory implements MultiTermAwareComponent {
 
   public ScandinavianNormalizationFilterFactory(Map<String, String> args) {
     super(args);
@@ -51,7 +49,7 @@ public class ScandinavianNormalizationFilterFactory extends TokenFilterFactory
   }
 
   @Override
-  public AbstractAnalysisFactory getMultiTermComponent() {
-    return this;
+  public TokenStream normalize(TokenStream input) {
+    return create(input);
   }
 }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/TrimFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/TrimFilterFactory.java
@@ -20,8 +20,6 @@ package org.apache.lucene.analysis.miscellaneous;
 import java.util.Map;
 
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.miscellaneous.TrimFilter;
-import org.apache.lucene.analysis.util.AbstractAnalysisFactory;
 import org.apache.lucene.analysis.util.MultiTermAwareComponent;
 import org.apache.lucene.analysis.util.TokenFilterFactory;
 
@@ -53,7 +51,7 @@ public class TrimFilterFactory extends TokenFilterFactory implements MultiTermAw
   }
 
   @Override
-  public AbstractAnalysisFactory getMultiTermComponent() {
-    return this;
+  public TrimFilter normalize(TokenStream input) {
+    return create(input);
   }
 }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/pattern/PatternReplaceCharFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/pattern/PatternReplaceCharFilterFactory.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 import org.apache.lucene.analysis.CharFilter;
-import org.apache.lucene.analysis.util.AbstractAnalysisFactory;
 import org.apache.lucene.analysis.util.CharFilterFactory;
 import org.apache.lucene.analysis.util.MultiTermAwareComponent;
 
@@ -59,7 +58,7 @@ public class PatternReplaceCharFilterFactory extends CharFilterFactory implement
   }
 
   @Override
-  public AbstractAnalysisFactory getMultiTermComponent() {
-    return this;
+  public CharFilter normalize(Reader input) {
+    return create(input);
   }
 }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/sr/SerbianNormalizationFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/sr/SerbianNormalizationFilterFactory.java
@@ -21,7 +21,6 @@ import java.util.Arrays;
 import java.util.Map;
 
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.util.AbstractAnalysisFactory;
 import org.apache.lucene.analysis.util.MultiTermAwareComponent;
 import org.apache.lucene.analysis.util.TokenFilterFactory;
 
@@ -61,8 +60,7 @@ public class SerbianNormalizationFilterFactory extends TokenFilterFactory implem
   }
 
   @Override
-  public AbstractAnalysisFactory getMultiTermComponent() {
-    return this;
+  public TokenStream normalize(TokenStream input) {
+    return create(input);
   }
-
 }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/tr/TurkishLowerCaseFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/tr/TurkishLowerCaseFilterFactory.java
@@ -20,8 +20,6 @@ package org.apache.lucene.analysis.tr;
 import java.util.Map;
 
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.tr.TurkishLowerCaseFilter;
-import org.apache.lucene.analysis.util.AbstractAnalysisFactory;
 import org.apache.lucene.analysis.util.MultiTermAwareComponent;
 import org.apache.lucene.analysis.util.TokenFilterFactory;
 
@@ -36,7 +34,7 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * &lt;/fieldType&gt;</pre>
  * @since 3.1.0
  */
-public class TurkishLowerCaseFilterFactory extends TokenFilterFactory  implements MultiTermAwareComponent {
+public class TurkishLowerCaseFilterFactory extends TokenFilterFactory implements MultiTermAwareComponent {
   
   /** Creates a new TurkishLowerCaseFilterFactory */
   public TurkishLowerCaseFilterFactory(Map<String,String> args) {
@@ -52,7 +50,7 @@ public class TurkishLowerCaseFilterFactory extends TokenFilterFactory  implement
   }
 
   @Override
-  public AbstractAnalysisFactory getMultiTermComponent() {
-    return this;
+  public TokenStream normalize(TokenStream input) {
+    return create(input);
   }
 }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/CharFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/CharFilterFactory.java
@@ -71,4 +71,13 @@ public abstract class CharFilterFactory extends AbstractAnalysisFactory {
 
   /** Wraps the given Reader with a CharFilter. */
   public abstract Reader create(Reader input);
+
+  /**
+   * Normalize the specified input Reader
+   * While the default implementation returns input unchanged,
+   * char filters that should be applied at normalization time can delegate to {@code create} method.
+   */
+  public Reader normalize(Reader input) {
+    return input;
+  }
 }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/ElisionFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/ElisionFilterFactory.java
@@ -66,8 +66,8 @@ public class ElisionFilterFactory extends TokenFilterFactory implements Resource
   }
 
   @Override
-  public AbstractAnalysisFactory getMultiTermComponent() {
-    return this;
+  public ElisionFilter normalize(TokenStream input) {
+    return create(input);
   }
 }
 

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/MultiTermAwareComponent.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/MultiTermAwareComponent.java
@@ -29,8 +29,4 @@ package org.apache.lucene.analysis.util;
  * @lucene.experimental
  */
 public interface MultiTermAwareComponent {
-  /** Returns an analysis component to handle analysis if multi-term queries.
-   * The returned component must be a TokenizerFactory, TokenFilterFactory or CharFilterFactory.
-   */
-  public AbstractAnalysisFactory getMultiTermComponent();
 }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/TokenFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/TokenFilterFactory.java
@@ -71,4 +71,13 @@ public abstract class TokenFilterFactory extends AbstractAnalysisFactory {
 
   /** Transform the specified input TokenStream */
   public abstract TokenStream create(TokenStream input);
+
+  /**
+   * Normalize the specified input TokenStream
+   * While the default implementation returns input unchanged,
+   * filters that should be applied at normalization time can delegate to {@code create} method.
+   */
+  public TokenStream normalize(TokenStream input) {
+    return input;
+  }
 }

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/core/TestFactories.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/core/TestFactories.java
@@ -34,7 +34,6 @@ import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.miscellaneous.DelimitedTermFrequencyTokenFilterFactory;
 import org.apache.lucene.analysis.util.AbstractAnalysisFactory;
 import org.apache.lucene.analysis.util.CharFilterFactory;
-import org.apache.lucene.analysis.util.MultiTermAwareComponent;
 import org.apache.lucene.analysis.util.ResourceLoaderAware;
 import org.apache.lucene.analysis.util.StringMockResourceLoader;
 import org.apache.lucene.analysis.util.TokenFilterFactory;
@@ -78,15 +77,6 @@ public class TestFactories extends BaseTokenStreamTestCase {
     TokenizerFactory factory = (TokenizerFactory) initialize(factoryClazz);
     if (factory != null) {
       // we managed to fully create an instance. check a few more things:
-      
-      // if it implements MultiTermAware, sanity check its impl
-      if (factory instanceof MultiTermAwareComponent) {
-        AbstractAnalysisFactory mtc = ((MultiTermAwareComponent) factory).getMultiTermComponent();
-        assertNotNull(mtc);
-        // it's not ok to return e.g. a charfilter here: but a tokenizer could wrap a filter around it
-        assertFalse(mtc instanceof CharFilterFactory);
-      }
-      
       if (!EXCLUDE_FACTORIES_RANDOM_DATA.contains(factory.getClass())) {
         // beast it just a little, it shouldnt throw exceptions:
         // (it should have thrown them in initialize)
@@ -102,15 +92,6 @@ public class TestFactories extends BaseTokenStreamTestCase {
     TokenFilterFactory factory = (TokenFilterFactory) initialize(factoryClazz);
     if (factory != null) {
       // we managed to fully create an instance. check a few more things:
-      
-      // if it implements MultiTermAware, sanity check its impl
-      if (factory instanceof MultiTermAwareComponent) {
-        AbstractAnalysisFactory mtc = ((MultiTermAwareComponent) factory).getMultiTermComponent();
-        assertNotNull(mtc);
-        // it's not ok to return a charfilter or tokenizer here, this makes no sense
-        assertTrue(mtc instanceof TokenFilterFactory);
-      }
-      
       if (!EXCLUDE_FACTORIES_RANDOM_DATA.contains(factory.getClass())) {
         // beast it just a little, it shouldnt throw exceptions:
         // (it should have thrown them in initialize)
@@ -126,15 +107,6 @@ public class TestFactories extends BaseTokenStreamTestCase {
     CharFilterFactory factory = (CharFilterFactory) initialize(factoryClazz);
     if (factory != null) {
       // we managed to fully create an instance. check a few more things:
-      
-      // if it implements MultiTermAware, sanity check its impl
-      if (factory instanceof MultiTermAwareComponent) {
-        AbstractAnalysisFactory mtc = ((MultiTermAwareComponent) factory).getMultiTermComponent();
-        assertNotNull(mtc);
-        // it's not ok to return a tokenizer or tokenfilter here, this makes no sense
-        assertTrue(mtc instanceof CharFilterFactory);
-      }
-      
       if (!EXCLUDE_FACTORIES_RANDOM_DATA.contains(factory.getClass())) {
         // beast it just a little, it shouldnt throw exceptions:
         // (it should have thrown them in initialize)

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestAsciiFoldingFilterFactory.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/miscellaneous/TestAsciiFoldingFilterFactory.java
@@ -24,7 +24,6 @@ import org.apache.lucene.analysis.CannedTokenStream;
 import org.apache.lucene.analysis.Token;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.util.BaseTokenStreamFactoryTestCase;
-import org.apache.lucene.analysis.util.MultiTermAwareComponent;
 import org.apache.lucene.analysis.util.TokenFilterFactory;
 
 public class TestAsciiFoldingFilterFactory extends BaseTokenStreamFactoryTestCase {
@@ -35,9 +34,8 @@ public class TestAsciiFoldingFilterFactory extends BaseTokenStreamFactoryTestCas
     stream = factory.create(stream);
     assertTokenStreamContents(stream, new String[] { "Ete" });
 
-    factory = (TokenFilterFactory) ((MultiTermAwareComponent) factory).getMultiTermComponent();
     stream = new CannedTokenStream(new Token("Été", 0, 3));
-    stream = factory.create(stream);
+    stream = factory.normalize(stream);
     assertTokenStreamContents(stream, new String[] { "Ete" });
 
     factory = new ASCIIFoldingFilterFactory(new HashMap<>(Collections.singletonMap("preserveOriginal", "true")));
@@ -45,9 +43,8 @@ public class TestAsciiFoldingFilterFactory extends BaseTokenStreamFactoryTestCas
     stream = factory.create(stream);
     assertTokenStreamContents(stream, new String[] { "Ete", "Été" });
 
-    factory = (TokenFilterFactory) ((MultiTermAwareComponent) factory).getMultiTermComponent();
     stream = new CannedTokenStream(new Token("Été", 0, 3));
-    stream = factory.create(stream);
+    stream = factory.normalize(stream);
     assertTokenStreamContents(stream, new String[] { "Ete" });
   }
 

--- a/lucene/analysis/icu/src/java/org/apache/lucene/analysis/icu/ICUFoldingFilterFactory.java
+++ b/lucene/analysis/icu/src/java/org/apache/lucene/analysis/icu/ICUFoldingFilterFactory.java
@@ -20,8 +20,6 @@ package org.apache.lucene.analysis.icu;
 import java.util.Map;
 
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.icu.ICUFoldingFilter;
-import org.apache.lucene.analysis.util.AbstractAnalysisFactory; // javadocs
 import org.apache.lucene.analysis.util.MultiTermAwareComponent;
 import org.apache.lucene.analysis.util.TokenFilterFactory;
 
@@ -68,7 +66,7 @@ public class ICUFoldingFilterFactory extends TokenFilterFactory implements Multi
   }
 
   @Override
-  public AbstractAnalysisFactory getMultiTermComponent() {
-    return this;
+  public TokenStream normalize(TokenStream input) {
+    return create(input);
   }
 }

--- a/lucene/analysis/icu/src/java/org/apache/lucene/analysis/icu/ICUNormalizer2CharFilterFactory.java
+++ b/lucene/analysis/icu/src/java/org/apache/lucene/analysis/icu/ICUNormalizer2CharFilterFactory.java
@@ -21,13 +21,12 @@ import java.io.Reader;
 import java.util.Arrays;
 import java.util.Map;
 
-import org.apache.lucene.analysis.util.AbstractAnalysisFactory;
 import org.apache.lucene.analysis.util.CharFilterFactory;
-import org.apache.lucene.analysis.util.MultiTermAwareComponent;
 
 import com.ibm.icu.text.FilteredNormalizer2;
 import com.ibm.icu.text.Normalizer2;
 import com.ibm.icu.text.UnicodeSet;
+import org.apache.lucene.analysis.util.MultiTermAwareComponent;
 
 /**
  * Factory for {@link ICUNormalizer2CharFilter}
@@ -76,8 +75,7 @@ public class ICUNormalizer2CharFilterFactory extends CharFilterFactory implement
   }
 
   @Override
-  public AbstractAnalysisFactory getMultiTermComponent() {
-    return this;
+  public Reader normalize(Reader input) {
+    return create(input);
   }
-  
 }

--- a/lucene/analysis/icu/src/java/org/apache/lucene/analysis/icu/ICUNormalizer2FilterFactory.java
+++ b/lucene/analysis/icu/src/java/org/apache/lucene/analysis/icu/ICUNormalizer2FilterFactory.java
@@ -21,7 +21,6 @@ import java.util.Arrays;
 import java.util.Map;
 
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.util.AbstractAnalysisFactory; // javadocs
 import org.apache.lucene.analysis.util.MultiTermAwareComponent;
 import org.apache.lucene.analysis.util.TokenFilterFactory;
 
@@ -79,7 +78,7 @@ public class ICUNormalizer2FilterFactory extends TokenFilterFactory implements M
   }
 
   @Override
-  public AbstractAnalysisFactory getMultiTermComponent() {
-    return this;
+  public TokenStream normalize(TokenStream input) {
+    return create(input);
   }
 }

--- a/lucene/analysis/icu/src/java/org/apache/lucene/analysis/icu/ICUTransformFilterFactory.java
+++ b/lucene/analysis/icu/src/java/org/apache/lucene/analysis/icu/ICUTransformFilterFactory.java
@@ -21,7 +21,6 @@ import java.util.Arrays;
 import java.util.Map;
 
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.util.AbstractAnalysisFactory; // javadocs
 import org.apache.lucene.analysis.util.MultiTermAwareComponent;
 import org.apache.lucene.analysis.util.TokenFilterFactory;
 
@@ -58,9 +57,9 @@ public class ICUTransformFilterFactory extends TokenFilterFactory implements Mul
   public TokenStream create(TokenStream input) {
     return new ICUTransformFilter(input, transliterator);
   }
-  
+
   @Override
-  public AbstractAnalysisFactory getMultiTermComponent() {
-    return this;
+  public TokenStream normalize(TokenStream input) {
+    return create(input);
   }
 }

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/JapaneseIterationMarkCharFilterFactory.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/JapaneseIterationMarkCharFilterFactory.java
@@ -18,8 +18,6 @@ package org.apache.lucene.analysis.ja;
 
 
 import org.apache.lucene.analysis.CharFilter;
-import org.apache.lucene.analysis.ja.JapaneseIterationMarkCharFilter;
-import org.apache.lucene.analysis.util.AbstractAnalysisFactory;
 import org.apache.lucene.analysis.util.CharFilterFactory;
 import org.apache.lucene.analysis.util.MultiTermAwareComponent;
 
@@ -60,7 +58,7 @@ public class JapaneseIterationMarkCharFilterFactory extends CharFilterFactory im
   }
 
   @Override
-  public AbstractAnalysisFactory getMultiTermComponent() {
-    return this;
+  public CharFilter normalize(Reader input) {
+    return create(input);
   }
 }

--- a/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/TestFactories.java
+++ b/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/TestFactories.java
@@ -34,7 +34,6 @@ import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.miscellaneous.DelimitedTermFrequencyTokenFilterFactory;
 import org.apache.lucene.analysis.util.AbstractAnalysisFactory;
 import org.apache.lucene.analysis.util.CharFilterFactory;
-import org.apache.lucene.analysis.util.MultiTermAwareComponent;
 import org.apache.lucene.analysis.util.ResourceLoaderAware;
 import org.apache.lucene.analysis.util.TokenFilterFactory;
 import org.apache.lucene.analysis.util.TokenizerFactory;
@@ -75,15 +74,6 @@ public class TestFactories extends BaseTokenStreamTestCase {
     TokenizerFactory factory = (TokenizerFactory) initialize(factoryClazz);
     if (factory != null) {
       // we managed to fully create an instance. check a few more things:
-      
-      // if it implements MultiTermAware, sanity check its impl
-      if (factory instanceof MultiTermAwareComponent) {
-        AbstractAnalysisFactory mtc = ((MultiTermAwareComponent) factory).getMultiTermComponent();
-        assertNotNull(mtc);
-        // it's not ok to return e.g. a charfilter here: but a tokenizer could wrap a filter around it
-        assertFalse(mtc instanceof CharFilterFactory);
-      }
-      
       if (!EXCLUDE_FACTORIES_RANDOM_DATA.contains(factory.getClass())) {
         // beast it just a little, it shouldnt throw exceptions:
         // (it should have thrown them in initialize)
@@ -99,15 +89,6 @@ public class TestFactories extends BaseTokenStreamTestCase {
     TokenFilterFactory factory = (TokenFilterFactory) initialize(factoryClazz);
     if (factory != null) {
       // we managed to fully create an instance. check a few more things:
-      
-      // if it implements MultiTermAware, sanity check its impl
-      if (factory instanceof MultiTermAwareComponent) {
-        AbstractAnalysisFactory mtc = ((MultiTermAwareComponent) factory).getMultiTermComponent();
-        assertNotNull(mtc);
-        // it's not ok to return a charfilter or tokenizer here, this makes no sense
-        assertTrue(mtc instanceof TokenFilterFactory);
-      }
-      
       if (!EXCLUDE_FACTORIES_RANDOM_DATA.contains(factory.getClass())) {
         // beast it just a little, it shouldnt throw exceptions:
         // (it should have thrown them in initialize)
@@ -123,15 +104,6 @@ public class TestFactories extends BaseTokenStreamTestCase {
     CharFilterFactory factory = (CharFilterFactory) initialize(factoryClazz);
     if (factory != null) {
       // we managed to fully create an instance. check a few more things:
-      
-      // if it implements MultiTermAware, sanity check its impl
-      if (factory instanceof MultiTermAwareComponent) {
-        AbstractAnalysisFactory mtc = ((MultiTermAwareComponent) factory).getMultiTermComponent();
-        assertNotNull(mtc);
-        // it's not ok to return a tokenizer or tokenfilter here, this makes no sense
-        assertTrue(mtc instanceof CharFilterFactory);
-      }
-      
       if (!EXCLUDE_FACTORIES_RANDOM_DATA.contains(factory.getClass())) {
         // beast it just a little, it shouldnt throw exceptions:
         // (it should have thrown them in initialize)

--- a/solr/core/src/java/org/apache/solr/analysis/TokenizerChain.java
+++ b/solr/core/src/java/org/apache/solr/analysis/TokenizerChain.java
@@ -21,7 +21,6 @@ import java.io.Reader;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.util.CharFilterFactory;
-import org.apache.lucene.analysis.util.MultiTermAwareComponent;
 import org.apache.lucene.analysis.util.TokenFilterFactory;
 import org.apache.lucene.analysis.util.TokenizerFactory;
 
@@ -89,10 +88,7 @@ public final class TokenizerChain extends SolrAnalyzer {
   protected Reader initReaderForNormalization(String fieldName, Reader reader) {
     if (charFilters != null && charFilters.length > 0) {
       for (CharFilterFactory charFilter : charFilters) {
-        if (charFilter instanceof MultiTermAwareComponent) {
-          charFilter = (CharFilterFactory) ((MultiTermAwareComponent) charFilter).getMultiTermComponent();
-          reader = charFilter.create(reader);
-        }
+        reader = charFilter.normalize(reader);
       }
     }
     return reader;
@@ -112,10 +108,7 @@ public final class TokenizerChain extends SolrAnalyzer {
   protected TokenStream normalize(String fieldName, TokenStream in) {
     TokenStream result = in;
     for (TokenFilterFactory filter : filters) {
-      if (filter instanceof MultiTermAwareComponent) {
-        filter = (TokenFilterFactory) ((MultiTermAwareComponent) filter).getMultiTermComponent();
-        result = filter.create(result);
-      }
+      result = filter.normalize(result);
     }
     return result;
   }

--- a/solr/core/src/java/org/apache/solr/schema/FieldTypePluginLoader.java
+++ b/solr/core/src/java/org/apache/solr/schema/FieldTypePluginLoader.java
@@ -30,7 +30,6 @@ import java.util.Map;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.core.KeywordAnalyzer;
 import org.apache.lucene.analysis.core.KeywordTokenizerFactory;
-import org.apache.lucene.analysis.util.AbstractAnalysisFactory;
 import org.apache.lucene.analysis.util.CharFilterFactory;
 import org.apache.lucene.analysis.util.MultiTermAwareComponent;
 import org.apache.lucene.analysis.util.TokenFilterFactory;
@@ -212,22 +211,21 @@ public final class FieldTypePluginLoader
 
     public void add(Object current) {
       if (!(current instanceof MultiTermAwareComponent)) return;
-      AbstractAnalysisFactory newComponent = ((MultiTermAwareComponent)current).getMultiTermComponent();
-      if (newComponent instanceof TokenFilterFactory) {
+      if (current instanceof TokenFilterFactory) {
         if (filters == null) {
           filters = new ArrayList<>(2);
         }
-        filters.add((TokenFilterFactory)newComponent);
-      } else if (newComponent instanceof TokenizerFactory) {
-        tokenizer = (TokenizerFactory)newComponent;
-      } else if (newComponent instanceof CharFilterFactory) {
+        filters.add((TokenFilterFactory)current);
+      } else if (current instanceof TokenizerFactory) {
+        tokenizer = (TokenizerFactory)current;
+      } else if (current instanceof CharFilterFactory) {
         if (charFilters == null) {
           charFilters = new ArrayList<>(1);
         }
-        charFilters.add( (CharFilterFactory)newComponent);
+        charFilters.add( (CharFilterFactory)current);
 
       } else {
-        throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "Unknown analysis component from MultiTermAwareComponent: " + newComponent);
+        throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "Unknown analysis component from MultiTermAwareComponent: " + current);
       }
     }
 


### PR DESCRIPTION
- Add `normalize` method to CharFilterFactory and TokenFilterFactory

The goal is to get rid of MultiTermAwareComponent interface,
and instead use `normalize` method.

But as solr/core/src/java/org/apache/solr/schema/FieldTypePluginLoader.java
depends on MultiTermAwareComponent interface,
this patch still keeps it.