### PR TITLE
[SOLR-13234] Fix tests for Turkish locales

### DIFF
--- a/solr/contrib/prometheus-exporter/src/test/org/apache/solr/prometheus/exporter/SolrExporterIntegrationTest.java
+++ b/solr/contrib/prometheus-exporter/src/test/org/apache/solr/prometheus/exporter/SolrExporterIntegrationTest.java
@@ -33,10 +33,10 @@ public class SolrExporterIntegrationTest extends SolrExporterTestBase {
     startMetricsExporterWithConfiguration("conf/prometheus-solr-exporter-integration-test-config.xml");
   }
 
-  private Map<String, Double> metricsWithName(Map<String, Double> allMetrics, String name) {
+  private Map<String, Double> metricsWithName(Map<String, Double> allMetrics, String desiredMetricName) {
     return allMetrics.entrySet()
         .stream()
-        .filter(entry -> entry.getKey().startsWith(name))
+        .filter(entry -> entry.getKey().startsWith(desiredMetricName))
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
@@ -64,8 +64,12 @@ public class SolrExporterIntegrationTest extends SolrExporterTestBase {
 
   @Test
   public void jvmMetrics() throws Exception {
-    Map<String, Double> jvmMetrics = metricsWithName(getAllMetrics(), "solr_metrics_jvm_threads{item=\"terminated\"");
-    assertEquals(NUM_NODES, jvmMetrics.size());
+    Map<String, Double> jvmMetrics = metricsWithName(
+        getAllMetrics(), "solr_metrics_jvm_threads");
+
+    // Include all thread states + plus overall count + number of daemon threads + number of deadlocked threads
+    assertEquals(NUM_NODES * (Thread.State.values().length + 3),
+        jvmMetrics.size());
   }
 
   @Test


### PR DESCRIPTION
### Description
When`SolrExporterIntegrationTest.jvmMetrics` ran on a JVM with the Turkish locale, (test seed: 62880F3B9F140C89). The JVM metric for terminated thread-count has a dotless-i e.g. `termınated`.
This causes the check for matching metrics to fail.  

We could normalize the text in this case, however I think it's better to ensure we have the correct total number of JVM thread metrics rather than looking at Prometheus labels which maybe localized.