### PR TITLE
Support for moving FST offheap except PK

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/blocktree/BlockTreeTermsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/blocktree/BlockTreeTermsReader.java
@@ -102,6 +102,8 @@ public final class BlockTreeTermsReader extends FieldsProducer {
 
   // Open input to the main terms dict file (_X.tib)
   final IndexInput termsIn;
+  // Open input to the terms index file (_X.tip)
+  final IndexInput indexIn;
 
   //private static final boolean DEBUG = BlockTreeTermsWriter.DEBUG;
 
@@ -118,7 +120,6 @@ public final class BlockTreeTermsReader extends FieldsProducer {
   /** Sole constructor. */
   public BlockTreeTermsReader(PostingsReaderBase postingsReader, SegmentReadState state) throws IOException {
     boolean success = false;
-    IndexInput indexIn = null;
     
     this.postingsReader = postingsReader;
     this.segment = state.segmentInfo.name;
@@ -197,13 +198,11 @@ public final class BlockTreeTermsReader extends FieldsProducer {
           throw new CorruptIndexException("duplicate field: " + fieldInfo.name, termsIn);
         }
       }
-      
-      indexIn.close();
       success = true;
     } finally {
       if (!success) {
         // this.close() will close in:
-        IOUtils.closeWhileHandlingException(indexIn, this);
+        IOUtils.closeWhileHandlingException(this);
       }
     }
   }
