### PR TITLE
LUCENE-8026: ExitableDirectoryReader does not instrument points

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
@@ -211,13 +211,15 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
      * or if {@link Thread#interrupted()} returns true.
      */
     private void checkAndThrow() {
-      if (calls++ % MAX_CALLS_BEFORE_QUERY_TIMEOUT_CHECK == 0 && queryTimeout.shouldExit()) {
-        throw new ExitingReaderException("The request took too long to intersect point values. Timeout: "
-            + queryTimeout.toString()
-            + ", PointValues=" + in
-        );
-      } else if (Thread.interrupted()) {
-        throw new ExitingReaderException("Interrupted while intersecting point values. PointValues=" + in);
+      if (calls++ % MAX_CALLS_BEFORE_QUERY_TIMEOUT_CHECK == 0) {
+        if (queryTimeout.shouldExit()) {
+          throw new ExitingReaderException("The request took too long to intersect point values. Timeout: "
+              + queryTimeout.toString()
+              + ", PointValues=" + in
+          );
+        } else if (Thread.interrupted()) {
+          throw new ExitingReaderException("Interrupted while intersecting point values. PointValues=" + in);
+        }
       }
     }
 

--- a/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
@@ -129,12 +129,12 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
      */
     private void checkAndThrow() {
       if (queryTimeout.shouldExit()) {
-        throw new ExitingReaderException("The request took too long to iterate over terms. Timeout: "
+        throw new ExitingReaderException("The request took too long to iterate over point values. Timeout: "
             + queryTimeout.toString()
             + ", PointValues=" + in
         );
       } else if (Thread.interrupted()) {
-        throw new ExitingReaderException("Interrupted while iterating over terms. PointValues=" + in);
+        throw new ExitingReaderException("Interrupted while iterating over point values. PointValues=" + in);
       }
     }
 

--- a/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
@@ -112,13 +112,12 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
   /**
    * Wrapper class for another PointValues implementation that is used by ExitableFields.
    */
-  public static class ExitablePointValues extends PointValues {
+  private static class ExitablePointValues extends PointValues {
 
     private final PointValues in;
     private final QueryTimeout queryTimeout;
 
-    /** Constructor **/
-    public ExitablePointValues(PointValues in, QueryTimeout queryTimeout) {
+    private ExitablePointValues(PointValues in, QueryTimeout queryTimeout) {
       this.in = in;
       this.queryTimeout = queryTimeout;
       checkAndThrow();

--- a/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
@@ -193,15 +193,15 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
     }
   }
 
-  public static class ExitableIntersectVisitor implements PointValues.IntersectVisitor {
+  private static class ExitableIntersectVisitor implements PointValues.IntersectVisitor {
 
-    public static final int MAX_CALLS_BEFORE_QUERY_TIMEOUT_CHECK = 10;
+    private static final int MAX_CALLS_BEFORE_QUERY_TIMEOUT_CHECK = 10;
 
     private final PointValues.IntersectVisitor in;
     private final QueryTimeout queryTimeout;
     private int calls;
 
-    public ExitableIntersectVisitor(PointValues.IntersectVisitor in, QueryTimeout queryTimeout) {
+    private ExitableIntersectVisitor(PointValues.IntersectVisitor in, QueryTimeout queryTimeout) {
       this.in = in;
       this.queryTimeout = queryTimeout;
     }

--- a/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
@@ -237,13 +237,11 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
 
     @Override
     public PointValues.Relation compare(byte[] minPackedValue, byte[] maxPackedValue) {
-      checkAndThrow();
       return in.compare(minPackedValue, maxPackedValue);
     }
 
     @Override
     public void grow(int count) {
-      checkAndThrow();
       in.grow(count);
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
@@ -199,7 +199,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
 
     private final PointValues.IntersectVisitor in;
     private final QueryTimeout queryTimeout;
-    private int calls = 0;
+    private int calls;
 
     public ExitableIntersectVisitor(PointValues.IntersectVisitor in, QueryTimeout queryTimeout) {
       this.in = in;

--- a/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
@@ -195,22 +195,15 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
 
   public static class ExitableIntersectVisitor implements PointValues.IntersectVisitor {
 
-    public static final int DEFAULT_MAX_CALLS_BEFORE_QUERY_TIMEOUT_CHECK = 10;
+    public static final int MAX_CALLS_BEFORE_QUERY_TIMEOUT_CHECK = 10;
 
     private final PointValues.IntersectVisitor in;
     private final QueryTimeout queryTimeout;
-    private final int maxCallsBeforeQueryTimeoutCheck;
     private int calls = 0;
 
     public ExitableIntersectVisitor(PointValues.IntersectVisitor in, QueryTimeout queryTimeout) {
-      this(in, queryTimeout, DEFAULT_MAX_CALLS_BEFORE_QUERY_TIMEOUT_CHECK);
-    }
-
-    public ExitableIntersectVisitor(PointValues.IntersectVisitor in,
-                                    QueryTimeout queryTimeout, int maxCallsBeforeQueryTimeoutCheck) {
       this.in = in;
       this.queryTimeout = queryTimeout;
-      this.maxCallsBeforeQueryTimeoutCheck = maxCallsBeforeQueryTimeoutCheck;
     }
 
     /**
@@ -218,7 +211,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
      * or if {@link Thread#interrupted()} returns true.
      */
     private void checkAndThrow() {
-      if (calls++ % maxCallsBeforeQueryTimeoutCheck == 0 && queryTimeout.shouldExit()) {
+      if (calls++ % MAX_CALLS_BEFORE_QUERY_TIMEOUT_CHECK == 0 && queryTimeout.shouldExit()) {
         throw new ExitingReaderException("The request took too long to intersect point values. Timeout: "
             + queryTimeout.toString()
             + ", PointValues=" + in

--- a/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
@@ -78,6 +78,15 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
     }
 
     @Override
+    public PointValues getPointValues(String field) throws IOException {
+      final PointValues pointValues = in.getPointValues(field);
+      if (pointValues == null) {
+        return null;
+      }
+      return (queryTimeout.isTimeoutEnabled()) ? new ExitablePointValues(pointValues, queryTimeout) : pointValues;
+    }
+
+    @Override
     public Terms terms(String field) throws IOException {
       Terms terms = in.terms(field);
       if (terms == null) {
@@ -101,12 +110,96 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
   }
 
   /**
+   * Wrapper class for another PointValues implementation that is used by ExitableFields.
+   */
+  public static class ExitablePointValues extends PointValues {
+
+    private final PointValues in;
+    private final QueryTimeout queryTimeout;
+
+    public ExitablePointValues(PointValues in, QueryTimeout queryTimeout) {
+      this.in = in;
+      this.queryTimeout = queryTimeout;
+      checkAndThrow();
+    }
+
+    /**
+     * Throws {@link ExitingReaderException} if {@link QueryTimeout#shouldExit()} returns true,
+     * or if {@link Thread#interrupted()} returns true.
+     */
+    private void checkAndThrow() {
+      if (queryTimeout.shouldExit()) {
+        throw new ExitingReaderException("The request took too long to iterate over terms. Timeout: "
+            + queryTimeout.toString()
+            + ", PointValues=" + in
+        );
+      } else if (Thread.interrupted()) {
+        throw new ExitingReaderException("Interrupted while iterating over terms. PointValues=" + in);
+      }
+    }
+
+    @Override
+    public void intersect(IntersectVisitor visitor) throws IOException {
+      checkAndThrow();
+      in.intersect(visitor);
+    }
+
+    @Override
+    public long estimatePointCount(IntersectVisitor visitor) {
+      checkAndThrow();
+      return in.estimatePointCount(visitor);
+    }
+
+    @Override
+    public byte[] getMinPackedValue() throws IOException {
+      checkAndThrow();
+      return in.getMinPackedValue();
+    }
+
+    @Override
+    public byte[] getMaxPackedValue() throws IOException {
+      checkAndThrow();
+      return in.getMaxPackedValue();
+    }
+
+    @Override
+    public int getNumDataDimensions() throws IOException {
+      checkAndThrow();
+      return in.getNumDataDimensions();
+    }
+
+    @Override
+    public int getNumIndexDimensions() throws IOException {
+      checkAndThrow();
+      return in.getNumIndexDimensions();
+    }
+
+    @Override
+    public int getBytesPerDimension() throws IOException {
+      checkAndThrow();
+      return in.getBytesPerDimension();
+    }
+
+    @Override
+    public long size() {
+      checkAndThrow();
+      return in.size();
+    }
+
+    @Override
+    public int getDocCount() {
+      checkAndThrow();
+      return in.getDocCount();
+    }
+  }
+
+  /**
    * Wrapper class for another Terms implementation that is used by ExitableFields.
    */
   public static class ExitableTerms extends FilterTerms {
 
     private QueryTimeout queryTimeout;
-    
+
     /** Constructor **/
     public ExitableTerms(Terms terms, QueryTimeout queryTimeout) {
       super(terms);

--- a/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
@@ -117,6 +117,7 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
     private final PointValues in;
     private final QueryTimeout queryTimeout;
 
+    /** Constructor **/
     public ExitablePointValues(PointValues in, QueryTimeout queryTimeout) {
       this.in = in;
       this.queryTimeout = queryTimeout;

--- a/lucene/core/src/test/org/apache/lucene/index/TestExitableDirectoryReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestExitableDirectoryReader.java
@@ -128,7 +128,7 @@ public class TestExitableDirectoryReader extends LuceneTestCase {
     searcher.search(query, 10);
     reader.close();
 
-    // Set a really low timeout value (1 millisecond) and expect an Exception
+    // Set a really low timeout value (immediate) and expect an Exception
     directoryReader = DirectoryReader.open(directory);
     exitableDirectoryReader = new ExitableDirectoryReader(directoryReader, immediateQueryTimeout());
     reader = new TestReader(getOnlyLeafReader(exitableDirectoryReader));
@@ -200,7 +200,7 @@ public class TestExitableDirectoryReader extends LuceneTestCase {
     searcher.search(query, 10);
     reader.close();
 
-    // Set a really low timeout value (1 millisecond) and expect an Exception
+    // Set a really low timeout value (immediate) and expect an Exception
     directoryReader = DirectoryReader.open(directory);
     exitableDirectoryReader = new ExitableDirectoryReader(directoryReader, immediateQueryTimeout());
     reader = new TestReader(getOnlyLeafReader(exitableDirectoryReader));

--- a/lucene/core/src/test/org/apache/lucene/index/TestExitableDirectoryReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestExitableDirectoryReader.java
@@ -122,7 +122,7 @@ public class TestExitableDirectoryReader extends LuceneTestCase {
     // Set a fairly high timeout value (infinite) and expect the query to complete in that time frame.
     // Not checking the validity of the result, all we are bothered about in this test is the timing out.
     directoryReader = DirectoryReader.open(directory);
-    exitableDirectoryReader = new ExitableDirectoryReader(directoryReader, inifiniteQueryTimeout());
+    exitableDirectoryReader = new ExitableDirectoryReader(directoryReader, infiniteQueryTimeout());
     reader = new TestReader(getOnlyLeafReader(exitableDirectoryReader));
     searcher = new IndexSearcher(reader);
     searcher.search(query, 10);
@@ -141,7 +141,7 @@ public class TestExitableDirectoryReader extends LuceneTestCase {
     // Set maximum time out and expect the query to complete. 
     // Not checking the validity of the result, all we are bothered about in this test is the timing out.
     directoryReader = DirectoryReader.open(directory);
-    exitableDirectoryReader = new ExitableDirectoryReader(directoryReader, inifiniteQueryTimeout());
+    exitableDirectoryReader = new ExitableDirectoryReader(directoryReader, infiniteQueryTimeout());
     reader = new TestReader(getOnlyLeafReader(exitableDirectoryReader));
     searcher = new IndexSearcher(reader);
     searcher.search(query, 10);
@@ -194,7 +194,7 @@ public class TestExitableDirectoryReader extends LuceneTestCase {
     // Set a fairly high timeout value (infinite) and expect the query to complete in that time frame.
     // Not checking the validity of the result, all we are bothered about in this test is the timing out.
     directoryReader = DirectoryReader.open(directory);
-    exitableDirectoryReader = new ExitableDirectoryReader(directoryReader, inifiniteQueryTimeout());
+    exitableDirectoryReader = new ExitableDirectoryReader(directoryReader, infiniteQueryTimeout());
     reader = new TestReader(getOnlyLeafReader(exitableDirectoryReader));
     searcher = new IndexSearcher(reader);
     searcher.search(query, 10);
@@ -213,7 +213,7 @@ public class TestExitableDirectoryReader extends LuceneTestCase {
     // Set maximum time out and expect the query to complete.
     // Not checking the validity of the result, all we are bothered about in this test is the timing out.
     directoryReader = DirectoryReader.open(directory);
-    exitableDirectoryReader = new ExitableDirectoryReader(directoryReader, inifiniteQueryTimeout());
+    exitableDirectoryReader = new ExitableDirectoryReader(directoryReader, infiniteQueryTimeout());
     reader = new TestReader(getOnlyLeafReader(exitableDirectoryReader));
     searcher = new IndexSearcher(reader);
     searcher.search(query, 10);
@@ -246,7 +246,7 @@ public class TestExitableDirectoryReader extends LuceneTestCase {
     };
   }
 
-  private static QueryTimeout inifiniteQueryTimeout() {
+  private static QueryTimeout infiniteQueryTimeout() {
     return new QueryTimeout() {
 
       @Override

--- a/lucene/core/src/test/org/apache/lucene/index/TestExitableDirectoryReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestExitableDirectoryReader.java
@@ -119,7 +119,7 @@ public class TestExitableDirectoryReader extends LuceneTestCase {
 
     Query query = new PrefixQuery(new Term("default", "o"));
 
-    // Set a fairly high timeout value (1 second) and expect the query to complete in that time frame.
+    // Set a fairly high timeout value (infinite) and expect the query to complete in that time frame.
     // Not checking the validity of the result, all we are bothered about in this test is the timing out.
     directoryReader = DirectoryReader.open(directory);
     exitableDirectoryReader = new ExitableDirectoryReader(directoryReader, inifiniteQueryTimeout());
@@ -191,7 +191,7 @@ public class TestExitableDirectoryReader extends LuceneTestCase {
 
     Query query = IntPoint.newRangeQuery("default", 10, 20);
 
-    // Set a fairly high timeout value (1 second) and expect the query to complete in that time frame.
+    // Set a fairly high timeout value (infinite) and expect the query to complete in that time frame.
     // Not checking the validity of the result, all we are bothered about in this test is the timing out.
     directoryReader = DirectoryReader.open(directory);
     exitableDirectoryReader = new ExitableDirectoryReader(directoryReader, inifiniteQueryTimeout());

--- a/lucene/core/src/test/org/apache/lucene/index/TestExitableDirectoryReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestExitableDirectoryReader.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import org.apache.lucene.analysis.MockAnalyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
+import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.index.ExitableDirectoryReader.ExitingReaderException;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.PrefixQuery;
@@ -93,7 +94,7 @@ public class TestExitableDirectoryReader extends LuceneTestCase {
    * @throws Exception on error
    */
   @Ignore("this test relies on wall clock time and sometimes false fails")
-  public void testExitableFilterIndexReader() throws Exception {
+  public void testExitableFilterTermsIndexReader() throws Exception {
     Directory directory = newDirectory();
     IndexWriter writer = new IndexWriter(directory, newIndexWriterConfig(new MockAnalyzer(random())));
 
@@ -108,8 +109,8 @@ public class TestExitableDirectoryReader extends LuceneTestCase {
     Document d3 = new Document();
     d3.add(newTextField("default", "ones two four", Field.Store.YES));
     writer.addDocument(d3);
-    writer.forceMerge(1);
 
+    writer.forceMerge(1);
     writer.commit();
     writer.close();
 
@@ -129,7 +130,6 @@ public class TestExitableDirectoryReader extends LuceneTestCase {
     searcher.search(query, 10);
     reader.close();
 
-
     // Set a really low timeout value (1 millisecond) and expect an Exception
     directoryReader = DirectoryReader.open(directory);
     exitableDirectoryReader = new ExitableDirectoryReader(directoryReader, new QueryTimeoutImpl(1));
@@ -141,6 +141,79 @@ public class TestExitableDirectoryReader extends LuceneTestCase {
     reader.close();
    
     // Set maximum time out and expect the query to complete. 
+    // Not checking the validity of the result, all we are bothered about in this test is the timing out.
+    directoryReader = DirectoryReader.open(directory);
+    exitableDirectoryReader = new ExitableDirectoryReader(directoryReader, new QueryTimeoutImpl(Long.MAX_VALUE));
+    reader = new TestReader(getOnlyLeafReader(exitableDirectoryReader));
+    searcher = new IndexSearcher(reader);
+    searcher.search(query, 10);
+    reader.close();
+
+    // Set a negative time allowed and expect the query to complete (should disable timeouts)
+    // Not checking the validity of the result, all we are bothered about in this test is the timing out.
+    directoryReader = DirectoryReader.open(directory);
+    exitableDirectoryReader = new ExitableDirectoryReader(directoryReader, new QueryTimeoutImpl(-189034L));
+    reader = new TestReader(getOnlyLeafReader(exitableDirectoryReader));
+    searcher = new IndexSearcher(reader);
+    searcher.search(query, 10);
+    reader.close();
+
+    directory.close();
+  }
+
+  /**
+   * Tests timing out of PointValues queries
+   *
+   * @throws Exception on error
+   */
+  @Ignore("this test relies on wall clock time and sometimes false fails")
+  public void testExitablePointValuesIndexReader() throws Exception {
+    Directory directory = newDirectory();
+    IndexWriter writer = new IndexWriter(directory, newIndexWriterConfig(new MockAnalyzer(random())));
+
+    Document d1 = new Document();
+    d1.add(new IntPoint("default", 10));
+    writer.addDocument(d1);
+
+    Document d2 = new Document();
+    d2.add(new IntPoint("default", 100));
+    writer.addDocument(d2);
+
+    Document d3 = new Document();
+    d3.add(new IntPoint("default", 1000));
+    writer.addDocument(d3);
+
+    writer.forceMerge(1);
+    writer.commit();
+    writer.close();
+
+    DirectoryReader directoryReader;
+    DirectoryReader exitableDirectoryReader;
+    IndexReader reader;
+    IndexSearcher searcher;
+
+    Query query = IntPoint.newRangeQuery("default", 10, 20);
+
+    // Set a fairly high timeout value (1 second) and expect the query to complete in that time frame.
+    // Not checking the validity of the result, all we are bothered about in this test is the timing out.
+    directoryReader = DirectoryReader.open(directory);
+    exitableDirectoryReader = new ExitableDirectoryReader(directoryReader, new QueryTimeoutImpl(1000));
+    reader = new TestReader(getOnlyLeafReader(exitableDirectoryReader));
+    searcher = new IndexSearcher(reader);
+    searcher.search(query, 10);
+    reader.close();
+
+    // Set a really low timeout value (1 millisecond) and expect an Exception
+    directoryReader = DirectoryReader.open(directory);
+    exitableDirectoryReader = new ExitableDirectoryReader(directoryReader, new QueryTimeoutImpl(1));
+    reader = new TestReader(getOnlyLeafReader(exitableDirectoryReader));
+    IndexSearcher slowSearcher = new IndexSearcher(reader);
+    expectThrows(ExitingReaderException.class, () -> {
+      slowSearcher.search(query, 10);
+    });
+    reader.close();
+
+    // Set maximum time out and expect the query to complete.
     // Not checking the validity of the result, all we are bothered about in this test is the timing out.
     directoryReader = DirectoryReader.open(directory);
     exitableDirectoryReader = new ExitableDirectoryReader(directoryReader, new QueryTimeoutImpl(Long.MAX_VALUE));


### PR DESCRIPTION
> This means it cannot interrupt range or geo queries.

See [LUCENE-8026](https://issues.apache.org/jira/browse/LUCENE-8026).