### PR TITLE
SOLR-13257: support for stable replica routing preferences

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -85,6 +85,8 @@ New Features
 
 * SOLR-13440: Support saving/restoring autoscaling state for repeatable simulations. (ab)
 
+* SOLR-13257: Support deterministic replica routing preferences for better cache usage (Michael Gibney)
+
 Other Changes
 ----------------------
 

--- a/solr/core/src/java/org/apache/solr/handler/component/AffinityReplicaListTransformer.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/AffinityReplicaListTransformer.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.handler.component;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.ListIterator;
+import org.apache.solr.common.cloud.Replica;
+import org.apache.solr.common.params.SolrParams;
+import org.apache.solr.common.util.Hash;
+import org.apache.solr.request.SolrQueryRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Allows better caching by establishing deterministic evenly-distributed replica routing preferences according to
+ * either explicitly configured hash routing parameter, or the hash of a query parameter (configurable, usually related
+ * to the main query).
+ */
+public class AffinityReplicaListTransformer implements ReplicaListTransformer {
+
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private final int routingDividend;
+
+  public AffinityReplicaListTransformer(String hashVal) {
+    this.routingDividend = Math.abs(Hash.lookup3ycs(hashVal, 0, hashVal.length(), 0));
+  }
+
+  public AffinityReplicaListTransformer(int routingDividend) {
+    this.routingDividend = routingDividend;
+  }
+
+  /**
+   *
+   * @param dividendParam int param to be used directly for mod-based routing
+   * @param hashParam String param to be hashed into an int for mod-based routing
+   * @param req the request from which param values will be drawn
+   * @return null if specified routing vals are not able to be parsed properly
+   */
+  public static ReplicaListTransformer getInstance(String dividendParam, String hashParam, SolrQueryRequest req) {
+    SolrParams params = req.getOriginalParams();
+    String dividendVal;
+    if (dividendParam != null && (dividendVal = params.get(dividendParam)) != null && !dividendVal.isEmpty()) {
+      try {
+        return new AffinityReplicaListTransformer(Integer.parseInt(dividendVal));
+      } catch (NumberFormatException ex) {
+        log.warn("unable to parse int from " + dividendParam + "=" + dividendVal);
+      }
+    }
+    String hashVal;
+    if (hashParam != null && (hashVal = params.get(hashParam)) != null && !hashVal.isEmpty()) {
+      return new AffinityReplicaListTransformer(hashVal);
+    } else {
+      return null;
+    }
+  }
+
+  @Override
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public void transform(List<?> choices) {
+    int size = choices.size();
+    if (size > 1) {
+      int i = 0;
+      SortableChoice[] sortableChoices = new SortableChoice[size];
+      for (Object o : choices) {
+        sortableChoices[i++] = new SortableChoice(o);
+      }
+      Arrays.sort(sortableChoices, SORTABLE_CHOICE_COMPARATOR);
+      ListIterator iter = choices.listIterator();
+      i = routingDividend % size;
+      final int limit = i + size;
+      do {
+        iter.next();
+        iter.set(sortableChoices[i % size].choice);
+      } while (++i < limit);
+    }
+  }
+
+  private static final class SortableChoice {
+
+    private final Object choice;
+    private final String sortableCoreLabel;
+
+    private SortableChoice(Object choice) {
+      this.choice = choice;
+      if (choice instanceof Replica) {
+        this.sortableCoreLabel = ((Replica)choice).getCoreUrl();
+      } else if (choice instanceof String) {
+        this.sortableCoreLabel = (String)choice;
+      } else {
+        throw new IllegalArgumentException("can't handle type " + choice.getClass());
+      }
+    }
+
+  }
+
+  private static final Comparator<SortableChoice> SORTABLE_CHOICE_COMPARATOR = new Comparator<SortableChoice>() {
+
+    @Override
+    public int compare(SortableChoice o1, SortableChoice o2) {
+      return o1.sortableCoreLabel.compareTo(o2.sortableCoreLabel);
+    }
+  };
+
+}

