### PR TITLE
SOLR-13330: Improve HDFS tests

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -158,6 +158,8 @@ Other Changes
 
 * SOLR-13307: Ensure HDFS tests clear System properties they set (Kevin Risden)
 
+* SOLR-13330: Improve HDFS tests (Kevin Risden)
+
 ==================  8.0.0 ==================
 
 Consult the LUCENE_CHANGES.txt file for additional, low level, changes in this release.

--- a/solr/core/src/java/org/apache/solr/core/HdfsDirectoryFactory.java
+++ b/solr/core/src/java/org/apache/solr/core/HdfsDirectoryFactory.java
@@ -531,7 +531,7 @@ public class HdfsDirectoryFactory extends CachingDirectoryFactory implements Sol
           boolean accept = false;
           String pathName = path.getName();
           try {
-            accept = fs.isDirectory(path) && !path.equals(currentIndexDirPath) &&
+            accept = fs.getFileStatus(path).isDirectory() && !path.equals(currentIndexDirPath) &&
                 (pathName.equals("index") || pathName.matches(INDEX_W_TIMESTAMP_REGEX));
           } catch (IOException e) {
             log.error("Error checking if path {} is an old index directory, caused by: {}", path, e);

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-minhash.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-minhash.xml
@@ -49,8 +49,8 @@
     <bool name="solr.hdfs.blockcache.enabled">${solr.hdfs.blockcache.enabled:true}</bool> 
     <bool name="solr.hdfs.blockcache.global">${solr.hdfs.blockcache.global:true}</bool>
     <bool name="solr.hdfs.blockcache.write.enabled">${solr.hdfs.blockcache.write.enabled:false}</bool>
-    <int name="solr.hdfs.blockcache.blocksperbank">10</int>
-    <int name="solr.hdfs.blockcache.slab.count">1</int>
+    <int name="solr.hdfs.blockcache.blocksperbank">${solr.hdfs.blockcache.blocksperbank:10}</int>
+    <int name="solr.hdfs.blockcache.slab.count">${solr.hdfs.blockcache.slab.count:1}</int>
   </directoryFactory>
 
   <schemaFactory class="ClassicIndexSchemaFactory"/>

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig.xml
@@ -49,8 +49,8 @@
     <bool name="solr.hdfs.blockcache.enabled">${solr.hdfs.blockcache.enabled:true}</bool> 
     <bool name="solr.hdfs.blockcache.global">${solr.hdfs.blockcache.global:true}</bool>
     <bool name="solr.hdfs.blockcache.write.enabled">${solr.hdfs.blockcache.write.enabled:false}</bool>
-    <int name="solr.hdfs.blockcache.blocksperbank">10</int>
-    <int name="solr.hdfs.blockcache.slab.count">1</int>
+    <int name="solr.hdfs.blockcache.blocksperbank">${solr.hdfs.blockcache.blocksperbank:10}</int>
+    <int name="solr.hdfs.blockcache.slab.count">${solr.hdfs.blockcache.slab.count:1}</int>
   </directoryFactory>
 
   <schemaFactory class="ClassicIndexSchemaFactory"/>

--- a/solr/core/src/test/org/apache/solr/cloud/MoveReplicaHDFSFailoverTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/MoveReplicaHDFSFailoverTest.java
@@ -52,13 +52,10 @@ public class MoveReplicaHDFSFailoverTest extends SolrCloudTestCase {
         .addConfig("conf1", TEST_PATH().resolve("configsets").resolve("cloud-dynamic").resolve("conf"))
         .configure();
 
-    System.setProperty("solr.hdfs.blockcache.enabled", "false");
     dfsCluster = HdfsTestUtil.setupClass(createTempDir().toFile().getAbsolutePath());
 
     ZkConfigManager configManager = new ZkConfigManager(zkClient());
     configManager.uploadConfigDir(configset("cloud-hdfs"), "conf1");
-
-    System.setProperty("solr.hdfs.home", HdfsTestUtil.getDataDir(dfsCluster, "data"));
   }
 
   @AfterClass
@@ -70,8 +67,6 @@ public class MoveReplicaHDFSFailoverTest extends SolrCloudTestCase {
         HdfsTestUtil.teardownClass(dfsCluster);
       } finally {
         dfsCluster = null;
-        System.clearProperty("solr.hdfs.home");
-        System.clearProperty("solr.hdfs.blockcache.enabled");
       }
     }
   }

