### PR TITLE
SOLR-12013: collections API CUSTERSTATUS command fails when configset…

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -133,6 +133,8 @@ Bug Fixes
 
 * SOLR-13496: Fix distributed grouping related NullPointerException in JSONWriter.writeSolrDocument (Christine Poerschke)
 
+* SOLR-12013: collections API CUSTERSTATUS command fails when configset missing (Erick Erickson)
+
 Other Changes
 ----------------------
 

--- a/solr/core/src/java/org/apache/solr/cloud/OverseerConfigSetMessageHandler.java
+++ b/solr/core/src/java/org/apache/solr/cloud/OverseerConfigSetMessageHandler.java
@@ -358,7 +358,14 @@ public class OverseerConfigSetMessageHandler implements OverseerMessageHandler {
     }
 
     for (Map.Entry<String, DocCollection> entry : zkStateReader.getClusterState().getCollectionsMap().entrySet()) {
-      if (configSetName.equals(zkStateReader.readConfigName(entry.getKey())))
+      String configName = null;
+      try {
+        configName = zkStateReader.readConfigName(entry.getKey());
+      } catch (KeeperException ex) {
+        throw new SolrException(ErrorCode.BAD_REQUEST,
+            "Can not delete ConfigSet as it is currently being used by collection [" + entry.getKey() + "]");
+      }
+      if (configSetName.equals(configName))
         throw new SolrException(ErrorCode.BAD_REQUEST,
             "Can not delete ConfigSet as it is currently being used by collection [" + entry.getKey() + "]");
     }

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/AddReplicaCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/AddReplicaCmd.java
@@ -68,6 +68,7 @@ import org.apache.solr.common.params.ShardParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.Utils;
 import org.apache.solr.handler.component.ShardHandler;
+import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -92,7 +93,7 @@ public class AddReplicaCmd implements OverseerCollectionMessageHandler.Cmd {
   }
 
   List<ZkNodeProps> addReplica(ClusterState clusterState, ZkNodeProps message, NamedList results, Runnable onComplete)