--- a/solr/core/src/java/org/apache/solr/handler/component/AffinityReplicaListTransformer.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/AffinityReplicaListTransformer.java
@@ -56,13 +56,9 @@ class AffinityReplicaListTransformer implements ReplicaListTransformer {
    */
   public static ReplicaListTransformer getInstance(String dividendParam, String hashParam, SolrQueryRequest req) {
     SolrParams params = req.getOriginalParams();
-    String dividendVal;
-    if (dividendParam != null && (dividendVal = params.get(dividendParam)) != null && !dividendVal.isEmpty()) {
-      try {
-        return new AffinityReplicaListTransformer(Integer.parseInt(dividendVal));
-      } catch (NumberFormatException ex) {
-        log.warn("unable to parse int from " + dividendParam + "=" + dividendVal);
-      }
+    Integer dividendVal;
+    if (dividendParam != null && (dividendVal = params.getInt(dividendParam)) != null) {
+      return new AffinityReplicaListTransformer(dividendVal);
     }
     String hashVal;
     if (hashParam != null && (hashVal = params.get(hashParam)) != null && !hashVal.isEmpty()) {

--- a/solr/core/src/java/org/apache/solr/handler/component/AffinityReplicaListTransformer.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/AffinityReplicaListTransformer.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  * either explicitly configured hash routing parameter, or the hash of a query parameter (configurable, usually related
  * to the main query).
  */
-public class AffinityReplicaListTransformer implements ReplicaListTransformer {
+class AffinityReplicaListTransformer implements ReplicaListTransformer {
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 

--- a/solr/core/src/java/org/apache/solr/handler/component/AffinityReplicaListTransformerFactory.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/AffinityReplicaListTransformerFactory.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.handler.component;
+
+import org.apache.solr.common.params.CommonParams;
+import org.apache.solr.common.params.ShardParams;
+import org.apache.solr.common.util.NamedList;
+import org.apache.solr.request.SolrQueryRequest;
+
+/**
+ *
+ */
+class AffinityReplicaListTransformerFactory implements ReplicaListTransformerFactory {
+  private final String defaultDividendParam;
+  private final String defaultHashParam;
+
+  public AffinityReplicaListTransformerFactory() {
+    this.defaultDividendParam = null;
+    this.defaultHashParam = CommonParams.Q;
+  }
+
+  public AffinityReplicaListTransformerFactory(String defaultDividendParam, String defaultHashParam) {
+    this.defaultDividendParam = defaultDividendParam;
+    this.defaultHashParam = defaultHashParam == null ? CommonParams.Q : defaultHashParam;
+  }
+
+  public AffinityReplicaListTransformerFactory(NamedList<?> c) {
+    this((String)c.get(ShardParams.ROUTING_DIVIDEND), (String)c.get(ShardParams.ROUTING_HASH));
+  }
+
+  @Override
+  public ReplicaListTransformer getInstance(String configSpec, SolrQueryRequest request, ReplicaListTransformerFactory fallback) {
+    ReplicaListTransformer rlt;
+    if (configSpec == null) {
+      rlt = AffinityReplicaListTransformer.getInstance(defaultDividendParam, defaultHashParam, request);
+    } else {
+      String[] parts = configSpec.split(":", 2);
+      switch (parts[0]) {
+        case ShardParams.ROUTING_DIVIDEND:
+          rlt = AffinityReplicaListTransformer.getInstance(parts.length == 1 ? defaultDividendParam : parts[1], defaultHashParam, request);
+          break;
+        case ShardParams.ROUTING_HASH:
+          rlt = AffinityReplicaListTransformer.getInstance(null, parts.length == 1 ? defaultHashParam : parts[1], request);
+          break;
+        default:
+          throw new IllegalArgumentException("Invalid routing spec: \"" + configSpec + '"');
+      }
+    }
+    return rlt != null ? rlt : fallback.getInstance(null, request, null);
+  }
+
+}

--- a/solr/core/src/java/org/apache/solr/handler/component/AffinityReplicaListTransformerFactory.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/AffinityReplicaListTransformerFactory.java
@@ -43,11 +43,28 @@ class AffinityReplicaListTransformerFactory implements ReplicaListTransformerFac
 
   public AffinityReplicaListTransformerFactory(String defaultDividendParam, String defaultHashParam) {
     this.defaultDividendParam = defaultDividendParam;
-    this.defaultHashParam = defaultHashParam == null ? CommonParams.Q : defaultHashParam;
+    this.defaultHashParam = defaultHashParam;
   }
 
   public AffinityReplicaListTransformerFactory(NamedList<?> c) {
-    this((String)c.get(ShardParams.ROUTING_DIVIDEND), (String)c.get(ShardParams.ROUTING_HASH));
+    this((String)c.get(ShardParams.ROUTING_DIVIDEND), translateHashParam((String)c.get(ShardParams.ROUTING_HASH)));
+  }
+
+  /**
+   * Null arg indicates no configuration, which should be translated to the default value {@link CommonParams#Q}.
+   * Empty String is translated to null, allowing users to explicitly disable hash-based stable routing.
+   *
+   * @param hashParam configured hash param (null indicates unconfigured).
+   * @return translated value to be used as default hash param in RLT.
+   */
+  private static String translateHashParam(String hashParam) {
+    if (hashParam == null) {
+      return CommonParams.Q;
+    } else if (hashParam.isEmpty()) {
+      return null;
+    } else {
+      return hashParam;
+    }
   }
 
   @Override

--- a/solr/core/src/java/org/apache/solr/handler/component/AffinityReplicaListTransformerFactory.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/AffinityReplicaListTransformerFactory.java
@@ -22,7 +22,15 @@ import org.apache.solr.common.util.NamedList;
 import org.apache.solr.request.SolrQueryRequest;
 
 /**
+ * Factory for constructing an {@link AffinityReplicaListTransformer} that reorders replica routing
+ * preferences deterministically, based on request parameters.
  *
+ * Default names of params that contain the values by which routing is determined may be configured
+ * at the time of {@link AffinityReplicaListTransformerFactory} construction, and may be
+ * overridden by the config spec passed to {@link #getInstance(String, SolrQueryRequest, ReplicaListTransformerFactory)}
+ *
+ * If no defaultHashParam name is specified at time of factory construction, the routing dividend will
+ * be derived by hashing the {@link String} value of the {@link CommonParams#Q} param.
  */
 class AffinityReplicaListTransformerFactory implements ReplicaListTransformerFactory {
   private final String defaultDividendParam;

--- a/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
@@ -221,26 +221,28 @@ public class HttpShardHandlerFactory extends ShardHandlerFactory implements org.
   }
 
   private void initReplicaListTransformers(NamedList args) {
-    NamedList routingConfig = (NamedList)args.get("replicaRouting");
     String defaultRouting = null;
-    if (routingConfig != null && routingConfig.size() > 0) {
-      Iterator<Entry<String,?>> iter = routingConfig.iterator();
-      do {
-        Entry<String, ?> e = iter.next();
-        String key = e.getKey();
-        switch (key) {
-          case ShardParams.REPLICA_RANDOM:
-            defaultRouting = checkDefaultReplicaListTransformer(getNamedList(e.getValue()), key, defaultRouting);
-            break;
-          case ShardParams.REPLICA_STABLE:
-            NamedList<?> c = getNamedList(e.getValue());
-            defaultRouting = checkDefaultReplicaListTransformer(c, key, defaultRouting);
-            this.stableRltFactory = new AffinityReplicaListTransformerFactory(c);
-            break;
-          default:
-            throw new IllegalArgumentException("invalid replica routing spec name: " + key);
-        }
-      } while (iter.hasNext());
+    if (args != null) {
+      NamedList routingConfig = (NamedList)args.get("replicaRouting");
+      if (routingConfig != null && routingConfig.size() > 0) {
+        Iterator<Entry<String,?>> iter = routingConfig.iterator();
+        do {
+          Entry<String, ?> e = iter.next();
+          String key = e.getKey();
+          switch (key) {
+            case ShardParams.REPLICA_RANDOM:
+              defaultRouting = checkDefaultReplicaListTransformer(getNamedList(e.getValue()), key, defaultRouting);
+              break;
+            case ShardParams.REPLICA_STABLE:
+              NamedList<?> c = getNamedList(e.getValue());
+              defaultRouting = checkDefaultReplicaListTransformer(c, key, defaultRouting);
+              this.stableRltFactory = new AffinityReplicaListTransformerFactory(c);
+              break;
+            default:
+              throw new IllegalArgumentException("invalid replica routing spec name: " + key);
+          }
+        } while (iter.hasNext());
+      }
     }
     if (this.stableRltFactory == null) {
       this.stableRltFactory = new AffinityReplicaListTransformerFactory();

--- a/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
@@ -204,7 +204,7 @@ public class HttpShardHandlerFactory extends ShardHandlerFactory implements org.
     if (val instanceof NamedList) {
       return (NamedList<?>)val;
     } else {
-      throw new IllegalArgumentException("Invalid config for replicaRouting: " + val);
+      throw new IllegalArgumentException("Invalid config for replicaRouting; expected NamedList, but got " + val);
     }
   }
 
@@ -222,9 +222,10 @@ public class HttpShardHandlerFactory extends ShardHandlerFactory implements org.
 
   private void initReplicaListTransformers(NamedList args) {
     String defaultRouting = null;
-    if (args != null) {
-      NamedList routingConfig = (NamedList)args.get("replicaRouting");
-      if (routingConfig != null && routingConfig.size() > 0) {
+    Object routingConfigObj;
+    if (args != null && (routingConfigObj = args.get("replicaRouting")) != null) {
+      NamedList routingConfig = getNamedList(routingConfigObj);
+      if (routingConfig.size() > 0) {
         Iterator<Entry<String,?>> iter = routingConfig.iterator();
         do {
           Entry<String, ?> e = iter.next();

--- a/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
@@ -288,24 +288,6 @@ public class HttpShardHandlerFactory extends ShardHandlerFactory implements org.
     this.accessPolicy = getParameter(args, INIT_FAIRNESS_POLICY, accessPolicy,sb);
     this.whitelistHostChecker = new WhitelistHostChecker(args == null? null: (String) args.get(INIT_SHARDS_WHITELIST), !getDisableShardsWhitelist());
     log.info("Host whitelist initialized: {}", this.whitelistHostChecker);
-
-    this.httpListenerFactory = new InstrumentedHttpListenerFactory(this.metricNameStrategy);
-    int connectionTimeout = getParameter(args, HttpClientUtil.PROP_CONNECTION_TIMEOUT,
-        HttpClientUtil.DEFAULT_CONNECT_TIMEOUT, sb);
-    int maxConnectionsPerHost = getParameter(args, HttpClientUtil.PROP_MAX_CONNECTIONS_PER_HOST,
-        HttpClientUtil.DEFAULT_MAXCONNECTIONSPERHOST, sb);
-    int soTimeout = getParameter(args, HttpClientUtil.PROP_SO_TIMEOUT,
-        HttpClientUtil.DEFAULT_SO_TIMEOUT, sb);
-
-    this.defaultClient = new Http2SolrClient.Builder()
-        .connectionTimeout(connectionTimeout)
-        .idleTimeout(soTimeout)
-        .maxConnectionsPerHost(maxConnectionsPerHost).build();
-    this.defaultClient.addListenerFactory(this.httpListenerFactory);
-    this.loadbalancer = new LBHttp2SolrClient(defaultClient);
-    initReplicaListTransformers(getParameter(args, "replicaRouting", null, sb));
-
-    log.debug("created with {}",sb);
     
     // magic sysprop to make tests reproducible: set by SolrTestCaseJ4.
     String v = System.getProperty("tests.shardhandler.randomSeed");
@@ -324,6 +306,25 @@ public class HttpShardHandlerFactory extends ShardHandlerFactory implements org.
         blockingQueue,
         new DefaultSolrThreadFactory("httpShardExecutor")
     );
+
+    this.httpListenerFactory = new InstrumentedHttpListenerFactory(this.metricNameStrategy);
+    int connectionTimeout = getParameter(args, HttpClientUtil.PROP_CONNECTION_TIMEOUT,
+        HttpClientUtil.DEFAULT_CONNECT_TIMEOUT, sb);
+    int maxConnectionsPerHost = getParameter(args, HttpClientUtil.PROP_MAX_CONNECTIONS_PER_HOST,
+        HttpClientUtil.DEFAULT_MAXCONNECTIONSPERHOST, sb);
+    int soTimeout = getParameter(args, HttpClientUtil.PROP_SO_TIMEOUT,
+        HttpClientUtil.DEFAULT_SO_TIMEOUT, sb);
+
+    this.defaultClient = new Http2SolrClient.Builder()
+        .connectionTimeout(connectionTimeout)
+        .idleTimeout(soTimeout)
+        .maxConnectionsPerHost(maxConnectionsPerHost).build();
+    this.defaultClient.addListenerFactory(this.httpListenerFactory);
+    this.loadbalancer = new LBHttp2SolrClient(defaultClient);
+
+    initReplicaListTransformers(getParameter(args, "replicaRouting", null, sb));
+
+    log.debug("created with {}",sb);
   }
 
   @Override

--- a/solr/core/src/java/org/apache/solr/handler/component/ReplicaListTransformerFactory.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/ReplicaListTransformerFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.handler.component;
+
+import org.apache.solr.request.SolrQueryRequest;
+
+public interface ReplicaListTransformerFactory {
+
+  /**
+   * 
+   * @param configSpec spec for dynamic configuration of ReplicaListTransformer
+   * @param request the request for which the ReplicaListTransformer is being generated
+   * @param fallback used to generate fallback value; the getInstance() method of the specified fallback must not
+   * return null; The fallback value itself may be null if this implementation is known to never return null (i.e., if
+   * fallback will never be needed)
+   * @return ReplicaListTransformer to be used for routing this request
+   */
+  ReplicaListTransformer getInstance(String configSpec, SolrQueryRequest request, ReplicaListTransformerFactory fallback);
+
+}

--- a/solr/solr-ref-guide/src/distributed-requests.adoc
+++ b/solr/solr-ref-guide/src/distributed-requests.adoc
@@ -180,7 +180,19 @@ In other words, this feature is mostly useful for optimizing queries directed to
 +
 Also, this option should only be used if you are load balancing requests across all nodes that host replicas for the collection you are querying, as Solr's `CloudSolrClient` will do. If not load-balancing, this feature can introduce a hotspot in the cluster since queries won't be evenly distributed across the cluster.
 
+`replica.base`::
+Applied after sorting by inherent replica attributes, this property defines a fallback ordering among sets of preference-equivalent replicas; if specified, only one value may be specified for this property, and it must be specified last.
++
+`random`, the default, randomly shuffles replicas for each request. This distributes requests evenly, but can result in sub-optimal cache usage for shards with replication factor > 1.
++
+`stable:dividend:_paramName_` parses an integer from the value associated with the given param name; this integer is used as the dividend (mod equivalent replica count) to determine (via list rotation) order of preference among equivalent replicas.
++
+`stable[:hash[:_paramName_]]` the string value associated with the given param name is hashed to a dividend that is used to determine replica preference order (analogous to the explicit `dividend` property above); `_paramName_` defaults to `q` if not specified, providing stable routing keyed to the string value of the "main query". Note that this may be inappropriate for some use cases (e.g., static main queries that leverage parameter substitution)
+
 Examples:
+
+* Prefer stable routing (keyed to client "sessionId" param) among otherwise equivalent replicas:
+   `shards.preference=replica.base:stable:hash:sessionId&sessionId=abc123`
 
 * Prefer PULL replicas:
    `shards.preference=replica.type:PULL`

--- a/solr/solr-ref-guide/src/format-of-solr-xml.adoc
+++ b/solr/solr-ref-guide/src/format-of-solr-xml.adoc
@@ -203,6 +203,22 @@ If the threadpool uses a backing queue, what is its maximum size to use direct h
 `fairnessPolicy`::
 A boolean to configure if the threadpool favors fairness over throughput. Default is false to favor throughput.
 
+`replicaRouting`::
+A NamedList specifying replica routing preference configuration. This may be used to select and configure replica routing preferences. `default=true` may be used to set the default base replica routing preference. Only positive default status assertions are respected; i.e., `default=false` has no effect. If no explicit default base replica routing preference is configured, the implicit default will be `random`.
+----
+<shardHandlerFactory class="HttpShardHandlerFactory">
+  <lst name="replicaRouting">
+    <lst name="stable">
+      <!--
+      <bool name="default">true</bool>
+      -->
+      <str name="dividend">routingDividend</str> <!-- no default -->
+      <str name="hash">q</str> <!-- defaults to hash of String value of main query param -->
+    </lst>
+  </lst>
+</shardHandlerFactory>
+----
+Replica routing may also be specified (overriding defaults) per-request, via the `shards.preference` request parameter.
 
 === The <metrics> Element
 

--- a/solr/solr-ref-guide/src/format-of-solr-xml.adoc
+++ b/solr/solr-ref-guide/src/format-of-solr-xml.adoc
@@ -209,16 +209,14 @@ A NamedList specifying replica routing preference configuration. This may be use
 <shardHandlerFactory class="HttpShardHandlerFactory">
   <lst name="replicaRouting">
     <lst name="stable">
-      <!--
       <bool name="default">true</bool>
-      -->
-      <str name="dividend">routingDividend</str> <!-- no default -->
-      <str name="hash">q</str> <!-- defaults to hash of String value of main query param -->
+      <str name="dividend">routingDividend</str>
+      <str name="hash">q</str>
     </lst>
   </lst>
 </shardHandlerFactory>
 ----
-Replica routing may also be specified (overriding defaults) per-request, via the `shards.preference` request parameter.
+Replica routing may also be specified (overriding defaults) per-request, via the `shards.preference` request parameter. If a request contains both dividend param and hash param, dividend param takes priority for routing. For configuring `stable` routing, the `hash` param implicitly defaults to a hash of the String value of the main query param (i.e., `q`). `dividend` param must be configured explicitly; there is no implicit default. If only `dividend` routing is desired, `hash` may be explicitly set to the empty string, entirely disabling implicit hash-based routing.
 
 === The <metrics> Element
 

--- a/solr/solrj/src/java/org/apache/solr/common/params/ShardParams.java
+++ b/solr/solrj/src/java/org/apache/solr/common/params/ShardParams.java
@@ -66,8 +66,23 @@ public interface ShardParams {
   /** Node with same system property sort rule */
   String SHARDS_PREFERENCE_NODE_WITH_SAME_SYSPROP = "node.sysprop";
 
+  /** Replica base/fallback sort rule */
+  String SHARDS_PREFERENCE_REPLICA_BASE = "replica.base";
+
   /** Value denoting local replicas */
   String REPLICA_LOCAL = "local";
+
+  /** Value denoting randomized replica sort */
+  String REPLICA_RANDOM = "random";
+
+  /** Value denoting stable replica sort */
+  String REPLICA_STABLE = "stable";
+
+  /** configure dividend param for stable replica sort */
+  String ROUTING_DIVIDEND = "dividend";
+
+  /** configure hash param for stable replica sort */
+  String ROUTING_HASH = "hash";
 
   String _ROUTE_ = "_route_";
 


### PR DESCRIPTION
`shards.preferences` parameter allows users to assert replica preferences based on inherent replica attributes. This PR integrates support for user-specified ordering behavior applied to replicas that are equivalent with respect to preferred inherent attributes. 

The extant implementation shuffles replicas randomly per-request. Propose to leave shuffling as the default, but add support for stable replica routing preferences (list rotation by dividend|hash % number equivalent replicas)