### PR TITLE
LUCENE-8463: Early-terminate queries sorted by SortField.DOC

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/TopFieldCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TopFieldCollector.java
@@ -203,11 +203,9 @@ public abstract class TopFieldCollector extends TopDocsCollector<Entry> {
     @Override
     public LeafCollector getLeafCollector(LeafReaderContext context) throws IOException {
       docBase = context.docBase;
-
       final int afterDoc = after.doc - docBase;
       final Sort indexSort = context.reader().getMetaData().getSort();
       final boolean canEarlyTerminate = canEarlyTerminate(sort, indexSort);
-      
       return new MultiComparatorLeafCollector(queue.getComparators(context), queue.getReverseMul()) {
 
         boolean collectedAllCompetitiveHits = false;

--- a/lucene/core/src/java/org/apache/lucene/search/TopFieldCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TopFieldCollector.java
@@ -75,9 +75,7 @@ public abstract class TopFieldCollector extends TopDocsCollector<Entry> {
   private static boolean canEarlyTerminateOnDocId(Sort searchSort, Sort indexSort) {
     final SortField[] fields1 = searchSort.getSort();
     final SortField[] fields2 = indexSort.getSort();
-    return fields1.length == 1 &&
-           fields2.length == 1 &&
-           SortField.FIELD_DOC.equals(fields1[0]) &&
+    return SortField.FIELD_DOC.equals(fields1[0]) &&
            SortField.FIELD_DOC.equals(fields2[0]);
   }
 

--- a/lucene/core/src/java/org/apache/lucene/search/TopFieldCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TopFieldCollector.java
@@ -68,6 +68,20 @@ public abstract class TopFieldCollector extends TopDocsCollector<Entry> {
   }
 
   static boolean canEarlyTerminate(Sort searchSort, Sort indexSort) {
+    return canEarlyTerminateOnDocId(searchSort, indexSort) ||
+           canEarlyTerminateOnPrefix(searchSort, indexSort);
+  }
+
+  private static boolean canEarlyTerminateOnDocId(Sort searchSort, Sort indexSort) {
+    final SortField[] fields1 = searchSort.getSort();
+    final SortField[] fields2 = indexSort.getSort();
+    return fields1.length == 1 &&
+           fields2.length == 1 &&
+           SortField.FIELD_DOC.equals(fields1[0]) &&
+           SortField.FIELD_DOC.equals(fields2[0]);
+  }
+
+  private static boolean canEarlyTerminateOnPrefix(Sort searchSort, Sort indexSort) {
     final SortField[] fields1 = searchSort.getSort();
     final SortField[] fields2 = indexSort.getSort();
     // early termination is possible if fields1 is a prefix of fields2

--- a/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollectorEarlyTermination.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollectorEarlyTermination.java
@@ -102,7 +102,7 @@ public class TestTopFieldCollectorEarlyTermination extends LuceneTestCase {
       reader = iw.getReader();
     }
   }
-
+  
   private void closeIndex() throws IOException {
     reader.close();
     iw.close();
@@ -166,7 +166,7 @@ public class TestTopFieldCollectorEarlyTermination extends LuceneTestCase {
       closeIndex();
     }
   }
-
+  
   public void testCanEarlyTerminateOnDocId() {
     assertTrue(TopFieldCollector.canEarlyTerminate(
         new Sort(SortField.FIELD_DOC),

--- a/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollectorEarlyTermination.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollectorEarlyTermination.java
@@ -102,7 +102,7 @@ public class TestTopFieldCollectorEarlyTermination extends LuceneTestCase {
       reader = iw.getReader();
     }
   }
-  
+
   private void closeIndex() throws IOException {
     reader.close();
     iw.close();
@@ -166,8 +166,34 @@ public class TestTopFieldCollectorEarlyTermination extends LuceneTestCase {
       closeIndex();
     }
   }
-  
-  public void testCanEarlyTerminate() {
+
+  public void testCanEarlyTerminateOnDocId() {
+    assertTrue(TopFieldCollector.canEarlyTerminate(
+        new Sort(SortField.FIELD_DOC),
+        new Sort(SortField.FIELD_DOC)));
+
+    assertFalse(TopFieldCollector.canEarlyTerminate(
+        new Sort(new SortField("a", SortField.Type.LONG)),
+        new Sort(new SortField("b", SortField.Type.LONG))));
+
+    assertFalse(TopFieldCollector.canEarlyTerminate(
+        new Sort(SortField.FIELD_DOC),
+        new Sort(new SortField("b", SortField.Type.LONG))));
+
+    assertFalse(TopFieldCollector.canEarlyTerminate(
+        new Sort(SortField.FIELD_DOC),
+        new Sort(new SortField("b", SortField.Type.LONG), SortField.FIELD_DOC)));
+
+    assertFalse(TopFieldCollector.canEarlyTerminate(
+        new Sort(new SortField("a", SortField.Type.LONG)),
+        new Sort(SortField.FIELD_DOC)));
+
+    assertFalse(TopFieldCollector.canEarlyTerminate(
+        new Sort(new SortField("a", SortField.Type.LONG), SortField.FIELD_DOC),
+        new Sort(SortField.FIELD_DOC)));
+  }
+
+  public void testCanEarlyTerminateOnPrefix() {
     assertTrue(TopFieldCollector.canEarlyTerminate(
         new Sort(new SortField("a", SortField.Type.LONG)),
         new Sort(new SortField("a", SortField.Type.LONG))));

--- a/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollectorEarlyTermination.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollectorEarlyTermination.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 
+import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import org.apache.lucene.analysis.MockAnalyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field.Store;
@@ -38,8 +39,6 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.TestUtil;
-
-import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 
 public class TestTopFieldCollectorEarlyTermination extends LuceneTestCase {
 
@@ -171,16 +170,24 @@ public class TestTopFieldCollectorEarlyTermination extends LuceneTestCase {
     assertTrue(TopFieldCollector.canEarlyTerminate(
         new Sort(SortField.FIELD_DOC),
         new Sort(SortField.FIELD_DOC)));
+    
+    assertTrue(TopFieldCollector.canEarlyTerminate(
+        new Sort(SortField.FIELD_DOC),
+        null));
+
+    assertFalse(TopFieldCollector.canEarlyTerminate(
+        new Sort(new SortField("a", SortField.Type.LONG)),
+        null));
 
     assertFalse(TopFieldCollector.canEarlyTerminate(
         new Sort(new SortField("a", SortField.Type.LONG)),
         new Sort(new SortField("b", SortField.Type.LONG))));
 
-    assertFalse(TopFieldCollector.canEarlyTerminate(
+    assertTrue(TopFieldCollector.canEarlyTerminate(
         new Sort(SortField.FIELD_DOC),
         new Sort(new SortField("b", SortField.Type.LONG))));
 
-    assertFalse(TopFieldCollector.canEarlyTerminate(
+    assertTrue(TopFieldCollector.canEarlyTerminate(
         new Sort(SortField.FIELD_DOC),
         new Sort(new SortField("b", SortField.Type.LONG), SortField.FIELD_DOC)));
 
@@ -206,6 +213,10 @@ public class TestTopFieldCollectorEarlyTermination extends LuceneTestCase {
         new Sort(new SortField("a", SortField.Type.LONG)),
         new Sort(new SortField("a", SortField.Type.LONG), new SortField("b", SortField.Type.STRING))));
 
+    assertFalse(TopFieldCollector.canEarlyTerminate(
+        new Sort(new SortField("a", SortField.Type.LONG, true)),
+        null));
+    
     assertFalse(TopFieldCollector.canEarlyTerminate(
         new Sort(new SortField("a", SortField.Type.LONG, true)),
         new Sort(new SortField("a", SortField.Type.LONG, false))));


### PR DESCRIPTION
> Currently TopFieldCollector only early-terminates when the search sort is a prefix of the index sort, but it could also early-terminate when sorting by doc id.

See [LUCENE-8463](https://issues.apache.org/jira/browse/LUCENE-8463).