--- a/solr/core/src/test/org/apache/solr/cloud/MoveReplicaHDFSTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/MoveReplicaHDFSTest.java
@@ -39,8 +39,6 @@ public class MoveReplicaHDFSTest extends MoveReplicaTest {
 
   @BeforeClass
   public static void setupClass() throws Exception {
-    System.setProperty("solr.hdfs.blockcache.blocksperbank", "512");
-    System.setProperty("tests.hdfs.numdatanodes", "1");
     dfsCluster = HdfsTestUtil.setupClass(createTempDir().toFile().getAbsolutePath());
   }
 
@@ -50,8 +48,6 @@ public class MoveReplicaHDFSTest extends MoveReplicaTest {
       HdfsTestUtil.teardownClass(dfsCluster);
     } finally {
       dfsCluster = null;
-      System.clearProperty("solr.hdfs.blockcache.blocksperbank");
-      System.clearProperty("tests.hdfs.numdatanodes");
     }
   }
 

--- a/solr/core/src/test/org/apache/solr/cloud/api/collections/HdfsCollectionsAPIDistributedZkTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/api/collections/HdfsCollectionsAPIDistributedZkTest.java
@@ -38,8 +38,6 @@ public class HdfsCollectionsAPIDistributedZkTest extends CollectionsAPIDistribut
 
   @BeforeClass
   public static void setupClass() throws Exception {
-    System.setProperty("solr.hdfs.blockcache.blocksperbank", "512");
-    System.setProperty("tests.hdfs.numdatanodes", "1");
     dfsCluster = HdfsTestUtil.setupClass(createTempDir().toFile().getAbsolutePath());
   }
 
@@ -49,8 +47,6 @@ public class HdfsCollectionsAPIDistributedZkTest extends CollectionsAPIDistribut
       HdfsTestUtil.teardownClass(dfsCluster);
     } finally {
       dfsCluster = null;
-      System.clearProperty("solr.hdfs.blockcache.blocksperbank");
-      System.clearProperty("tests.hdfs.numdatanodes");
     }
   }
 

--- a/solr/core/src/test/org/apache/solr/cloud/api/collections/TestHdfsCloudBackupRestore.java
+++ b/solr/core/src/test/org/apache/solr/cloud/api/collections/TestHdfsCloudBackupRestore.java
@@ -112,7 +112,6 @@ public class TestHdfsCloudBackupRestore extends AbstractCloudBackupRestoreTestCa
     try {
       URI uri = new URI(hdfsUri);
       Configuration conf = HdfsTestUtil.getClientConfiguration(dfsCluster);
-      conf.setBoolean("fs.hdfs.impl.disable.cache", true);
       fs = FileSystem.get(uri, conf);
 
       if (fs instanceof DistributedFileSystem) {

--- a/solr/core/src/test/org/apache/solr/cloud/autoscaling/HdfsAutoAddReplicasIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/autoscaling/HdfsAutoAddReplicasIntegrationTest.java
@@ -38,9 +38,6 @@ public class HdfsAutoAddReplicasIntegrationTest extends AutoAddReplicasIntegrati
 
   @BeforeClass
   public static void setupClass() throws Exception {
-    System.setProperty("solr.hdfs.blockcache.global", "true");
-    System.setProperty("solr.hdfs.blockcache.blocksperbank", "512");
-    System.setProperty("tests.hdfs.numdatanodes", "1");
     dfsCluster = HdfsTestUtil.setupClass(createTempDir().toFile().getAbsolutePath());
   }
 
@@ -50,9 +47,6 @@ public class HdfsAutoAddReplicasIntegrationTest extends AutoAddReplicasIntegrati
       HdfsTestUtil.teardownClass(dfsCluster);
     } finally {
       dfsCluster = null;
-      System.clearProperty("solr.hdfs.blockcache.global");
-      System.clearProperty("solr.hdfs.blockcache.blocksperbank");
-      System.clearProperty("tests.hdfs.numdatanodes");
     }
   }
 

