### PR TITLE
LUCENE-8681: prorated early termination

### DIFF
--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/ReadTask.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/ReadTask.java
@@ -112,7 +112,9 @@ public abstract class ReadTask extends PerfTask {
             // Weight public again, we can go back to
             // pulling the Weight ourselves:
             TopFieldCollector collector = TopFieldCollector.create(sort, numHits,
-                                                                   withTotalHits() ? Integer.MAX_VALUE : 1);
+                                                                   withTotalHits()
+                                                                   ? IndexSearcher.TerminationStrategy.NONE
+                                                                   : IndexSearcher.TerminationStrategy.HIT_COUNT);
             searcher.search(q, collector);
             hits = collector.topDocs();
           } else {
@@ -174,7 +176,7 @@ public abstract class ReadTask extends PerfTask {
   }
 
   protected Collector createCollector() throws Exception {
-    return TopScoreDocCollector.create(numHits(), withTotalHits() ? Integer.MAX_VALUE : 1);
+    return TopScoreDocCollector.create(numHits(), withTotalHits() ? IndexSearcher.TerminationStrategy.NONE : IndexSearcher.TerminationStrategy.HIT_COUNT);
   }
 
 

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/SearchWithCollectorTask.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/SearchWithCollectorTask.java
@@ -20,6 +20,7 @@ import org.apache.lucene.benchmark.byTask.PerfRunData;
 import org.apache.lucene.benchmark.byTask.feeds.QueryMaker;
 import org.apache.lucene.benchmark.byTask.utils.Config;
 import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.IndexSearcher.TerminationStrategy;;
 import org.apache.lucene.search.TopScoreDocCollector;
 
 /**
@@ -53,7 +54,7 @@ public class SearchWithCollectorTask extends SearchTask {
   protected Collector createCollector() throws Exception {
     Collector collector = null;
     if (clnName.equalsIgnoreCase("topScoreDoc") == true) {
-      collector = TopScoreDocCollector.create(numHits(), Integer.MAX_VALUE);
+      collector = TopScoreDocCollector.create(numHits(), TerminationStrategy.NONE);
     } else if (clnName.length() > 0){
       collector = Class.forName(clnName).asSubclass(Collector.class).newInstance();
 

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -443,16 +443,10 @@ public class IndexSearcher {
     search(leafContexts, createWeight(query, results.scoreMode(), 1), results);
   }
 
-  /** Search implementation with arbitrary sorting, plus
-   * control over whether hit scores and max score
-   * should be computed.  Finds
-   * the top <code>n</code> hits for <code>query</code>, and sorting
-   * the hits by the criteria in <code>sort</code>.
-   * If <code>doDocScores</code> is <code>true</code>
-   * then the score of each hit will be computed and
-   * returned.  If <code>doMaxScore</code> is
-   * <code>true</code> then the maximum score over all
-   * collected hits will be computed.
+  /** Search implementation with arbitrary sorting, plus control over whether hit scores should be
+   * computed.  Finds the top <code>n</code> hits for <code>query</code>, and sorting the hits by
+   * the criteria in <code>sort</code>.  If <code>doDocScores</code> is <code>true</code> then the
+   * score of each hit will be computed and returned.
    * 
    * @throws BooleanQuery.TooManyClauses If a query would exceed 
    *         {@link BooleanQuery#getMaxClauseCount()} clauses.
@@ -492,15 +486,13 @@ public class IndexSearcher {
   /** Finds the top <code>n</code>
    * hits for <code>query</code> where all results are after a previous
    * result (<code>after</code>), allowing control over
-   * whether hit scores and max score should be computed.
+   * whether hit scores should be computed.
    * <p>
    * By passing the bottom result from a previous page as <code>after</code>,
    * this method can be used for efficient 'deep-paging' across potentially
    * large result sets.  If <code>doDocScores</code> is <code>true</code>
    * then the score of each hit will be computed and
-   * returned.  If <code>doMaxScore</code> is
-   * <code>true</code> then the maximum score over all
-   * collected hits will be computed.
+   * returned.
    *
    * @throws BooleanQuery.TooManyClauses If a query would exceed 
    *         {@link BooleanQuery#getMaxClauseCount()} clauses.
@@ -525,25 +517,8 @@ public class IndexSearcher {
     final int cappedNumHits = Math.min(numHits, limit);
     final Sort rewrittenSort = sort.rewrite(this);
 
-    final CollectorManager<TopFieldCollector, TopFieldDocs> manager = new CollectorManager<TopFieldCollector, TopFieldDocs>() {
-
-      @Override
-      public TopFieldCollector newCollector() throws IOException {
-        // TODO: don't pay the price for accurate hit counts by default
-        return TopFieldCollector.create(rewrittenSort, cappedNumHits, after, TOTAL_HITS_THRESHOLD);
-      }
-
-      @Override
-      public TopFieldDocs reduce(Collection<TopFieldCollector> collectors) throws IOException {
-        final TopFieldDocs[] topDocs = new TopFieldDocs[collectors.size()];
-        int i = 0;
-        for (TopFieldCollector collector : collectors) {
-          topDocs[i++] = collector.topDocs();
-        }
-        return TopDocs.merge(rewrittenSort, 0, cappedNumHits, topDocs, true);
-      }
-
-    };
+    final CollectorManager<TopFieldCollector, TopFieldDocs> manager =
+        TopFieldCollector.createManager(rewrittenSort, cappedNumHits, after, TOTAL_HITS_THRESHOLD, Integer.MAX_VALUE);
 
     TopFieldDocs topDocs = search(query, manager);
     if (doDocScores) {

--- a/lucene/core/src/java/org/apache/lucene/search/SortRescorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/SortRescorer.java
@@ -50,7 +50,7 @@ public class SortRescorer extends Rescorer {
 
     List<LeafReaderContext> leaves = searcher.getIndexReader().leaves();
 
-    TopFieldCollector collector = TopFieldCollector.create(sort, topN, Integer.MAX_VALUE);
+    TopFieldCollector collector = TopFieldCollector.create(sort, topN, IndexSearcher.TerminationStrategy.NONE);
 
     // Now merge sort docIDs from hits, with reader's leaves:
     int hitUpto = 0;

--- a/lucene/core/src/test/org/apache/lucene/document/TestLatLonPointDistanceFeatureQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestLatLonPointDistanceFeatureQuery.java
@@ -99,7 +99,7 @@ public class TestLatLonPointDistanceFeatureQuery extends LuceneTestCase {
     IndexSearcher searcher = newSearcher(reader);
     
     Query q = LatLonPoint.newDistanceFeatureQuery("foo", 3, 10, 10, pivotDistance);
-    TopScoreDocCollector collector = TopScoreDocCollector.create(2, null, 1);
+    TopScoreDocCollector collector = TopScoreDocCollector.create(2, null, IndexSearcher.TerminationStrategy.HIT_COUNT);
     searcher.search(q, collector);
     TopDocs topHits = collector.topDocs();
     assertEquals(2, topHits.scoreDocs.length);
@@ -118,7 +118,7 @@ public class TestLatLonPointDistanceFeatureQuery extends LuceneTestCase {
     distance2 = SloppyMath.haversinMeters(GeoEncodingUtils.decodeLatitude(GeoEncodingUtils.encodeLatitude(8)) , GeoEncodingUtils.decodeLongitude(GeoEncodingUtils.encodeLongitude(8)), 9,9);
 
     q = LatLonPoint.newDistanceFeatureQuery("foo", 3, 9, 9,  pivotDistance);
-    collector = TopScoreDocCollector.create(2, null, 1);
+    collector = TopScoreDocCollector.create(2, null, IndexSearcher.TerminationStrategy.HIT_COUNT);
     searcher.search(q, collector);
     topHits = collector.topDocs();
     assertEquals(2, topHits.scoreDocs.length);
@@ -172,7 +172,7 @@ public class TestLatLonPointDistanceFeatureQuery extends LuceneTestCase {
     IndexSearcher searcher = newSearcher(reader);
 
     Query q = LatLonPoint.newDistanceFeatureQuery("foo", 3, 0, 179, pivotDistance);
-    TopScoreDocCollector collector = TopScoreDocCollector.create(2, null, 1);
+    TopScoreDocCollector collector = TopScoreDocCollector.create(2, null, IndexSearcher.TerminationStrategy.HIT_COUNT);
     searcher.search(q, collector);
     TopDocs topHits = collector.topDocs();
     assertEquals(2, topHits.scoreDocs.length);
@@ -225,7 +225,7 @@ public class TestLatLonPointDistanceFeatureQuery extends LuceneTestCase {
     IndexSearcher searcher = newSearcher(reader);
     
     Query q = LatLonPoint.newDistanceFeatureQuery("foo", 3, 10, 10, 5);
-    TopScoreDocCollector collector = TopScoreDocCollector.create(3, null, 1);
+    TopScoreDocCollector collector = TopScoreDocCollector.create(3, null, IndexSearcher.TerminationStrategy.HIT_COUNT);
     searcher.search(q, collector);
     TopDocs topHits = collector.topDocs();
     assertEquals(2, topHits.scoreDocs.length);
@@ -291,7 +291,7 @@ public class TestLatLonPointDistanceFeatureQuery extends LuceneTestCase {
     IndexSearcher searcher = newSearcher(reader);
 
     Query q = LatLonPoint.newDistanceFeatureQuery("foo", 3, 0, 0, 200);
-    TopScoreDocCollector collector = TopScoreDocCollector.create(2, null, 1);
+    TopScoreDocCollector collector = TopScoreDocCollector.create(2, null, IndexSearcher.TerminationStrategy.HIT_COUNT);
     searcher.search(q, collector);
     TopDocs topHits = collector.topDocs();
     assertEquals(2, topHits.scoreDocs.length);
@@ -307,7 +307,7 @@ public class TestLatLonPointDistanceFeatureQuery extends LuceneTestCase {
         topHits.scoreDocs);
 
     q = LatLonPoint.newDistanceFeatureQuery("foo", 3, -90, 0, 10000.);
-    collector = TopScoreDocCollector.create(2, null, 1);
+    collector = TopScoreDocCollector.create(2, null, IndexSearcher.TerminationStrategy.HIT_COUNT);
     searcher.search(q, collector);
     topHits = collector.topDocs();
     assertEquals(2, topHits.scoreDocs.length);

--- a/lucene/core/src/test/org/apache/lucene/document/TestLongDistanceFeatureQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/document/TestLongDistanceFeatureQuery.java
@@ -87,7 +87,7 @@ public class TestLongDistanceFeatureQuery extends LuceneTestCase {
     IndexSearcher searcher = newSearcher(reader);
     
     Query q = LongPoint.newDistanceFeatureQuery("foo", 3, 10, 5);
-    TopScoreDocCollector collector = TopScoreDocCollector.create(2, null, 1);
+    TopScoreDocCollector collector = TopScoreDocCollector.create(2, null, IndexSearcher.TerminationStrategy.HIT_COUNT);
     searcher.search(q, collector);
     TopDocs topHits = collector.topDocs();
     assertEquals(2, topHits.scoreDocs.length);
@@ -100,7 +100,7 @@ public class TestLongDistanceFeatureQuery extends LuceneTestCase {
         topHits.scoreDocs);
 
     q = LongPoint.newDistanceFeatureQuery("foo", 3, 7, 5);
-    collector = TopScoreDocCollector.create(2, null, 1);
+    collector = TopScoreDocCollector.create(2, null, IndexSearcher.TerminationStrategy.HIT_COUNT);
     searcher.search(q, collector);
     topHits = collector.topDocs();
     assertEquals(2, topHits.scoreDocs.length);
@@ -152,7 +152,7 @@ public class TestLongDistanceFeatureQuery extends LuceneTestCase {
     IndexSearcher searcher = newSearcher(reader);
     
     Query q = LongPoint.newDistanceFeatureQuery("foo", 3, Long.MAX_VALUE - 1, 100);
-    TopScoreDocCollector collector = TopScoreDocCollector.create(2, null, 1);
+    TopScoreDocCollector collector = TopScoreDocCollector.create(2, null, IndexSearcher.TerminationStrategy.HIT_COUNT);
     searcher.search(q, collector);
     TopDocs topHits = collector.topDocs();
     assertEquals(2, topHits.scoreDocs.length);
@@ -165,7 +165,7 @@ public class TestLongDistanceFeatureQuery extends LuceneTestCase {
         topHits.scoreDocs);
 
     q = LongPoint.newDistanceFeatureQuery("foo", 3, Long.MIN_VALUE + 1, 100);
-    collector = TopScoreDocCollector.create(2, null, 1);
+    collector = TopScoreDocCollector.create(2, null, IndexSearcher.TerminationStrategy.HIT_COUNT);
     searcher.search(q, collector);
     topHits = collector.topDocs();
     assertEquals(2, topHits.scoreDocs.length);
@@ -216,7 +216,7 @@ public class TestLongDistanceFeatureQuery extends LuceneTestCase {
     IndexSearcher searcher = newSearcher(reader);
     
     Query q = LongPoint.newDistanceFeatureQuery("foo", 3, 10, 5);
-    TopScoreDocCollector collector = TopScoreDocCollector.create(3, null, 1);
+    TopScoreDocCollector collector = TopScoreDocCollector.create(3, null, IndexSearcher.TerminationStrategy.HIT_COUNT);
     searcher.search(q, collector);
     TopDocs topHits = collector.topDocs();
     assertEquals(2, topHits.scoreDocs.length);
@@ -279,7 +279,7 @@ public class TestLongDistanceFeatureQuery extends LuceneTestCase {
     IndexSearcher searcher = newSearcher(reader);
     
     Query q = LongPoint.newDistanceFeatureQuery("foo", 3, 10, 5);
-    TopScoreDocCollector collector = TopScoreDocCollector.create(2, null, 1);
+    TopScoreDocCollector collector = TopScoreDocCollector.create(2, null, IndexSearcher.TerminationStrategy.HIT_COUNT);
     searcher.search(q, collector);
     TopDocs topHits = collector.topDocs();
     assertEquals(2, topHits.scoreDocs.length);
@@ -292,7 +292,7 @@ public class TestLongDistanceFeatureQuery extends LuceneTestCase {
         topHits.scoreDocs);
 
     q = LongPoint.newDistanceFeatureQuery("foo", 3, 7, 5);
-    collector = TopScoreDocCollector.create(2, null, 1);
+    collector = TopScoreDocCollector.create(2, null, IndexSearcher.TerminationStrategy.HIT_COUNT);
     searcher.search(q, collector);
     topHits = collector.topDocs();
     assertEquals(2, topHits.scoreDocs.length);

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexSorting.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexSorting.java
@@ -2567,11 +2567,11 @@ public class TestIndexSorting extends LuceneTestCase {
         System.out.println("TEST: iter=" + iter + " numHits=" + numHits);
       }
 
-      TopFieldCollector c1 = TopFieldCollector.create(sort, numHits, Integer.MAX_VALUE);
+      TopFieldCollector c1 = TopFieldCollector.create(sort, numHits, IndexSearcher.TerminationStrategy.NONE);
       s1.search(new MatchAllDocsQuery(), c1);
       TopDocs hits1 = c1.topDocs();
 
-      TopFieldCollector c2 = TopFieldCollector.create(sort, numHits, 1);
+      TopFieldCollector c2 = TopFieldCollector.create(sort, numHits, IndexSearcher.TerminationStrategy.HIT_COUNT);
       s2.search(new MatchAllDocsQuery(), c2);
 
       TopDocs hits2 = c2.topDocs();

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMaxDocs.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMaxDocs.java
@@ -68,7 +68,7 @@ public class TestIndexWriterMaxDocs extends LuceneTestCase {
       assertEquals(IndexWriter.MAX_DOCS, ir.maxDoc());
       assertEquals(IndexWriter.MAX_DOCS, ir.numDocs());
       IndexSearcher searcher = new IndexSearcher(ir);
-      TopScoreDocCollector collector = TopScoreDocCollector.create(10, Integer.MAX_VALUE);
+      TopScoreDocCollector collector = TopScoreDocCollector.create(10, IndexSearcher.TerminationStrategy.NONE);
       searcher.search(new TermQuery(new Term("field", "text")), collector);
       TopDocs hits = collector.topDocs();
       assertEquals(IndexWriter.MAX_DOCS, hits.totalHits.value);

--- a/lucene/core/src/test/org/apache/lucene/search/TestBoolean2.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBoolean2.java
@@ -34,6 +34,7 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.IndexSearcher.TerminationStrategy;
 import org.apache.lucene.search.similarities.ClassicSimilarity;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
@@ -237,10 +238,10 @@ public class TestBoolean2 extends LuceneTestCase {
     // The asserting searcher will sometimes return the bulk scorer and
     // sometimes return a default impl around the scorer so that we can
     // compare BS1 and BS2
-    TopScoreDocCollector collector = TopScoreDocCollector.create(topDocsToCheck, Integer.MAX_VALUE);
+    TopScoreDocCollector collector = TopScoreDocCollector.create(topDocsToCheck, TerminationStrategy.NONE);
     searcher.search(query, collector);
     ScoreDoc[] hits1 = collector.topDocs().scoreDocs;
-    collector = TopScoreDocCollector.create(topDocsToCheck, Integer.MAX_VALUE);
+    collector = TopScoreDocCollector.create(topDocsToCheck, TerminationStrategy.NONE);
     searcher.search(query, collector);
     ScoreDoc[] hits2 = collector.topDocs().scoreDocs; 
 
@@ -248,7 +249,7 @@ public class TestBoolean2 extends LuceneTestCase {
 
     // Since we have no deleted docs, we should also be able to verify identical matches &
     // scores against an single segment copy of our index
-    collector = TopScoreDocCollector.create(topDocsToCheck, Integer.MAX_VALUE);
+    collector = TopScoreDocCollector.create(topDocsToCheck, TerminationStrategy.NONE);
     singleSegmentSearcher.search(query, collector);
     hits2 = collector.topDocs().scoreDocs; 
     CheckHits.checkHitsQuery(query, hits1, hits2, expDocNrs);
@@ -258,10 +259,10 @@ public class TestBoolean2 extends LuceneTestCase {
                  bigSearcher.count(query));
 
     // now check 2 diff scorers from the bigSearcher as well
-    collector = TopScoreDocCollector.create(topDocsToCheck, Integer.MAX_VALUE);
+    collector = TopScoreDocCollector.create(topDocsToCheck, TerminationStrategy.NONE);
     bigSearcher.search(query, collector);
     hits1 = collector.topDocs().scoreDocs;
-    collector = TopScoreDocCollector.create(topDocsToCheck, Integer.MAX_VALUE);
+    collector = TopScoreDocCollector.create(topDocsToCheck, TerminationStrategy.NONE);
     bigSearcher.search(query, collector);
     hits2 = collector.topDocs().scoreDocs; 
 
@@ -386,10 +387,10 @@ public class TestBoolean2 extends LuceneTestCase {
         }
 
         // check diff (randomized) scorers (from AssertingSearcher) produce the same results
-        TopFieldCollector collector = TopFieldCollector.create(sort, 1000, 1);
+        TopFieldCollector collector = TopFieldCollector.create(sort, 1000, IndexSearcher.TerminationStrategy.HIT_COUNT);
         searcher.search(q1, collector);
         ScoreDoc[] hits1 = collector.topDocs().scoreDocs;
-        collector = TopFieldCollector.create(sort, 1000, 1);
+        collector = TopFieldCollector.create(sort, 1000, IndexSearcher.TerminationStrategy.HIT_COUNT);
         searcher.search(q1, collector);
         ScoreDoc[] hits2 = collector.topDocs().scoreDocs;
         tot+=hits2.length;
@@ -401,10 +402,10 @@ public class TestBoolean2 extends LuceneTestCase {
         assertEquals(mulFactor*collector.totalHits + NUM_EXTRA_DOCS/2, bigSearcher.count(q3.build()));
 
         // test diff (randomized) scorers produce the same results on bigSearcher as well
-        collector = TopFieldCollector.create(sort, 1000 * mulFactor, 1);
+        collector = TopFieldCollector.create(sort, 1000 * mulFactor, IndexSearcher.TerminationStrategy.HIT_COUNT);
         bigSearcher.search(q1, collector);
         hits1 = collector.topDocs().scoreDocs;
-        collector = TopFieldCollector.create(sort, 1000 * mulFactor, 1);
+        collector = TopFieldCollector.create(sort, 1000 * mulFactor, IndexSearcher.TerminationStrategy.HIT_COUNT);
         bigSearcher.search(q1, collector);
         hits2 = collector.topDocs().scoreDocs;
         CheckHits.checkEqual(q1, hits1, hits2);

--- a/lucene/core/src/test/org/apache/lucene/search/TestBooleanMinShouldMatch.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBooleanMinShouldMatch.java
@@ -91,7 +91,7 @@ public class TestBooleanMinShouldMatch extends LuceneTestCase {
         assertEquals("result count", expected, h.length);
         //System.out.println("TEST: now check");
         // bs2
-        TopScoreDocCollector collector = TopScoreDocCollector.create(1000, Integer.MAX_VALUE);
+        TopScoreDocCollector collector = TopScoreDocCollector.create(1000, IndexSearcher.TerminationStrategy.NONE);
         s.search(q, collector);
         ScoreDoc[] h2 = collector.topDocs().scoreDocs;
         if (expected != h2.length) {

--- a/lucene/core/src/test/org/apache/lucene/search/TestBooleanQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBooleanQuery.java
@@ -43,6 +43,7 @@ import org.apache.lucene.index.MultiReader;
 import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause.Occur;
+import org.apache.lucene.search.IndexSearcher.TerminationStrategy;
 import org.apache.lucene.search.similarities.ClassicSimilarity;
 import org.apache.lucene.search.spans.SpanQuery;
 import org.apache.lucene.search.spans.SpanTermQuery;
@@ -391,7 +392,7 @@ public class TestBooleanQuery extends LuceneTestCase {
     SpanQuery sq2 = new SpanTermQuery(new Term(FIELD, "clckwork"));
     query.add(sq1, BooleanClause.Occur.SHOULD);
     query.add(sq2, BooleanClause.Occur.SHOULD);
-    TopScoreDocCollector collector = TopScoreDocCollector.create(1000, Integer.MAX_VALUE);
+    TopScoreDocCollector collector = TopScoreDocCollector.create(1000, TerminationStrategy.NONE);
     searcher.search(query.build(), collector);
     hits = collector.topDocs().scoreDocs.length;
     for (ScoreDoc scoreDoc : collector.topDocs().scoreDocs){

--- a/lucene/core/src/test/org/apache/lucene/search/TestBooleanQueryVisitSubscorers.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBooleanQueryVisitSubscorers.java
@@ -37,6 +37,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause.Occur;
+import org.apache.lucene.search.IndexSearcher.TerminationStrategy;
 import org.apache.lucene.search.similarities.ClassicSimilarity;
 import org.apache.lucene.search.similarities.Similarity;
 import org.apache.lucene.store.Directory;
@@ -140,7 +141,7 @@ public class TestBooleanQueryVisitSubscorers extends LuceneTestCase {
     private final Set<Scorer> tqsSet = new HashSet<>();
     
     MyCollector() {
-      super(TopScoreDocCollector.create(10, Integer.MAX_VALUE));
+      super(TopScoreDocCollector.create(10, TerminationStrategy.NONE));
     }
 
     public LeafCollector getLeafCollector(LeafReaderContext context)

--- a/lucene/core/src/test/org/apache/lucene/search/TestConstantScoreScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestConstantScoreScorer.java
@@ -29,6 +29,7 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.IndexSearcher.TerminationStrategy;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.LuceneTestCase;
 
@@ -236,12 +237,12 @@ public class TestConstantScoreScorer extends LuceneTestCase {
 
     IndexSearcher is = newSearcher(ir);
 
-    TopScoreDocCollector c = TopScoreDocCollector.create(10, null, 10);
+    TopScoreDocCollector c = TopScoreDocCollector.create(10, null, TerminationStrategy.RESULT_COUNT);
     is.search(new ConstantScoreQuery(new TermQuery(new Term("key", "foo"))), c);
     assertEquals(11, c.totalHits);
     assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, c.totalHitsRelation);
 
-    c = TopScoreDocCollector.create(10, null, 10);
+    c = TopScoreDocCollector.create(10, null, TerminationStrategy.RESULT_COUNT);
     Query query = new BooleanQuery.Builder()
         .add(new ConstantScoreQuery(new TermQuery(new Term("key", "foo"))), Occur.SHOULD)
         .add(new ConstantScoreQuery(new TermQuery(new Term("key", "bar"))), Occur.FILTER)

--- a/lucene/core/src/test/org/apache/lucene/search/TestDisjunctionMaxQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDisjunctionMaxQuery.java
@@ -501,7 +501,7 @@ public class TestDisjunctionMaxQuery extends LuceneTestCase {
             new SpanTermQuery(new Term(FIELD, "clockwork")),
             new SpanTermQuery(new Term(FIELD, "clckwork"))),
         1.0f);
-    TopScoreDocCollector collector = TopScoreDocCollector.create(1000, Integer.MAX_VALUE);
+    TopScoreDocCollector collector = TopScoreDocCollector.create(1000, IndexSearcher.TerminationStrategy.NONE);
     searcher.search(query, collector);
     hits = collector.topDocs().scoreDocs.length;
     for (ScoreDoc scoreDoc : collector.topDocs().scoreDocs){

--- a/lucene/core/src/test/org/apache/lucene/search/TestElevationComparator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestElevationComparator.java
@@ -86,7 +86,7 @@ public class TestElevationComparator extends LuceneTestCase {
         new SortField(null, SortField.Type.SCORE, reversed)
       );
 
-    TopDocsCollector<Entry> topCollector = TopFieldCollector.create(sort, 50, Integer.MAX_VALUE);
+    TopDocsCollector<Entry> topCollector = TopFieldCollector.create(sort, 50, IndexSearcher.TerminationStrategy.NONE);
     searcher.search(newq.build(), topCollector);
 
     TopDocs topDocs = topCollector.topDocs(0, 10);

--- a/lucene/core/src/test/org/apache/lucene/search/TestMatchAllDocsQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestMatchAllDocsQuery.java
@@ -26,6 +26,7 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.IndexSearcher.TerminationStrategy;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.LuceneTestCase;
 
@@ -115,10 +116,10 @@ public class TestMatchAllDocsQuery extends LuceneTestCase {
     TopScoreDocCollector c = TopScoreDocCollector.create(10, null, totalHitsThreshold);
 
     is.search(new MatchAllDocsQuery(), c);
-    assertEquals(totalHitsThreshold+1, c.totalHits);
+    assertEquals(totalHitsThreshold + 1, c.totalHits);
     assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, c.totalHitsRelation);
 
-    TopScoreDocCollector c1 = TopScoreDocCollector.create(10, null, numDocs);
+    TopScoreDocCollector c1 = TopScoreDocCollector.create(10, null, TerminationStrategy.NONE);
 
     is.search(new MatchAllDocsQuery(), c1);
     assertEquals(numDocs, c1.totalHits);

--- a/lucene/core/src/test/org/apache/lucene/search/TestPhraseQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestPhraseQuery.java
@@ -42,6 +42,7 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig.OpenMode;
 import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.IndexSearcher.TerminationStrategy;
 import org.apache.lucene.search.similarities.BM25Similarity;
 import org.apache.lucene.search.similarities.ClassicSimilarity;
 import org.apache.lucene.store.Directory;
@@ -748,10 +749,10 @@ public class TestPhraseQuery extends LuceneTestCase {
         new PhraseQuery("f", "d", "d")  // repeated term
         )) {
       for (int topN = 1; topN <= 2; ++topN) {
-        TopScoreDocCollector collector1 = TopScoreDocCollector.create(topN, null, Integer.MAX_VALUE);
+        TopScoreDocCollector collector1 = TopScoreDocCollector.create(topN, null, TerminationStrategy.NONE);
         searcher.search(query, collector1);
         ScoreDoc[] hits1 = collector1.topDocs().scoreDocs;
-        TopScoreDocCollector collector2 = TopScoreDocCollector.create(topN, null, 1);
+        TopScoreDocCollector collector2 = TopScoreDocCollector.create(topN, null, TerminationStrategy.HIT_COUNT);
         searcher.search(query, collector2);
         ScoreDoc[] hits2 = collector2.topDocs().scoreDocs;
         assertTrue("" + query, hits1.length > 0);

--- a/lucene/core/src/test/org/apache/lucene/search/TestPositiveScoresOnlyCollector.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestPositiveScoresOnlyCollector.java
@@ -99,7 +99,7 @@ public class TestPositiveScoresOnlyCollector extends LuceneTestCase {
     IndexSearcher searcher = newSearcher(ir);
     Weight fake = new TermQuery(new Term("fake", "weight")).createWeight(searcher, ScoreMode.COMPLETE, 1f);
     Scorer s = new SimpleScorer(fake);
-    TopDocsCollector<ScoreDoc> tdc = TopScoreDocCollector.create(scores.length, Integer.MAX_VALUE);
+    TopDocsCollector<ScoreDoc> tdc = TopScoreDocCollector.create(scores.length, IndexSearcher.TerminationStrategy.NONE);
     Collector c = new PositiveScoresOnlyCollector(tdc);
     LeafCollector ac = c.getLeafCollector(ir.leaves().get(0));
     ac.setScorer(s);

--- a/lucene/core/src/test/org/apache/lucene/search/TestReqOptSumScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestReqOptSumScorer.java
@@ -35,6 +35,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause.Occur;
+import org.apache.lucene.search.IndexSearcher.TerminationStrategy;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.LuceneTestCase;
 
@@ -258,7 +259,7 @@ public class TestReqOptSumScorer extends LuceneTestCase {
         .add(shouldTerm, Occur.SHOULD)
         .build();
 
-    TopScoreDocCollector coll = TopScoreDocCollector.create(10, null, Integer.MAX_VALUE);
+    TopScoreDocCollector coll = TopScoreDocCollector.create(10, null, TerminationStrategy.NONE);
     searcher.search(query, coll);
     ScoreDoc[] expected = coll.topDocs().scoreDocs;
 
@@ -269,7 +270,7 @@ public class TestReqOptSumScorer extends LuceneTestCase {
         .add(new TermQuery(new Term("f", "C")), Occur.FILTER)
         .build();
 
-    coll = TopScoreDocCollector.create(10, null, Integer.MAX_VALUE);
+    coll = TopScoreDocCollector.create(10, null, TerminationStrategy.NONE);
     searcher.search(query, coll);
     ScoreDoc[] expectedFiltered = coll.topDocs().scoreDocs;
 
@@ -281,7 +282,7 @@ public class TestReqOptSumScorer extends LuceneTestCase {
           .add(shouldTerm, Occur.SHOULD)
           .build();
 
-      coll = TopScoreDocCollector.create(10, null, 1);
+      coll = TopScoreDocCollector.create(10, null, TerminationStrategy.HIT_COUNT);
       searcher.search(q, coll);
       ScoreDoc[] actual = coll.topDocs().scoreDocs;
       CheckHits.checkEqual(query, expected, actual);
@@ -290,7 +291,7 @@ public class TestReqOptSumScorer extends LuceneTestCase {
           .add(mustTerm, Occur.MUST)
           .add(new RandomApproximationQuery(shouldTerm, random()), Occur.SHOULD)
           .build();
-      coll = TopScoreDocCollector.create(10, null, 1);
+      coll = TopScoreDocCollector.create(10, null, TerminationStrategy.HIT_COUNT);
       searcher.search(q, coll);
       actual = coll.topDocs().scoreDocs;
       CheckHits.checkEqual(q, expected, actual);
@@ -299,7 +300,7 @@ public class TestReqOptSumScorer extends LuceneTestCase {
           .add(new RandomApproximationQuery(mustTerm, random()), Occur.MUST)
           .add(new RandomApproximationQuery(shouldTerm, random()), Occur.SHOULD)
           .build();
-      coll = TopScoreDocCollector.create(10, null, 1);
+      coll = TopScoreDocCollector.create(10, null, TerminationStrategy.HIT_COUNT);
       searcher.search(q, coll);
       actual = coll.topDocs().scoreDocs;
       CheckHits.checkEqual(q, expected, actual);
@@ -317,7 +318,7 @@ public class TestReqOptSumScorer extends LuceneTestCase {
           .add(new RandomApproximationQuery(new TermQuery(new Term("f", "C")), random()), Occur.FILTER)
           .build();
 
-      coll = TopScoreDocCollector.create(10, null, 1);
+      coll = TopScoreDocCollector.create(10, null, TerminationStrategy.HIT_COUNT);
       searcher.search(nestedQ, coll);
       ScoreDoc[] actualFiltered = coll.topDocs().scoreDocs;
       CheckHits.checkEqual(nestedQ, expectedFiltered, actualFiltered);

--- a/lucene/core/src/test/org/apache/lucene/search/TestSearchAfter.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSearchAfter.java
@@ -34,6 +34,7 @@ import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.IndexSearcher.TerminationStrategy;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.English;
@@ -219,13 +220,13 @@ public class TestSearchAfter extends LuceneTestCase {
     final boolean doScores;
     final TopDocsCollector allCollector;
     if (sort == null) {
-      allCollector = TopScoreDocCollector.create(maxDoc, null, Integer.MAX_VALUE);
+      allCollector = TopScoreDocCollector.create(maxDoc, null, TerminationStrategy.NONE);
       doScores = false;
     } else if (sort == Sort.RELEVANCE) {
-      allCollector = TopFieldCollector.create(sort, maxDoc, Integer.MAX_VALUE);
+      allCollector = TopFieldCollector.create(sort, maxDoc, TerminationStrategy.NONE);
       doScores = true;
     } else {
-      allCollector = TopFieldCollector.create(sort, maxDoc, Integer.MAX_VALUE);
+      allCollector = TopFieldCollector.create(sort, maxDoc, TerminationStrategy.NONE);
       doScores = random().nextBoolean();
     }
     searcher.search(query, allCollector);
@@ -250,15 +251,15 @@ public class TestSearchAfter extends LuceneTestCase {
         if (VERBOSE) {
           System.out.println("  iter lastBottom=" + lastBottom);
         }
-        pagedCollector = TopScoreDocCollector.create(pageSize, lastBottom, Integer.MAX_VALUE);
+        pagedCollector = TopScoreDocCollector.create(pageSize, lastBottom, TerminationStrategy.NONE);
       } else {
         if (VERBOSE) {
           System.out.println("  iter lastBottom=" + lastBottom);
         }
         if (sort == Sort.RELEVANCE) {
-          pagedCollector = TopFieldCollector.create(sort, pageSize, (FieldDoc) lastBottom, Integer.MAX_VALUE);
+          pagedCollector = TopFieldCollector.create(sort, pageSize, (FieldDoc) lastBottom, TerminationStrategy.NONE);
         } else {
-          pagedCollector = TopFieldCollector.create(sort, pageSize, (FieldDoc) lastBottom, Integer.MAX_VALUE);
+          pagedCollector = TopFieldCollector.create(sort, pageSize, (FieldDoc) lastBottom, TerminationStrategy.NONE);
         }
       }
       searcher.search(query, pagedCollector);

--- a/lucene/core/src/test/org/apache/lucene/search/TestSubScorerFreqs.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSubScorerFreqs.java
@@ -33,6 +33,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause.Occur;
+import org.apache.lucene.search.IndexSearcher.TerminationStrategy;
 import org.apache.lucene.search.similarities.Similarity;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
@@ -135,7 +136,7 @@ public class TestSubScorerFreqs extends LuceneTestCase {
   @Test
   public void testTermQuery() throws Exception {
     TermQuery q = new TermQuery(new Term("f", "d"));
-    CountingCollector c = new CountingCollector(TopScoreDocCollector.create(10, Integer.MAX_VALUE));
+    CountingCollector c = new CountingCollector(TopScoreDocCollector.create(10, TerminationStrategy.NONE));
     s.search(q, c);
     final int maxDocs = s.getIndexReader().maxDoc();
     assertEquals(maxDocs, c.docCounts.size());
@@ -175,7 +176,7 @@ public class TestSubScorerFreqs extends LuceneTestCase {
     
     for (final Set<String> occur : occurList) {
       CountingCollector c = new CountingCollector(TopScoreDocCollector.create(
-          10, Integer.MAX_VALUE), occur);
+          10, TerminationStrategy.NONE), occur);
       s.search(query.build(), c);
       final int maxDocs = s.getIndexReader().maxDoc();
       assertEquals(maxDocs, c.docCounts.size());
@@ -205,7 +206,7 @@ public class TestSubScorerFreqs extends LuceneTestCase {
   @Test
   public void testPhraseQuery() throws Exception {
     PhraseQuery q = new PhraseQuery("f", "b", "c");
-    CountingCollector c = new CountingCollector(TopScoreDocCollector.create(10, Integer.MAX_VALUE));
+    CountingCollector c = new CountingCollector(TopScoreDocCollector.create(10, TerminationStrategy.NONE));
     s.search(q, c);
     final int maxDocs = s.getIndexReader().maxDoc();
     assertEquals(maxDocs, c.docCounts.size());

--- a/lucene/core/src/test/org/apache/lucene/search/TestSynonymQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestSynonymQuery.java
@@ -36,6 +36,7 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause.Occur;
+import org.apache.lucene.search.IndexSearcher.TerminationStrategy;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.LuceneTestCase;
@@ -414,8 +415,8 @@ public class TestSynonymQuery extends LuceneTestCase {
           .addTerm(new Term("foo", Integer.toString(term2)), boost2)
           .build();
 
-      TopScoreDocCollector collector1 = TopScoreDocCollector.create(10, null, Integer.MAX_VALUE); // COMPLETE
-      TopScoreDocCollector collector2 = TopScoreDocCollector.create(10, null, 1); // TOP_SCORES
+      TopScoreDocCollector collector1 = TopScoreDocCollector.create(10, null, TerminationStrategy.NONE); // COMPLETE
+      TopScoreDocCollector collector2 = TopScoreDocCollector.create(10, null, TerminationStrategy.HIT_COUNT); // TOP_SCORES
 
       searcher.search(query, collector1);
       searcher.search(query, collector2);
@@ -427,8 +428,8 @@ public class TestSynonymQuery extends LuceneTestCase {
           .add(new TermQuery(new Term("foo", Integer.toString(filterTerm))), Occur.FILTER)
           .build();
 
-      collector1 = TopScoreDocCollector.create(10, null, Integer.MAX_VALUE); // COMPLETE
-      collector2 = TopScoreDocCollector.create(10, null, 1); // TOP_SCORES
+      collector1 = TopScoreDocCollector.create(10, null, TerminationStrategy.NONE); // COMPLETE
+      collector2 = TopScoreDocCollector.create(10, null, TerminationStrategy.HIT_COUNT); // TOP_SCORES
       searcher.search(filteredQuery, collector1);
       searcher.search(filteredQuery, collector2);
       CheckHits.checkEqual(query, collector1.topDocs().scoreDocs, collector2.topDocs().scoreDocs);

--- a/lucene/core/src/test/org/apache/lucene/search/TestTermScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTermScorer.java
@@ -36,6 +36,7 @@ import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause.Occur;
+import org.apache.lucene.search.IndexSearcher.TerminationStrategy;
 import org.apache.lucene.search.similarities.ClassicSimilarity;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.LuceneTestCase;
@@ -233,8 +234,8 @@ public class TestTermScorer extends LuceneTestCase {
     for (int iter = 0; iter < 15; ++iter) {
       Query query = new TermQuery(new Term("foo", Integer.toString(iter)));
 
-      TopScoreDocCollector collector1 = TopScoreDocCollector.create(10, null, Integer.MAX_VALUE); // COMPLETE
-      TopScoreDocCollector collector2 = TopScoreDocCollector.create(10, null, 1); // TOP_SCORES
+      TopScoreDocCollector collector1 = TopScoreDocCollector.create(10, null, TerminationStrategy.NONE); // COMPLETE
+      TopScoreDocCollector collector2 = TopScoreDocCollector.create(10, null, TerminationStrategy.HIT_COUNT); // TOP_SCORES
       
       searcher.search(query, collector1);
       searcher.search(query, collector2);
@@ -246,8 +247,8 @@ public class TestTermScorer extends LuceneTestCase {
           .add(new TermQuery(new Term("foo", Integer.toString(filterTerm))), Occur.FILTER)
           .build();
 
-      collector1 = TopScoreDocCollector.create(10, null, Integer.MAX_VALUE); // COMPLETE
-      collector2 = TopScoreDocCollector.create(10, null, 1); // TOP_SCORES
+      collector1 = TopScoreDocCollector.create(10, null, TerminationStrategy.NONE); // COMPLETE
+      collector2 = TopScoreDocCollector.create(10, null, TerminationStrategy.HIT_COUNT); // TOP_SCORES
       searcher.search(filteredQuery, collector1);
       searcher.search(filteredQuery, collector2);
       CheckHits.checkEqual(query, collector1.topDocs().scoreDocs, collector2.topDocs().scoreDocs);

--- a/lucene/core/src/test/org/apache/lucene/search/TestTopDocsCollector.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTopDocsCollector.java
@@ -27,6 +27,7 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.RandomIndexWriter;
+import org.apache.lucene.search.IndexSearcher.TerminationStrategy;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.LuceneTestCase;
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestTopDocsMerge.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTopDocsMerge.java
@@ -36,6 +36,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.index.ReaderUtil;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.IndexSearcher.TerminationStrategy;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
@@ -57,7 +58,7 @@ public class TestTopDocsMerge extends LuceneTestCase {
     }
 
     public TopDocs search(Weight weight, int topN) throws IOException {
-      TopScoreDocCollector collector = TopScoreDocCollector.create(topN, Integer.MAX_VALUE);
+      TopScoreDocCollector collector = TopScoreDocCollector.create(topN, TerminationStrategy.NONE);
       search(ctx, weight, collector);
       return collector.topDocs();    }
 
@@ -262,7 +263,7 @@ public class TestTopDocsMerge extends LuceneTestCase {
       final TopDocs topHits;
       if (sort == null) {
         if (useFrom) {
-          TopScoreDocCollector c = TopScoreDocCollector.create(numHits, Integer.MAX_VALUE);
+          TopScoreDocCollector c = TopScoreDocCollector.create(numHits, TerminationStrategy.NONE);
           searcher.search(query, c);
           from = TestUtil.nextInt(random(), 0, numHits - 1);
           size = numHits - from;
@@ -281,7 +282,7 @@ public class TestTopDocsMerge extends LuceneTestCase {
           topHits = searcher.search(query, numHits);
         }
       } else {
-        final TopFieldCollector c = TopFieldCollector.create(sort, numHits, Integer.MAX_VALUE);
+        final TopFieldCollector c = TopFieldCollector.create(sort, numHits, TerminationStrategy.NONE);
         searcher.search(query, c);
         if (useFrom) {
           from = TestUtil.nextInt(random(), 0, numHits - 1);
@@ -330,7 +331,7 @@ public class TestTopDocsMerge extends LuceneTestCase {
         if (sort == null) {
           subHits = subSearcher.search(w, numHits);
         } else {
-          final TopFieldCollector c = TopFieldCollector.create(sort, numHits, Integer.MAX_VALUE);
+          final TopFieldCollector c = TopFieldCollector.create(sort, numHits, TerminationStrategy.NONE);
           subSearcher.search(w, c);
           subHits = c.topDocs(0, numHits);
         }

--- a/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollector.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollector.java
@@ -35,6 +35,7 @@ import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.FieldValueHitQueue.Entry;
+import org.apache.lucene.search.IndexSearcher.TerminationStrategy;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.TestUtil;
@@ -78,7 +79,7 @@ public class TestTopFieldCollector extends LuceneTestCase {
     Sort[] sort = new Sort[] { new Sort(SortField.FIELD_DOC), new Sort() };
     for(int i = 0; i < sort.length; i++) {
       Query q = new MatchAllDocsQuery();
-      TopDocsCollector<Entry> tdc = TopFieldCollector.create(sort[i], 10, Integer.MAX_VALUE);
+      TopDocsCollector<Entry> tdc = TopFieldCollector.create(sort[i], 10, TerminationStrategy.NONE);
       
       is.search(q, tdc);
       
@@ -96,7 +97,7 @@ public class TestTopFieldCollector extends LuceneTestCase {
     Sort[] sort = new Sort[] {new Sort(SortField.FIELD_DOC), new Sort() };
     for(int i = 0; i < sort.length; i++) {
       Query q = new MatchAllDocsQuery();
-      TopDocsCollector<Entry> tdc = TopFieldCollector.create(sort[i], 10, Integer.MAX_VALUE);
+      TopDocsCollector<Entry> tdc = TopFieldCollector.create(sort[i], 10, TerminationStrategy.NONE);
       
       is.search(q, tdc);
       
@@ -116,10 +117,10 @@ public class TestTopFieldCollector extends LuceneTestCase {
       // the index is not sorted
       TopDocsCollector<Entry> tdc;
       if (i % 2 == 0) {
-        tdc =  TopFieldCollector.create(sort, 10, 1);
+        tdc =  TopFieldCollector.create(sort, 10, TerminationStrategy.HIT_COUNT);
       } else {
         FieldDoc fieldDoc = new FieldDoc(1, Float.NaN, new Object[] { 1 });
-        tdc = TopFieldCollector.create(sort, 10, fieldDoc, 1);
+        tdc = TopFieldCollector.create(sort, 10, fieldDoc, TerminationStrategy.HIT_COUNT);
       }
 
       is.search(q, tdc);
@@ -150,7 +151,7 @@ public class TestTopFieldCollector extends LuceneTestCase {
 
     for (int totalHitsThreshold = 0; totalHitsThreshold < 20; ++ totalHitsThreshold) {
       for (FieldDoc after : new FieldDoc[] { null, new FieldDoc(4, Float.NaN, new Object[] { 2L })}) {
-        TopFieldCollector collector = TopFieldCollector.create(sort, 2, after, totalHitsThreshold);
+          TopFieldCollector collector = TopFieldCollector.create(sort, 2, after, totalHitsThreshold, Integer.MAX_VALUE);
         ScoreAndDoc scorer = new ScoreAndDoc();
 
         LeafCollector leafCollector1 = collector.getLeafCollector(reader.leaves().get(0));
@@ -232,7 +233,7 @@ public class TestTopFieldCollector extends LuceneTestCase {
     w.close();
 
     Sort sort = new Sort(FIELD_SCORE, new SortField("foo", SortField.Type.LONG));
-    TopFieldCollector collector = TopFieldCollector.create(sort, 2, null, 1);
+    TopFieldCollector collector = TopFieldCollector.create(sort, 2, null, 1, Integer.MAX_VALUE);
     ScoreAndDoc scorer = new ScoreAndDoc();
 
     LeafCollector leafCollector = collector.getLeafCollector(reader.leaves().get(0));
@@ -295,7 +296,7 @@ public class TestTopFieldCollector extends LuceneTestCase {
 
     for (int totalHitsThreshold = 0; totalHitsThreshold < 20; ++ totalHitsThreshold) {
       Sort sort = new Sort(FIELD_SCORE, new SortField("foo", SortField.Type.LONG));
-      TopFieldCollector collector = TopFieldCollector.create(sort, 2, null, totalHitsThreshold);
+      TopFieldCollector collector = TopFieldCollector.create(sort, 2, null, totalHitsThreshold, Integer.MAX_VALUE);
       ScoreAndDoc scorer = new ScoreAndDoc();
 
       LeafCollector leafCollector = collector.getLeafCollector(reader.leaves().get(0));
@@ -334,7 +335,7 @@ public class TestTopFieldCollector extends LuceneTestCase {
     // Two Sort criteria to instantiate the multi/single comparators.
     Sort[] sort = new Sort[] {new Sort(SortField.FIELD_DOC), new Sort() };
     for(int i = 0; i < sort.length; i++) {
-      TopDocsCollector<Entry> tdc = TopFieldCollector.create(sort[i], 10, Integer.MAX_VALUE);
+      TopDocsCollector<Entry> tdc = TopFieldCollector.create(sort[i], 10, TerminationStrategy.NONE);
       TopDocs td = tdc.topDocs();
       assertEquals(0, td.totalHits.value);
     }
@@ -366,7 +367,7 @@ public class TestTopFieldCollector extends LuceneTestCase {
         .build();
     final IndexSearcher searcher = new IndexSearcher(reader);
     for (Sort sort : new Sort[] {new Sort(FIELD_SCORE), new Sort(new SortField("f", SortField.Type.SCORE))}) {
-      final TopFieldCollector topCollector = TopFieldCollector.create(sort, TestUtil.nextInt(random(), 1, 2), Integer.MAX_VALUE);
+      final TopFieldCollector topCollector = TopFieldCollector.create(sort, TestUtil.nextInt(random(), 1, 2), TerminationStrategy.NONE);
       final Collector assertingCollector = new Collector() {
         @Override
         public LeafCollector getLeafCollector(LeafReaderContext context) throws IOException {

--- a/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollectorEarlyTermination.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTopFieldCollectorEarlyTermination.java
@@ -145,7 +145,7 @@ public class TestTopFieldCollectorEarlyTermination extends LuceneTestCase {
           after = null;
         }
         final TopFieldCollector collector1 = TopFieldCollector.create(sort, numHits, after, TerminationStrategy.NONE);
-        final TopFieldCollector collector2 = TopFieldCollector.create(sort, numHits, after, 1, Integer.MAX_VALUE);
+        final TopFieldCollector collector2 = TopFieldCollector.create(sort, numHits, after, TerminationStrategy.RESULT_COUNT);
 
         final Query query;
         if (random().nextBoolean()) {

--- a/lucene/facet/src/java/org/apache/lucene/facet/DrillSideways.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/DrillSideways.java
@@ -241,7 +241,7 @@ public class DrillSideways {
 
                   @Override
                   public TopFieldCollector newCollector() throws IOException {
-                    return TopFieldCollector.create(sort, fTopN, after, Integer.MAX_VALUE);
+                    return TopFieldCollector.create(sort, fTopN, after, IndexSearcher.TerminationStrategy.NONE);
                   }
 
                   @Override
@@ -264,7 +264,7 @@ public class DrillSideways {
       } else {
 
         final TopFieldCollector hitCollector =
-                TopFieldCollector.create(sort, fTopN, after, Integer.MAX_VALUE);
+                TopFieldCollector.create(sort, fTopN, after, IndexSearcher.TerminationStrategy.NONE);
         DrillSidewaysResult r = search(query, hitCollector);
         TopFieldDocs topDocs = hitCollector.topDocs();
         if (doDocScores) {
@@ -303,7 +303,7 @@ public class DrillSideways {
 
                 @Override
                 public TopScoreDocCollector newCollector() throws IOException {
-                  return TopScoreDocCollector.create(fTopN, after, Integer.MAX_VALUE);
+                  return TopScoreDocCollector.create(fTopN, after, IndexSearcher.TerminationStrategy.NONE);
                 }
 
                 @Override
@@ -321,7 +321,7 @@ public class DrillSideways {
 
     } else {
 
-      TopScoreDocCollector hitCollector = TopScoreDocCollector.create(topN, after, Integer.MAX_VALUE);
+      TopScoreDocCollector hitCollector = TopScoreDocCollector.create(topN, after, IndexSearcher.TerminationStrategy.NONE);
       DrillSidewaysResult r = search(query, hitCollector);
       return new DrillSidewaysResult(r.facets, hitCollector.topDocs());
     }

--- a/lucene/facet/src/java/org/apache/lucene/facet/FacetsCollector.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/FacetsCollector.java
@@ -231,9 +231,9 @@ public class FacetsCollector extends SimpleCollector implements Collector {
         }
         hitsCollector = TopFieldCollector.create(sort, n,
                                                  (FieldDoc) after,
-                                                 Integer.MAX_VALUE); // TODO: can we disable exact hit counts
+                                                 IndexSearcher.TerminationStrategy.NONE); // TODO: can we disable exact hit counts?
       } else {
-        hitsCollector = TopScoreDocCollector.create(n, after, Integer.MAX_VALUE);
+        hitsCollector = TopScoreDocCollector.create(n, after, IndexSearcher.TerminationStrategy.NONE);
       }
       searcher.search(q, MultiCollector.wrap(hitsCollector, fc));
     

--- a/lucene/grouping/src/java/org/apache/lucene/search/grouping/BlockGroupingCollector.java
+++ b/lucene/grouping/src/java/org/apache/lucene/search/grouping/BlockGroupingCollector.java
@@ -22,6 +22,7 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.FieldComparator;
+import org.apache.lucene.search.IndexSearcher.TerminationStrategy;
 import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.LeafFieldComparator;
 import org.apache.lucene.search.Scorable;
@@ -303,10 +304,10 @@ public class BlockGroupingCollector extends SimpleCollector {
         if (!needsScores) {
           throw new IllegalArgumentException("cannot sort by relevance within group: needsScores=false");
         }
-        collector = TopScoreDocCollector.create(maxDocsPerGroup, Integer.MAX_VALUE);
+        collector = TopScoreDocCollector.create(maxDocsPerGroup, TerminationStrategy.NONE);
       } else {
         // Sort by fields
-        collector = TopFieldCollector.create(withinGroupSort, maxDocsPerGroup, Integer.MAX_VALUE); // TODO: disable exact counts?
+        collector = TopFieldCollector.create(withinGroupSort, maxDocsPerGroup, TerminationStrategy.NONE); // TODO: disable exact counts?
       }
 
       float groupMaxScore = needsScores ? Float.NEGATIVE_INFINITY : Float.NaN;

--- a/lucene/grouping/src/java/org/apache/lucene/search/grouping/GroupingSearch.java
+++ b/lucene/grouping/src/java/org/apache/lucene/search/grouping/GroupingSearch.java
@@ -25,6 +25,7 @@ import org.apache.lucene.queries.function.ValueSource;
 import org.apache.lucene.search.CachingCollector;
 import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.IndexSearcher.TerminationStrategy;
 import org.apache.lucene.search.MultiCollector;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreMode;

--- a/lucene/grouping/src/java/org/apache/lucene/search/grouping/TopGroupsCollector.java
+++ b/lucene/grouping/src/java/org/apache/lucene/search/grouping/TopGroupsCollector.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 import java.util.function.Supplier;
 
 import org.apache.lucene.search.FilterCollector;
+import org.apache.lucene.search.IndexSearcher.TerminationStrategy;
 import org.apache.lucene.search.MultiCollector;
 import org.apache.lucene.search.Scorable;
 import org.apache.lucene.search.ScoreDoc;
@@ -116,10 +117,10 @@ public class TopGroupsCollector<T> extends SecondPassGroupingCollector<T> {
                    int maxDocsPerGroup, boolean getMaxScores) {
       this.needsScores = getMaxScores || withinGroupSort.needsScores();
       if (withinGroupSort == Sort.RELEVANCE) {
-        supplier = () -> new TopDocsAndMaxScoreCollector(true, TopScoreDocCollector.create(maxDocsPerGroup, Integer.MAX_VALUE), null);
+        supplier = () -> new TopDocsAndMaxScoreCollector(true, TopScoreDocCollector.create(maxDocsPerGroup, TerminationStrategy.NONE), null);
       } else {
         supplier = () -> {
-          TopFieldCollector topDocsCollector = TopFieldCollector.create(withinGroupSort, maxDocsPerGroup, Integer.MAX_VALUE); // TODO: disable exact counts?
+          TopFieldCollector topDocsCollector = TopFieldCollector.create(withinGroupSort, maxDocsPerGroup, TerminationStrategy.NONE); // TODO: disable exact counts?
           MaxScoreCollector maxScoreCollector = getMaxScores ? new MaxScoreCollector() : null;
           return new TopDocsAndMaxScoreCollector(false, topDocsCollector, maxScoreCollector);
         };

--- a/lucene/join/src/test/org/apache/lucene/search/join/TestJoinUtil.java
+++ b/lucene/join/src/test/org/apache/lucene/search/join/TestJoinUtil.java
@@ -423,7 +423,7 @@ public class TestJoinUtil extends LuceneTestCase {
       }
 
       final BitSet actualResult = new FixedBitSet(indexSearcher.getIndexReader().maxDoc());
-      final TopScoreDocCollector topScoreDocCollector = TopScoreDocCollector.create(10, Integer.MAX_VALUE);
+      final TopScoreDocCollector topScoreDocCollector = TopScoreDocCollector.create(10, IndexSearcher.TerminationStrategy.NONE);
       indexSearcher.search(joinQuery, MultiCollector.wrap(new BitSetCollector(actualResult), topScoreDocCollector));
       assertBitSet(expectedResult, actualResult, indexSearcher);
       TopDocs expectedTopDocs = createExpectedTopDocs(randomValue, from, scoreMode, context);
@@ -1245,7 +1245,7 @@ public class TestJoinUtil extends LuceneTestCase {
 
         // Need to know all documents that have matches. TopDocs doesn't give me that and then I'd be also testing TopDocsCollector...
         final BitSet actualResult = new FixedBitSet(indexSearcher.getIndexReader().maxDoc());
-        final TopScoreDocCollector topScoreDocCollector = TopScoreDocCollector.create(10, Integer.MAX_VALUE);
+        final TopScoreDocCollector topScoreDocCollector = TopScoreDocCollector.create(10, IndexSearcher.TerminationStrategy.NONE);
         indexSearcher.search(joinQuery, MultiCollector.wrap(new BitSetCollector(actualResult), topScoreDocCollector));
         // Asserting bit set...
         assertBitSet(expectedResult, actualResult, indexSearcher);

--- a/lucene/luke/src/java/org/apache/lucene/luke/models/search/SearchImpl.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/models/search/SearchImpl.java
@@ -51,6 +51,7 @@ import org.apache.lucene.queryparser.flexible.standard.config.PointsConfig;
 import org.apache.lucene.queryparser.flexible.standard.config.StandardQueryConfigHandler;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.IndexSearcher.TerminationStrategy;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.Sort;
@@ -295,8 +296,8 @@ public final class SearchImpl extends LukeModel implements Search {
     if (sort != null) {
       topDocs = searcher.searchAfter(after, query, pageSize, sort);
     } else {
-      int hitsThreshold = exactHitsCount ? Integer.MAX_VALUE : DEFAULT_TOTAL_HITS_THRESHOLD;
-      TopScoreDocCollector collector = TopScoreDocCollector.create(pageSize, after, hitsThreshold);
+      TerminationStrategy terminationStrategy = exactHitsCount ? TerminationStrategy.NONE : TerminationStrategy.HIT_COUNT;
+      TopScoreDocCollector collector = TopScoreDocCollector.create(pageSize, after, terminationStrategy);
       searcher.search(query, collector);
       topDocs = collector.topDocs();
     }

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/analyzing/AnalyzingInfixSuggester.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/analyzing/AnalyzingInfixSuggester.java
@@ -647,7 +647,7 @@ public class AnalyzingInfixSuggester extends Lookup implements Closeable {
     //System.out.println("finalQuery=" + finalQuery);
 
     // Sort by weight, descending:
-    TopFieldCollector c = TopFieldCollector.create(SORT, num, 1);
+    TopFieldCollector c = TopFieldCollector.create(SORT, num, IndexSearcher.TerminationStrategy.HIT_COUNT);
     List<LookupResult> results = null;
     SearcherManager mgr;
     IndexSearcher searcher;

--- a/lucene/test-framework/src/java/org/apache/lucene/search/CheckHits.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/search/CheckHits.java
@@ -583,8 +583,8 @@ public class CheckHits {
   }
 
   private static void doCheckTopScores(Query query, IndexSearcher searcher, int numHits) throws IOException {
-    TopScoreDocCollector collector1 = TopScoreDocCollector.create(numHits, null, Integer.MAX_VALUE); // COMPLETE
-    TopScoreDocCollector collector2 = TopScoreDocCollector.create(numHits, null, 1); // TOP_SCORES
+    TopScoreDocCollector collector1 = TopScoreDocCollector.create(numHits, null, IndexSearcher.TerminationStrategy.NONE); // COMPLETE
+    TopScoreDocCollector collector2 = TopScoreDocCollector.create(numHits, null, IndexSearcher.TerminationStrategy.HIT_COUNT); // TOP_SCORES
     searcher.search(query, collector1);
     searcher.search(query, collector2);
     checkEqual(query, collector1.topDocs().scoreDocs, collector2.topDocs().scoreDocs);

--- a/solr/core/src/java/org/apache/solr/handler/component/ExpandComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/ExpandComponent.java
@@ -42,6 +42,7 @@ import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher.TerminationStrategy;
 import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Scorable;
@@ -526,7 +527,7 @@ public class ExpandComponent extends SearchComponent implements PluginInfoInitia
       DocIdSetIterator iterator = new BitSetIterator(groupBits, 0); // cost is not useful here
       int group;
       while ((group = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
-        Collector collector = (sort == null) ? TopScoreDocCollector.create(limit, Integer.MAX_VALUE) : TopFieldCollector.create(sort, limit, Integer.MAX_VALUE);
+        Collector collector = (sort == null) ? TopScoreDocCollector.create(limit, TerminationStrategy.NONE) : TopFieldCollector.create(sort, limit, TerminationStrategy.NONE);
         groups.put(group, collector);
       }
 
@@ -610,7 +611,7 @@ public class ExpandComponent extends SearchComponent implements PluginInfoInitia
       Iterator<LongCursor> iterator = groupSet.iterator();
       while (iterator.hasNext()) {
         LongCursor cursor = iterator.next();
-        Collector collector = (sort == null) ? TopScoreDocCollector.create(limit, Integer.MAX_VALUE) : TopFieldCollector.create(sort, limit, Integer.MAX_VALUE);
+        Collector collector = (sort == null) ? TopScoreDocCollector.create(limit, TerminationStrategy.NONE) : TopFieldCollector.create(sort, limit, TerminationStrategy.NONE);
         groups.put(cursor.value, collector);
       }
 

--- a/solr/core/src/java/org/apache/solr/search/Grouping.java
+++ b/solr/core/src/java/org/apache/solr/search/Grouping.java
@@ -36,6 +36,7 @@ import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.CachingCollector;
 import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.IndexSearcher.TerminationStrategy;
 import org.apache.lucene.search.MultiCollector;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
@@ -861,9 +862,9 @@ public class Grouping {
       int groupDocsToCollect = getMax(groupOffset, docsPerGroup, maxDoc);
       Collector subCollector;
       if (withinGroupSort == null || withinGroupSort.equals(Sort.RELEVANCE)) {
-        subCollector = topCollector = TopScoreDocCollector.create(groupDocsToCollect, Integer.MAX_VALUE);
+        subCollector = topCollector = TopScoreDocCollector.create(groupDocsToCollect, TerminationStrategy.NONE);
       } else {
-        topCollector = TopFieldCollector.create(searcher.weightSort(withinGroupSort), groupDocsToCollect, Integer.MAX_VALUE);
+        topCollector = TopFieldCollector.create(searcher.weightSort(withinGroupSort), groupDocsToCollect, TerminationStrategy.NONE);
         if (needScores) {
           maxScoreCollector = new MaxScoreCollector();
           subCollector = MultiCollector.wrap(topCollector, maxScoreCollector);

--- a/solr/core/src/java/org/apache/solr/search/ReRankCollector.java
+++ b/solr/core/src/java/org/apache/solr/search/ReRankCollector.java
@@ -26,6 +26,7 @@ import com.carrotsearch.hppc.IntFloatHashMap;
 import com.carrotsearch.hppc.IntIntHashMap;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.IndexSearcher.TerminationStrategy;
 import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Rescorer;
@@ -68,11 +69,11 @@ public class ReRankCollector extends TopDocsCollector {
     Sort sort = cmd.getSort();
     if(sort == null) {
       this.sort = null;
-      this.mainCollector = TopScoreDocCollector.create(Math.max(this.reRankDocs, length), Integer.MAX_VALUE);
+      this.mainCollector = TopScoreDocCollector.create(Math.max(this.reRankDocs, length), TerminationStrategy.NONE);
     } else {
       this.sort = sort = sort.rewrite(searcher);
       //scores are needed for Rescorer (regardless of whether sort needs it)
-      this.mainCollector = TopFieldCollector.create(sort, Math.max(this.reRankDocs, length), Integer.MAX_VALUE);
+      this.mainCollector = TopFieldCollector.create(sort, Math.max(this.reRankDocs, length), TerminationStrategy.NONE);
     }
     this.searcher = searcher;
     this.reRankQueryRescorer = reRankQueryRescorer;

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -1511,14 +1511,14 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
 
     if (null == cmd.getSort()) {
       assert null == cmd.getCursorMark() : "have cursor but no sort";
-      return TopScoreDocCollector.create(len, Integer.MAX_VALUE);
+      return TopScoreDocCollector.create(len, IndexSearcher.TerminationStrategy.NONE);
     } else {
       // we have a sort
       final Sort weightedSort = weightSort(cmd.getSort());
       final CursorMark cursor = cmd.getCursorMark();
 
       final FieldDoc searchAfter = (null != cursor ? cursor.getSearchAfterFieldDoc() : null);
-      return TopFieldCollector.create(weightedSort, len, searchAfter, Integer.MAX_VALUE);
+      return TopFieldCollector.create(weightedSort, len, searchAfter, IndexSearcher.TerminationStrategy.NONE);
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/search/grouping/distributed/command/QueryCommand.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/distributed/command/QueryCommand.java
@@ -17,6 +17,7 @@
 package org.apache.solr.search.grouping.distributed.command;
 
 import org.apache.lucene.search.*;
+import org.apache.lucene.search.IndexSearcher.TerminationStrategy;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.search.DocSet;
 import org.apache.solr.search.MaxScoreCollector;
@@ -129,9 +130,9 @@ public class QueryCommand implements Command<QueryCommandResult> {
   public List<Collector> create() throws IOException {
     Collector subCollector;
     if (sort == null || sort.equals(Sort.RELEVANCE)) {
-      subCollector = topDocsCollector = TopScoreDocCollector.create(docsToCollect, Integer.MAX_VALUE);
+      subCollector = topDocsCollector = TopScoreDocCollector.create(docsToCollect, TerminationStrategy.NONE);
     } else {
-      topDocsCollector = TopFieldCollector.create(sort, docsToCollect, Integer.MAX_VALUE);
+      topDocsCollector = TopFieldCollector.create(sort, docsToCollect, TerminationStrategy.NONE);
       if (needScores) {
         maxScoreCollector = new MaxScoreCollector();
         subCollector = MultiCollector.wrap(topDocsCollector, maxScoreCollector);

--- a/solr/core/src/test/org/apache/solr/legacy/TestMultiValuedNumericRangeQuery.java
+++ b/solr/core/src/test/org/apache/solr/legacy/TestMultiValuedNumericRangeQuery.java
@@ -27,6 +27,7 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.IndexSearcher.TerminationStrategy;
 import org.apache.lucene.search.TermRangeQuery;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TopScoreDocCollector;
@@ -72,8 +73,8 @@ public class TestMultiValuedNumericRangeQuery extends SolrTestCase {
       }
       TermRangeQuery cq=TermRangeQuery.newStringRange("asc", format.format(lower), format.format(upper), true, true);
       LegacyNumericRangeQuery<Integer> tq= LegacyNumericRangeQuery.newIntRange("trie", lower, upper, true, true);
-      TopScoreDocCollector trCollector = TopScoreDocCollector.create(1, Integer.MAX_VALUE);
-      TopScoreDocCollector nrCollector = TopScoreDocCollector.create(1, Integer.MAX_VALUE);
+      TopScoreDocCollector trCollector = TopScoreDocCollector.create(1, TerminationStrategy.NONE);
+      TopScoreDocCollector nrCollector = TopScoreDocCollector.create(1, TerminationStrategy.NONE);
       searcher.search(cq, trCollector);
       searcher.search(tq, nrCollector);
       TopDocs trTopDocs = trCollector.topDocs();

--- a/solr/core/src/test/org/apache/solr/legacy/TestNumericRangeQuery32.java
+++ b/solr/core/src/test/org/apache/solr/legacy/TestNumericRangeQuery32.java
@@ -25,6 +25,7 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.IndexSearcher.TerminationStrategy;
 import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryUtils;
@@ -149,7 +150,7 @@ public class TestNumericRangeQuery32 extends SolrTestCase {
     int lower=(distance*3/2)+startOffset, upper=lower + count*distance + (distance/3);
     LegacyNumericRangeQuery<Integer> q = LegacyNumericRangeQuery.newIntRange(field, precisionStep, lower, upper, true, true);
     for (byte i=0; i<2; i++) {
-      TopFieldCollector collector = TopFieldCollector.create(Sort.INDEXORDER, noDocs, Integer.MAX_VALUE);
+      TopFieldCollector collector = TopFieldCollector.create(Sort.INDEXORDER, noDocs, TerminationStrategy.NONE);
       String type;
       switch (i) {
         case 0:
@@ -244,7 +245,7 @@ public class TestNumericRangeQuery32 extends SolrTestCase {
     int count=3000;
     int lower=(count-1)*distance + (distance/3) +startOffset;
     LegacyNumericRangeQuery<Integer> q= LegacyNumericRangeQuery.newIntRange(field, precisionStep, lower, null, true, true);
-    TopFieldCollector collector = TopFieldCollector.create(Sort.INDEXORDER, noDocs, Integer.MAX_VALUE);
+    TopFieldCollector collector = TopFieldCollector.create(Sort.INDEXORDER, noDocs, TerminationStrategy.NONE);
     searcher.search(q, collector);
     TopDocs topDocs = collector.topDocs();
     ScoreDoc[] sd = topDocs.scoreDocs;
@@ -256,7 +257,7 @@ public class TestNumericRangeQuery32 extends SolrTestCase {
     assertEquals("Last doc", (noDocs-1)*distance+startOffset, doc.getField(field).numericValue().intValue());
 
     q= LegacyNumericRangeQuery.newIntRange(field, precisionStep, lower, null, true, false);
-    collector = TopFieldCollector.create(Sort.INDEXORDER, noDocs, Integer.MAX_VALUE);
+    collector = TopFieldCollector.create(Sort.INDEXORDER, noDocs, TerminationStrategy.NONE);
     searcher.search(q, collector);
     topDocs = collector.topDocs();
     sd = topDocs.scoreDocs;
@@ -366,25 +367,25 @@ public class TestNumericRangeQuery32 extends SolrTestCase {
       }
       // test inclusive range
       Query tq= LegacyNumericRangeQuery.newIntRange(field, precisionStep, lower, upper, true, true);
-      TopScoreDocCollector collector = TopScoreDocCollector.create(1, Integer.MAX_VALUE);
+      TopScoreDocCollector collector = TopScoreDocCollector.create(1, TerminationStrategy.NONE);
       searcher.search(tq, collector);
       TopDocs tTopDocs = collector.topDocs();
       assertEquals("Returned count of range query must be equal to inclusive range length", upper-lower+1, tTopDocs.totalHits.value );
       // test exclusive range
       tq= LegacyNumericRangeQuery.newIntRange(field, precisionStep, lower, upper, false, false);
-      collector = TopScoreDocCollector.create(1, Integer.MAX_VALUE);
+      collector = TopScoreDocCollector.create(1, TerminationStrategy.NONE);
       searcher.search(tq, collector);
       tTopDocs = collector.topDocs();
       assertEquals("Returned count of range query must be equal to exclusive range length", Math.max(upper-lower-1, 0), tTopDocs.totalHits.value );
       // test left exclusive range
       tq= LegacyNumericRangeQuery.newIntRange(field, precisionStep, lower, upper, false, true);
-      collector = TopScoreDocCollector.create(1, Integer.MAX_VALUE);
+      collector = TopScoreDocCollector.create(1, TerminationStrategy.NONE);
       searcher.search(tq, collector);
       tTopDocs = collector.topDocs();
       assertEquals("Returned count of range query must be equal to half exclusive range length", upper-lower, tTopDocs.totalHits.value );
       // test right exclusive range
       tq= LegacyNumericRangeQuery.newIntRange(field, precisionStep, lower, upper, true, false);
-      collector = TopScoreDocCollector.create(1, Integer.MAX_VALUE);
+      collector = TopScoreDocCollector.create(1, TerminationStrategy.NONE);
       searcher.search(tq, collector);
       tTopDocs = collector.topDocs();
       assertEquals("Returned count of range query must be equal to half exclusive range length", upper-lower, tTopDocs.totalHits.value );
@@ -413,7 +414,7 @@ public class TestNumericRangeQuery32 extends SolrTestCase {
     
     Query tq= LegacyNumericRangeQuery.newFloatRange(field, precisionStep,
         NumericUtils.sortableIntToFloat(lower), NumericUtils.sortableIntToFloat(upper), true, true);
-    TopScoreDocCollector collector = TopScoreDocCollector.create(1, Integer.MAX_VALUE);
+    TopScoreDocCollector collector = TopScoreDocCollector.create(1, TerminationStrategy.NONE);
     searcher.search(tq, collector);
     TopDocs tTopDocs = collector.topDocs();
     assertEquals("Returned count of range query must be equal to inclusive range length", upper-lower+1, tTopDocs.totalHits.value );

--- a/solr/core/src/test/org/apache/solr/legacy/TestNumericRangeQuery64.java
+++ b/solr/core/src/test/org/apache/solr/legacy/TestNumericRangeQuery64.java
@@ -25,6 +25,7 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.IndexSearcher.TerminationStrategy;
 import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryUtils;
@@ -158,7 +159,7 @@ public class TestNumericRangeQuery64 extends SolrTestCase {
     long lower=(distance*3/2)+startOffset, upper=lower + count*distance + (distance/3);
     LegacyNumericRangeQuery<Long> q = LegacyNumericRangeQuery.newLongRange(field, precisionStep, lower, upper, true, true);
     for (byte i=0; i<2; i++) {
-      TopFieldCollector collector = TopFieldCollector.create(Sort.INDEXORDER, noDocs, Integer.MAX_VALUE);
+      TopFieldCollector collector = TopFieldCollector.create(Sort.INDEXORDER, noDocs, TerminationStrategy.NONE);
       String type;
       switch (i) {
         case 0:
@@ -387,25 +388,25 @@ public class TestNumericRangeQuery64 extends SolrTestCase {
       }
       // test inclusive range
       Query tq= LegacyNumericRangeQuery.newLongRange(field, precisionStep, lower, upper, true, true);
-      TopScoreDocCollector collector = TopScoreDocCollector.create(1, Integer.MAX_VALUE);
+      TopScoreDocCollector collector = TopScoreDocCollector.create(1, TerminationStrategy.NONE);
       searcher.search(tq, collector);
       TopDocs tTopDocs = collector.topDocs();
       assertEquals("Returned count of range query must be equal to inclusive range length", upper-lower+1, tTopDocs.totalHits.value );
       // test exclusive range
       tq= LegacyNumericRangeQuery.newLongRange(field, precisionStep, lower, upper, false, false);
-      collector = TopScoreDocCollector.create(1, Integer.MAX_VALUE);
+      collector = TopScoreDocCollector.create(1, TerminationStrategy.NONE);
       searcher.search(tq, collector);
       tTopDocs = collector.topDocs();
       assertEquals("Returned count of range query must be equal to exclusive range length", Math.max(upper-lower-1, 0), tTopDocs.totalHits.value );
       // test left exclusive range
       tq= LegacyNumericRangeQuery.newLongRange(field, precisionStep, lower, upper, false, true);
-      collector = TopScoreDocCollector.create(1, Integer.MAX_VALUE);
+      collector = TopScoreDocCollector.create(1, TerminationStrategy.NONE);
       searcher.search(tq, collector);
       tTopDocs = collector.topDocs();
       assertEquals("Returned count of range query must be equal to half exclusive range length", upper-lower, tTopDocs.totalHits.value );
       // test right exclusive range
       tq= LegacyNumericRangeQuery.newLongRange(field, precisionStep, lower, upper, true, false);
-      collector = TopScoreDocCollector.create(1, Integer.MAX_VALUE);
+      collector = TopScoreDocCollector.create(1, TerminationStrategy.NONE);
       searcher.search(tq, collector);
       tTopDocs = collector.topDocs();
       assertEquals("Returned count of range query must be equal to half exclusive range length", upper-lower, tTopDocs.totalHits.value );
@@ -439,7 +440,7 @@ public class TestNumericRangeQuery64 extends SolrTestCase {
     
     Query tq= LegacyNumericRangeQuery.newDoubleRange(field, precisionStep,
         NumericUtils.sortableLongToDouble(lower), NumericUtils.sortableLongToDouble(upper), true, true);
-    TopScoreDocCollector collector = TopScoreDocCollector.create(1, Integer.MAX_VALUE);
+    TopScoreDocCollector collector = TopScoreDocCollector.create(1, TerminationStrategy.NONE);
     searcher.search(tq, collector);
     TopDocs tTopDocs = collector.topDocs();
     assertEquals("Returned count of range query must be equal to inclusive range length", upper-lower+1, tTopDocs.totalHits.value );

--- a/solr/core/src/test/org/apache/solr/search/TestSort.java
+++ b/solr/core/src/test/org/apache/solr/search/TestSort.java
@@ -38,6 +38,7 @@ import org.apache.lucene.search.DocIdSet;
 import org.apache.lucene.search.FilterCollector;
 import org.apache.lucene.search.FilterLeafCollector;
 import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.IndexSearcher.TerminationStrategy;
 import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.Sort;
@@ -283,7 +284,7 @@ public class TestSort extends SolrTestCaseJ4 {
         final String nullRep2 = luceneSort2 || sortMissingFirst2 && !reverse2 || sortMissingLast2 && reverse2 ? "" : "zzz";
 
         boolean scoreInOrder = r.nextBoolean();
-        final TopFieldCollector topCollector = TopFieldCollector.create(sort, top, Integer.MAX_VALUE);
+        final TopFieldCollector topCollector = TopFieldCollector.create(sort, top, TerminationStrategy.NONE);
 
         final List<MyDoc> collectedDocs = new ArrayList<>();
         // delegate and collect docs ourselves


### PR DESCRIPTION
This adds support for prorated early termination in TopFieldsCollector, a new unit test that demonstrates that, and a convenience method for creating a CollectorManager that uses that. It also refactors IndexSearcher to use the new convenience method and cleans up some leftover javadocs about a search parameter that was removed. See LUCENE-8681 