### PR TITLE
Intervals Query Parser

### DIFF
--- a/lucene/sandbox/src/java/org/apache/lucene/search/intervals/IntervalsQueryParser.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/search/intervals/IntervalsQueryParser.java
@@ -1,0 +1,162 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.apache.lucene.search.intervals;
+
+/**
+ *
+ * @author John Murphy
+ * @email john.murphy@elastic.co
+ */
+
+
+
+
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.lucene.index.Term;
+
+/**
+ * Created by murphy on 8/14/18.
+ */
+public class IntervalsQueryParser {
+  private final objectHolder objectHolder;
+  protected final Pattern quotes = Pattern.compile("\"[^\"(/]*\"");
+  protected final Pattern parenthesis = Pattern.compile("\\([^)(]*\\)");
+  protected final Pattern within = Pattern.compile("/[0-9]*");
+  protected final Pattern wildcard = Pattern.compile("\\*");
+  protected final Pattern space = Pattern.compile(("[\\s]"));
+
+  public IntervalsQueryParser() {
+    this.objectHolder = new objectHolder();
+  }
+  public IntervalQuery getQuery(String fieldName, String query) throws Exception {
+    String code = makeQuery( fieldName, query.replaceAll("\\)\\(",") ("));
+    IntervalQuery iq = new IntervalQuery(fieldName, objectHolder.getIntervalsSourceFromCode(code));
+    System.out.println(iq.toString());
+    return iq;
+  }
+
+  String makeQuery( String fieldName, String query) throws Exception {
+    if(objectHolder.isCode(query))
+      return query;
+    while(true){
+      Matcher m = quotes.matcher(query);
+      if(!m.find())
+        break;
+      String sub = query.substring(m.start()+1,m.end()-1);
+      String replacement = processString(fieldName, sub);
+      query = m.replaceFirst(replacement);
+    }
+    while(true){
+      Matcher m = parenthesis.matcher(query);
+      if(!m.find())
+        break;
+      String sub = query.substring(m.start()+1,m.end()-1);
+      String replacement = makeQuery( fieldName, sub);
+      query = m.replaceFirst(replacement);
+      query = makeQuery(fieldName, query);
+    }
+    while(true){
+      Matcher m = within.matcher(query);
+      if(!m.find())
+        break;
+      String srange = query.substring(m.start()+1, m.end());
+      int range = Integer.parseInt(srange);
+      String first = query.substring(0,m.start()-1);
+      String second = query.substring(m.end()+1, query.length());
+      String firsteplacement = makeQuery( fieldName, first);
+      String secondreplacement = makeQuery( fieldName, second);
+      IntervalsSource sqFirst = objectHolder.getIntervalsSourceFromCode(firsteplacement);
+      IntervalsSource sqSecond = objectHolder.getIntervalsSourceFromCode(secondreplacement);
+      IntervalsSource snq = Intervals.unordered(sqFirst, sqSecond);
+      IntervalsSource irange = Intervals.maxwidth(range, snq);
+      String code = objectHolder.addIntervalsSource(fieldName, irange);
+      query = code;
+      query = makeQuery(fieldName, query);
+      }
+          //String
+      query = query.trim();
+      String[] subqueries = space.split(query);
+      if(subqueries.length==1){
+        query = processString( fieldName, query);
+      }
+      if(subqueries.length > 1){
+        IntervalsSource[] codes = new IntervalsSource[subqueries.length];
+        for(int i=0;i<subqueries.length;i++){
+          codes[i] = objectHolder.getIntervalsSourceFromCode(processString( fieldName, subqueries[i]));
+      }
+      IntervalsSource soq = Intervals.or(codes);
+      String ret = objectHolder.addIntervalsSource(fieldName, soq);
+      query = makeQuery( fieldName, ret);
+    }
+    return query;
+  }
+
+
+  String processString( String fieldName, String query) throws Exception {
+    if(objectHolder.isCode(query))
+      return query;
+    String[] toks = query.split("[\\s]");
+    for(int i=0;i<toks.length;i++) {
+      String ganal = toks[i];
+      if (ganal.contains(" ")) {
+        String rganal = ganal.replace(" ", ".");
+        toks[i] = toks[i].replaceAll(rganal, ganal);
+        toks[i] = processString(fieldName,toks[i]);
+      }
+    }
+    if(toks.length < 1)
+      throw new Exception("No tokens in stream " + query);
+    if(toks.length == 1) {
+      if(objectHolder.isCode(toks[0]))
+        return toks[0];
+      if(query.contains("*"))
+        return objectHolder.addIntervalsSource(fieldName, Intervals.wildcard( query));
+      return objectHolder.addIntervalsSource(fieldName, Intervals.term(toks[0]));
+    }
+    else {
+      IntervalsSource[] sq = new IntervalsSource[toks.length];
+      for(int i=0;i<toks.length;i++){
+        if(objectHolder.isCode(toks[i]))
+          sq[i] = objectHolder.getIntervalsSourceFromCode(toks[i]);
+        else{
+          sq[i] = objectHolder.getIntervalsSourceFromCode(processString(fieldName, toks[i]));
+        }                    
+      }
+      IntervalsSource snq = Intervals.phrase(sq);
+      return objectHolder.addIntervalsSource(fieldName, snq);
+    }
+
+  }
+  class objectHolder{
+    private final HashMap<String, IntervalsSource> hashmap;
+    private int count = 0;
+    public objectHolder(){
+      hashmap = new HashMap();
+    }
+    public String addIntervalsSource(String fieldName, IntervalsSource sq){
+      if(sq.getClass().toString().equals("class org.apache.lucene.search.intervals.IntervalsSource")){
+        Set<Term> st = new LinkedHashSet();
+        sq.extractTerms(fieldName, st);
+        if(st.isEmpty())
+          return null;
+      }
+      String code = String.format("zz%012dzz", count);
+      hashmap.put(code, sq);
+      count++;
+      return code;
+    }
+    public IntervalsSource getIntervalsSourceFromCode(String code){
+      return hashmap.get(code);
+    }
+    public Boolean isCode(String code){
+      return hashmap.containsKey(code);
+    }
+  }
+}

