### PR TITLE
SOLR-12878 - Use the cached SolrIndexSearch.fieldInfos instead of recreating one each time FacetFieldProcessorByHashDV is constructed

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
@@ -126,6 +126,8 @@ public class FieldInfos implements Iterable<FieldInfo> {
     values = Collections.unmodifiableCollection(Arrays.asList(valuesTemp.toArray(new FieldInfo[0])));
   }
 
+  public final static FieldInfos EMPTY = new FieldInfos(new FieldInfo[0]);
+
   /** Call this to get the (merged) FieldInfos for a
    *  composite reader.
    *  <p>

--- a/lucene/core/src/java/org/apache/lucene/index/LeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/LeafReader.java
@@ -206,6 +206,10 @@ public abstract class LeafReader extends IndexReader {
   /**
    * Get the {@link FieldInfos} describing all fields in
    * this reader.
+   *
+   * Note: Implementations should cache the FieldInfos
+   * instance returned by this method such that subsequent
+   * calls to this method return the same instance.
    * @lucene.experimental
    */
   public abstract FieldInfos getFieldInfos();

--- a/lucene/core/src/test/org/apache/lucene/index/TestPendingDeletes.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestPendingDeletes.java
@@ -132,7 +132,7 @@ public class TestPendingDeletes extends LuceneTestCase {
     SegmentInfo si = new SegmentInfo(dir, Version.LATEST, Version.LATEST, "test", 3, false, Codec.getDefault(),
         Collections.emptyMap(), StringHelper.randomId(), new HashMap<>(), null);
     SegmentCommitInfo commitInfo = new SegmentCommitInfo(si, 0, 0, -1, -1, -1);
-    FieldInfos fieldInfos = new FieldInfos(new FieldInfo[0]);
+    FieldInfos fieldInfos = FieldInfos.EMPTY;
     si.getCodec().fieldInfosFormat().write(dir, si, "", fieldInfos, IOContext.DEFAULT);
     PendingDeletes deletes = newPendingDeletes(commitInfo);
     for (int i = 0; i < 3; i++) {

--- a/lucene/core/src/test/org/apache/lucene/index/TestTermVectorsReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestTermVectorsReader.java
@@ -47,7 +47,7 @@ public class TestTermVectorsReader extends LuceneTestCase {
   private int[][] positions = new int[testTerms.length][];
   private Directory dir;
   private SegmentCommitInfo seg;
-  private FieldInfos fieldInfos = new FieldInfos(new FieldInfo[0]);
+  private FieldInfos fieldInfos = FieldInfos.EMPTY;
   private static int TERM_FREQ = 3;
 
   private static class TestToken implements Comparable<TestToken> {

--- a/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
+++ b/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
@@ -1142,12 +1142,20 @@ public class MemoryIndex {
   private final class MemoryIndexReader extends LeafReader {
 
     private final MemoryFields memoryFields = new MemoryFields(fields);
+    private final FieldInfos fieldInfos;
 
     private MemoryIndexReader() {
       super(); // avoid as much superclass baggage as possible
+
+      FieldInfo[] fieldInfosArr = new FieldInfo[fields.size()];
+
+      int i = 0;
       for (Info info : fields.values()) {
         info.prepareDocValuesAndPointValues();
+        fieldInfosArr[i++] = info.fieldInfo;
       }
+
+      fieldInfos = new FieldInfos(fieldInfosArr);
     }
 
     private Info getInfoForExpectedDocValuesType(String fieldName, DocValuesType expectedType) {
@@ -1171,12 +1179,7 @@ public class MemoryIndex {
     
     @Override
     public FieldInfos getFieldInfos() {
-      FieldInfo[] fieldInfos = new FieldInfo[fields.size()];
-      int i = 0;
-      for (Info info : fields.values()) {
-        fieldInfos[i++] = info.fieldInfo;
-      }
-      return new FieldInfos(fieldInfos);
+      return fieldInfos;
     }
 
     @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/search/QueryUtils.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/search/QueryUtils.java
@@ -207,7 +207,7 @@ public class QueryUtils {
 
       @Override
       public FieldInfos getFieldInfos() {
-        return new FieldInfos(new FieldInfo[0]);
+        return FieldInfos.EMPTY;
       }
 
       final Bits liveDocs = new Bits.MatchNoBits(maxDoc);

--- a/lucene/test-framework/src/java/org/apache/lucene/util/TestUtil.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/util/TestUtil.java
@@ -335,6 +335,11 @@ public final class TestUtil {
       }
       assert Accountables.toString(sr) != null;
     }
+
+    // FieldInfos should be cached at the reader and always return the same instance
+    if (reader.getFieldInfos() != reader.getFieldInfos()) {
+      throw new RuntimeException("getFieldInfos() returned different instances for class: "+reader.getClass());
+    }
   }
   
   // used by TestUtil.checkReader to check some things really unrelated to the index,

--- a/solr/core/src/java/org/apache/solr/handler/component/ExpandComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/ExpandComponent.java
@@ -769,17 +769,19 @@ public class ExpandComponent extends SearchComponent implements PluginInfoInitia
   private static class ReaderWrapper extends FilterLeafReader {
 
     private String field;
+    private FieldInfos fieldInfos;
 
     public ReaderWrapper(LeafReader leafReader, String field) {
       super(leafReader);
       this.field = field;
+      this.fieldInfos = initFieldInfos();
     }
 
     public SortedDocValues getSortedDocValues(String field) {
       return null;
     }
 
-    public FieldInfos getFieldInfos() {
+    private FieldInfos initFieldInfos() {
       Iterator<FieldInfo> it = in.getFieldInfos().iterator();
       List<FieldInfo> newInfos = new ArrayList<>();
       while(it.hasNext()) {
@@ -807,6 +809,10 @@ public class ExpandComponent extends SearchComponent implements PluginInfoInitia
       }
       FieldInfos infos = new FieldInfos(newInfos.toArray(new FieldInfo[newInfos.size()]));
       return infos;
+    }
+
+    public FieldInfos getFieldInfos() {
+      return fieldInfos;
     }
 
     // NOTE: delegating the caches is wrong here as we are altering the content

--- a/solr/core/src/java/org/apache/solr/search/CollapsingQParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/search/CollapsingQParserPlugin.java
@@ -390,10 +390,12 @@ public class CollapsingQParserPlugin extends QParserPlugin {
   private static class ReaderWrapper extends FilterLeafReader {
 
     private String field;
+    private FieldInfos fieldInfos;
 
     public ReaderWrapper(LeafReader leafReader, String field) {
       super(leafReader);
       this.field = field;
+      this.fieldInfos = initFieldInfos();
     }
 
     // NOTE: delegating the caches is wrong here as we are altering the content
@@ -415,7 +417,7 @@ public class CollapsingQParserPlugin extends QParserPlugin {
       return null;
     }
 
-    public FieldInfos getFieldInfos() {
+    private FieldInfos initFieldInfos() {
       Iterator<FieldInfo> it = in.getFieldInfos().iterator();
       List<FieldInfo> newInfos = new ArrayList();
       while(it.hasNext()) {
@@ -440,6 +442,10 @@ public class CollapsingQParserPlugin extends QParserPlugin {
       }
       FieldInfos infos = new FieldInfos(newInfos.toArray(new FieldInfo[newInfos.size()]));
       return infos;
+    }
+
+    public FieldInfos getFieldInfos() {
+      return fieldInfos;
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -126,8 +126,6 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
   // list of all caches associated with this searcher.
   private final SolrCache[] cacheList;
 
-  private final FieldInfos fieldInfos;
-
   private DirectoryFactory directoryFactory;
 
   private final LeafReader leafReader;
@@ -263,7 +261,6 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     this.queryResultMaxDocsCached = solrConfig.queryResultMaxDocsCached;
     this.useFilterForSortedQuery = solrConfig.useFilterForSortedQuery;
 
-    this.fieldInfos = leafReader.getFieldInfos();
     this.docFetcher = new SolrDocumentFetcher(this, solrConfig, enableCache);
 
     this.cachingEnabled = enableCache;
@@ -319,7 +316,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
   }
 
   public FieldInfos getFieldInfos() {
-    return fieldInfos;
+    return leafReader.getFieldInfos();
   }
 
   /*
@@ -494,7 +491,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
    * Returns a collection of all field names the index reader knows about.
    */
   public Iterable<String> getFieldNames() {
-    return Iterables.transform(fieldInfos, fieldInfo -> fieldInfo.name);
+    return Iterables.transform(getFieldInfos(), fieldInfo -> fieldInfo.name);
   }
 
   public SolrCache<Query,DocSet> getFilterCache() {

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetFieldProcessorByHashDV.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetFieldProcessorByHashDV.java
@@ -199,7 +199,7 @@ class FacetFieldProcessorByHashDV extends FacetFieldProcessor {
       throw new SolrException(SolrException.ErrorCode.BAD_REQUEST,
           getClass()+" doesn't support prefix"); // yet, but it could
     }
-    FieldInfo fieldInfo = fcontext.searcher.getSlowAtomicReader().getFieldInfos().fieldInfo(sf.getName());
+    FieldInfo fieldInfo = fcontext.searcher.getFieldInfos().fieldInfo(sf.getName());
     if (fieldInfo != null &&
         fieldInfo.getDocValuesType() != DocValuesType.NUMERIC &&
         fieldInfo.getDocValuesType() != DocValuesType.SORTED &&

--- a/solr/core/src/test/org/apache/solr/search/TestDocSet.java
+++ b/solr/core/src/test/org/apache/solr/search/TestDocSet.java
@@ -391,7 +391,7 @@ public class TestDocSet extends LuceneTestCase {
 
       @Override
       public FieldInfos getFieldInfos() {
-        return new FieldInfos(new FieldInfo[0]);
+        return FieldInfos.EMPTY;
       }
 
       @Override


### PR DESCRIPTION
Also this updates one of the collect methods to use the `advanceExact` method to match the other collect methods.