### PR TITLE
LUCENE-8700: IndexWriter.yield()

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterFlushControl.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterFlushControl.java
@@ -187,7 +187,7 @@ final class DocumentsWriterFlushControl implements Accountable {
     }
   }
 
-  private DocumentsWriterPerThread checkout(ThreadState perThread, boolean markPending) {
+  DocumentsWriterPerThread checkout(ThreadState perThread, boolean markPending) {
     if (fullFlush) {
       if (perThread.flushPending) {
         checkoutAndBlock(perThread);


### PR DESCRIPTION
This provides a new `IndexWriter.yield()` method, and adds testing for it to `RandomIndexWriter` which will now use `yield()` to flush concurrently during `commit()`. I also added a flag for disabling this behavior. I'm not sure if it's needed though, since no tests failed I pulled out the flushing logic from `DocumentupdateDocument` into a standalone method `flushPending` - I initially wanted to refactor and share but the code doesn't lend itself to that without adding arguments to these methods, and it wasn't clear the result would be better.