### PR TITLE
LUCENE-8831: Fix bug on hashCode for LatLonShapeBoundingBoxQuery

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -51,6 +51,8 @@ New Features
 
 Bug Fixes
 
+* LUCENE-8831: Fixed LatLonShapeBoundingBoxQuery .hashCode methods. (Ignacio Vera)
+
 * LUCENE-8785: Ensure new threadstates are locked before retrieving the number of active threadstates.
   This causes assertion errors and potentially broken field attributes in the IndexWriter when
   IndexWriter#deleteAll is called while actively indexing. (Simon Willnauer)

--- a/lucene/sandbox/src/java/org/apache/lucene/document/LatLonShapeBoundingBoxQuery.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/document/LatLonShapeBoundingBoxQuery.java
@@ -29,12 +29,13 @@ import org.apache.lucene.index.PointValues.Relation;
  *  @lucene.experimental
  **/
 final class LatLonShapeBoundingBoxQuery extends LatLonShapeQuery {
+  final Rectangle rectangle;
   final Rectangle2D rectangle2D;
 
   public LatLonShapeBoundingBoxQuery(String field, LatLonShape.QueryRelation queryRelation, double minLat, double maxLat, double minLon, double maxLon) {
     super(field, queryRelation);
-    Rectangle rectangle = new Rectangle(minLat, maxLat, minLon, maxLon);
-    this.rectangle2D = Rectangle2D.create(rectangle);
+    this.rectangle = new Rectangle(minLat, maxLat, minLon, maxLon);
+    this.rectangle2D = Rectangle2D.create(this.rectangle);
   }
 
   @Override
@@ -69,13 +70,13 @@ final class LatLonShapeBoundingBoxQuery extends LatLonShapeQuery {
 
   @Override
   protected boolean equalsTo(Object o) {
-    return super.equalsTo(o) && rectangle2D.equals(((LatLonShapeBoundingBoxQuery)o).rectangle2D);
+    return super.equalsTo(o) && rectangle.equals(((LatLonShapeBoundingBoxQuery)o).rectangle);
   }
 
   @Override
   public int hashCode() {
     int hash = super.hashCode();
-    hash = 31 * hash + rectangle2D.hashCode();
+    hash = 31 * hash + rectangle.hashCode();
     return hash;
   }
 
@@ -89,7 +90,7 @@ final class LatLonShapeBoundingBoxQuery extends LatLonShapeQuery {
       sb.append(this.field);
       sb.append(':');
     }
-    sb.append(rectangle2D.toString());
+    sb.append(rectangle.toString());
     return sb.toString();
   }
 }

--- a/lucene/sandbox/src/java/org/apache/lucene/geo/Rectangle2D.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/geo/Rectangle2D.java
@@ -274,36 +274,4 @@ public class Rectangle2D {
                                          final int bMinX, final int bMaxX, final int bMinY, final int bMaxY) {
     return (aMaxX < bMinX || aMinX > bMaxX || aMaxY < bMinY || aMinY > bMaxY);
   }
-
-  @Override
-  public boolean equals(Object o) {
-    return Arrays.equals(bbox, ((Rectangle2D)o).bbox)
-        && Arrays.equals(west, ((Rectangle2D)o).west);
-  }
-
-  @Override
-  public int hashCode() {
-    int hash = super.hashCode();
-    hash = 31 * hash + Arrays.hashCode(bbox);
-    hash = 31 * hash + Arrays.hashCode(west);
-    return hash;
-  }
-
-  @Override
-  public String toString() {
-    final StringBuilder sb = new StringBuilder();
-    sb.append("Rectangle(lat=");
-    sb.append(decodeLatitude(minY));
-    sb.append(" TO ");
-    sb.append(decodeLatitude(maxY));
-    sb.append(" lon=");
-    sb.append(decodeLongitude(minX));
-    sb.append(" TO ");
-    sb.append(decodeLongitude(maxX));
-    if (maxX < minX) {
-      sb.append(" [crosses dateline!]");
-    }
-    sb.append(")");
-    return sb.toString();
-  }
 }

