### PR TITLE
SOLR-13546: Fix typo 'hightlight' in webapp query interface

### DIFF
--- a/solr/webapp/web/partials/query.html
+++ b/solr/webapp/web/partials/query.html
@@ -235,7 +235,7 @@ limitations under the License.
         </label>
 
         <label for="hl_highlightMultiTerm" class="checkbox">
-          <input type="checkbox" ng-model="hl['hightlightMultiTerm']" name="hl.highlightMultiTerm" id="hl_highlightMultiTerm" value="true">
+          <input type="checkbox" ng-model="hl['highlightMultiTerm']" name="hl.highlightMultiTerm" id="hl_highlightMultiTerm" value="true">
           hl.highlightMultiTerm
         </label>
 


### PR DESCRIPTION
Due to a typo in the webapp query interface, the used query string is incorrect.