--- a/lucene/sandbox/src/test/org/apache/lucene/search/intervals/TestIntervalsQueryParser.java
+++ b/lucene/sandbox/src/test/org/apache/lucene/search/intervals/TestIntervalsQueryParser.java
@@ -1,0 +1,29 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.apache.lucene.search.intervals;
+
+import org.apache.lucene.util.LuceneTestCase;
+
+/**
+ *
+ * @author murphy
+ */
+public class TestIntervalsQueryParser extends LuceneTestCase{
+    public void testParsingstatic() throws Exception{
+        IntervalsQueryParser iqp = new IntervalsQueryParser();
+        assertEquals("or(a,b)", iqp.getQuery("content","a b").toString());
+        assertEquals("or(a,b,c)", iqp.getQuery("content","(a b c)").toString());
+        assertEquals("MAXWIDTH/5(UNORDERED(a,b))", iqp.getQuery("content","a /5 b").toString());
+        assertEquals("or(MAXWIDTH/5(UNORDERED(a,b)),c)", iqp.getQuery("content","(a /5 b) c").toString());
+        assertEquals("BLOCK(a,b)", iqp.getQuery("content","\"a b\"").toString());
+        assertEquals("MAXWIDTH/3(UNORDERED(MAXWIDTH/3(UNORDERED(MAXWIDTH/3(UNORDERED(MAXWIDTH/3(UNORDERED(a,BLOCK(b,f,g))),c)),d)),e))", iqp.getQuery("content","((((a /3 \"b f g\") /3 c) /3 d) /3 e)").toString());
+        assertEquals("MAXWIDTH/12(UNORDERED(or(can,could),MultiTerm(figur*)))", iqp.getQuery("content","(can could) /12 \"figur*\"").toString());
+        assertEquals("MAXWIDTH/75(UNORDERED(MultiTerm(search*),MAXWIDTH/10(UNORDERED(MultiTerm(could*),BLOCK(MultiTerm(lat*),night)))))", iqp.getQuery("content","(search*) /75 (could* /10 \"lat* night\")").toString());
+        assertEquals("BLOCK(MultiTerm(can*),MultiTerm(expect*))", iqp.getQuery("content","\"can* expect*\"").toString());
+        assertEquals("BLOCK(or(can,might),MultiTerm(expect*))", iqp.getQuery("content","\"(can might) expect*\"").toString());
+        assertEquals("\"(red green blue)(cluster* node* shard*)\"", iqp.getQuery("content","\"(red green blue)(cluster* node* shard*)\"").toString());
+    }
+}


### PR DESCRIPTION
A query parser that converts syntax to an intervals query. This is a completely stand-alone query parser with the sole use of building an query of intervals.
One class IntervalsQueryParser
One public method getQuery that passes in field name and query and returns an IntervalsQuery
One test class TestIntervalsQueryParser

Examples

a b
or(a,b)

a b c
or(a,b,c)

(a b c)
or(a,b,c)

a /5 b
MAXWIDTH/5(UNORDERED(a,b))

(a /5 b) c
or(MAXWIDTH/5(UNORDERED(a,b)),c)

"a b"
BLOCK(a,b)

"a b v"
BLOCK(a,b,v)

((((a /3 "b f g") /3 c) /3 d) /3 e)
MAXWIDTH/3(UNORDERED(MAXWIDTH/3(UNORDERED(MAXWIDTH/3(UNORDERED(MAXWIDTH/3(UNORDERED(a,BLOCK(b,f,g))),c)),d)),e))

(a /3 (b /3 (c /3 (d /3 e))))
MAXWIDTH/3(UNORDERED(a,MAXWIDTH/3(UNORDERED(b,MAXWIDTH/3(UNORDERED(c,MAXWIDTH/3(UNORDERED(d,e))))))))

(can could) /12 "figur*"
MAXWIDTH/12(UNORDERED(or(can,could),MultiTerm(figur*)))

(search*) /75 (could* /10 "lat* night")
MAXWIDTH/75(UNORDERED(MultiTerm(search*),MAXWIDTH/10(UNORDERED(MultiTerm(could*),BLOCK(MultiTerm(lat*),night)))))

"can* expect*"
BLOCK(MultiTerm(can*),MultiTerm(expect*))

"(can might) expect*"
BLOCK(or(can,might),MultiTerm(expect*))

"(red green blue)(cluster* node* shard*)"
BLOCK(or(red,green,blue),or(MultiTerm(cluster*),MultiTerm(node*),MultiTerm(shard*)))