### PR TITLE
SOLR-13549: Fix opentracing mock dependency for Solr core tests

### DIFF
--- a/solr/core/ivy.xml
+++ b/solr/core/ivy.xml
@@ -33,6 +33,7 @@
     <dependency org="io.opentracing" name="opentracing-api" rev="${/io.opentracing/opentracing-api}" conf="compile"/>
     <dependency org="io.opentracing" name="opentracing-noop" rev="${/io.opentracing/opentracing-noop}" conf="compile"/>
     <dependency org="io.opentracing" name="opentracing-util" rev="${/io.opentracing/opentracing-util}" conf="compile"/>
+    <dependency org="io.opentracing" name="opentracing-mock" rev="${/io.opentracing/opentracing-mock}" conf="test"/>
 
     <dependency org="commons-codec" name="commons-codec" rev="${/commons-codec/commons-codec}" conf="compile"/>
     <dependency org="commons-io" name="commons-io" rev="${/commons-io/commons-io}" conf="compile"/>


### PR DESCRIPTION
<!--
Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

Adds a dependency on opentracing-mock for the Solr core tests

# Solution

This is just a build fix.

# Tests

Solr builds using maven now.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I am authorized to contribute this code to the ASF and have removed any code I do not have a license to distribute.
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [n/a] I have added tests for my changes.
- [n/a] I have added documentation for the Ref Guide (for Solr changes only).
