### PR TITLE
Simplified JAVA_VER_NUM to utilize single expr execution

### DIFF
--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -138,7 +138,7 @@ if [[ $? -ne 0 ]] ; then
   echo >&2 "${PATH}"
   exit 1
 else
-  JAVA_VER_NUM=$(expr match "${JAVA_VER}" '.*java version.*\([0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}_[0-9]\{1,3\}\).*')
+  JAVA_VER_NUM=$(expr match "${JAVA_VER}" '.*java version.*[0-9]\{1,3\}\.\([0-9]\{1,3\}\)\.[0-9]\{1,3\}_[0-9]\{1,3\}.*')
   if [[ "$JAVA_VER_NUM" -lt "$JAVA_VER_REQ" ]] ; then
     echo >&2 "Your current version of Java is too old to run this version of Solr."
     echo >&2 "We found major version $JAVA_VER_NUM, using command '${JAVA} -version', with response:"

--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -138,7 +138,7 @@ if [[ $? -ne 0 ]] ; then
   echo >&2 "${PATH}"
   exit 1
 else
-  JAVA_VER_NUM=$(echo $JAVA_VER | head -1 | awk -F '"' '/version/ {print $2}' | sed -e's/^1\.//' | sed -e's/[._-].*$//')
+  JAVA_VER_NUM=$(expr match "${JAVA_VER}" '.*java version.*\([0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}_[0-9]\{1,3\}\).*')
   if [[ "$JAVA_VER_NUM" -lt "$JAVA_VER_REQ" ]] ; then
     echo >&2 "Your current version of Java is too old to run this version of Solr."
     echo >&2 "We found major version $JAVA_VER_NUM, using command '${JAVA} -version', with response:"


### PR DESCRIPTION
The fragility of the previous JAVA_VER_NUM causes solr to fail to start when JAVA_TOOL_OPTIONS is set:

```
+ /jenkins/tools/hudson.model.JDK/jdk8-latest/bin/java -version
+ JAVA_VER=Picked up JAVA_TOOL_OPTIONS: -Dmaven.ext.class.path="/jenkins/workspace/Bates/bates-java_ver-test/7@tmp/withMavena29da72d/pipeline-maven-spy.jar" -Dorg.jenkinsci.plugins.pipeline.maven.reportsFolder="/jenkins/workspace/Bates/bates-java_ver-test/7@tmp/withMavena29da72d" 
java version "1.8.0_172"
Java(TM) SE Runtime Environment (build 1.8.0_172-b11)
Java HotSpot(TM) 64-Bit Server VM (build 25.172-b11, mixed mode)
+ echo Picked up JAVA_TOOL_OPTIONS: -Dmaven.ext.class.path="/jenkins/workspace/Bates/bates-java_ver-test/7@tmp/withMavena29da72d/pipeline-maven-spy.jar" -Dorg.jenkinsci.plugins.pipeline.maven.reportsFolder="/jenkins/workspace/Bates/bates-java_ver-test/7@tmp/withMavena29da72d" java version "1.8.0_172" Java(TM) SE Runtime Environment (build 1.8.0_172-b11) Java HotSpot(TM) 64-Bit Server VM (build 25.172-b11, mixed mode)
+ head -1
+ awk -F " /version/ {print $2}
+ sed -e s/^1\.//
+ sed -e s/[._-].*$//
+ JAVA_VER_NUM=/jenkins/workspace/Bates/bates
+ echo /jenkins/workspace/Bates/bates
```