### PR TITLE
SOLR-13545: AutoClose stream in ContentStreamUpdateRequest

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/ContentStreamUpdateRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/ContentStreamUpdateRequest.java
@@ -18,12 +18,10 @@ package org.apache.solr.client.solrj.request;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.solr.common.util.ContentStream;
 import org.apache.solr.common.util.ContentStreamBase;
 
@@ -58,19 +56,7 @@ public class ContentStreamUpdateRequest extends AbstractUpdateRequest {
   public RequestWriter.ContentWriter getContentWriter(String expectedType) {
     if (contentStreams == null || contentStreams.isEmpty() || contentStreams.size() > 1) return null;
     ContentStream stream = contentStreams.get(0);
-    return new RequestWriter.ContentWriter() {
-      @Override
-      public void write(OutputStream os) throws IOException {
-        try(var inStream = stream.getStream()) {
-          IOUtils.copy(inStream, os);
-        }
-      }
-
-      @Override
-      public String getContentType() {
-        return stream.getContentType();
-      }
-    };
+    return new RequestWriter.StreamCopyContentWriter(() -> stream.getStream(), stream.getContentType());
   }
 
   /**

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/RequestWriter.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/RequestWriter.java
@@ -18,6 +18,7 @@ package org.apache.solr.client.solrj.request;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
@@ -25,6 +26,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.util.ClientUtils;
 import org.apache.solr.common.util.ContentStream;
@@ -126,6 +128,32 @@ public class RequestWriter {
     @Override
     public String getContentType() {
       return type;
+    }
+  }
+
+  public static class StreamCopyContentWriter implements ContentWriter {
+    public final InputStreamSupplier payload;
+    public final String type;
+
+    public StreamCopyContentWriter(InputStreamSupplier payload, String type) {
+      this.payload = payload;
+      this.type = type;
+    }
+
+    @Override
+    public void write(OutputStream os) throws IOException {
+      try (InputStream is = payload.get()) {
+        IOUtils.copy(is, os);
+      }
+    }
+
+    @Override
+    public String getContentType() {
+      return type;
+    }
+
+    public interface InputStreamSupplier {
+      InputStream get() throws IOException;
     }
   }
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/StreamingUpdateRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/StreamingUpdateRequest.java
@@ -20,11 +20,8 @@ package org.apache.solr.client.solrj.request;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
-
-import org.apache.commons.io.IOUtils;
 
 /** A simple update request which streams content to the server
  */
@@ -53,19 +50,7 @@ public class StreamingUpdateRequest extends AbstractUpdateRequest {
   }
 
   public StreamingUpdateRequest(String path, File f, String contentType) {
-    this(path, new RequestWriter.ContentWriter() {
-      @Override
-      public void write(OutputStream os) throws IOException {
-        try (InputStream is = new FileInputStream(f)) {
-          IOUtils.copy(is, os);
-        }
-      }
-
-      @Override
-      public String getContentType() {
-        return contentType;
-      }
-    });
+    this(path, new RequestWriter.StreamCopyContentWriter(() -> new FileInputStream(f), contentType));
   }
 
   @Override


### PR DESCRIPTION
<!--
Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

As discussed on SOLR-13545, ContentStreamUpdateRequest doesn't close the InputStream it creates, after a change made in SOLR-12142

# Solution

Use try-with-resources to autoclose the stream

# Tests

I've updated existing tests that make update requests backed by file streams, so that they attempt to delete the file they have streamed to Solr. If the stream isn't closed, the test will fail on Windows, since the file will be locked. On Linux the file will appear to be deleted even if the stream isn't immediately closed.

I think the alternative would be to change the request classes to expose the InputStream so that it can be mocked or spied on, to explicitly check that close is called, but that also feels fragile.

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I am authorized to contribute this code to the ASF and have removed any code I do not have a license to distribute.
- [X] I have developed this patch against the `master` branch.
- [X] I have run `ant precommit` and the appropriate test suite.
- [X] I have added tests for my changes.
- [] I have added documentation for the Ref Guide (for Solr changes only).
