### PR TITLE
Use append() when StringBuilder is being used, instead of regular concat.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -83,6 +83,10 @@ Test Framework
 * LUCENE-8825: CheckHits now display the shard index in case of mismatch
   between top hits. (Atri Sharma via Adrien Grand)
 
+Other
+
+* LUCENE-8847: Code Cleanup: Remove StringBuilder.append with concatted strings
+
 ======================= Lucene 8.1.1 =======================
 (No Changes)
 

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/tokenattributes/PartOfSpeechAttributeImpl.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/tokenattributes/PartOfSpeechAttributeImpl.java
@@ -80,7 +80,7 @@ public class PartOfSpeechAttributeImpl extends AttributeImpl implements PartOfSp
       if (builder.length() > 0) {
         builder.append("+");
       }
-      builder.append(morpheme.surfaceForm + "/" + morpheme.posTag.name() + "(" + morpheme.posTag.description() + ")");
+      builder.append(morpheme.surfaceForm).append('/').append(morpheme.posTag.name()).append('(').append(morpheme.posTag.description()).append(')');
     }
     return builder.toString();
   }

--- a/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/BiSegGraph.java
+++ b/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/BiSegGraph.java
@@ -222,7 +222,7 @@ class BiSegGraph {
     Collection<ArrayList<SegTokenPair>>  values = tokenPairListTable.values();
     for (ArrayList<SegTokenPair> segList : values) {
       for (SegTokenPair pair : segList) {
-        sb.append(pair + "\n");
+        sb.append(pair).append("\n");
       }
     }
     return sb.toString();

--- a/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/SegGraph.java
+++ b/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/hhmm/SegGraph.java
@@ -136,7 +136,7 @@ class SegGraph {
     List<SegToken> tokenList = this.toTokenList();
     StringBuilder sb = new StringBuilder();
     for (SegToken t : tokenList) {
-      sb.append(t + "\n");
+      sb.append(t).append("\n");
     }
     return sb.toString();
   }

--- a/lucene/analysis/stempel/src/java/org/egothor/stemmer/Diff.java
+++ b/lucene/analysis/stempel/src/java/org/egothor/stemmer/Diff.java
@@ -239,7 +239,7 @@ public class Diff {
       switch (way[x][y]) {
         case X:
           if (equals != base) {
-            result.append("-" + (equals));
+            result.append('-').append(equals);
             equals = base;
           }
           deletes++;
@@ -248,11 +248,11 @@ public class Diff {
         // delete
         case Y:
           if (deletes != base) {
-            result.append("D" + (deletes));
+            result.append('D').append(deletes);
             deletes = base;
           }
           if (equals != base) {
-            result.append("-" + (equals));
+            result.append('-').append(equals);
             equals = base;
           }
           result.append('I');
@@ -261,11 +261,11 @@ public class Diff {
         // insert
         case R:
           if (deletes != base) {
-            result.append("D" + (deletes));
+            result.append('D').append(deletes);
             deletes = base;
           }
           if (equals != base) {
-            result.append("-" + (equals));
+            result.append('-').append(equals);
             equals = base;
           }
           result.append('R');
@@ -275,7 +275,7 @@ public class Diff {
         // replace
         case D:
           if (deletes != base) {
-            result.append("D" + (deletes));
+            result.append('D').append(deletes);
             deletes = base;
           }
           equals++;
@@ -286,7 +286,7 @@ public class Diff {
       }
     }
     if (deletes != base) {
-      result.append("D" + (deletes));
+      result.append('D').append(deletes);
       deletes = base;
     }
     

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/feeds/AbstractQueryMaker.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/feeds/AbstractQueryMaker.java
@@ -50,7 +50,7 @@ public abstract class AbstractQueryMaker implements QueryMaker {
     StringBuilder sb = new StringBuilder();
     if (queries != null) {
       for (int i = 0; i < queries.length; i++) {
-        sb.append(i+". "+ queries[i].getClass().getSimpleName()+" - "+queries[i].toString());
+        sb.append(i).append(". ").append(queries[i].getClass().getSimpleName()).append(" - ").append(queries[i].toString());
         sb.append(newline);
       }
     }

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/feeds/ContentItemsSource.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/feeds/ContentItemsSource.java
@@ -159,19 +159,19 @@ public abstract class ContentItemsSource implements Closeable {
     int nut = getTotalItemsCount();
     if (nut > lastPrintedNumUniqueTexts) {
       print = true;
-      sb.append("total count of "+itemsName+": ").append(Format.format(0,nut,col)).append(newline);
+      sb.append("total count of ").append(itemsName).append(": ").append(Format.format(0,nut,col)).append(newline);
       lastPrintedNumUniqueTexts = nut;
     }
     long nub = getTotalBytesCount();
     if (nub > lastPrintedNumUniqueBytes) {
       print = true;
-      sb.append("total bytes of "+itemsName+": ").append(Format.format(0,nub,col)).append(newline);
+      sb.append("total bytes of ").append(itemsName).append(": ").append(Format.format(0,nub,col)).append(newline);
       lastPrintedNumUniqueBytes = nub;
     }
     if (getItemsCount() > 0) {
       print = true;
-      sb.append("num "+itemsName+" added since last inputs reset:   ").append(Format.format(0,getItemsCount(),col)).append(newline);
-      sb.append("total bytes added for "+itemsName+" since last inputs reset: ").append(Format.format(0,getBytesCount(),col)).append(newline);
+      sb.append("num ").append(itemsName).append(" added since last inputs reset:   ").append(Format.format(0,getItemsCount(),col)).append(newline);
+      sb.append("total bytes added for ").append(itemsName).append(" since last inputs reset: ").append(Format.format(0,getBytesCount(),col)).append(newline);
     }
     if (print) {
       System.out.println(sb.append(newline).toString());

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/TaskSequence.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/TaskSequence.java
@@ -436,14 +436,14 @@ public class TaskSequence extends PerfTask {
     sb.append(padd);
     sb.append(!letChildReport ? ">" : (parallel ? "]" : "}"));
     if (fixedTime) {
-      sb.append(" " + NumberFormat.getNumberInstance(Locale.ROOT).format(runTimeSec) + "s");
+      sb.append(' ').append(NumberFormat.getNumberInstance(Locale.ROOT).format(runTimeSec)).append('s');
     } else if (repetitions>1) {
-      sb.append(" * " + repetitions);
+      sb.append(" * ").append(repetitions);
     } else if (repetitions==REPEAT_EXHAUST) {
       sb.append(" * EXHAUST");
     }
     if (rate>0) {
-      sb.append(",  rate: " + rate+"/"+(perMin?"min":"sec"));
+      sb.append(",  rate: ").append(rate).append('/').append(perMin ? "min" : "sec");
     }
     if (getRunInBackground()) {
       sb.append(" &");

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/quality/trec/TrecTopicsReader.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/quality/trec/TrecTopicsReader.java
@@ -122,13 +122,13 @@ public class TrecTopicsReader {
       }
       if (line.startsWith(prefix)) {
         if (collectMatchLine) {
-          sb.append(sep+line);
+          sb.append(sep).append(line);
           sep = newline;
         }
         break;
       }
       if (collectAll) {
-        sb.append(sep+line);
+        sb.append(sep).append(line);
         sep = newline;
       }
     }

--- a/lucene/core/src/java/org/apache/lucene/document/LatLonPointSortField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LatLonPointSortField.java
@@ -92,7 +92,7 @@ final class LatLonPointSortField extends SortField {
     builder.append(" longitude=");
     builder.append(longitude);
     if (Double.POSITIVE_INFINITY != getMissingValue()) {
-      builder.append(" missingValue=" + getMissingValue());
+      builder.append(" missingValue=").append(getMissingValue());
     }
     builder.append('>');
     return builder.toString();

--- a/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
@@ -303,7 +303,7 @@ public abstract class MergePolicy {
         b.append(" into ").append(info.info.name);
       }
       if (maxNumSegments != -1) {
-        b.append(" [maxNumSegments=" + maxNumSegments + "]");
+        b.append(" [maxNumSegments=").append(maxNumSegments).append(']');
       }
       if (isAborted()) {
         b.append(" [ABORTED]");

--- a/lucene/core/src/java/org/apache/lucene/index/MultiBits.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MultiBits.java
@@ -98,18 +98,18 @@ public final class MultiBits implements Bits {
   @Override
   public String toString() {
     StringBuilder b = new StringBuilder();
-    b.append(subs.length + " subs: ");
+    b.append(subs.length).append(" subs: ");
     for(int i=0;i<subs.length;i++) {
       if (i != 0) {
         b.append("; ");
       }
       if (subs[i] == null) {
-        b.append("s=" + starts[i] + " l=null");
+        b.append("s=").append(starts[i]).append(" l=null");
       } else {
-        b.append("s=" + starts[i] + " l=" + subs[i].length() + " b=" + subs[i]);
+        b.append("s=").append(starts[i]).append(" l=").append(subs[i].length()).append(" b=").append(subs[i]);
       }
     }
-    b.append(" end=" + starts[subs.length]);
+    b.append(" end=").append(starts[subs.length]);
     return b.toString();
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/Terms.java
+++ b/lucene/core/src/java/org/apache/lucene/index/Terms.java
@@ -209,11 +209,11 @@ public abstract class Terms {
    */
   public Object getStats() throws IOException {
     StringBuilder sb = new StringBuilder();
-    sb.append("impl=" + getClass().getSimpleName());
-    sb.append(",size=" + size());
-    sb.append(",docCount=" + getDocCount());
-    sb.append(",sumTotalTermFreq=" + getSumTotalTermFreq());
-    sb.append(",sumDocFreq=" + getSumDocFreq());
+    sb.append("impl=").append(getClass().getSimpleName());
+    sb.append(",size=").append(size());
+    sb.append(",docCount=").append(getDocCount());
+    sb.append(",sumTotalTermFreq=").append(getSumTotalTermFreq());
+    sb.append(",sumDocFreq=").append(getSumDocFreq());
     return sb.toString();
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/UnicodeUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/UnicodeUtil.java
@@ -569,7 +569,7 @@ public final class UnicodeUtil {
           }
         }
         
-        sb.append("0x" + Integer.toHexString(ch));
+        sb.append("0x").append(Integer.toHexString(ch));
       }
     }
     return sb.toString();

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/Automaton.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/Automaton.java
@@ -589,9 +589,9 @@ public class Automaton implements Accountable {
       b.append("  ");
       b.append(state);
       if (isAccept(state)) {
-        b.append(" [shape=doublecircle,label=\"" + state + "\"]\n");
+        b.append(" [shape=doublecircle,label=\"").append(state).append("\"]\n");
       } else {
-        b.append(" [shape=circle,label=\"" + state + "\"]\n");
+        b.append(" [shape=circle,label=\"").append(state).append("\"]\n");
       }
       int numTransitions = initTransition(state, t);
       //System.out.println("toDot: state " + state + " has " + numTransitions + " transitions; t.nextTrans=" + t.transitionUpto);

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/RunAutomaton.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/RunAutomaton.java
@@ -103,7 +103,7 @@ public abstract class RunAutomaton {
     StringBuilder b = new StringBuilder();
     b.append("initial state: 0\n");
     for (int i = 0; i < size; i++) {
-      b.append("state " + i);
+      b.append("state ").append(i);
       if (accept[i]) b.append(" [accept]:\n");
       else b.append(" [reject]:\n");
       for (int j = 0; j < points.length; j++) {

--- a/lucene/core/src/java/org/apache/lucene/util/fst/FST.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/FST.java
@@ -208,8 +208,8 @@ public final class FST<T> implements Accountable {
     @Override
     public String toString() {
       StringBuilder b = new StringBuilder();
-      b.append(" target=" + target);
-      b.append(" label=0x" + Integer.toHexString(label));
+      b.append(" target=").append(target);
+      b.append(" label=0x").append(Integer.toHexString(label));
       if (flag(BIT_FINAL_ARC)) {
         b.append(" final");
       }
@@ -223,13 +223,13 @@ public final class FST<T> implements Accountable {
         b.append(" stop");
       }
       if (flag(BIT_ARC_HAS_OUTPUT)) {
-        b.append(" output=" + output);
+        b.append(" output=").append(output);
       }
       if (flag(BIT_ARC_HAS_FINAL_OUTPUT)) {
-        b.append(" nextFinalOutput=" + nextFinalOutput);
+        b.append(" nextFinalOutput=").append(nextFinalOutput);
       }
       if (bytesPerArc != 0) {
-        b.append(" arcArray(idx=" + arcIdx + " of " + numArcs + ")");
+        b.append(" arcArray(idx=").append(arcIdx).append(" of ").append(numArcs).append(")");
       }
       return b.toString();
     }

--- a/lucene/facet/src/java/org/apache/lucene/facet/FacetResult.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/FacetResult.java
@@ -60,7 +60,7 @@ public final class FacetResult {
     sb.append(childCount);
     sb.append('\n');
     for(LabelAndValue labelValue : labelValues) {
-      sb.append("  " + labelValue + "\n");
+      sb.append("  ").append(labelValue).append("\n");
     }
     return sb.toString();
   }

--- a/lucene/facet/src/java/org/apache/lucene/facet/range/LongRangeCounter.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/range/LongRangeCounter.java
@@ -295,9 +295,9 @@ final class LongRangeCounter {
       indent(sb, depth);
       if (left == null) {
         assert right == null;
-        sb.append("leaf: " + start + " to " + end);
+        sb.append("leaf: ").append(start).append(" to ").append(end);
       } else {
-        sb.append("node: " + start + " to " + end);
+        sb.append("node: ").append(start).append(" to ").append(end);
       }
       if (outputs != null) {
         sb.append(" outputs=");

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/directory/DirectoryTaxonomyReader.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/directory/DirectoryTaxonomyReader.java
@@ -412,14 +412,14 @@ public class DirectoryTaxonomyReader extends TaxonomyReader implements Accountab
       try {
         FacetLabel category = this.getPath(i);
         if (category == null) {
-          sb.append(i + ": NULL!! \n");
+          sb.append(i).append(": NULL!! \n");
           continue;
         } 
         if (category.length == 0) {
-          sb.append(i + ": EMPTY STRING!! \n");
+          sb.append(i).append(": EMPTY STRING!! \n");
           continue;
         }
-        sb.append(i +": "+category.toString()+"\n");
+        sb.append(i).append(": ").append(category.toString()).append("\n");
       } catch (IOException e) {
         if (log.isLoggable(Level.FINEST)) {
           log.log(Level.FINEST, e.getMessage(), e);

--- a/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
+++ b/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
@@ -728,7 +728,7 @@ public class MemoryIndex {
       String fieldName = entry.getKey();
       Info info = entry.getValue();
       info.sortTerms();
-      result.append(fieldName + ":\n");
+      result.append(fieldName).append(":\n");
       SliceByteStartArray sliceArray = info.sliceArray;
       int numPositions = 0;
       SliceReader postingsReader = new SliceReader(intBlockPool);
@@ -736,7 +736,7 @@ public class MemoryIndex {
         int ord = info.sortedTerms[j];
         info.terms.get(ord, spare);
         int freq = sliceArray.freq[ord];
-        result.append("\t'" + spare + "':" + freq + ":");
+        result.append("\t'").append(spare).append("':").append(freq).append(':');
         postingsReader.reset(sliceArray.start[ord], sliceArray.end[ord]);
         result.append(" [");
         final int iters = storeOffsets ? 3 : 1;
@@ -752,7 +752,7 @@ public class MemoryIndex {
           if (storePayloads) {
             int payloadIndex = postingsReader.readInt();
             if (payloadIndex != -1) {
-                result.append(", " + payloadsBytesRefs.get(payloadBuilder, payloadIndex));
+                result.append(", ").append(payloadsBytesRefs.get(payloadBuilder, payloadIndex));
             }
           }
           result.append(")");
@@ -767,16 +767,16 @@ public class MemoryIndex {
         numPositions += freq;
       }
 
-      result.append("\tterms=" + info.terms.size());
-      result.append(", positions=" + numPositions);
+      result.append("\tterms=").append(info.terms.size());
+      result.append(", positions=").append(numPositions);
       result.append("\n");
       sumPositions += numPositions;
       sumTerms += info.terms.size();
     }
     
-    result.append("\nfields=" + fields.size());
-    result.append(", terms=" + sumTerms);
-    result.append(", positions=" + sumPositions);
+    result.append("\nfields=").append(fields.size());
+    result.append(", terms=").append(sumTerms);
+    result.append(", positions=").append(sumPositions);
     return result.toString();
   }
   

--- a/lucene/misc/src/java/org/apache/lucene/misc/SweetSpotSimilarity.java
+++ b/lucene/misc/src/java/org/apache/lucene/misc/SweetSpotSimilarity.java
@@ -207,8 +207,7 @@ public class SweetSpotSimilarity extends ClassicSimilarity {
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("SweetSpotSimilarity")
-        .append("(")
-        .append("ln_min="+ln_min+", ")
+        .append('(').append("ln_min=").append(ln_min).append(", ")
         .append("ln_max=").append(ln_max).append(", ")
         .append("ln_steep=").append(ln_steep).append(", ")
         .append("tf_base=").append(tf_base).append(", ")

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/ParseException.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/ParseException.java
@@ -173,7 +173,7 @@ public class ParseException extends Exception {
            default:
               if ((ch = str.charAt(i)) < 0x20 || ch > 0x7e) {
                  String s = "0000" + Integer.toString(ch, 16);
-                 retval.append("\\u" + s.substring(s.length() - 4, s.length()));
+                 retval.append("\\u").append(s.substring(s.length() - 4, s.length()));
               } else {
                  retval.append(ch);
               }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/TokenMgrError.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/TokenMgrError.java
@@ -82,7 +82,7 @@ public class TokenMgrError extends Error
         default:
           if ((ch = str.charAt(i)) < 0x20 || ch > 0x7e) {
             String s = "0000" + Integer.toString(ch, 16);
-            retval.append("\\u" + s.substring(s.length() - 4, s.length()));
+            retval.append("\\u").append(s.substring(s.length() - 4, s.length()));
           } else {
             retval.append(ch);
           }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/core/nodes/AnyQueryNode.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/core/nodes/AnyQueryNode.java
@@ -109,8 +109,7 @@ public class AnyQueryNode extends AndQueryNode {
       return "<any field='" + this.field + "'  matchelements="
           + this.minimumMatchingmElements + "/>";
     StringBuilder sb = new StringBuilder();
-    sb.append("<any field='" + this.field + "'  matchelements="
-        + this.minimumMatchingmElements + ">");
+    sb.append("<any field='").append(this.field).append("'  matchelements=").append(this.minimumMatchingmElements).append('>');
     for (QueryNode clause : getChildren()) {
       sb.append("\n");
       sb.append(clause.toString());

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/core/nodes/ProximityQueryNode.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/core/nodes/ProximityQueryNode.java
@@ -150,8 +150,7 @@ public class ProximityQueryNode extends BooleanQueryNode {
           + "' type='" + this.proximityType.toString() + "'" + distanceSTR
           + "/>";
     StringBuilder sb = new StringBuilder();
-    sb.append("<proximity field='" + this.field + "' inorder='" + this.inorder
-        + "' type='" + this.proximityType.toString() + "'" + distanceSTR + ">");
+    sb.append("<proximity field='").append(this.field).append("' inorder='").append(this.inorder).append("' type='").append(this.proximityType.toString()).append("'").append(distanceSTR).append(">");
     for (QueryNode child : getChildren()) {
       sb.append("\n");
       sb.append(child.toString());

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/parser/ParseException.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/parser/ParseException.java
@@ -176,7 +176,7 @@ public class ParseException extends QueryNodeParseException {
            default:
               if ((ch = str.charAt(i)) < 0x20 || ch > 0x7e) {
                  String s = "0000" + Integer.toString(ch, 16);
-                 retval.append("\\u" + s.substring(s.length() - 4, s.length()));
+                 retval.append("\\u").append(s.substring(s.length() - 4, s.length()));
               } else {
                  retval.append(ch);
               }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/parser/TokenMgrError.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/parser/TokenMgrError.java
@@ -82,7 +82,7 @@ public class TokenMgrError extends Error
         default:
           if ((ch = str.charAt(i)) < 0x20 || ch > 0x7e) {
             String s = "0000" + Integer.toString(ch, 16);
-            retval.append("\\u" + s.substring(s.length() - 4, s.length()));
+            retval.append("\\u").append(s.substring(s.length() - 4, s.length()));
           } else {
             retval.append(ch);
           }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/surround/parser/ParseException.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/surround/parser/ParseException.java
@@ -173,7 +173,7 @@ public class ParseException extends Exception {
            default:
               if ((ch = str.charAt(i)) < 0x20 || ch > 0x7e) {
                  String s = "0000" + Integer.toString(ch, 16);
-                 retval.append("\\u" + s.substring(s.length() - 4, s.length()));
+                 retval.append("\\u").append(s.substring(s.length() - 4, s.length()));
               } else {
                  retval.append(ch);
               }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/surround/parser/TokenMgrError.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/surround/parser/TokenMgrError.java
@@ -82,7 +82,7 @@ public class TokenMgrError extends Error
         default:
           if ((ch = str.charAt(i)) < 0x20 || ch > 0x7e) {
             String s = "0000" + Integer.toString(ch, 16);
-            retval.append("\\u" + s.substring(s.length() - 4, s.length()));
+            retval.append("\\u").append(s.substring(s.length() - 4, s.length()));
           } else {
             retval.append(ch);
           }

--- a/lucene/sandbox/src/java/org/apache/lucene/document/LatLonShapeLineQuery.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/document/LatLonShapeLineQuery.java
@@ -111,7 +111,7 @@ final class LatLonShapeLineQuery extends LatLonShapeQuery {
       sb.append(this.field);
       sb.append(':');
     }
-    sb.append("Line(" + lines[0].toGeoJSON() + ")");
+    sb.append("Line(").append(lines[0].toGeoJSON()).append(')');
     return sb.toString();
   }
 

--- a/lucene/sandbox/src/java/org/apache/lucene/document/LatLonShapePolygonQuery.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/document/LatLonShapePolygonQuery.java
@@ -100,7 +100,7 @@ final class LatLonShapePolygonQuery extends LatLonShapeQuery {
       sb.append(this.field);
       sb.append(':');
     }
-    sb.append("Polygon(" + polygons[0].toGeoJSON() + ")");
+    sb.append("Polygon(").append(polygons[0].toGeoJSON()).append(')');
     return sb.toString();
   }
 

--- a/lucene/sandbox/src/java/org/apache/lucene/geo/Tessellator.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/geo/Tessellator.java
@@ -873,12 +873,12 @@ final public class Tessellator {
       if (this.previous == null)
         builder.append("||-");
       else
-        builder.append(this.previous.idx + " <- ");
+        builder.append(this.previous.idx).append(" <- ");
       builder.append(this.idx);
       if (this.next == null)
         builder.append(" -||");
       else
-        builder.append(" -> " + this.next.idx);
+        builder.append(" -> ").append(this.next.idx);
       return builder.toString();
     }
   }

--- a/lucene/sandbox/src/java/org/apache/lucene/search/TermAutomatonQuery.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/search/TermAutomatonQuery.java
@@ -284,9 +284,9 @@ public class TermAutomatonQuery extends Query {
       b.append("  ");
       b.append(state);
       if (det.isAccept(state)) {
-        b.append(" [shape=doublecircle,label=\"" + state + "\"]\n");
+        b.append(" [shape=doublecircle,label=\"").append(state).append("\"]\n");
       } else {
-        b.append(" [shape=circle,label=\"" + state + "\"]\n");
+        b.append(" [shape=circle,label=\"").append(state).append("\"]\n");
       }
       int numTransitions = det.initTransition(state, t);
       for(int i=0;i<numTransitions;i++) {

--- a/lucene/spatial-extras/src/java/org/apache/lucene/spatial/prefix/NumberRangePrefixTreeStrategy.java
+++ b/lucene/spatial-extras/src/java/org/apache/lucene/spatial/prefix/NumberRangePrefixTreeStrategy.java
@@ -191,7 +191,7 @@ public class NumberRangePrefixTreeStrategy extends RecursivePrefixTreeStrategy {
     @Override
     public String toString() {
       StringBuilder buf = new StringBuilder(2048);
-      buf.append("Facets: level=" + detailLevel + " topLeaves=" + topLeaves + " parentCount=" + parents.size());
+      buf.append("Facets: level=").append(detailLevel).append(" topLeaves=").append(topLeaves).append(" parentCount=").append(parents.size());
       for (Map.Entry<UnitNRShape, FacetParentVal> entry : parents.entrySet()) {
         buf.append('\n');
         if (buf.length() > 1000) {
@@ -199,7 +199,7 @@ public class NumberRangePrefixTreeStrategy extends RecursivePrefixTreeStrategy {
           break;
         }
         final FacetParentVal pVal = entry.getValue();
-        buf.append(' ').append(entry.getKey()+" leafCount=" + pVal.parentLeaves);
+        buf.append(' ').append(entry.getKey()).append(" leafCount=").append(pVal.parentLeaves);
         if (pVal.childCounts != null) {
           buf.append(' ').append(Arrays.toString(pVal.childCounts));
         }

--- a/lucene/spatial-extras/src/java/org/apache/lucene/spatial/prefix/RecursivePrefixTreeStrategy.java
+++ b/lucene/spatial-extras/src/java/org/apache/lucene/spatial/prefix/RecursivePrefixTreeStrategy.java
@@ -116,7 +116,7 @@ public class RecursivePrefixTreeStrategy extends PrefixTreeStrategy {
     if (pruneLeafyBranches)
       str.append(",pruneLeafyBranches");
     if (prefixGridScanLevel != grid.getMaxLevels() - 4)
-      str.append(",prefixGridScanLevel:").append(""+prefixGridScanLevel);
+      str.append(",prefixGridScanLevel:").append("").append(prefixGridScanLevel);
     if (!multiOverlappingIndexedShapes)
       str.append(",!multiOverlappingIndexedShapes");
     return str.append(')').toString();

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/Geo3DPoint.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/Geo3DPoint.java
@@ -186,9 +186,9 @@ public final class Geo3DPoint extends Field {
     result.append(':');
 
     BytesRef bytes = (BytesRef) fieldsData;
-    result.append(" x=" + decodeDimension(bytes.bytes, bytes.offset));
-    result.append(" y=" + decodeDimension(bytes.bytes, bytes.offset + Integer.BYTES));
-    result.append(" z=" + decodeDimension(bytes.bytes, bytes.offset + 2*Integer.BYTES));
+    result.append(" x=").append(decodeDimension(bytes.bytes, bytes.offset));
+    result.append(" y=").append(decodeDimension(bytes.bytes, bytes.offset + Integer.BYTES));
+    result.append(" z=").append(decodeDimension(bytes.bytes, bytes.offset + 2 * Integer.BYTES));
     result.append('>');
     return result.toString();
   }

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/Geo3DPointOutsideSortField.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/Geo3DPointOutsideSortField.java
@@ -85,7 +85,7 @@ final class Geo3DPointOutsideSortField extends SortField {
     builder.append(" shape=");
     builder.append(distanceShape);
     if (Double.POSITIVE_INFINITY != getMissingValue()) {
-      builder.append(" missingValue=" + getMissingValue());
+      builder.append(" missingValue=").append(getMissingValue());
     }
     builder.append('>');
     return builder.toString();

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/Geo3DPointSortField.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/Geo3DPointSortField.java
@@ -85,7 +85,7 @@ final class Geo3DPointSortField extends SortField {
     builder.append(" shape=");
     builder.append(distanceShape);
     if (Double.POSITIVE_INFINITY != getMissingValue()) {
-      builder.append(" missingValue=" + getMissingValue());
+      builder.append(" missingValue=").append(getMissingValue());
     }
     builder.append('>');
     return builder.toString();

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/jaspell/JaspellTernarySearchTrie.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/jaspell/JaspellTernarySearchTrie.java
@@ -439,14 +439,14 @@ public class JaspellTernarySearchTrie implements Accountable {
   protected String getKey(TSTNode node) {
     StringBuilder getKeyBuffer = new StringBuilder();
     getKeyBuffer.setLength(0);
-    getKeyBuffer.append("" + node.splitchar);
+    getKeyBuffer.append("").append(node.splitchar);
     TSTNode currentNode;
     TSTNode lastNode;
     currentNode = node.relatives[TSTNode.PARENT];
     lastNode = node;
     while (currentNode != null) {
       if (currentNode.relatives[TSTNode.EQKID] == lastNode) {
-        getKeyBuffer.append("" + currentNode.splitchar);
+        getKeyBuffer.append("").append(currentNode.splitchar);
       }
       lastNode = currentNode;
       currentNode = currentNode.relatives[TSTNode.PARENT];

--- a/lucene/test-framework/src/java/org/apache/lucene/geo/BaseGeoPointTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/geo/BaseGeoPointTestCase.java
@@ -856,17 +856,17 @@ public abstract class BaseGeoPointTestCase extends LuceneTestCase {
 
         if (hits.get(docID) != expected) {
           StringBuilder b = new StringBuilder();
-          b.append("docID=(" + docID + ")\n");
+          b.append("docID=(").append(docID).append(")\n");
 
           if (expected) {
-            b.append("FAIL: id=" + id + " should match but did not\n");
+            b.append("FAIL: id=").append(id).append(" should match but did not\n");
           } else {
-            b.append("FAIL: id=" + id + " should not match but did\n");
+            b.append("FAIL: id=").append(id).append(" should not match but did\n");
           }
-          b.append("  box=" + rect + "\n");
-          b.append("  query=" + query + " docID=" + docID + "\n");
-          b.append("  lat=" + lats[id] + " lon=" + lons[id] + "\n");
-          b.append("  deleted?=" + (liveDocs != null && liveDocs.get(docID) == false));
+          b.append("  box=").append(rect).append("\n");
+          b.append("  query=").append(query).append(" docID=").append(docID).append("\n");
+          b.append("  lat=").append(lats[id]).append(" lon=").append(lons[id]).append("\n");
+          b.append("  deleted?=").append(liveDocs != null && liveDocs.get(docID) == false);
           if (true) {
             fail("wrong hit (first of possibly more):\n\n" + b);
           } else {
@@ -997,16 +997,16 @@ public abstract class BaseGeoPointTestCase extends LuceneTestCase {
           StringBuilder b = new StringBuilder();
 
           if (expected) {
-            b.append("FAIL: id=" + id + " should match but did not\n");
+            b.append("FAIL: id=").append(id).append(" should match but did not\n");
           } else {
-            b.append("FAIL: id=" + id + " should not match but did\n");
+            b.append("FAIL: id=").append(id).append(" should not match but did\n");
           }
-          b.append("  query=" + query + " docID=" + docID + "\n");
-          b.append("  lat=" + lats[id] + " lon=" + lons[id] + "\n");
-          b.append("  deleted?=" + (liveDocs != null && liveDocs.get(docID) == false));
+          b.append("  query=").append(query).append(" docID=").append(docID).append("\n");
+          b.append("  lat=").append(lats[id]).append(" lon=").append(lons[id]).append("\n");
+          b.append("  deleted?=").append(liveDocs != null && liveDocs.get(docID) == false);
           if (Double.isNaN(lats[id]) == false) {
             double distanceMeters = SloppyMath.haversinMeters(centerLat, centerLon, lats[id], lons[id]);
-            b.append("  centerLat=" + centerLat + " centerLon=" + centerLon + " distanceMeters=" + distanceMeters + " vs radiusMeters=" + radiusMeters);
+            b.append("  centerLat=").append(centerLat).append(" centerLon=").append(centerLon).append(" distanceMeters=").append(distanceMeters).append(" vs radiusMeters=").append(radiusMeters);
           }
           if (true) {
             fail("wrong hit (first of possibly more):\n\n" + b);
@@ -1129,14 +1129,14 @@ public abstract class BaseGeoPointTestCase extends LuceneTestCase {
           StringBuilder b = new StringBuilder();
 
           if (expected) {
-            b.append("FAIL: id=" + id + " should match but did not\n");
+            b.append("FAIL: id=").append(id).append(" should match but did not\n");
           } else {
-            b.append("FAIL: id=" + id + " should not match but did\n");
+            b.append("FAIL: id=").append(id).append(" should not match but did\n");
           }
-          b.append("  query=" + query + " docID=" + docID + "\n");
-          b.append("  lat=" + lats[id] + " lon=" + lons[id] + "\n");
-          b.append("  deleted?=" + (liveDocs != null && liveDocs.get(docID) == false));
-          b.append("  polygon=" + polygon);
+          b.append("  query=").append(query).append(" docID=").append(docID).append("\n");
+          b.append("  lat=").append(lats[id]).append(" lon=").append(lons[id]).append("\n");
+          b.append("  deleted?=").append(liveDocs != null && liveDocs.get(docID) == false);
+          b.append("  polygon=").append(polygon);
           if (true) {
             fail("wrong hit (first of possibly more):\n\n" + b);
           } else {

--- a/lucene/test-framework/src/java/org/apache/lucene/geo/EarthDebugger.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/geo/EarthDebugger.java
@@ -46,7 +46,7 @@ public class EarthDebugger {
     b.append("    <script src=\"http://www.webglearth.com/v2/api.js\"></script>\n");
     b.append("    <script>\n");
     b.append("      function initialize() {\n");
-    b.append("        var earth = new WE.map('earth_div', {center: [" + centerLat + ", " + centerLon + "], altitude: " + altitudeMeters + "});\n");
+    b.append("        var earth = new WE.map('earth_div', {center: [").append(centerLat).append(", ").append(centerLon).append("], altitude: ").append(altitudeMeters).append("});\n");
   }
 
   public void addPolygon(Polygon poly) {
@@ -57,14 +57,14 @@ public class EarthDebugger {
     String name = "poly" + nextShape;
     nextShape++;
 
-    b.append("        var " + name + " = WE.polygon([\n");
+    b.append("        var ").append(name).append(" = WE.polygon([\n");
     double[] polyLats = poly.getPolyLats();
     double[] polyLons = poly.getPolyLons();
     for(int i=0;i<polyLats.length;i++) {
-      b.append("          [" + polyLats[i] + ", " + polyLons[i] + "],\n");
+      b.append("          [").append(polyLats[i]).append(", ").append(polyLons[i]).append("],\n");
     }
-    b.append("        ], {color: '" + color + "', fillColor: \"#000000\", fillOpacity: 0.0001});\n");
-    b.append("        " + name + ".addTo(earth);\n");
+    b.append("        ], {color: '").append(color).append("', fillColor: \"#000000\", fillOpacity: 0.0001});\n");
+    b.append("        ").append(name).append(".addTo(earth);\n");
 
     for (Polygon hole : poly.getHoles()) {
       addPolygon(hole, "#ffffff");
@@ -84,7 +84,7 @@ public class EarthDebugger {
   private void drawSegment(double minLat, double maxLat, double minLon, double maxLon) {
     int steps = getStepCount(minLat, maxLat, minLon, maxLon);
     for(int i=0;i<steps;i++) {
-      b.append("          [" + (minLat + (maxLat - minLat) * i / steps) + ", " + (minLon + (maxLon - minLon) * i / steps) + "],\n");
+      b.append("          [").append(minLat + (maxLat - minLat) * i / steps).append(", ").append(minLon + (maxLon - minLon) * i / steps).append("],\n");
     }
   }
 
@@ -96,8 +96,8 @@ public class EarthDebugger {
     String name = "rect" + nextShape;
     nextShape++;
 
-    b.append("        // lat: " + minLat + " TO " + maxLat + "; lon: " + minLon + " TO " + maxLon + "\n");
-    b.append("        var " + name + " = WE.polygon([\n");
+    b.append("        // lat: ").append(minLat).append(" TO ").append(maxLat).append("; lon: ").append(minLon).append(" TO ").append(maxLon).append("\n");
+    b.append("        var ").append(name).append(" = WE.polygon([\n");
 
     b.append("          // min -> max lat, min lon\n");
     drawSegment(minLat, maxLat, minLon, minLon);
@@ -112,9 +112,9 @@ public class EarthDebugger {
     drawSegment(minLat, minLat, maxLon, minLon);
 
     b.append("          // min lat, min lon\n");
-    b.append("          [" + minLat + ", " + minLon + "]\n");
-    b.append("        ], {color: \"" + color + "\", fillColor: \"" + color + "\"});\n");
-    b.append("        " + name + ".addTo(earth);\n");
+    b.append("          [").append(minLat).append(", ").append(minLon).append("]\n");
+    b.append("        ], {color: \"").append(color).append("\", fillColor: \"").append(color).append("\"});\n");
+    b.append("        ").append(name).append(".addTo(earth);\n");
   }
 
   /** Draws a line a fixed latitude, spanning the min/max longitude */
@@ -122,19 +122,19 @@ public class EarthDebugger {
     String name = "latline" + nextShape;
     nextShape++;
 
-    b.append("        var " + name + " = WE.polygon([\n");
+    b.append("        var ").append(name).append(" = WE.polygon([\n");
     double lon;
     int steps = getStepCount(lat, minLon, lat, maxLon);
     for(lon = minLon;lon<=maxLon;lon += (maxLon-minLon)/steps) {
-      b.append("          [" + lat + ", " + lon + "],\n");
+      b.append("          [").append(lat).append(", ").append(lon).append("],\n");
     }
-    b.append("          [" + lat + ", " + maxLon + "],\n");
+    b.append("          [").append(lat).append(", ").append(maxLon).append("],\n");
     lon -= (maxLon-minLon)/steps;
     for(;lon>=minLon;lon -= (maxLon-minLon)/steps) {
-      b.append("          [" + lat + ", " + lon + "],\n");
+      b.append("          [").append(lat).append(", ").append(lon).append("],\n");
     }
     b.append("        ], {color: \"#ff0000\", fillColor: \"#ffffff\", opacity: 1, fillOpacity: 0.0001});\n");
-    b.append("        " + name + ".addTo(earth);\n");
+    b.append("        ").append(name).append(".addTo(earth);\n");
   }
 
   /** Draws a line a fixed longitude, spanning the min/max latitude */
@@ -142,33 +142,33 @@ public class EarthDebugger {
     String name = "lonline" + nextShape;
     nextShape++;
 
-    b.append("        var " + name + " = WE.polygon([\n");
+    b.append("        var ").append(name).append(" = WE.polygon([\n");
     double lat;
     int steps = getStepCount(minLat, lon, maxLat, lon);
     for(lat = minLat;lat<=maxLat;lat += (maxLat-minLat)/steps) {
-      b.append("          [" + lat + ", " + lon + "],\n");
+      b.append("          [").append(lat).append(", ").append(lon).append("],\n");
     }
-    b.append("          [" + maxLat + ", " + lon + "],\n");
+    b.append("          [").append(maxLat).append(", ").append(lon).append("],\n");
     lat -= (maxLat-minLat)/36;
     for(;lat>=minLat;lat -= (maxLat-minLat)/steps) {
-      b.append("          [" + lat + ", " + lon + "],\n");
+      b.append("          [").append(lat).append(", ").append(lon).append("],\n");
     }
     b.append("        ], {color: \"#ff0000\", fillColor: \"#ffffff\", opacity: 1, fillOpacity: 0.0001});\n");
-    b.append("        " + name + ".addTo(earth);\n");
+    b.append("        ").append(name).append(".addTo(earth);\n");
   }
 
   public void addPoint(double lat, double lon) {
-    b.append("        WE.marker([" + lat + ", " + lon + "]).addTo(earth);\n");    
+    b.append("        WE.marker([").append(lat).append(", ").append(lon).append("]).addTo(earth);\n");
   }
 
   public void addCircle(double centerLat, double centerLon, double radiusMeters, boolean alsoAddBBox) {
     addPoint(centerLat, centerLon);
     String name = "circle" + nextShape;
     nextShape++;
-    b.append("        var " + name + " = WE.polygon([\n");
+    b.append("        var ").append(name).append(" = WE.polygon([\n");
     inverseHaversin(b, centerLat, centerLon, radiusMeters);
     b.append("        ], {color: '#00ff00', fillColor: \"#000000\", fillOpacity: 0.0001 });\n");
-    b.append("        " + name + ".addTo(earth);\n");
+    b.append("        ").append(name).append(".addTo(earth);\n");
 
     if (alsoAddBBox) {
       Rectangle box = Rectangle.fromPointDistance(centerLat, centerLon, radiusMeters);
@@ -235,7 +235,7 @@ public class EarthDebugger {
 
         //System.out.println("  iter lat=" + lat + " lon=" + lon + " distance=" + distanceMeters + " vs " + radiusMeters);
         if (Math.abs(distanceMeters - radiusMeters) < 0.1) {
-          b.append("          [" + lat + ", " + lon + "],\n");
+          b.append("          [").append(lat).append(", ").append(lon).append("],\n");
           break;
         }
         if (distanceMeters > radiusMeters) {

--- a/lucene/test-framework/src/java/org/apache/lucene/geo/GeoTestUtil.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/geo/GeoTestUtil.java
@@ -590,10 +590,10 @@ public class GeoTestUtil {
       if (o instanceof double[]) {
         double point[] = (double[]) o;
         sb.append("<!-- point: ");
-        sb.append(point[0] + "," + point[1]);
+        sb.append(point[0]).append(',').append(point[1]);
         sb.append(" -->\n");
       } else {
-        sb.append("<!-- " + o.getClass().getSimpleName() + ": \n");
+        sb.append("<!-- ").append(o.getClass().getSimpleName()).append(": \n");
         sb.append(o.toString());
         sb.append("\n-->\n");
       }
@@ -620,7 +620,7 @@ public class GeoTestUtil {
       // polygon
       double polyLats[] = gon.getPolyLats();
       double polyLons[] = gon.getPolyLons();
-      sb.append("<polygon fill-opacity=\"" + opacity + "\" points=\"");
+      sb.append("<polygon fill-opacity=\"").append(opacity).append("\" points=\"");
       for (int i = 0; i < polyLats.length; i++) {
         if (i > 0) {
           sb.append(" ");
@@ -629,7 +629,7 @@ public class GeoTestUtil {
         .append(",")
         .append(90 - polyLats[i]);
       }
-      sb.append("\" style=\"" + style + "\"/>\n");
+      sb.append("\" style=\"").append(style).append("\"/>\n");
       for (Polygon hole : gon.getHoles()) {
         double holeLats[] = hole.getPolyLats();
         double holeLons[] = hole.getPolyLons();

--- a/lucene/test-framework/src/java/org/apache/lucene/search/BaseRangeFieldQueryTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/search/BaseRangeFieldQueryTestCase.java
@@ -272,20 +272,20 @@ public abstract class BaseRangeFieldQueryTestCase extends LuceneTestCase {
 
         if (hits.get(docID) != expected) {
           StringBuilder b = new StringBuilder();
-          b.append("FAIL (iter " + iter + "): ");
+          b.append("FAIL (iter ").append(iter).append("): ");
           if (expected == true) {
-            b.append("id=" + id + (ranges[id].length > 1 ? " (MultiValue) " : " ") + "should match but did not\n");
+            b.append("id=").append(id).append(ranges[id].length > 1 ? " (MultiValue) " : " ").append("should match but did not\n");
           } else {
-            b.append("id=" + id + " should not match but did\n");
+            b.append("id=").append(id).append(" should not match but did\n");
           }
-          b.append(" queryRange=" + queryRange + "\n");
-          b.append(" box" + ((ranges[id].length > 1) ? "es=" : "=" ) + ranges[id][0]);
+          b.append(" queryRange=").append(queryRange).append("\n");
+          b.append(" box").append((ranges[id].length > 1) ? "es=" : "=").append(ranges[id][0]);
           for (int n=1; n<ranges[id].length; ++n) {
             b.append(", ");
             b.append(ranges[id][n]);
           }
-          b.append("\n queryType=" + queryType + "\n");
-          b.append(" deleted?=" + (liveDocs != null && liveDocs.get(docID) == false));
+          b.append("\n queryType=").append(queryType).append("\n");
+          b.append(" deleted?=").append(liveDocs != null && liveDocs.get(docID) == false);
           fail("wrong hit (first of possibly more):\n\n" + b);
         }
       }

--- a/lucene/test-framework/src/java/org/apache/lucene/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/util/LuceneTestCase.java
@@ -1284,8 +1284,8 @@ public abstract class LuceneTestCase extends Assert {
       if (previousLines.length == currentLines.length) {
         for (int i = 0; i < previousLines.length; i++) {
           if (!previousLines[i].equals(currentLines[i])) {
-            diff.append("- " + previousLines[i] + "\n");
-            diff.append("+ " + currentLines[i] + "\n");
+            diff.append("- ").append(previousLines[i]).append("\n");
+            diff.append("+ ").append(currentLines[i]).append("\n");
           }
         }
       } else {

--- a/lucene/tools/src/java/org/apache/lucene/validation/LicenseCheckTask.java
+++ b/lucene/tools/src/java/org/apache/lucene/validation/LicenseCheckTask.java
@@ -304,9 +304,7 @@ outer:
     if (foundLicenses.isEmpty()) {
       this.failures = true;
       StringBuilder message = new StringBuilder();
-      message.append(
-          "MISSING LICENSE for the following file:\n  " + jarFile.getAbsolutePath()
-          + "\n  Expected locations below:\n");
+      message.append("MISSING LICENSE for the following file:\n  ").append(jarFile.getAbsolutePath()).append("\n  Expected locations below:\n");
       for (File location : expectedLocations) {
         message.append("  => ").append(location.getAbsolutePath()).append("\n");
       }

--- a/solr/contrib/extraction/src/java/org/apache/solr/handler/extraction/XLSXResponseWriter.java
+++ b/solr/contrib/extraction/src/java/org/apache/solr/handler/extraction/XLSXResponseWriter.java
@@ -284,12 +284,12 @@ class XLSXWriter extends TabularResponseWriter {
       if (v instanceof IndexableField) {
         IndexableField f = (IndexableField)v;
         if (v instanceof Date) {
-          output.append(((Date) val).toInstant().toString() + "; ");
+          output.append(((Date) val).toInstant().toString()).append("; ");
         } else {
-          output.append(f.stringValue() + "; ");
+          output.append(f.stringValue()).append("; ");
         }
       } else {
-        output.append(v.toString() + "; ");
+        output.append(v.toString()).append("; ");
       }
     }
     if (output.length() > 0) {

--- a/solr/core/src/java/org/apache/solr/cloud/autoscaling/sim/SimCloudManager.java
+++ b/solr/core/src/java/org/apache/solr/cloud/autoscaling/sim/SimCloudManager.java
@@ -387,7 +387,7 @@ public class SimCloudManager implements SolrCloudManager {
     sb.append("#######################################\n");
     sb.append("############ CLUSTER STATE ############\n");
     sb.append("#######################################\n");
-    sb.append("## Live nodes:\t\t" + getLiveNodesSet().size() + "\n");
+    sb.append("## Live nodes:\t\t").append(getLiveNodesSet().size()).append("\n");
     int emptyNodes = 0;
     int maxReplicas = 0;
     int minReplicas = Integer.MAX_VALUE;
@@ -414,37 +414,37 @@ public class SimCloudManager implements SolrCloudManager {
     if (minReplicas == Integer.MAX_VALUE) {
       minReplicas = 0;
     }
-    sb.append("## Empty nodes:\t" + emptyNodes + "\n");
+    sb.append("## Empty nodes:\t").append(emptyNodes).append("\n");
     Set<String> deadNodes = getSimNodeStateProvider().simGetDeadNodes();
-    sb.append("## Dead nodes:\t\t" + deadNodes.size() + "\n");
-    deadNodes.forEach(n -> sb.append("##\t\t" + n + "\n"));
+    sb.append("## Dead nodes:\t\t").append(deadNodes.size()).append("\n");
+    deadNodes.forEach(n -> sb.append("##\t\t").append(n).append("\n"));
     sb.append("## Collections:\n");
       clusterStateProvider.simGetCollectionStats().forEach((coll, stats) -> {
         sb.append("##  * ").append(coll).append('\n');
         stats.forEach((k, v) -> {
-          sb.append("##    " + k + "\t" + v + "\n");
+          sb.append("##    ").append(k).append("\t").append(v).append("\n");
         });
       });
     if (withCollections) {
       ClusterState state = clusterStateProvider.getClusterState();
-      state.forEachCollection(coll -> sb.append(coll.toString() + "\n"));
+      state.forEachCollection(coll -> sb.append(coll.toString()).append("\n"));
     }
-    sb.append("## Max replicas per node:\t" + maxReplicas + "\n");
-    sb.append("## Min replicas per node:\t" + minReplicas + "\n");
-    sb.append("## Total replicas:\t\t" + numReplicas + "\n");
+    sb.append("## Max replicas per node:\t").append(maxReplicas).append("\n");
+    sb.append("## Min replicas per node:\t").append(minReplicas).append("\n");
+    sb.append("## Total replicas:\t\t").append(numReplicas).append("\n");
     replicaStates.forEach((c, map) -> {
       AtomicInteger repCnt = new AtomicInteger();
       map.forEach((s, cnt) -> repCnt.addAndGet(cnt.get()));
-      sb.append("## * " + c + "\t\t" + repCnt.get() + "\n");
-      map.forEach((s, cnt) -> sb.append("##\t\t- " + String.format(Locale.ROOT, "%-12s  %4d", s, cnt.get()) + "\n"));
+      sb.append("## * ").append(c).append("\t\t").append(repCnt.get()).append("\n");
+      map.forEach((s, cnt) -> sb.append("##\t\t- ").append(String.format(Locale.ROOT, "%-12s  %4d", s, cnt.get())).append("\n"));
     });
     sb.append("######### Solr op counts ##########\n");
-    simGetOpCounts().forEach((k, cnt) -> sb.append("##\t\t- " + String.format(Locale.ROOT, "%-14s  %4d", k, cnt.get()) + "\n"));
+    simGetOpCounts().forEach((k, cnt) -> sb.append("##\t\t- ").append(String.format(Locale.ROOT, "%-14s  %4d", k, cnt.get())).append("\n"));
     sb.append("######### Autoscaling event counts ###########\n");
     Map<String, Map<String, AtomicInteger>> counts = simGetEventCounts();
     counts.forEach((trigger, map) -> {
-      sb.append("## * Trigger: " + trigger + "\n");
-      map.forEach((s, cnt) -> sb.append("##\t\t- " + String.format(Locale.ROOT, "%-11s  %4d", s, cnt.get()) + "\n"));
+      sb.append("## * Trigger: ").append(trigger).append("\n");
+      map.forEach((s, cnt) -> sb.append("##\t\t- ").append(String.format(Locale.ROOT, "%-11s  %4d", s, cnt.get())).append("\n"));
     });
     return sb.toString();
   }

--- a/solr/core/src/java/org/apache/solr/core/PluginInfo.java
+++ b/solr/core/src/java/org/apache/solr/core/PluginInfo.java
@@ -108,11 +108,11 @@ public class PluginInfo implements MapSerializable {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder("{");
-    if (type != null) sb.append("type = " + type + ",");
-    if (name != null) sb.append("name = " + name + ",");
-    if (className != null) sb.append("class = " + className + ",");
-    if (attributes != null && attributes.size() > 0) sb.append("attributes = " + attributes + ",");
-    if (initArgs != null && initArgs.size() > 0) sb.append("args = " + initArgs);
+    if (type != null) sb.append("type = ").append(type).append(',');
+    if (name != null) sb.append("name = ").append(name).append(',');
+    if (className != null) sb.append("class = ").append(className).append(',');
+    if (attributes != null && attributes.size() > 0) sb.append("attributes = ").append(attributes).append(',');
+    if (initArgs != null && initArgs.size() > 0) sb.append("args = ").append(initArgs);
     sb.append("}");
     return sb.toString();
   }

--- a/solr/core/src/java/org/apache/solr/handler/admin/SegmentsInfoRequestHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/SegmentsInfoRequestHandler.java
@@ -350,8 +350,8 @@ public class SegmentsInfoRequestHandler extends RequestHandlerBase {
     flags.append( (fi.isSoftDeletesField() ? "s" : "-"));
     if (fi.getPointDataDimensionCount() > 0 || fi.getPointIndexDimensionCount() > 0) {
       flags.append(":");
-      flags.append(fi.getPointDataDimensionCount() + ":");
-      flags.append(fi.getPointIndexDimensionCount() + ":");
+      flags.append(fi.getPointDataDimensionCount()).append(':');
+      flags.append(fi.getPointIndexDimensionCount()).append(':');
       flags.append(fi.getPointNumBytes());
     }
 

--- a/solr/core/src/java/org/apache/solr/handler/export/SortDoc.java
+++ b/solr/core/src/java/org/apache/solr/handler/export/SortDoc.java
@@ -118,9 +118,9 @@ class SortDoc {
 
   public String toString() {
     StringBuilder builder = new StringBuilder();
-    builder.append("docId: " + docId + "; ");
+    builder.append("docId: ").append(docId).append("; ");
     for (int i=0; i < sortValues.length; i++) {
-      builder.append("value" + i + ": " + sortValues[i] + ", ");
+      builder.append("value").append(i).append(": ").append(sortValues[i]).append(", ");
     }
     return builder.toString();
   }

--- a/solr/core/src/java/org/apache/solr/parser/ParseException.java
+++ b/solr/core/src/java/org/apache/solr/parser/ParseException.java
@@ -173,7 +173,7 @@ public class ParseException extends Exception {
            default:
               if ((ch = str.charAt(i)) < 0x20 || ch > 0x7e) {
                  String s = "0000" + Integer.toString(ch, 16);
-                 retval.append("\\u" + s.substring(s.length() - 4, s.length()));
+                 retval.append("\\u").append(s.substring(s.length() - 4, s.length()));
               } else {
                  retval.append(ch);
               }

--- a/solr/core/src/java/org/apache/solr/parser/TokenMgrError.java
+++ b/solr/core/src/java/org/apache/solr/parser/TokenMgrError.java
@@ -82,7 +82,7 @@ public class TokenMgrError extends Error
         default:
           if ((ch = str.charAt(i)) < 0x20 || ch > 0x7e) {
             String s = "0000" + Integer.toString(ch, 16);
-            retval.append("\\u" + s.substring(s.length() - 4, s.length()));
+            retval.append("\\u").append(s.substring(s.length() - 4, s.length()));
           } else {
             retval.append(ch);
           }

--- a/solr/core/src/java/org/apache/solr/schema/SimplePreAnalyzedParser.java
+++ b/solr/core/src/java/org/apache/solr/schema/SimplePreAnalyzedParser.java
@@ -495,23 +495,23 @@ public final class SimplePreAnalyzedParser implements PreAnalyzedParser {
           } else {
             if (tok.length() > 0) tok.append(',');
             if (cl.isAssignableFrom(FlagsAttribute.class)) {
-              tok.append("f=" + Integer.toHexString(((FlagsAttribute)att).getFlags()));
+              tok.append("f=").append(Integer.toHexString(((FlagsAttribute) att).getFlags()));
             } else if (cl.isAssignableFrom(OffsetAttribute.class)) {
-              tok.append("s=" + ((OffsetAttribute)att).startOffset() + ",e=" + ((OffsetAttribute)att).endOffset());
+              tok.append("s=").append(((OffsetAttribute) att).startOffset()).append(",e=").append(((OffsetAttribute) att).endOffset());
             } else if (cl.isAssignableFrom(PayloadAttribute.class)) {
               BytesRef p = ((PayloadAttribute)att).getPayload();
               if (p != null && p.length > 0) {
-                tok.append("p=" + bytesToHex(p.bytes, p.offset, p.length));
+                tok.append("p=").append(bytesToHex(p.bytes, p.offset, p.length));
               } else if (tok.length() > 0) {
                 tok.setLength(tok.length() - 1); // remove the last comma
               }
             } else if (cl.isAssignableFrom(PositionIncrementAttribute.class)) {
-              tok.append("i=" + ((PositionIncrementAttribute)att).getPositionIncrement());
+              tok.append("i=").append(((PositionIncrementAttribute) att).getPositionIncrement());
             } else if (cl.isAssignableFrom(TypeAttribute.class)) {
-              tok.append("y=" + escape(((TypeAttribute)att).type()));
+              tok.append("y=").append(escape(((TypeAttribute) att).type()));
             } else {
               
-              tok.append(cl.getName() + "=" + escape(att.toString()));
+              tok.append(cl.getName()).append('=').append(escape(att.toString()));
             }
           }
         }

--- a/solr/core/src/java/org/apache/solr/search/QueryParsing.java
+++ b/solr/core/src/java/org/apache/solr/search/QueryParsing.java
@@ -178,7 +178,7 @@ public class QueryParsing {
     ft = schema.getFieldTypeNoEx(name);
     out.append(name);
     if (ft == null) {
-      out.append("(UNKNOWN FIELD " + name + ')');
+      out.append("(UNKNOWN FIELD ").append(name).append(String.valueOf(')'));
     }
     out.append(':');
     return ft;
@@ -328,12 +328,11 @@ public class QueryParsing {
     } else if (query instanceof BoostQuery) {
       BoostQuery q = (BoostQuery)query;
       toString(q.getQuery(), schema, out, subflag | FLAG_BOOSTED);
-      out.append("^");
+      out.append('^');
       out.append(Float.toString(q.getBoost()));
     }
     else {
-      out.append(query.getClass().getSimpleName()
-              + '(' + query.toString() + ')');
+      out.append(query.getClass().getSimpleName()).append('(').append(query.toString()).append(')');
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/search/join/GraphQuery.java
+++ b/solr/core/src/java/org/apache/solr/search/join/GraphQuery.java
@@ -118,14 +118,14 @@ public class GraphQuery extends Query {
   @Override
   public String toString(String field) {
     StringBuilder sb = new StringBuilder();
-    sb.append("[[" + q.toString() + "]," + fromField + "=" + toField + "]");
+    sb.append("[[").append(q.toString()).append("],").append(fromField).append('=').append(toField).append(']');
     if (traversalFilter != null) {
-      sb.append(" [TraversalFilter: " + traversalFilter.toString() + "]");
+      sb.append(" [TraversalFilter: ").append(traversalFilter.toString()).append(']');
     }
-    sb.append("[maxDepth=" + maxDepth + "]");
-    sb.append("[returnRoot=" + returnRoot + "]");
-    sb.append("[onlyLeafNodes=" + onlyLeafNodes + "]");
-    sb.append("[useAutn=" + useAutn + "]");
+    sb.append("[maxDepth=").append(maxDepth).append(']');
+    sb.append("[returnRoot=").append(returnRoot).append(']');
+    sb.append("[onlyLeafNodes=").append(onlyLeafNodes).append(']');
+    sb.append("[useAutn=").append(useAutn).append(']');
     return sb.toString();
   }
   

--- a/solr/core/src/java/org/apache/solr/update/SolrCmdDistributor.java
+++ b/solr/core/src/java/org/apache/solr/update/SolrCmdDistributor.java
@@ -122,7 +122,7 @@ public class SolrCmdDistributor implements Closeable {
       int maxErrorsToShow = 10;
       for (Error e:errors) {
         if (maxErrorsToShow-- <= 0) break;
-        builder.append("\n" + e);
+        builder.append("\n").append(e);
       }
       if (errors.size() > 10) {
         builder.append("\n... and ");

--- a/solr/core/src/java/org/apache/solr/update/SplitIndexCommand.java
+++ b/solr/core/src/java/org/apache/solr/update/SplitIndexCommand.java
@@ -60,17 +60,17 @@ public class SplitIndexCommand extends UpdateCommand {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder(super.toString());
-    sb.append(",paths=" + paths);
-    sb.append(",cores=" + cores);
-    sb.append(",ranges=" + ranges);
-    sb.append(",router=" + router);
+    sb.append(",paths=").append(paths);
+    sb.append(",cores=").append(cores);
+    sb.append(",ranges=").append(ranges);
+    sb.append(",router=").append(router);
     if (routeFieldName != null) {
-      sb.append(",routeFieldName=" + routeFieldName);
+      sb.append(",routeFieldName=").append(routeFieldName);
     }
     if (splitKey != null) {
-      sb.append(",split.key=" + splitKey);
+      sb.append(",split.key=").append(splitKey);
     }
-    sb.append(",method=" + splitMethod.toLower());
+    sb.append(",method=").append(splitMethod.toLower());
     sb.append('}');
     return sb.toString();
   }

--- a/solr/core/src/java/org/apache/solr/util/SimplePostTool.java
+++ b/solr/core/src/java/org/apache/solr/util/SimplePostTool.java
@@ -1042,7 +1042,7 @@ public class SimplePostTool {
     StringBuilder sb = new StringBuilder();
     if (nodes.getLength() > 0) {
       for(int i = 0; i < nodes.getLength() ; i++) {
-        sb.append(nodes.item(i).getNodeValue() + " ");
+        sb.append(nodes.item(i).getNodeValue()).append(' ');
         if(!concatAll) break;
       }
       return sb.toString().trim();

--- a/solr/core/src/java/org/apache/solr/util/SolrLogLayout.java
+++ b/solr/core/src/java/org/apache/solr/util/SolrLogLayout.java
@@ -160,16 +160,16 @@ public class SolrLogLayout extends AbstractStringLayout {
         coreInfoMap.put(core.hashCode(), info);
         
         if (sb.length() == 0) sb.append("ASYNC ");
-        sb.append(" NEW_CORE " + info.shortId);
-        sb.append(" name=" + core.getName());
-        sb.append(" " + core);
+        sb.append(" NEW_CORE ").append(info.shortId);
+        sb.append(" name=").append(core.getName());
+        sb.append(" ").append(core);
       }
 
       zkController = core.getCoreContainer().getZkController();
       if (zkController != null) {
         if (info.url == null) {
           info.url = zkController.getBaseUrl() + "/" + core.getName();
-          sb.append(" url=" + info.url + " node=" + zkController.getNodeName());
+          sb.append(" url=").append(info.url).append(" node=").append(zkController.getNodeName());
         }
         
         Map<String,Object> coreProps = getReplicaProps(zkController, core);
@@ -179,7 +179,7 @@ public class SolrLogLayout extends AbstractStringLayout {
               + core.getCoreDescriptor().getCloudDescriptor()
                   .getCollectionName() + " core:" + core.getName() + " props:"
               + coreProps;
-          sb.append(" " + info.shortId + "_STATE=" + corePropsString);
+          sb.append(" ").append(info.shortId).append("_STATE=").append(corePropsString);
         }
       }
     }

--- a/solr/core/src/java/org/apache/solr/util/SolrPluginUtils.java
+++ b/solr/core/src/java/org/apache/solr/util/SolrPluginUtils.java
@@ -1064,7 +1064,7 @@ public class SolrPluginUtils {
           StringBuilder builder = new StringBuilder();
           for (Map.Entry<Integer, String>entry : purposes.entrySet()) {
               if ((reqPurpose & entry.getKey()) != 0) {
-                  builder.append(entry.getValue() + ",");
+                  builder.append(entry.getValue()).append(',');
               }
           }
           if (builder.length() == 0) {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/Facet2DStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/Facet2DStream.java
@@ -350,16 +350,16 @@ public class Facet2DStream extends TupleStream implements Expressible {
     buf.append('"');
     buf.append(":{");
     buf.append("\"type\":\"terms\"");
-    buf.append(",\"field\":\"" + x.toString() + "\"");
-    buf.append(",\"limit\":" + dimensionX );
+    buf.append(",\"field\":\"").append(x.toString()).append('"');
+    buf.append(",\"limit\":").append(dimensionX);
     buf.append(",\"overrequest\":1000");
     String fsort = getFacetSort(adjustedSorts[0].getLeftFieldName(), metric);
-    buf.append(",\"sort\":\""+ fsort + " desc\"");
+    buf.append(",\"sort\":\"").append(fsort).append(" desc\"");
     buf.append(",\"facet\":{");
 
     String identifier = metric.getIdentifier();
     if (!identifier.startsWith("count(")) {
-      buf.append("\"agg\":\"" + identifier + "\"");
+      buf.append("\"agg\":\"").append(identifier).append('"');
       buf.append(",");
     }
     buf.append('"');
@@ -367,14 +367,14 @@ public class Facet2DStream extends TupleStream implements Expressible {
     buf.append('"');
     buf.append(":{");
     buf.append("\"type\":\"terms\"");
-    buf.append(",\"field\":\"" + y.toString() + "\"");
-    buf.append(",\"limit\":" + dimensionY );
+    buf.append(",\"field\":\"").append(y.toString()).append('"');
+    buf.append(",\"limit\":").append(dimensionY);
     buf.append(",\"overrequest\":1000");
     String fsortY = getFacetSort(adjustedSorts[1].getLeftFieldName(), metric);
-    buf.append(",\"sort\":\""+ fsortY + " desc\"");
+    buf.append(",\"sort\":\"").append(fsortY).append(" desc\"");
     buf.append(",\"facet\":{");
     if (!identifier.startsWith("count(")) {
-      buf.append("\"agg\":\"" + identifier + "\"");
+      buf.append("\"agg\":\"").append(identifier).append('"');
     }
     buf.append("}}}}");
   }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/FacetStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/FacetStream.java
@@ -644,20 +644,20 @@ public class FacetStream extends TupleStream implements Expressible  {
     buf.append('"');
     buf.append(":{");
     buf.append("\"type\":\"terms\"");
-    buf.append(",\"field\":\""+_buckets[level].toString()+"\"");
-    buf.append(",\"limit\":"+_limit);
+    buf.append(",\"field\":\"").append(_buckets[level].toString()).append('"');
+    buf.append(",\"limit\":").append(_limit);
 
     if(refine) {
       buf.append(",\"refine\":true");
     }
 
     if(method != null) {
-      buf.append(",\"method\":\""+method+"\"");
+      buf.append(",\"method\":\"").append(method).append('"');
     }
 
     String fsort = getFacetSort(_sorts[level].getLeftFieldName(), _metrics);
 
-    buf.append(",\"sort\":{\""+fsort+"\":\""+_sorts[level].getOrder()+"\"}");
+    buf.append(",\"sort\":{\"").append(fsort).append("\":\"").append(_sorts[level].getOrder()).append("\"}");
 
     buf.append(",\"facet\":{");
     int metricCount = 0;
@@ -673,7 +673,7 @@ public class FacetStream extends TupleStream implements Expressible  {
           if (metricCount > 0) {
             buf.append(",");
           }
-          buf.append("\""+ facetKey + "\":\"" + identifier + "\"");
+          buf.append('"').append(facetKey).append("\":\"").append(identifier).append('"');
           ++metricCount;
         }
       }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/KnnStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/KnnStream.java
@@ -195,7 +195,7 @@ public class KnnStream extends TupleStream implements Expressible  {
 
     for(String key : mltParams) {
       if(params.get(key) != null) {
-        builder.append(" " + key + "=" + params.get(key));
+        builder.append(' ').append(key).append('=').append(params.get(key));
         params.remove(key);
       }
     }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/TimeSeriesStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/TimeSeriesStream.java
@@ -344,10 +344,10 @@ public class TimeSeriesStream extends TupleStream implements Expressible  {
     buf.append('"');
     buf.append(":{");
     buf.append("\"type\":\"range\"");
-    buf.append(",\"field\":\""+field+"\"");
-    buf.append(",\"start\":\""+start+"\"");
-    buf.append(",\"end\":\""+end+"\"");
-    buf.append(",\"gap\":\""+gap+"\"");
+    buf.append(",\"field\":\"").append(field).append('"');
+    buf.append(",\"start\":\"").append(start).append('"');
+    buf.append(",\"end\":\"").append(end).append('"');
+    buf.append(",\"gap\":\"").append(gap).append('"');
 
     buf.append(",\"facet\":{");
     int metricCount = 0;
@@ -357,7 +357,7 @@ public class TimeSeriesStream extends TupleStream implements Expressible  {
         if(metricCount>0) {
           buf.append(",");
         }
-        buf.append("\"facet_" + metricCount + "\":\"" +identifier+"\"");
+        buf.append("\"facet_").append(metricCount).append("\":\"").append(identifier).append('"');
         ++metricCount;
       }
     }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/UpdateRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/UpdateRequest.java
@@ -486,7 +486,7 @@ public class UpdateRequest extends AbstractUpdateRequest {
     boolean deleteQ = deleteQuery != null && deleteQuery.size() > 0;
     if (deleteI || deleteQ) {
       if (commitWithin > 0) {
-        writer.append("<delete commitWithin=\"" + commitWithin + "\">");
+        writer.append("<delete commitWithin=\"").append(String.valueOf(commitWithin)).append("\">");
       } else {
         writer.append("<delete>");
       }
@@ -498,11 +498,11 @@ public class UpdateRequest extends AbstractUpdateRequest {
             Long version = (Long) map.get(VER);
             String route = (String)map.get(_ROUTE_);
             if (version != null) {
-              writer.append(" version=\"" + version + "\"");
+              writer.append(" version=\"").append(String.valueOf(version)).append('"');
             }
             
             if (route != null) {
-              writer.append(" _route_=\"" + route + "\"");
+              writer.append(" _route_=\"").append(route).append('"');
             }
           }
           writer.append(">");

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/ClusterState.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/ClusterState.java
@@ -214,11 +214,11 @@ public class ClusterState implements JSONWriter.Writable {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    sb.append("znodeVersion: " + znodeVersion);
+    sb.append("znodeVersion: ").append(znodeVersion);
     sb.append("\n");
-    sb.append("live nodes:" + liveNodes);
+    sb.append("live nodes:").append(liveNodes);
     sb.append("\n");
-    sb.append("collections:" + collectionStates);
+    sb.append("collections:").append(collectionStates);
     return sb.toString();
   }
 

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/SolrZkClient.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/SolrZkClient.java
@@ -503,7 +503,7 @@ public class SolrZkClient implements Closeable {
     StringBuilder sbPath = new StringBuilder();
     for (int i = 0; i < paths.length; i++) {
       String pathPiece = paths[i];
-      sbPath.append("/" + pathPiece);
+      sbPath.append("/").append(pathPiece);
       if (i < skipPathParts) {
         continue;
       }
@@ -597,7 +597,7 @@ public class SolrZkClient implements Closeable {
     for (int i = 0; i < indent; i++) {
       dent.append(" ");
     }
-    string.append(dent + path + " (" + children.size() + ")" + NEWL);
+    string.append(dent).append(path).append(" (").append(children.size()).append(")").append(NEWL);
     if (data != null) {
       String dataString = new String(data, StandardCharsets.UTF_8);
       if ((!path.endsWith(".txt") && !path.endsWith(".xml")) || path.endsWith(ZkStateReader.CLUSTER_STATE)) {
@@ -606,10 +606,9 @@ public class SolrZkClient implements Closeable {
           dataString = prettyPrint(dataString);
         }
 
-        string.append(dent + "DATA:\n" + dent + "    "
-            + dataString.replaceAll("\n", "\n" + dent + "    ") + NEWL);
+        string.append(dent).append("DATA:\n").append(dent).append("    ").append(dataString.replaceAll("\n", "\n" + dent + "    ")).append(NEWL);
       } else {
-        string.append(dent + "DATA: ...supressed..." + NEWL);
+        string.append(dent).append("DATA: ...supressed...").append(NEWL);
       }
     }
 

--- a/solr/solrj/src/java/org/apache/solr/common/util/ExecutorUtil.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/ExecutorUtil.java
@@ -172,7 +172,7 @@ public class ExecutorUtil {
         Collection<String> values = submitterContext.values();
 
         for (String value : values) {
-          contextString.append(value + " ");
+          contextString.append(value).append(' ');
         }
         if (contextString.length() > 1) {
           contextString.setLength(contextString.length() - 1);

--- a/solr/test-framework/src/java/org/apache/solr/cloud/AbstractFullDistribZkTestBase.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/AbstractFullDistribZkTestBase.java
@@ -899,7 +899,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
       StringBuilder sb = new StringBuilder();
       for (int i = 0; i < sliceCount; i++) {
         if (i > 0) sb.append(',');
-        sb.append("shard" + (i + 1));
+        sb.append("shard").append(i + 1);
       }
       params.set("shards", sb.toString());
     }

--- a/solr/test-framework/src/java/org/apache/solr/cloud/ChaosMonkey.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/ChaosMonkey.java
@@ -653,7 +653,7 @@ public class ChaosMonkey {
     StringBuilder builder = new StringBuilder();
     builder.append("Collection status: {");
     for (Slice slice:docCollection.getSlices()) {
-      builder.append(slice.getName() + ": {");
+      builder.append(slice.getName()).append(": {");
       for (Replica replica:slice.getReplicas()) {
         log.info(replica.toString());
         java.util.regex.Matcher m = portPattern.matcher(replica.getBaseUrl());


### PR DESCRIPTION
This PR is related to the following ticket:

https://issues.apache.org/jira/browse/LUCENE-8847

As stated in the ticket, this was done in my spare time, please do not review this PR during your working hours. More details in the Jira ticket.

This specific commit affects all points in the codebase where the argument of a StringBuilder.append() call is itself a regular String concatenation.
This defeats the purpose of using StringBuilder and also introduces an extra alloction.
These changes should avoid that.

It's a big commit, yet it's 1 automated change, performed by Intellij's static code analysis.

ant tests have run, succeeded on local machine.