--- a/solr/core/src/test/org/apache/solr/cloud/hdfs/HDFSCollectionsAPITest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/hdfs/HDFSCollectionsAPITest.java
@@ -43,13 +43,10 @@ public class HDFSCollectionsAPITest extends SolrCloudTestCase {
     configureCluster(2)
         .configure();
 
-    System.setProperty("solr.hdfs.blockcache.enabled", "false");
     dfsCluster = HdfsTestUtil.setupClass(createTempDir().toFile().getAbsolutePath());
 
     ZkConfigManager configManager = new ZkConfigManager(zkClient());
     configManager.uploadConfigDir(configset("cloud-hdfs"), "conf1");
-
-    System.setProperty("solr.hdfs.home", HdfsTestUtil.getDataDir(dfsCluster, "data"));
   }
 
 
@@ -62,8 +59,6 @@ public class HDFSCollectionsAPITest extends SolrCloudTestCase {
         HdfsTestUtil.teardownClass(dfsCluster);
       } finally {
         dfsCluster = null;
-        System.clearProperty("solr.hdfs.blockcache.enabled");
-        System.clearProperty("solr.hdfs.home");
       }
     }
   }

--- a/solr/core/src/test/org/apache/solr/cloud/hdfs/HdfsBasicDistributedZkTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/hdfs/HdfsBasicDistributedZkTest.java
@@ -38,7 +38,6 @@ public class HdfsBasicDistributedZkTest extends BasicDistributedZkTest {
   
   @BeforeClass
   public static void setupClass() throws Exception {
-    System.setProperty("tests.hdfs.numdatanodes", "1");
     dfsCluster = HdfsTestUtil.setupClass(createTempDir().toFile().getAbsolutePath());
   }
 
@@ -53,7 +52,6 @@ public class HdfsBasicDistributedZkTest extends BasicDistributedZkTest {
       HdfsTestUtil.teardownClass(dfsCluster);
     } finally {
       dfsCluster = null;
-      System.clearProperty("tests.hdfs.numdatanodes");
     }
   }
   

--- a/solr/core/src/test/org/apache/solr/cloud/hdfs/HdfsRecoverLeaseTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/hdfs/HdfsRecoverLeaseTest.java
@@ -72,8 +72,7 @@ public class HdfsRecoverLeaseTest extends SolrTestCaseJ4 {
     
     URI uri = dfsCluster.getURI();
     Path path = new Path(uri);
-    Configuration conf = new Configuration();
-    conf.setBoolean("fs.hdfs.impl.disable.cache", true);
+    Configuration conf = HdfsTestUtil.getClientConfiguration(dfsCluster);
     FileSystem fs1 = FileSystem.get(path.toUri(), conf);
     Path testFile = new Path(uri.toString() + "/testfile");
     FSDataOutputStream out = fs1.create(testFile);
@@ -131,8 +130,7 @@ public class HdfsRecoverLeaseTest extends SolrTestCaseJ4 {
     
     final URI uri = dfsCluster.getURI();
     final Path path = new Path(uri);
-    final Configuration conf = new Configuration();
-    conf.setBoolean("fs.hdfs.impl.disable.cache", true);
+    final Configuration conf = HdfsTestUtil.getClientConfiguration(dfsCluster);
     
     // n threads create files
     class WriterThread extends Thread {

--- a/solr/core/src/test/org/apache/solr/cloud/hdfs/HdfsRecoveryZkTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/hdfs/HdfsRecoveryZkTest.java
@@ -18,35 +18,30 @@ package org.apache.solr.cloud.hdfs;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
-import org.apache.lucene.util.LuceneTestCase;
+import org.apache.lucene.util.LuceneTestCase.BadApple;
+import org.apache.lucene.util.LuceneTestCase.Nightly;
 import org.apache.lucene.util.LuceneTestCase.Slow;
 import org.apache.solr.cloud.RecoveryZkTest;
 import org.apache.solr.common.cloud.ZkConfigManager;
 import org.apache.solr.util.BadHdfsThreadsFilter;
-import org.apache.solr.util.LogLevel;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
 @Slow
-@LuceneTestCase.BadApple(bugUrl="https://issues.apache.org/jira/browse/SOLR-12028")
-//@Nightly
+@BadApple(bugUrl="https://issues.apache.org/jira/browse/SOLR-12028")
+@Nightly
 @ThreadLeakFilters(defaultFilters = true, filters = {
     BadHdfsThreadsFilter.class // hdfs currently leaks thread(s)
 })
-@LogLevel("org.apache.solr.update.HdfsTransactionLog=DEBUG")
 public class HdfsRecoveryZkTest extends RecoveryZkTest {
-
   private static MiniDFSCluster dfsCluster;
   
   @BeforeClass
   public static void setupClass() throws Exception {
     dfsCluster = HdfsTestUtil.setupClass(createTempDir().toFile().getAbsolutePath());
-    System.setProperty("solr.hdfs.blockcache.blocksperbank", "2048");
 
     ZkConfigManager configManager = new ZkConfigManager(zkClient());
     configManager.uploadConfigDir(configset("cloud-hdfs"), "conf");
-
-    System.setProperty("solr.hdfs.home", HdfsTestUtil.getDataDir(dfsCluster, "data"));
   }
   
   @AfterClass
@@ -58,10 +53,7 @@ public class HdfsRecoveryZkTest extends RecoveryZkTest {
         HdfsTestUtil.teardownClass(dfsCluster);
       } finally {
         dfsCluster = null;
-        System.clearProperty("solr.hdfs.blockcache.blocksperbank");
-        System.clearProperty("solr.hdfs.home");
       }
     }
   }
-
 }

--- a/solr/core/src/test/org/apache/solr/cloud/hdfs/HdfsRestartWhileUpdatingTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/hdfs/HdfsRestartWhileUpdatingTest.java
@@ -16,8 +16,6 @@
  */
 package org.apache.solr.cloud.hdfs;
 
-import java.io.IOException;
-
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.lucene.util.LuceneTestCase.Slow;
 import org.apache.solr.cloud.RestartWhileUpdatingTest;
@@ -34,16 +32,15 @@ import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
     BadHdfsThreadsFilter.class // hdfs currently leaks thread(s)
 })
 public class HdfsRestartWhileUpdatingTest extends RestartWhileUpdatingTest {
+  private static MiniDFSCluster dfsCluster;
+
   public HdfsRestartWhileUpdatingTest() throws Exception {
     super();
   }
 
-  private static MiniDFSCluster dfsCluster;
-  
   @BeforeClass
   public static void setupClass() throws Exception {
     dfsCluster = HdfsTestUtil.setupClass(createTempDir().toFile().getAbsolutePath());
-    System.setProperty("solr.hdfs.blockcache.blocksperbank", "2048");
   }
   
   @AfterClass
@@ -52,12 +49,11 @@ public class HdfsRestartWhileUpdatingTest extends RestartWhileUpdatingTest {
       HdfsTestUtil.teardownClass(dfsCluster);
     } finally {
       dfsCluster = null;
-      System.clearProperty("solr.hdfs.blockcache.blocksperbank");
     }
   }
   
   @Override