@@ -237,7 +236,7 @@ public final class BlockTreeTermsReader extends FieldsProducer {
   @Override
   public void close() throws IOException {
     try {
-      IOUtils.close(termsIn, postingsReader);
+      IOUtils.close(indexIn, termsIn, postingsReader);
     } finally { 
       // Clear so refs to terms index is GCable even if
       // app hangs onto us:

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBufferIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBufferIndexInput.java
@@ -33,7 +33,7 @@ import java.nio.ByteBuffer;
  * For efficiency, this class requires that the buffers
  * are a power-of-two (<code>chunkSizePower</code>).
  */
-abstract class ByteBufferIndexInput extends IndexInput implements RandomAccessInput {
+public abstract class ByteBufferIndexInput extends IndexInput implements RandomAccessInput {
   protected final long length;
   protected final long chunkSizeMask;
   protected final int chunkSizePower;

--- a/lucene/core/src/java/org/apache/lucene/util/fst/FSTStore.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/FSTStore.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.util.fst;
+
+import org.apache.lucene.store.DataInput;
+import org.apache.lucene.store.DataOutput;
+import org.apache.lucene.util.Accountable;
+
+import java.io.IOException;
+
+public interface FSTStore extends Accountable {
+    void init(DataInput in, long numBytes) throws IOException;
+    FST.BytesReader getReverseBytesReader();
+    void writeTo(DataOutput out) throws IOException;
+}

--- a/lucene/core/src/java/org/apache/lucene/util/fst/OffHeapFSTStore.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/OffHeapFSTStore.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.util.fst;
+
+import org.apache.lucene.store.DataInput;
+import org.apache.lucene.store.DataOutput;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.RandomAccessInput;
+import org.apache.lucene.util.RamUsageEstimator;
+
+import java.io.IOException;
+
+/** Provides off heap storage of finite state machine (FST),
+ *  using underlying index input instead of byte store on heap
+ *
+ * @lucene.experimental
+ */
+public final class OffHeapFSTStore implements FSTStore {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(OffHeapFSTStore.class);
+
+    private IndexInput in;
+    private long offset;
+    private long numBytes;
+
+    @Override
+    public void init(DataInput in, long numBytes) throws IOException {
+        if (in instanceof IndexInput) {
+            this.in = (IndexInput) in;
+            this.numBytes = numBytes;
+            this.offset = this.in.getFilePointer();
+        } else {
+            throw new IllegalArgumentException("parameter:in should be an instance of RandomAccessInput for using OffHeapFSTStore, not a "
+                                               + in.getClass().getName());
+        }
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return BASE_RAM_BYTES_USED;
+    }
+
+    @Override
+    public FST.BytesReader getReverseBytesReader() {
+        try {
+            return new ReverseRandomAccessReader(in.randomAccessSlice(offset, numBytes));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
+        throw new UnsupportedOperationException("writeToOutput operation is not supported for OffHeapFSTStore");
+    }
+}

--- a/lucene/core/src/java/org/apache/lucene/util/fst/OnHeapFSTStore.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/OnHeapFSTStore.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.util.fst;
+
+import org.apache.lucene.store.DataInput;
+import org.apache.lucene.store.DataOutput;
+import org.apache.lucene.util.RamUsageEstimator;
+
+import java.io.IOException;
+
+/** Provides storage of finite state machine (FST),
+ *  using byte array or byte store allocated on heap.
+ *
+ * @lucene.experimental
+ */
+public final class OnHeapFSTStore implements FSTStore {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(OnHeapFSTStore.class);
+
+    /** A {@link BytesStore}, used during building, or during reading when
+     *  the FST is very large (more than 1 GB).  If the FST is less than 1
+     *  GB then bytesArray is set instead. */
+    private BytesStore bytes;
+
+    /** Used at read time when the FST fits into a single byte[]. */
+    private byte[] bytesArray;
+
+    private final int maxBlockBits;
+
+    public OnHeapFSTStore(int maxBlockBits) {
+        if (maxBlockBits < 1 || maxBlockBits > 30) {
+            throw new IllegalArgumentException("maxBlockBits should be 1 .. 30; got " + maxBlockBits);
+        }
+
+        this.maxBlockBits = maxBlockBits;
+    }
+
+    @Override
+    public void init(DataInput in, long numBytes) throws IOException {
+        if (numBytes > 1 << this.maxBlockBits) {
+            // FST is big: we need multiple pages
+            bytes = new BytesStore(in, numBytes, 1<<this.maxBlockBits);
+        } else {
+            // FST fits into a single block: use ByteArrayBytesStoreReader for less overhead
+            bytesArray = new byte[(int) numBytes];
+            in.readBytes(bytesArray, 0, bytesArray.length);
+        }
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        long size = BASE_RAM_BYTES_USED;
+        if (bytesArray != null) {
+            size += bytesArray.length;
+        } else {
+            size += bytes.ramBytesUsed();
+        }
+
+        return size;
+    }
+
+    @Override
+    public FST.BytesReader getReverseBytesReader() {
+        if (bytesArray != null) {
+            return new ReverseBytesReader(bytesArray);
+        } else {
+            return bytes.getReverseReader();
+        }
+    }
+
+    @Override
+    public void writeTo(DataOutput out) throws IOException {
+        if (bytes != null) {
+            long numBytes = bytes.getPosition();
+            out.writeVLong(numBytes);
+            bytes.writeTo(out);
+        } else {
+            assert bytesArray != null;
+            out.writeVLong(bytesArray.length);
+            out.writeBytes(bytesArray, 0, bytesArray.length);
+        }
+    }
+}

--- a/lucene/core/src/java/org/apache/lucene/util/fst/ReverseRandomAccessReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/ReverseRandomAccessReader.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.util.fst;
+
+import java.io.IOException;
+import org.apache.lucene.store.RandomAccessInput;
+
+/** Implements reverse read from a RandomAccessInput. */
+final class ReverseRandomAccessReader extends FST.BytesReader {
+    private final RandomAccessInput in;
+    private long pos;
+
+    public ReverseRandomAccessReader(RandomAccessInput in) {
+        this.in = in;
+    }
+
+    @Override
+    public byte readByte() throws IOException {
+        return in.readByte(pos--);
+    }
+
+    @Override
+    public void readBytes(byte[] b, int offset, int len) throws IOException {
+        int i = offset, end = offset + len;
+        while (i < end) {
+            b[i++] = in.readByte(pos--);
+        }
+    }
+
+    @Override
+    public void skipBytes(long count) {
+        pos -= count;
+    }
+
+    @Override
+    public long getPosition() {
+        return pos;
+    }
+
+    @Override
+    public void setPosition(long pos) {
+        this.pos = pos;
+    }
+
+    @Override
+    public boolean reversed() {
+        return true;
+    }
+}


### PR DESCRIPTION
The change adds support for initializing FST offheap using mapped files during index open. To avoid impact on PKLookup performance, this change initializes FST offheap only if docCount != sumDocFreq (implying field is not PK) and indexInput isinstanceof ByteBufferIndexInput (implying MMapDirectory is being used). More details can be found in the issue below:

https://issues.apache.org/jira/browse/LUCENE-8635