### PR TITLE
Replace instances of Math.random with Random.nextDouble

### DIFF
--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/jaspell/JaspellTernarySearchTrie.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/jaspell/JaspellTernarySearchTrie.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Vector;
 import java.util.zip.GZIPInputStream;
+import java.util.Random;
 
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.IOUtils;
@@ -362,7 +363,8 @@ public class JaspellTernarySearchTrie implements Accountable {
     int movingKid;
     TSTNode targetNode;
     if (deltaHi == deltaLo) {
-      if (Math.random() < 0.5) {
+      Random rand = new Random();
+      if (rand.nextDouble() < 0.5) {
         deltaHi++;
       } else {
         deltaLo++;

--- a/solr/contrib/analytics/src/java/org/apache/solr/analytics/util/OrdinalCalculator.java
+++ b/solr/contrib/analytics/src/java/org/apache/solr/analytics/util/OrdinalCalculator.java
@@ -19,6 +19,7 @@ package org.apache.solr.analytics.util;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Random;
 
 /**
  * Calculates ordinals of a comparable list by placing them in the correct positions in the list.
@@ -84,7 +85,8 @@ public class OrdinalCalculator {
   private static <T extends Comparable<T>> void select(List<T> list, int place, int begin, int end) {
     T split;
     if (end - begin < 10) {
-      split = list.get((int) (Math.random() * (end - begin + 1)) + begin);
+      Random rand = new Random();
+      split = list.get((int) (rand.nextDouble() * (end - begin + 1)) + begin);
     } else {
       split = split(list, begin, end);
     }


### PR DESCRIPTION
There is a performance overhead associated with Math.random these is unassociated with Random.nextDouble, which performs the same functionality as Math.random. Switching to Random.nextdouble removes this redundancy overhead.