### PR TITLE
SOLR-10751: PULL Replicas don’t replicate empty index

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/IndexFetcher.java
+++ b/solr/core/src/java/org/apache/solr/handler/IndexFetcher.java
@@ -448,7 +448,7 @@ public class IndexFetcher {
       log.info("Slave's version: " + IndexDeletionPolicyWrapper.getCommitTimestamp(commit));
 
       if (latestVersion == 0L) {
-        if (commit.getGeneration() != 0) {
+        if (commit.getGeneration() != 0 && (forceReplication || skipCommitOnMasterVersionZero)) {
           // since we won't get the files for an empty index,
           // we just clear ours and commit
           log.info("New index in Master. Deleting mine...");

--- a/solr/core/src/test/org/apache/solr/cloud/TestPullReplica.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestPullReplica.java
@@ -68,7 +68,7 @@ import org.slf4j.LoggerFactory;
 import com.carrotsearch.randomizedtesting.annotations.Repeat;
 
 @Slow
-@AwaitsFix(bugUrl="https://issues.apache.org/jira/browse/SOLR-12028")
+//@AwaitsFix(bugUrl="https://issues.apache.org/jira/browse/SOLR-12028")
 public class TestPullReplica extends SolrCloudTestCase {
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());

--- a/solr/core/src/test/org/apache/solr/cloud/TestPullReplica.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestPullReplica.java
@@ -481,13 +481,14 @@ public class TestPullReplica extends SolrCloudTestCase {
     docCollection = getCollectionState(collectionName);
     leader = docCollection.getSlice("shard1").getLeader();
     assertTrue(leader != null && leader.isActive(cluster.getSolrClient().getZkStateReader().getClusterState().getLiveNodes()));
-
-    // If jetty is restarted, the replication is not forced, and replica doesn't replicate from leader until new docs are added. Is this the correct behavior? Why should these two cases be different?
-    if (removeReplica) {
-      // Pull replicas will replicate the empty index if a new replica was added and becomes leader
-      waitForNumDocsInAllReplicas(0, docCollection.getReplicas(EnumSet.of(Replica.Type.PULL)));
+    
+    if (TEST_NIGHTLY) {
+      // Sleep to give time to replication
+      Thread.sleep(5000);
     }
-
+    // PULL replicas shouldn't replicate the empty index
+    waitForNumDocsInAllReplicas(1, docCollection.getReplicas(EnumSet.of(Replica.Type.PULL)));
+    
     // add docs agin
     cluster.getSolrClient().add(collectionName, new SolrInputDocument("id", "2", "foo", "zoo"));
     s = docCollection.getSlices().iterator().next();

--- a/solr/test-framework/src/java/org/apache/solr/cloud/AbstractFullDistribZkTestBase.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/AbstractFullDistribZkTestBase.java
@@ -2269,13 +2269,13 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
           continue;
         }
         while (true) {
-          long replicaIndexVersion = getIndexVersion(pullReplica); 
+          long replicaIndexVersion = getIndexVersion(pullReplica);
+          if (replicaIndexVersion == 0L) {
+            log.info("Leader replica's index has version ({}) in sync with replica({}): {} == {}", leader.getName(), pullReplica.getName(), leaderIndexVersion, replicaIndexVersion);
+            break;
+          }
           if (leaderIndexVersion == replicaIndexVersion) {
             log.info("Leader replica's version ({}) in sync with replica({}): {} == {}", leader.getName(), pullReplica.getName(), leaderIndexVersion, replicaIndexVersion);
-            
-            if (replicaIndexVersion == 0L) {
-              break;
-            }
             
             // Make sure the host is serving the correct version
             try (SolrCore core = containers.get(pullReplica.getNodeName()).getCore(pullReplica.getCoreName())) {

--- a/solr/test-framework/src/java/org/apache/solr/cloud/AbstractFullDistribZkTestBase.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/AbstractFullDistribZkTestBase.java
@@ -2273,6 +2273,10 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
           if (leaderIndexVersion == replicaIndexVersion) {
             log.info("Leader replica's version ({}) in sync with replica({}): {} == {}", leader.getName(), pullReplica.getName(), leaderIndexVersion, replicaIndexVersion);
             
+            if (replicaIndexVersion == 0L) {
+              break;
+            }
+            
             // Make sure the host is serving the correct version
             try (SolrCore core = containers.get(pullReplica.getNodeName()).getCore(pullReplica.getCoreName())) {
               RefCounted<SolrIndexSearcher> ref = core.getRegisteredSearcher();


### PR DESCRIPTION
This is still WIP. Should also solve SOLR-11094 (and maybe SOLR-12100). This PR also includes changes to TestTlogReplica, which I’m going to separate to a different commit