### PR TITLE
Expose IndexSearchers executor in order to enable searcher cloning

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -847,4 +847,11 @@ public class IndexSearcher {
     }
     return new CollectionStatistics(field, reader.maxDoc(), docCount, sumTotalTermFreq, sumDocFreq);
   }
+
+  /**
+   * Returns this searchers executor or <code>null</code> if no executor was provided
+   */
+  public Executor getExecutor() {
+    return executor;
+  }
 }


### PR DESCRIPTION
Today if an executor was added to the IndexSearcher it's impossible to
clone the searcher with it's cache, similarity and caching policy since
the executor is not exposed. This adds a simple getter to make cloning
easier.
