### PR TITLE
LUCENE-8865: Use incoming thread for execution if IndexSearcher has an executor

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -103,6 +103,10 @@ Improvements
 * LUCENE-8845: Allow Intervals.prefix() and Intervals.wildcard() to specify
   their maximum allowed expansions (Alan Woodward)
 
+* LUCENE-8865: Use incoming thread for execution if IndexSearcher has an executor.
+  Now caller threads execute at least one search on an index even if there is
+  an executor provided to minimize thread context switching. (Simon Willnauer)
+
 Test Framework
 
 * LUCENE-8825: CheckHits now display the shard index in case of mismatch

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -26,12 +26,10 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.DirectoryReader;

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -613,7 +613,7 @@ public class IndexSearcher {
   * @lucene.experimental
   */
   public <C extends Collector, T> T search(Query query, CollectorManager<C, T> collectorManager) throws IOException {
-    if (executor == null) {
+    if (executor == null || leafSlices.length <= 1) {
       final C collector = collectorManager.newCollector();
       search(query, collector);
       return collectorManager.reduce(Collections.singletonList(collector));

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -26,10 +26,10 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.DirectoryReader;
@@ -641,33 +641,7 @@ public class IndexSearcher {
         final C collector = collectors.get(i);
         if (i == leafSlices.length - 1) { // execute the last on the caller thread
           search(Arrays.asList(leaves), weight, collector);
-          topDocsFutures.add(new Future<>() {
-
-            @Override
-            public boolean cancel(boolean mayInterruptIfRunning) {
-              return false;
-            }
-
-            @Override
-            public boolean isCancelled() {
-              return false;
-            }
-
-            @Override
-            public boolean isDone() {
-              return true;
-            }
-
-            @Override
-            public C get() {
-              return collector;
-            }
-
-            @Override
-            public C get(long timeout, TimeUnit unit) {
-              return get();
-            }
-          });
+          topDocsFutures.add(CompletableFuture.completedFuture(collector));
         } else {
           topDocsFutures.add(executor.submit(() -> {
             search(Arrays.asList(leaves), weight, collector);

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -636,11 +636,10 @@ public class IndexSearcher {
       query = rewrite(query);
       final Weight weight = createWeight(query, scoreMode, 1);
       final List<Future<C>> topDocsFutures = new ArrayList<>(leafSlices.length);
-
       for (int i = 0; i < leafSlices.length; ++i) {
         final LeafReaderContext[] leaves = leafSlices[i].leaves;
         final C collector = collectors.get(i);
-        if (i == leafSlices.length-1) { // execute the last on the caller thread
+        if (i == leafSlices.length - 1) { // execute the last on the caller thread
           search(Arrays.asList(leaves), weight, collector);
           topDocsFutures.add(new Future<>() {
 


### PR DESCRIPTION
Today we don't utilize the incoming thread for a search when IndexSearcher
has an executor. This thread is only idling but can be used to execute a search
once all other collectors are dispatched.
