### PR TITLE
SOLR-12874 - Java 9+ GC Logging filesize parameter should be 20M instead of 20000

### DIFF
--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -1911,7 +1911,7 @@ if [ "$GC_LOG_OPTS" != "" ]; then
       # for simplicity, we only look at the prefix '-Xlog:gc'
       # (if 'all' or multiple tags are used starting with anything other then 'gc' the user is on their own)
       # if a single additional ':' exists in param, then there is already an explicit output specifier
-      GC_LOG_OPTS[$i]=$(echo ${GC_LOG_OPTS[$i]} | sed "s|^\(-Xlog:gc[^:]*$\)|\1:file=$SOLR_LOGS_DIR/solr_gc.log:time,uptime:filecount=9,filesize=20000|")
+      GC_LOG_OPTS[$i]=$(echo ${GC_LOG_OPTS[$i]} | sed "s|^\(-Xlog:gc[^:]*$\)|\1:file=$SOLR_LOGS_DIR/solr_gc.log:time,uptime:filecount=9,filesize=20M|")
     done
   fi
 fi

--- a/solr/bin/solr.cmd
+++ b/solr/bin/solr.cmd
@@ -1182,7 +1182,7 @@ if !JAVA_MAJOR_VERSION! GEQ 9  (
     echo ERROR: On Java 9 you cannot set GC_LOG_OPTS, only default GC logging is available. Exiting
     GOTO :eof
   )
-  set GC_LOG_OPTS="-Xlog:gc*:file=\"!SOLR_LOGS_DIR!\solr_gc.log\":time,uptime:filecount=9,filesize=20000"
+  set GC_LOG_OPTS="-Xlog:gc*:file=\"!SOLR_LOGS_DIR!\solr_gc.log\":time,uptime:filecount=9,filesize=20M"
 ) else (
   IF "%GC_LOG_OPTS%"=="" (
     rem Set defaults for Java 8


### PR DESCRIPTION
JEP 158 (https://openjdk.java.net/jeps/158) says the filesize parameter is the “file size in kb” however that appears to not be the case since when it is set to a value of 20000 you end up with GC logs that are only 20000 bytes in length.  Setting the value to 20M produces the desired result of GC log files that are 20MB in size.