-  protected String getDataDir(String dataDir) throws IOException {
+  protected String getDataDir(String dataDir) {
     return HdfsTestUtil.getDataDir(dfsCluster, dataDir);
   }
 }

--- a/solr/core/src/test/org/apache/solr/cloud/hdfs/HdfsTestUtil.java
+++ b/solr/core/src/test/org/apache/solr/cloud/hdfs/HdfsTestUtil.java
@@ -17,9 +17,9 @@
 package org.apache.solr.cloud.hdfs;
 
 import java.io.File;
-import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.net.URI;
+import java.util.Enumeration;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Timer;
@@ -46,6 +46,8 @@ import org.apache.solr.core.DirectoryFactory;
 import org.apache.solr.util.HdfsUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.apache.lucene.util.LuceneTestCase.random;
 
 public class HdfsTestUtil {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -99,49 +101,49 @@ public class HdfsTestUtil {
 
     if (!HA_TESTING_ENABLED) haTesting = false;
 
-    int dataNodes = Integer.getInteger("tests.hdfs.numdatanodes", 2);
-
-    Configuration conf = new Configuration();
-    conf.set("dfs.block.access.token.enable", "false");
-    conf.set("dfs.permissions.enabled", "false");
-    conf.set("hadoop.security.authentication", "simple");
+    Configuration conf = getBasicConfiguration(new Configuration());
     conf.set("hdfs.minidfs.basedir", dir + File.separator + "hdfsBaseDir");
     conf.set("dfs.namenode.name.dir", dir + File.separator + "nameNodeNameDir");
-    conf.setBoolean("fs.hdfs.impl.disable.cache", true);
+    // Disable metrics logging for HDFS
+    conf.setInt("dfs.namenode.metrics.logger.period.seconds", 0);
+    conf.setInt("dfs.datanode.metrics.logger.period.seconds", 0);
 
     System.setProperty("test.build.data", dir + File.separator + "hdfs" + File.separator + "build");
     System.setProperty("test.cache.data", dir + File.separator + "hdfs" + File.separator + "cache");
     System.setProperty("solr.lock.type", DirectoryFactory.LOCK_TYPE_HDFS);
 
-    System.setProperty("solr.hdfs.blockcache.global",
-        System.getProperty("solr.hdfs.blockcache.global", Boolean.toString(LuceneTestCase.random().nextBoolean())));
+    // test-files/solr/solr.xml sets this to be 15000. This isn't long enough for HDFS in some cases.
+    System.setProperty("socketTimeout", "90000");
 
-    final MiniDFSCluster dfsCluster;
-
-    if (!haTesting) {
-      dfsCluster = new MiniDFSCluster.Builder(conf).numDataNodes(dataNodes).format(true).build();
-
-      System.setProperty("solr.hdfs.home", getDataDir(dfsCluster, "solr_hdfs_home"));
+    String blockcacheGlobal = System.getProperty("solr.hdfs.blockcache.global", Boolean.toString(random().nextBoolean()));
+    System.setProperty("solr.hdfs.blockcache.global", blockcacheGlobal);
+    // Limit memory usage for HDFS tests
+    if(Boolean.parseBoolean(blockcacheGlobal)) {
+      System.setProperty("solr.hdfs.blockcache.blocksperbank", "4096");
     } else {
-      dfsCluster = new MiniDFSCluster.Builder(conf)
-          .nnTopology(MiniDFSNNTopology.simpleHATopology()).numDataNodes(dataNodes)
-          .build();
-
-      Configuration haConfig = getClientConfiguration(dfsCluster);
-
-      HdfsUtil.TEST_CONF = haConfig;
-      System.setProperty("solr.hdfs.home", getDataDir(dfsCluster, "solr_hdfs_home"));
+      System.setProperty("solr.hdfs.blockcache.blocksperbank", "512");
+      System.setProperty("tests.hdfs.numdatanodes", "1");
     }
+
+    int dataNodes = Integer.getInteger("tests.hdfs.numdatanodes", 2);
+    final MiniDFSCluster.Builder dfsClusterBuilder = new MiniDFSCluster.Builder(conf)
+        .numDataNodes(dataNodes).format(true);
+    if (haTesting) {
+      dfsClusterBuilder.nnTopology(MiniDFSNNTopology.simpleHATopology());
+    }
+    MiniDFSCluster dfsCluster = dfsClusterBuilder.build();
+    HdfsUtil.TEST_CONF = getClientConfiguration(dfsCluster);
+    System.setProperty("solr.hdfs.home", getDataDir(dfsCluster, "solr_hdfs_home"));
 
     dfsCluster.waitActive();
 
     if (haTesting) dfsCluster.transitionToActive(0);
 
-    int rndMode = LuceneTestCase.random().nextInt(3);
+    int rndMode = random().nextInt(3);
     if (safeModeTesting && rndMode == 1) {
       NameNodeAdapter.enterSafeMode(dfsCluster.getNameNode(), false);
 
-      int rnd = LuceneTestCase.random().nextInt(10000);
+      int rnd = random().nextInt(10000);
       Timer timer = new Timer();
       timers.put(dfsCluster, timer);
       timer.schedule(new TimerTask() {
@@ -151,9 +153,8 @@ public class HdfsTestUtil {
           NameNodeAdapter.leaveSafeMode(dfsCluster.getNameNode());
         }
       }, rnd);
-
     } else if (haTesting && rndMode == 2) {
-      int rnd = LuceneTestCase.random().nextInt(30000);
+      int rnd = random().nextInt(30000);
       Timer timer = new Timer();
       timers.put(dfsCluster, timer);
       timer.schedule(new TimerTask() {
@@ -176,7 +177,7 @@ public class HdfsTestUtil {
       URI uri = dfsCluster.getURI();
       Path hdfsDirPath = new Path(uri.toString() + "/solr/collection1/core_node1/data/tlog/tlog.0000000000000000000");
       // tran log already being created testing
-      badTlogOutStreamFs = FileSystem.get(hdfsDirPath.toUri(), conf);
+      badTlogOutStreamFs = FileSystem.get(hdfsDirPath.toUri(), getClientConfiguration(dfsCluster));
       badTlogOutStream = badTlogOutStreamFs.create(hdfsDirPath);
     }
 
@@ -185,18 +186,23 @@ public class HdfsTestUtil {
     return dfsCluster;
   }
 
+  private static Configuration getBasicConfiguration(Configuration conf) {
+    conf.setBoolean("dfs.block.access.token.enable", false);
+    conf.setBoolean("dfs.permissions.enabled", false);
+    conf.set("hadoop.security.authentication", "simple");
+    conf.setBoolean("fs.hdfs.impl.disable.cache", true);
+    return conf;
+  }
+
   public static Configuration getClientConfiguration(MiniDFSCluster dfsCluster) {
+    Configuration conf = getBasicConfiguration(dfsCluster.getConfiguration(0));
     if (dfsCluster.getNameNodeInfos().length > 1) {
-      Configuration conf = new Configuration();
       HATestUtil.setFailoverConfigurations(dfsCluster, conf);
-      return conf;
-    } else {
-      return new Configuration();
     }
+    return conf;
   }
 
   public static void teardownClass(MiniDFSCluster dfsCluster) throws Exception {
-
     if (badTlogOutStream != null) {
       IOUtils.closeQuietly(badTlogOutStream);
     }
@@ -205,16 +211,19 @@ public class HdfsTestUtil {
       IOUtils.closeQuietly(badTlogOutStreamFs);
     }
 
-    SolrTestCaseJ4.resetFactory();
-
     try {
+      try {
+        SolrTestCaseJ4.resetFactory();
+      } catch (Exception e) {
+        log.error("Exception trying to reset solr.directoryFactory", e);
+      }
       if (dfsCluster != null) {
         Timer timer = timers.remove(dfsCluster);
         if (timer != null) {
           timer.cancel();
         }
         try {
-          dfsCluster.shutdown();
+          dfsCluster.shutdown(true);
         } catch (Error e) {
           // Added in SOLR-7134
           // Rarely, this can fail to either a NullPointerException
@@ -224,16 +233,27 @@ public class HdfsTestUtil {
         }
       }
     } finally {
-      System.clearProperty("solr.lock.type");
       System.clearProperty("test.build.data");
       System.clearProperty("test.cache.data");
-      System.clearProperty("solr.hdfs.home");
-      System.clearProperty("solr.hdfs.blockcache.global");
+
+      System.clearProperty("socketTimeout");
+
+      System.clearProperty("tests.hdfs.numdatanodes");
+
+      System.clearProperty("solr.lock.type");
+
+      // Clear "solr.hdfs." system properties
+      Enumeration<?> propertyNames = System.getProperties().propertyNames();
+      while(propertyNames.hasMoreElements()) {
+        String propertyName = String.valueOf(propertyNames.nextElement());
+        if(propertyName.startsWith("solr.hdfs.")) {
+          System.clearProperty(propertyName);
+        }
+      }
     }
   }
 
-  public static String getDataDir(MiniDFSCluster dfsCluster, String dataDir)
-      throws IOException {
+  public static String getDataDir(MiniDFSCluster dfsCluster, String dataDir) {
     if (dataDir == null) {
       return null;
     }
@@ -250,7 +270,7 @@ public class HdfsTestUtil {
       return "hdfs://" + logicalName;
     } else {
       URI uri = dfsCluster.getURI(0);
-      return uri.toString() ;
+      return uri.toString();
     }
   }
 

--- a/solr/core/src/test/org/apache/solr/cloud/hdfs/HdfsTlogReplayBufferedWhileIndexingTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/hdfs/HdfsTlogReplayBufferedWhileIndexingTest.java
@@ -16,8 +16,6 @@
  */
 package org.apache.solr.cloud.hdfs;
 
-import java.io.IOException;
-
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.lucene.util.LuceneTestCase.Slow;
 import org.apache.solr.cloud.TlogReplayBufferedWhileIndexingTest;
@@ -42,7 +40,6 @@ public class HdfsTlogReplayBufferedWhileIndexingTest extends TlogReplayBufferedW
 
   @BeforeClass
   public static void setupClass() throws Exception {
-    System.setProperty("solr.hdfs.blockcache.blocksperbank", "2048");
     dfsCluster = HdfsTestUtil.setupClass(createTempDir().toFile().getAbsolutePath());
   }
   
@@ -52,12 +49,11 @@ public class HdfsTlogReplayBufferedWhileIndexingTest extends TlogReplayBufferedW
       HdfsTestUtil.teardownClass(dfsCluster);
     } finally {
       dfsCluster = null;
-      System.clearProperty("solr.hdfs.blockcache.blocksperbank");
     }
   }
   
   @Override
-  protected String getDataDir(String dataDir) throws IOException {
+  protected String getDataDir(String dataDir) {
     return HdfsTestUtil.getDataDir(dfsCluster, dataDir);
   }
 }

--- a/solr/core/src/test/org/apache/solr/cloud/hdfs/HdfsUnloadDistributedZkTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/hdfs/HdfsUnloadDistributedZkTest.java
@@ -16,8 +16,6 @@
  */
 package org.apache.solr.cloud.hdfs;
 
-import java.io.IOException;
-
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.lucene.util.LuceneTestCase.Slow;
 import org.apache.solr.cloud.UnloadDistributedZkTest;
@@ -51,7 +49,7 @@ public class HdfsUnloadDistributedZkTest extends UnloadDistributedZkTest {
   }
   
   @Override
-  protected String getDataDir(String dataDir) throws IOException {
+  protected String getDataDir(String dataDir) {
     return HdfsTestUtil.getDataDir(dfsCluster, dataDir);
   }
 }

--- a/solr/core/src/test/org/apache/solr/cloud/hdfs/HdfsWriteToMultipleCollectionsTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/hdfs/HdfsWriteToMultipleCollectionsTest.java
@@ -141,10 +141,9 @@ public class HdfsWriteToMultipleCollectionsTest extends BasicDistributedZkTest {
           Directory dir = factory.get(core.getDataDir(), null, null);
           try {
             long dataDirSize = factory.size(dir);
-            FileSystem fileSystem = null;
-            
-            fileSystem = FileSystem.newInstance(
-                new Path(core.getDataDir()).toUri(), new Configuration());
+            Configuration conf = HdfsTestUtil.getClientConfiguration(dfsCluster);
+            FileSystem fileSystem = FileSystem.newInstance(
+                new Path(core.getDataDir()).toUri(), conf);
             long size = fileSystem.getContentSummary(
                 new Path(core.getDataDir())).getLength();
             assertEquals(size, dataDirSize);

--- a/solr/core/src/test/org/apache/solr/cloud/hdfs/StressHdfsTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/hdfs/StressHdfsTest.java
@@ -229,7 +229,6 @@ public class StressHdfsTest extends BasicDistributedZkTest {
     // check that all dirs are gone
     for (String dataDir : dataDirs) {
       Configuration conf = HdfsTestUtil.getClientConfiguration(dfsCluster);
-      conf.setBoolean("fs.hdfs.impl.disable.cache", true);
       try(FileSystem fs = FileSystem.get(new URI(HdfsTestUtil.getURI(dfsCluster)), conf)) {
         assertFalse(
             "Data directory exists after collection removal : " + dataDir,

--- a/solr/core/src/test/org/apache/solr/update/TestHdfsUpdateLog.java
+++ b/solr/core/src/test/org/apache/solr/update/TestHdfsUpdateLog.java
@@ -50,14 +50,11 @@ public class TestHdfsUpdateLog extends SolrTestCaseJ4 {
     try {
       URI uri = new URI(hdfsUri);
       Configuration conf = HdfsTestUtil.getClientConfiguration(dfsCluster);
-      conf.setBoolean("fs.hdfs.impl.disable.cache", true);
       fs = FileSystem.get(uri, conf);
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    } catch (URISyntaxException e) {
+    } catch (IOException | URISyntaxException e) {
       throw new RuntimeException(e);
     }
-    
+
     System.setProperty("solr.ulog.dir", hdfsUri + "/solr/shard1");
     
     initCore("solrconfig-tlog.xml","schema15.xml");


### PR DESCRIPTION
Related JIRAs:
* SOLR-11010
* SOLR-11381
* SOLR-12040
* SOLR-13297

Changes:
* Consolidate hdfs configuration into HdfsTestUtil
* Ensure socketTimeout long enough for HDFS tests
* Ensure HdfsTestUtil.getClientConfiguration used in tests
* Replace deprecated HDFS calls
* Use try-with-resources to ensure closing of HDFS resources