### PR TITLE
SOLR-13268: SOLR-12055 log4j2 async test fixes

### DIFF
--- a/solr/core/src/java/org/apache/solr/util/StartupLoggingUtils.java
+++ b/solr/core/src/java/org/apache/solr/util/StartupLoggingUtils.java
@@ -127,24 +127,6 @@ public final class StartupLoggingUtils {
   }
 
   /**
-   * Perhaps odd to put in startup utils, but this is where the logging-init code is so it seems logical to put the
-   * shutdown here too.
-   *
-   * Tests are particularly sensitive to this call or the object release tracker will report "lmax.disruptor" not
-   * terminating when asynch logging (new default as of 8.1) is enabled.
-   *
-   *
-   */
-  @SuppressForbidden(reason = "Legitimate log4j2 access")
-  public static void shutdown() {
-
-//    if (!isLog4jActive()) {
-//      logNotSupported("Not running log4j2, could not call shutdown for async logging.");
-//      return;
-//    }
-//    LogManager.shutdown(true);
-  }
-  /**
    * Return a string representing the current static ROOT logging level
    * @return a string TRACE, DEBUG, WARN, ERROR or INFO representing current log level. Default is INFO
    */

--- a/solr/core/src/test/org/apache/solr/cloud/rule/ImplicitSnitchTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/rule/ImplicitSnitchTest.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.google.common.collect.Sets;
+import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.TestRuleLimitSysouts;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.SolrException;
@@ -40,7 +41,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 
 @TestRuleLimitSysouts.Limit(bytes=32000)
-public class ImplicitSnitchTest extends SolrTestCaseJ4 {
+public class ImplicitSnitchTest extends LuceneTestCase {
 
   private ImplicitSnitch snitch;
   private SnitchContext context;

--- a/solr/core/src/test/org/apache/solr/schema/UUIDFieldTest.java
+++ b/solr/core/src/test/org/apache/solr/schema/UUIDFieldTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.solr.schema;
 
-import org.apache.solr.SolrTestCaseJ4;
+import org.apache.lucene.util.LuceneTestCase;
 import org.apache.solr.common.SolrException;
 
-public class UUIDFieldTest extends SolrTestCaseJ4 {
+public class UUIDFieldTest extends LuceneTestCase {
   public void testToInternal() {
     boolean ok = false;
     UUIDField uuidfield = new UUIDField();

--- a/solr/core/src/test/org/apache/solr/search/SignificantTermsQParserPluginTest.java
+++ b/solr/core/src/test/org/apache/solr/search/SignificantTermsQParserPluginTest.java
@@ -17,10 +17,10 @@
 
 package org.apache.solr.search;
 
-import org.apache.solr.SolrTestCaseJ4;
+import org.apache.lucene.util.LuceneTestCase;
 import org.junit.Test;
 
-public class SignificantTermsQParserPluginTest extends SolrTestCaseJ4 {
+public class SignificantTermsQParserPluginTest extends LuceneTestCase {
 
   /**
    * Test the backwards compatibility for a typo in the SignificantTermsQParserPlugin. It will fail if the backwards

--- a/solr/core/src/test/org/apache/solr/util/TestObjectReleaseTracker.java
+++ b/solr/core/src/test/org/apache/solr/util/TestObjectReleaseTracker.java
@@ -16,6 +16,7 @@
  */
 package org.apache.solr.util;
 
+import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.TestRuleLimitSysouts.Limit;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.util.ObjectReleaseTracker;
@@ -23,7 +24,7 @@ import org.junit.Test;
 
 
 @Limit(bytes=150000) // raise limit as this writes to sys err
-public class TestObjectReleaseTracker extends SolrTestCaseJ4 {
+public class TestObjectReleaseTracker extends LuceneTestCase {
   
   @Test
   public void testObjectReleaseTracker() {

--- a/solr/core/src/test/org/apache/solr/util/TestSystemIdResolver.java
+++ b/solr/core/src/test/org/apache/solr/util/TestSystemIdResolver.java
@@ -23,11 +23,12 @@ import java.util.Arrays;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.lucene.analysis.util.ResourceLoader;
+import org.apache.lucene.util.LuceneTestCase;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.core.SolrResourceLoader;
 import org.xml.sax.InputSource;
 
-public class TestSystemIdResolver extends SolrTestCaseJ4 {
+public class TestSystemIdResolver extends LuceneTestCase {
   
   public void tearDown() throws Exception {
     System.clearProperty("solr.allow.unsafe.resourceloading");

--- a/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
+++ b/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
@@ -348,8 +348,6 @@ public abstract class SolrTestCaseJ4 extends LuceneTestCase {
       sslConfig = null;
       testSolrHome = null;
 
-      StartupLoggingUtils.shutdown();
-
       IpTables.unblockAllPorts();
 
       LogLevel.Configurer.restoreLogLevels(savedClassLogLevels);


### PR DESCRIPTION
- Upgrade log4j2 from 2.11.0 to 2.11.2
- Upgrade lmax from 3.4.0 to 3.4.2
- Add log4j-web dependency based on LOG4J2-1259 and https://logging.apache.org/log4j/2.0/manual/webapp.html