--- a/lucene/sandbox/src/java/org/apache/lucene/geo/Rectangle2D.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/geo/Rectangle2D.java
@@ -25,8 +25,6 @@ import org.apache.lucene.util.NumericUtils;
 import static java.lang.Integer.BYTES;
 import static org.apache.lucene.geo.GeoEncodingUtils.MAX_LON_ENCODED;
 import static org.apache.lucene.geo.GeoEncodingUtils.MIN_LON_ENCODED;
-import static org.apache.lucene.geo.GeoEncodingUtils.decodeLatitude;
-import static org.apache.lucene.geo.GeoEncodingUtils.decodeLongitude;
 import static org.apache.lucene.geo.GeoEncodingUtils.encodeLatitude;
 import static org.apache.lucene.geo.GeoEncodingUtils.encodeLatitudeCeil;
 import static org.apache.lucene.geo.GeoEncodingUtils.encodeLongitude;

--- a/lucene/sandbox/src/test/org/apache/lucene/document/BaseLatLonShapeTestCase.java
+++ b/lucene/sandbox/src/test/org/apache/lucene/document/BaseLatLonShapeTestCase.java
@@ -41,6 +41,7 @@ import org.apache.lucene.index.SerialMergeScheduler;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryUtils;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.SimpleCollector;
 import org.apache.lucene.store.Directory;
