### PR TITLE
SOLR-13499: Fix "Apache License, Version 2.0" spelling in pom.xml.template

### DIFF
--- a/dev-tools/maven/pom.xml.template
+++ b/dev-tools/maven/pom.xml.template
@@ -114,7 +114,7 @@
   </scm>
   <licenses>
     <license>
-      <name>Apache 2</name>
+      <name>Apache License, Version 2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>


### PR DESCRIPTION
Fix for [SOLR-13499](https://issues.apache.org/jira/browse/SOLR-13499).
There are many Java libraries licensed under "Apache License, Version 2.0" that do not use its official spelling.
This causes issues like https://issues.apache.org/jira/browse/MPIR-382: with every library defining its own spelling, it's difficult in large projects to have a clear view of all licenses in use.
This PR changes the license spelling to the official one, as advised by Maven developers.