### PR TITLE
LUCENE-8785: Ensure threadstates are locked before iterating

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -452,7 +452,11 @@ Optimizations
   (Toke Eskildsen, Adrien Grand)
 
 ======================= Lucene 7.7.1 =======================
-(No Changes)
+Bug fixes:
+
+* LUCENE-8785: Ensure new threadstates are locked before retrieving the number of active threadstates.
+  This causes assertion errors and potentially broken field attributes in the IndexWriter when
+  IndexWriter#deleteAll is called while actively indexing. (Simon Willnauer) 
 
 ======================= Lucene 7.7.0 =======================
 

--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriter.java
@@ -287,8 +287,8 @@ final class DocumentsWriter implements Closeable, Accountable {
     };
     try {
       deleteQueue.clear();
-      final int limit = perThreadPool.getMaxThreadStates();
       perThreadPool.lockNewThreadStates();
+      final int limit = perThreadPool.getMaxThreadStates();
       for (int i = 0; i < limit; i++) {
         final ThreadState perThread = perThreadPool.getThreadState(i);
         perThread.lock();


### PR DESCRIPTION
Ensure new threadstates are locked before retrieving the
number of active threadstates. This causes assertion errors
and potentially broken field attributes in the IndexWriter when
IndexWriter#deleteAll is called while actively indexing.