### PR TITLE
LUCENE-8768: Javadoc search support

### DIFF
--- a/lucene/common-build.xml
+++ b/lucene/common-build.xml
@@ -179,7 +179,7 @@
   <property name="javadoc.charset" value="utf-8"/>
   <property name="javadoc.dir" location="${common.dir}/build/docs"/>
   <property name="javadoc.maxmemory" value="512m" />
-  <property name="javadoc.noindex" value="true"/>
+  <property name="javadoc.noindex" value="false"/>
 
   <!---TODO: Fix accessibility (order of H1/H2/H3 headings), see https://issues.apache.org/jira/browse/LUCENE-8729 -->
   <property name="javadoc.doclint.args" value="-Xdoclint:all -Xdoclint:-missing -Xdoclint:-accessibility"/>
@@ -2097,6 +2097,7 @@ ${ant.project.name}.test.dependencies=${test.classpath.list}
       <record name="@{destdir}/log_javadoc.txt" action="start" append="no"/>
       <javadoc
           overview="@{overview}"
+          additionalparam="--no-module-directories"
           packagenames="org.apache.lucene.*,org.apache.solr.*"
           destdir="@{destdir}"
           access="${javadoc.access}"


### PR DESCRIPTION
This is a PR to support **"Javadoc search"** released in Java 9.

**[Before - Lucene Nightly Core Module Javadoc]**
![javadoc-nightly](https://user-images.githubusercontent.com/14330832/56313117-c7fbe280-618c-11e9-8c47-58341959919a.png)

**[After]**
![new-javadoc](https://user-images.githubusercontent.com/14330832/56313118-c7fbe280-618c-11e9-8305-23caaf4da2f3.png)

For more information, please refer to the following JIRA link.
(https://issues.apache.org/jira/browse/LUCENE-8768)

Signed-off-by: Namgyu Kim <kng0828@gmail.com>