### PR TITLE
SOLR-12584: Describe getting Prometheus metrics from a secure Solr

### DIFF
--- a/solr/solr-ref-guide/src/monitoring-solr-with-prometheus-and-grafana.adoc
+++ b/solr/solr-ref-guide/src/monitoring-solr-with-prometheus-and-grafana.adoc
@@ -108,6 +108,38 @@ The number of seconds between collecting metrics from Solr. The `solr-exporter` 
 
 The Solr's metrics exposed by `solr-exporter` can be seen at: `\http://localhost:9983/solr/admin/metrics`.
 
+=== Getting metrics from a secure Solr(Cloud)
+
+Your Solr(Cloud) might be secured by measures described in <<securing-solr.adoc#securing-solr,Securing Solr>>. The security configuration can be injected into `solr-exporter` using environment variables in a fashion similar to other clients using <<using-solrj.adoc#using-solrj,SolrJ>>. This is possible because the main script picks up two external environment variables and passes them on to the Java process:
+
+* `JAVA_OPTS` allows to add extra JVM options
+* `CLASSPATH_PREFIX` allows to add extra libraries
+
+Example for a SolrCloud instance secured by
+
+* <<basic-authentication-plugin.adoc#basic-authentication-plugin,Basic Authentication>>
+* <<enabling-ssl.adoc#enabling-ssl,SSL>>
+* <<zookeeper-access-control.adoc#zookeeper-access-control,ZooKeeper Access Control>>
+
+Suppose you have a file `basicauth.properties` with the Solr Basic-Auth credentials:
+
+----
+httpBasicAuthUser=myUser
+httpBasicAuthPassword=myPassword
+----
+
+Then you can start the Exporter as follows (Linux).
+
+[source,bash]
+----
+$ cd contrib/prometheus-exporter
+$ export JAVA_OPTS="-Djavax.net.ssl.trustStore=truststore.jks -Djavax.net.ssl.trustStorePassword=truststorePassword -Dsolr.httpclient.builder.factory=org.apache.solr.client.solrj.impl.PreemptiveBasicAuthClientBuilderFactory -Dsolr.httpclient.config=basicauth.properties -DzkCredentialsProvider=org.apache.solr.common.cloud.VMParamsSingleSetCredentialsDigestZkCredentialsProvider -DzkDigestUsername=readonly-user -DzkDigestPassword=zkUserPassword"
+$ export CLASSPATH_PREFIX="../../server/solr-webapp/webapp/WEB-INF/lib/commons-codec-1.11.jar"
+$ ./bin/solr-exporter -p 9854 -z zk1:2181,zk2:2181,zk3:2181 -f ./conf/solr-exporter-config.xml -n 16
+----
+
+Note: The Exporter needs the `commons-codec` library for SSL/BasicAuth, but does not bring it. Therefor the example reuses it from the Solr web app. Of course, you can use a different source.
+
 == Exporter Configuration
 The configuration for the `solr-exporter` defines the data to get from Solr. This includes the metrics, but can also include queries to the PingRequestHandler, the Collections API, and a query to any query request handler.
 

--- a/solr/solr-ref-guide/src/monitoring-solr-with-prometheus-and-grafana.adoc
+++ b/solr/solr-ref-guide/src/monitoring-solr-with-prometheus-and-grafana.adoc
@@ -115,11 +115,7 @@ Your Solr(Cloud) might be secured by measures described in <<securing-solr.adoc#
 * `JAVA_OPTS` allows to add extra JVM options
 * `CLASSPATH_PREFIX` allows to add extra libraries
 
-Example for a SolrCloud instance secured by
-
-* <<basic-authentication-plugin.adoc#basic-authentication-plugin,Basic Authentication>>
-* <<enabling-ssl.adoc#enabling-ssl,SSL>>
-* <<zookeeper-access-control.adoc#zookeeper-access-control,ZooKeeper Access Control>>
+Example for a SolrCloud instance secured by <<basic-authentication-plugin.adoc#basic-authentication-plugin,Basic Authentication>>, <<enabling-ssl.adoc#enabling-ssl,SSL>> and <<zookeeper-access-control.adoc#zookeeper-access-control,ZooKeeper Access Control>>:
 
 Suppose you have a file `basicauth.properties` with the Solr Basic-Auth credentials:
 
@@ -138,7 +134,7 @@ $ export CLASSPATH_PREFIX="../../server/solr-webapp/webapp/WEB-INF/lib/commons-c
 $ ./bin/solr-exporter -p 9854 -z zk1:2181,zk2:2181,zk3:2181 -f ./conf/solr-exporter-config.xml -n 16
 ----
 
-Note: The Exporter needs the `commons-codec` library for SSL/BasicAuth, but does not bring it. Therefor the example reuses it from the Solr web app. Of course, you can use a different source.
+Note: The Exporter needs the `commons-codec` library for SSL/BasicAuth, but does not bring it. Therefore the example reuses it from the Solr web app. Of course, you can use a different source.
 
 == Exporter Configuration
 The configuration for the `solr-exporter` defines the data to get from Solr. This includes the metrics, but can also include queries to the PingRequestHandler, the Collections API, and a query to any query request handler.


### PR DESCRIPTION
Getting the Solr-Prometheus-Exporter to work with a secure Solr is possible, but not straight-forward.
This pull request extends the documentation to show how it can be done.