@@ -66,7 +67,7 @@ public abstract class BaseLatLonShapeTestCase extends LuceneTestCase {
 
   /** name of the LatLonShape indexed field */
   protected static final String FIELD_NAME = "shape";
-  private static final QueryRelation[] POINT_LINE_RELATIONS = {QueryRelation.INTERSECTS, QueryRelation.DISJOINT};
+  protected static final QueryRelation[] POINT_LINE_RELATIONS = {QueryRelation.INTERSECTS, QueryRelation.DISJOINT};
 
   protected abstract ShapeType getShapeType();
 
@@ -145,14 +146,98 @@ public abstract class BaseLatLonShapeTestCase extends LuceneTestCase {
     return LatLonShape.newBoxQuery(field, queryRelation, minLat, maxLat, minLon, maxLon);
   }
 
+  public void testBoxQueryEqualsAndHashcode() {
+    Rectangle rectangle = GeoTestUtil.nextBox();
+    QueryRelation queryRelation = RandomPicks.randomFrom(random(), QueryRelation.values());
+    String fieldName = "foo";
+    Query q1 = newRectQuery(fieldName, queryRelation, rectangle.minLat, rectangle.maxLat, rectangle.minLon, rectangle.maxLon);
+    Query q2 = newRectQuery(fieldName, queryRelation, rectangle.minLat, rectangle.maxLat, rectangle.minLon, rectangle.maxLon);
+    QueryUtils.checkEqual(q1, q2);
+    //different field name
+    Query q3 = newRectQuery("bar", queryRelation, rectangle.minLat, rectangle.maxLat, rectangle.minLon, rectangle.maxLon);
+    QueryUtils.checkUnequal(q1, q3);
+    //different query relation
+    QueryRelation newQueryRelation = RandomPicks.randomFrom(random(), QueryRelation.values());
+    Query q4 = newRectQuery(fieldName, newQueryRelation, rectangle.minLat, rectangle.maxLat, rectangle.minLon, rectangle.maxLon);
+    if (queryRelation == newQueryRelation) {
+      QueryUtils.checkEqual(q1, q4);
+    } else {
+      QueryUtils.checkUnequal(q1, q4);
+    }
+    //different shape
+    Rectangle newRectangle = GeoTestUtil.nextBox();;
+    Query q5 = newRectQuery(fieldName, queryRelation, newRectangle.minLat, newRectangle.maxLat, newRectangle.minLon, newRectangle.maxLon);
+    if (rectangle.equals(newRectangle)) {
+      QueryUtils.checkEqual(q1, q5);
+    } else {
+      QueryUtils.checkUnequal(q1, q5);
+    }
+  }
+
   /** factory method to create a new line query */
   protected Query newLineQuery(String field, QueryRelation queryRelation, Line... lines) {
     return LatLonShape.newLineQuery(field, queryRelation, lines);
   }
 
+  public void testLineQueryEqualsAndHashcode() {
+    Line line = nextLine();
+    QueryRelation queryRelation = RandomPicks.randomFrom(random(), POINT_LINE_RELATIONS);
+    String fieldName = "foo";
+    Query q1 = newLineQuery(fieldName, queryRelation, line);
+    Query q2 = newLineQuery(fieldName, queryRelation, line);
+    QueryUtils.checkEqual(q1, q2);
+    //different field name
+    Query q3 = newLineQuery("bar", queryRelation, line);
+    QueryUtils.checkUnequal(q1, q3);
+    //different query relation
+    QueryRelation newQueryRelation = RandomPicks.randomFrom(random(), POINT_LINE_RELATIONS);
+    Query q4 = newLineQuery(fieldName, newQueryRelation, line);
+    if (queryRelation == newQueryRelation) {
+      QueryUtils.checkEqual(q1, q4);
+    } else {
+      QueryUtils.checkUnequal(q1, q4);
+    }
+    //different shape
+    Line newLine = nextLine();
+    Query q5 = newLineQuery(fieldName, queryRelation, newLine);
+    if (line.equals(newLine)) {
+      QueryUtils.checkEqual(q1, q5);
+    } else {
+      QueryUtils.checkUnequal(q1, q5);
+    }
+  }
+
   /** factory method to create a new polygon query */
   protected Query newPolygonQuery(String field, QueryRelation queryRelation, Polygon... polygons) {
     return LatLonShape.newPolygonQuery(field, queryRelation, polygons);
+  }
+
+  public void testPolygonQueryEqualsAndHashcode() {
+    Polygon polygon = GeoTestUtil.nextPolygon();
+    QueryRelation queryRelation = RandomPicks.randomFrom(random(), QueryRelation.values());
+    String fieldName = "foo";
+    Query q1 = newPolygonQuery(fieldName, queryRelation, polygon);
+    Query q2 = newPolygonQuery(fieldName, queryRelation, polygon);
+    QueryUtils.checkEqual(q1, q2);
+    //different field name
+    Query q3 = newPolygonQuery("bar", queryRelation, polygon);
+    QueryUtils.checkUnequal(q1, q3);
+    //different query relation
+    QueryRelation newQueryRelation = RandomPicks.randomFrom(random(), QueryRelation.values());
+    Query q4 = newPolygonQuery(fieldName, newQueryRelation, polygon);
+    if (queryRelation == newQueryRelation) {
+      QueryUtils.checkEqual(q1, q4);
+    } else {
+      QueryUtils.checkUnequal(q1, q4);
+    }
+    //different shape
+    Polygon newPolygon = GeoTestUtil.nextPolygon();;
+    Query q5 = newPolygonQuery(fieldName, queryRelation, newPolygon);
+    if (polygon.equals(newPolygon)) {
+      QueryUtils.checkEqual(q1, q5);
+    } else {
+      QueryUtils.checkUnequal(q1, q5);
+    }
   }
 
   // A particularly tricky adversary for BKD tree:

--- a/lucene/sandbox/src/test/org/apache/lucene/document/BaseLatLonShapeTestCase.java
+++ b/lucene/sandbox/src/test/org/apache/lucene/document/BaseLatLonShapeTestCase.java
@@ -67,7 +67,7 @@ public abstract class BaseLatLonShapeTestCase extends LuceneTestCase {
 
   /** name of the LatLonShape indexed field */
   protected static final String FIELD_NAME = "shape";
-  protected static final QueryRelation[] POINT_LINE_RELATIONS = {QueryRelation.INTERSECTS, QueryRelation.DISJOINT};
+  private static final QueryRelation[] POINT_LINE_RELATIONS = {QueryRelation.INTERSECTS, QueryRelation.DISJOINT};
 
   protected abstract ShapeType getShapeType();
 


### PR DESCRIPTION
The current problem is the implementation in Rectangle2D but looking into other shape implementations like Line2D or Polygon2D, they do not implement has code, equals or toString methods. To keep symmetry on the implementations this PR removes those implementation in Rectangle2D and uses the provided Rectangle object in LatLonShapeBoundingBoxQuery to generate the hashCode.