### PR TITLE
Use Map.copyOf in lucene core

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/Dictionary.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/Dictionary.java
@@ -660,14 +660,8 @@ public class Dictionary {
     }
   }
 
-  static final Map<String,String> CHARSET_ALIASES;
-  static {
-    Map<String,String> m = new HashMap<>();
-    m.put("microsoft-cp1251", "windows-1251");
-    m.put("TIS620-2533", "TIS-620");
-    CHARSET_ALIASES = Collections.unmodifiableMap(m);
-  }
-  
+  static final Map<String,String> CHARSET_ALIASES = Map.of("microsoft-cp1251", "windows-1251", "TIS620-2533", "TIS-620");
+
   /**
    * Retrieves the CharsetDecoder for the given encoding.  Note, This isn't perfect as I think ISCII-DEVANAGARI and
    * MICROSOFT-CP1251 etc are allowed...

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/AbstractAnalysisFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/AbstractAnalysisFactory.java
@@ -28,7 +28,6 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -69,7 +68,7 @@ public abstract class AbstractAnalysisFactory {
    * Initialize this factory via a set of key-value pairs.
    */
   protected AbstractAnalysisFactory(Map<String,String> args) {
-    originalArgs = Collections.unmodifiableMap(new HashMap<>(args));
+    originalArgs = Map.copyOf(args);
     String version = get(args, LUCENE_MATCH_VERSION_PARAM);
     if (version == null) {
       luceneMatchVersion = Version.LATEST;

--- a/lucene/core/src/java/org/apache/lucene/index/FrozenBufferedUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FrozenBufferedUpdates.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -111,7 +110,7 @@ final class FrozenBufferedUpdates {
     // so that it maps to all fields it affects, sorted by their docUpto, and traverse
     // that Term only once, applying the update to all fields that still need to be
     // updated.
-    this.fieldUpdates = Collections.unmodifiableMap(new HashMap<>(updates.fieldUpdates));
+    this.fieldUpdates = Map.copyOf(updates.fieldUpdates);
     this.fieldUpdatesCount = updates.numFieldUpdates.get();
 
     bytesUsed = (int) ((deleteTerms.ramBytesUsed() + deleteQueries.length * BYTES_PER_DEL_QUERY)

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriterConfig.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriterConfig.java
@@ -19,9 +19,7 @@ package org.apache.lucene.index;
 
 import java.io.PrintStream;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -554,8 +552,7 @@ public final class IndexWriterConfig extends LiveIndexWriterConfig {
    * Note: This method make a shallow copy of the provided map.
    */
   public IndexWriterConfig setReaderAttributes(Map<String, String> readerAttributes) {
-    this.readerAttributes = Collections.unmodifiableMap(new HashMap<>(Objects.requireNonNull(readerAttributes)));
+    this.readerAttributes = Map.copyOf(Objects.requireNonNull(readerAttributes));
     return this;
   }
-  
 }

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentInfo.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentInfo.java
@@ -87,7 +87,7 @@ public final class SegmentInfo {
   Version minVersion;
 
   void setDiagnostics(Map<String, String> diagnostics) {
-    this.diagnostics = Collections.unmodifiableMap(new HashMap<>(Objects.requireNonNull(diagnostics)));
+    this.diagnostics = Map.copyOf(Objects.requireNonNull(diagnostics));
   }
 
   /** Returns diagnostics saved into the segment when it was
@@ -112,12 +112,12 @@ public final class SegmentInfo {
     this.maxDoc = maxDoc;
     this.isCompoundFile = isCompoundFile;
     this.codec = codec;
-    this.diagnostics = Collections.unmodifiableMap(new HashMap<>(Objects.requireNonNull(diagnostics)));
+    this.diagnostics = Map.copyOf(Objects.requireNonNull(diagnostics));
     this.id = id;
     if (id.length != StringHelper.ID_LENGTH) {
       throw new IllegalArgumentException("invalid id: " + Arrays.toString(id));
     }
-    this.attributes = Collections.unmodifiableMap(new HashMap<>(Objects.requireNonNull(attributes)));
+    this.attributes = Map.copyOf(Objects.requireNonNull(attributes));
     this.indexSort = indexSort;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentReadState.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentReadState.java
@@ -17,8 +17,6 @@
 package org.apache.lucene.index;
 
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.lucene.codecs.PostingsFormat; // javadocs
@@ -82,7 +80,7 @@ public class SegmentReadState {
     this.context = context;
     this.segmentSuffix = segmentSuffix;
     this.openedFromWriter = openedFromWriter;
-    this.readerAttributes = Collections.unmodifiableMap(new HashMap<>(readerAttributes));
+    this.readerAttributes = Map.copyOf(readerAttributes);
   }
 
   /** Create a {@code SegmentReadState}. */

--- a/lucene/core/src/java/org/apache/lucene/index/StandardDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/StandardDirectoryReader.java
@@ -53,7 +53,7 @@ public final class StandardDirectoryReader extends DirectoryReader {
     this.segmentInfos = sis;
     this.applyAllDeletes = applyAllDeletes;
     this.writeAllDeletes = writeAllDeletes;
-    this.readerAttributes = Collections.unmodifiableMap(new HashMap<>(readerAttributes));
+    this.readerAttributes = Map.copyOf(readerAttributes);
   }
 
   /** called from DirectoryReader.open(...) methods */

--- a/lucene/core/src/test/org/apache/lucene/index/TestSegmentInfos.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSegmentInfos.java
@@ -29,7 +29,6 @@ import org.apache.lucene.util.Version;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class TestSegmentInfos extends LuceneTestCase {
@@ -111,14 +110,10 @@ public class TestSegmentInfos extends LuceneTestCase {
     Codec codec = Codec.getDefault();
 
     // diagnostics map
-    Map<String, String> diagnostics = new LinkedHashMap<>();
-    diagnostics.put("key1", "value1");
-    diagnostics.put("key2", "value2");
+    Map<String, String> diagnostics = Map.of("key1", "value1", "key2", "value2");
 
     // attributes map
-    Map<String,String> attributes = new LinkedHashMap<>();
-    attributes.put("key1", "value1");
-    attributes.put("key2", "value2");
+    Map<String,String> attributes =  Map.of("akey1", "value1", "akey2", "value2");
 
     // diagnostics X, attributes X
     si = new SegmentInfo(dir, Version.LATEST, Version.LATEST, "TEST", 10000, false, codec, Collections.emptyMap(), StringHelper.randomId(), new HashMap<>(), Sort.INDEXORDER);
@@ -131,23 +126,22 @@ public class TestSegmentInfos extends LuceneTestCase {
     assertEquals("TEST(" + Version.LATEST.toString() + ")" +
         ":C10000" +
         ":[indexSort=<doc>]" +
-        ":[diagnostics={key1=value1, key2=value2}]", si.toString());
+        ":[diagnostics=" + diagnostics + "]", si.toString());
 
     // diagnostics X, attributes O
     si = new SegmentInfo(dir, Version.LATEST, Version.LATEST, "TEST", 10000, false, codec, Collections.emptyMap(), StringHelper.randomId(), attributes, Sort.INDEXORDER);
     assertEquals("TEST(" + Version.LATEST.toString() + ")" +
         ":C10000" +
         ":[indexSort=<doc>]" +
-        ":[attributes={key1=value1, key2=value2}]", si.toString());
+        ":[attributes=" + attributes + "]", si.toString());
 
     // diagnostics O, attributes O
     si = new SegmentInfo(dir, Version.LATEST, Version.LATEST, "TEST", 10000, false, codec, diagnostics, StringHelper.randomId(), attributes, Sort.INDEXORDER);
-    System.out.println(si.toString());
     assertEquals("TEST(" + Version.LATEST.toString() + ")" +
         ":C10000" +
         ":[indexSort=<doc>]" +
-        ":[diagnostics={key1=value1, key2=value2}]" +
-        ":[attributes={key1=value1, key2=value2}]", si.toString());
+        ":[diagnostics=" + diagnostics + "]" +
+        ":[attributes=" + attributes + "]", si.toString());
 
     dir.close();
   }


### PR DESCRIPTION
This cuts over several places that use the pattern of creating a copy of
the supplied map with Map.copyOf.