### PR TITLE
LUCENE-8867: Store point with cardinality for low cardinality leaves

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/PointValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/PointValues.java
@@ -208,6 +208,12 @@ public abstract class PointValues {
      *  docID order. */
     void visit(int docID, byte[] packedValue) throws IOException;
 
+    default void visit(int[] docID, int offset, int length, byte[] packedValue) throws IOException {
+      for ( int i =offset; i < offset + length; i++) {
+        visit(docID[i], packedValue);
+      }
+    }
+
     /** Called for non-leaf cells to test how the cell relates to the query, to
      *  determine how to further recurse down the tree. */
     Relation compare(byte[] minPackedValue, byte[] maxPackedValue);

--- a/lucene/core/src/java/org/apache/lucene/index/PointValues.java
+++ b/lucene/core/src/java/org/apache/lucene/index/PointValues.java
@@ -208,6 +208,10 @@ public abstract class PointValues {
      *  docID order. */
     void visit(int docID, byte[] packedValue) throws IOException;
 
+    /** Called for all documents in a leaf cell that crosses the query.  The consumer
+     *  should scrutinize the packedValue to decide whether to accept it.  In the 1D case,
+     *  values are visited in increasing order, and in the case of ties, in increasing
+     *  docID order. */
     default void visit(int[] docID, int offset, int length, byte[] packedValue) throws IOException {
       for ( int i =offset; i < offset + length; i++) {
         visit(docID[i], packedValue);

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDReader.java
@@ -441,7 +441,7 @@ public final class BKDReader extends PointValues implements Accountable {
 
   void visitDocValues(int[] commonPrefixLengths, byte[] scratchDataPackedValue, byte[] scratchMinIndexPackedValue, byte[] scratchMaxIndexPackedValue,
                       IndexInput in, int[] docIDs, int count, IntersectVisitor visitor) throws IOException {
-    if (version >= BKDWriter.VERSION_LEAF_LOW_CARDINALITY) {
+    if (version >= BKDWriter.VERSION_LOW_CARDINALITY_LEAVES) {
       visitDocValuesWithCardinality(commonPrefixLengths, scratchDataPackedValue, scratchMinIndexPackedValue, scratchMaxIndexPackedValue, in, docIDs, count, visitor);
     } else {
       visitDocValuesNoCardinality(commonPrefixLengths, scratchDataPackedValue, scratchMinIndexPackedValue, scratchMaxIndexPackedValue, in, docIDs, count, visitor);

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDWriter.java
@@ -80,7 +80,7 @@ public class BKDWriter implements Closeable {
   //public static final int VERSION_CURRENT = VERSION_START;
   public static final int VERSION_LEAF_STORES_BOUNDS = 5;
   public static final int VERSION_SELECTIVE_INDEXING = 6;
-  public static final int VERSION_LOW_CARDINALITY_LEAVES= 7;
+  public static final int VERSION_LOW_CARDINALITY_LEAVES = 7;
   public static final int VERSION_CURRENT = VERSION_LOW_CARDINALITY_LEAVES;
 
   /** How many bytes each docs takes in the fixed-width offline format */


### PR DESCRIPTION
This pull request adds a new strategy for storing leaves with low cardinality and a new method to the IntersectsVisitor that can accept an array of docs. This can speed up searches when there are many equal points.