-      throws IOException, InterruptedException {
+      throws IOException, InterruptedException, KeeperException {
     log.debug("addReplica() : {}", Utils.toJSONString(message));
 
     String extCollectionName = message.getStr(COLLECTION_PROP);
@@ -204,7 +205,7 @@ public class AddReplicaCmd implements OverseerCollectionMessageHandler.Cmd {
         .collect(Collectors.toList());
   }
 
-  private ModifiableSolrParams getReplicaParams(ClusterState clusterState, ZkNodeProps message, NamedList results, String collectionName, DocCollection coll, boolean skipCreateReplicaInClusterState, String asyncId, ShardHandler shardHandler, CreateReplica createReplica) throws IOException, InterruptedException {
+  private ModifiableSolrParams getReplicaParams(ClusterState clusterState, ZkNodeProps message, NamedList results, String collectionName, DocCollection coll, boolean skipCreateReplicaInClusterState, String asyncId, ShardHandler shardHandler, CreateReplica createReplica) throws IOException, InterruptedException, KeeperException {
     if (coll.getStr(WITH_COLLECTION) != null) {
       String withCollectionName = coll.getStr(WITH_COLLECTION);
       DocCollection withCollection = clusterState.getCollection(withCollectionName);

--- a/solr/core/src/java/org/apache/solr/handler/admin/ClusterStatus.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/ClusterStatus.java
@@ -150,11 +150,9 @@ public class ClusterStatus {
         String configName = zkStateReader.readConfigName(name);
         collectionStatus.put("configName", configName);
         collectionProps.add(name, collectionStatus);
-      } catch (SolrException e) {
-        if (e.getCause() instanceof KeeperException.NoNodeException)  {
-          // skip this collection because the collection's znode has been deleted
-          // which can happen during aggressive collection removal, see SOLR-10720
-        } else throw e;
+      } catch (KeeperException.NoNodeException ex) {
+        // skip this collection because the configset's znode has been deleted
+        // which can happen during aggressive collection removal, see SOLR-10720
       }
     }
 

--- a/solr/core/src/test/org/apache/solr/cloud/SolrCLIZkUtilsTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/SolrCLIZkUtilsTest.java
@@ -67,7 +67,7 @@ public class SolrCLIZkUtilsTest extends SolrCloudTestCase {
 
     Path configSet = TEST_PATH().resolve("configsets");
     Path srcPathCheck = configSet.resolve("cloud-subdirs").resolve("conf");
-    copyConfigUp(configSet, "cloud-subdirs", "upconfig1");
+    AbstractDistribZkTestBase.copyConfigUp(configSet, "cloud-subdirs", "upconfig1", zkAddr);
     // Now do we have that config up on ZK?
     verifyZkLocalPathsMatch(srcPathCheck, "/configs/upconfig1");
 
@@ -112,7 +112,7 @@ public class SolrCLIZkUtilsTest extends SolrCloudTestCase {
     
     Path configSet = TEST_PATH().resolve("configsets");
     Path srcPathCheck = configSet.resolve("cloud-subdirs").resolve("conf");
-    copyConfigUp(configSet, "cloud-subdirs", "downconfig1");
+    AbstractDistribZkTestBase.copyConfigUp(configSet, "cloud-subdirs", "downconfig1", zkAddr);
     // Now do we have that config up on ZK?
     verifyZkLocalPathsMatch(srcPathCheck, "/configs/downconfig1");
 
@@ -133,7 +133,7 @@ public class SolrCLIZkUtilsTest extends SolrCloudTestCase {
     Files.createFile(emptyFile);
 
     // Now copy it up and back and insure it's still a file in the new place
-    copyConfigUp(tmp.getParent(), "myconfset", "downconfig2");
+    AbstractDistribZkTestBase.copyConfigUp(tmp.getParent(), "myconfset", "downconfig2", zkAddr);
     Path tmp2 = createTempDir("downConfigNewPlace2");
     downTool = new SolrCLI.ConfigSetDownloadTool();
     args = new String[]{
@@ -158,7 +158,7 @@ public class SolrCLIZkUtilsTest extends SolrCloudTestCase {
     Path configSet = TEST_PATH().resolve("configsets");
     Path srcPathCheck = configSet.resolve("cloud-subdirs").resolve("conf");
 
-    copyConfigUp(configSet, "cloud-subdirs", "cp1");
+    AbstractDistribZkTestBase.copyConfigUp(configSet, "cloud-subdirs", "cp1", zkAddr);
 
     // Now copy it somewhere else on ZK.
     String[] args = new String[]{
@@ -456,8 +456,8 @@ public class SolrCLIZkUtilsTest extends SolrCloudTestCase {
 
     Path configSet = TEST_PATH().resolve("configsets");
     Path srcPathCheck = configSet.resolve("cloud-subdirs").resolve("conf");
-    
-    copyConfigUp(configSet, "cloud-subdirs", "mv1");
+
+    AbstractDistribZkTestBase.copyConfigUp(configSet, "cloud-subdirs", "mv1", zkAddr);
 
     // Now move it somewhere else.
     String[] args = new String[]{
@@ -534,7 +534,7 @@ public class SolrCLIZkUtilsTest extends SolrCloudTestCase {
 
     Path configSet = TEST_PATH().resolve("configsets");
 
-    copyConfigUp(configSet, "cloud-subdirs", "lister");
+    AbstractDistribZkTestBase.copyConfigUp(configSet, "cloud-subdirs", "lister", zkAddr);
 
     // Should only find a single level.
     String[] args = new String[]{
@@ -632,9 +632,9 @@ public class SolrCLIZkUtilsTest extends SolrCloudTestCase {
     
     Path configSet = TEST_PATH().resolve("configsets");
     Path srcPathCheck = configSet.resolve("cloud-subdirs").resolve("conf");
-    
-    copyConfigUp(configSet, "cloud-subdirs", "rm1");
-    copyConfigUp(configSet, "cloud-subdirs", "rm2");
+
+    AbstractDistribZkTestBase.copyConfigUp(configSet, "cloud-subdirs", "rm1", zkAddr);
+    AbstractDistribZkTestBase.copyConfigUp(configSet, "cloud-subdirs", "rm2", zkAddr);
 
     // Should fail if recurse not set.
     String[] args = new String[]{
@@ -690,26 +690,9 @@ public class SolrCLIZkUtilsTest extends SolrCloudTestCase {
         "-zkHost", zkAddr,
     };
 
-    copyConfigUp(configSet, "cloud-subdirs", "rm3");
+    AbstractDistribZkTestBase.copyConfigUp(configSet, "cloud-subdirs", "rm3", zkAddr);
     res = tool.runTool(SolrCLI.processCommandLineArgs(SolrCLI.joinCommonAndToolOptions(tool.getOptions()), args));
     assertFalse("Should fail when trying to remove /.", res == 0);
-  }
-
-  // We can use this for testing since the goal is to move "some stuff" up to ZK.
-  // The fact that they're in configsets is irrelevant.
-  private void copyConfigUp(Path configSetDir, String srcConfigSet, String dstConfigName) throws Exception {
-    String[] args = new String[]{
-        "-confname", dstConfigName,
-        "-confdir", srcConfigSet,
-        "-zkHost", zkAddr,
-        "-configsetsDir", configSetDir.toAbsolutePath().toString(),
-    };
-
-    SolrCLI.ConfigSetUploadTool tool = new SolrCLI.ConfigSetUploadTool();
-
-    int res = tool.runTool(SolrCLI.processCommandLineArgs(SolrCLI.joinCommonAndToolOptions(tool.getOptions()), args));
-    assertEquals("Tool should have returned 0 for success, returned: " + res, res, 0);
-
   }
 
   // Check that all children of fileRoot are children of zkRoot and vice-versa

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/ZkStateReader.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/ZkStateReader.java
@@ -262,7 +262,7 @@ public class ZkStateReader implements SolrCloseable {
    *
    * @param collection to return config set name for
    */
-  public String readConfigName(String collection) {
+  public String readConfigName(String collection) throws KeeperException {
 
     String configName = null;
 
@@ -281,14 +281,14 @@ public class ZkStateReader implements SolrCloseable {
         String configPath = CONFIGS_ZKNODE + "/" + configName;
         if (!zkClient.exists(configPath, true)) {
           log.error("Specified config=[{}] does not exist in ZooKeeper at location=[{}]", configName, configPath);
-          throw new ZooKeeperException(ErrorCode.SERVER_ERROR, "Specified config does not exist in ZooKeeper: " + configName);
+          throw new KeeperException.NoNodeException(configPath);
         } else {
           log.debug("path=[{}] [{}]=[{}] specified config exists in ZooKeeper", configPath, CONFIGNAME_PROP, configName);
         }
       } else {
         throw new ZooKeeperException(ErrorCode.INVALID_STATE, "No config data found at path: " + path);
       }
-    } catch (KeeperException| InterruptedException e) {
+    } catch (InterruptedException e) {
       SolrZkClient.checkInterrupted(e);
       throw new SolrException(ErrorCode.SERVER_ERROR, "Error loading config name for collection " + collection, e);
     }

--- a/solr/test-framework/src/java/org/apache/solr/cloud/AbstractDistribZkTestBase.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/AbstractDistribZkTestBase.java
@@ -37,6 +37,7 @@ import org.apache.solr.common.cloud.SolrZkClient;
 import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.core.Diagnostics;
 import org.apache.solr.core.MockDirectoryFactory;
+import org.apache.solr.util.SolrCLI;
 import org.apache.solr.util.TimeOut;
 import org.apache.zookeeper.KeeperException;
 import org.junit.BeforeClass;
@@ -324,4 +325,26 @@ public abstract class AbstractDistribZkTestBase extends BaseDistributedSearchTes
     zkServer = new ZkTestServer(zkServer.getZkDir(), zkServer.getPort());
     zkServer.run(false);
   }
+
+
+  // Copy a configset up from some path on the local  machine to ZK.
+  // Example usage:
+  //
+  // copyConfigUp(TEST_PATH().resolve("configsets"), "cloud-minimal", "configset-name", zk_address);
+
+  static protected void copyConfigUp(Path configSetDir, String srcConfigSet, String dstConfigName, String zkAddr) throws Exception {
+    String[] args = new String[]{
+        "-confname", dstConfigName,
+        "-confdir", srcConfigSet,
+        "-zkHost", zkAddr,
+        "-configsetsDir", configSetDir.toAbsolutePath().toString(),
+    };
+
+    SolrCLI.ConfigSetUploadTool tool = new SolrCLI.ConfigSetUploadTool();
+
+    int res = tool.runTool(SolrCLI.processCommandLineArgs(SolrCLI.joinCommonAndToolOptions(tool.getOptions()), args));
+    assertEquals("Tool should have returned 0 for success, returned: " + res, res, 0);
+
+  }
+
 }


### PR DESCRIPTION
Trying to get all modern and use Git, so bear with me.

This fixes the problem, but by throwing a NoNodeException it affected
AddReplicaCmd, CloudConfigSetService and OverseerConfigSetMessageHandler, any extra eyes on those changes appreciated.

precommit and all tests pass if I haven't messed up the  whole PR thing.