### PR TITLE
LUCENE-8781: add FST array-with-gap addressing to Util.readCeilArc

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/fst/Util.java
+++ b/lucene/core/src/java/org/apache/lucene/util/fst/Util.java
@@ -924,7 +924,7 @@ public final class Util {
   */
 
   /**
-   * Reads the first arc greater or equal that the given label into the provided
+   * Reads the first arc greater or equal than the given label into the provided
    * arc in place and returns it iff found, otherwise return <code>null</code>.
    * 
    * @param label the label to ceil on
@@ -958,7 +958,19 @@ public final class Util {
     }
     fst.readFirstTargetArc(follow, arc, in);
     if (arc.bytesPerArc != 0 && arc.label != FST.END_LABEL) {
-      // Arcs are fixed array -- use binary search to find
+      if (arc.arcIdx == Integer.MIN_VALUE) {
+        // Arcs are in an array-with-gaps
+        int offset = label - arc.label;
+        if (offset >= arc.numArcs) {
+          return null;
+        } else if (offset < 0) {
+          return arc;
+        } else {
+          arc.nextArc = arc.posArcsStart - offset * arc.bytesPerArc;
+          return fst.readNextRealArc(arc, in);
+        }
+      }
+      // Arcs are packed array -- use binary search to find
       // the target.
 
       int low = arc.arcIdx;


### PR DESCRIPTION
This method got overlooked when I recently added the new FST encoding. Thanks to @dsmiley  for uncovering this.
