### PR TITLE
LUCENE-8774: Performance improvement for update?optimize=true

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldDocValuesFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldDocValuesFormat.java
@@ -18,10 +18,10 @@ package org.apache.lucene.codecs.perfield;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.TreeMap;
@@ -138,7 +138,7 @@ public abstract class PerFieldDocValuesFormat extends DocValuesFormat {
         DocValuesConsumer consumer = getInstance(fi);
         Collection<String> fieldsForConsumer = consumersToField.get(consumer);
         if (fieldsForConsumer == null) {
-          fieldsForConsumer = new ArrayList<>();
+          fieldsForConsumer = new LinkedHashSet<>();
           consumersToField.put(consumer, fieldsForConsumer);
         }
         fieldsForConsumer.add(fi.name);


### PR DESCRIPTION
For our use case we have a small number of documents with a large number of docValues.  During optimize we noticed a lot of time being spent in the FilterFieldInfos constructor, on the filterFields.contains(...) function.  

The small change from an ArrayList to a LinkedHashSet reduced our optimize time from 60min to < 1min.

This was added to branch 7_2 as that's the version we're still using, but the issue is still present in master:
https://github.com/apache/lucene-solr/blob/master/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldDocValuesFormat.java#L142


