### PR TITLE
LUCENE-8882: Extend QueryVisitor To Maintain Metadata State

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/QueryVisitor.java
+++ b/lucene/core/src/java/org/apache/lucene/search/QueryVisitor.java
@@ -56,6 +56,31 @@ public abstract class QueryVisitor {
     return true;
   }
 
+
+  /**
+   * Get the metadata object associated with the given metadata tag.
+   * Note that the implementation of how the metadata is represented is not
+   * relevant for this API -- that is a visitor's decision
+   *
+   * @return null if metadata does not exists, value otherwise
+   */
+  public Object getMetadata(String metadataTag) { return null; }
+
+  /**
+   * Add a metadata object to the visitor's metadata store. Note that
+   * this method will put a new object if none exists or replace if the tag
+   * already exists.
+   */
+  public void addOrUpdateMetadata(String metadataTag, Object metadata) { }
+
+  /**
+   * Add a metadata object iff it does not exist
+   *
+   * @return true if object was added, false if metadata tag already existed hence
+   * not added
+   */
+  public boolean addMetadata(String metadataTag, Object metadata) { return false; }
+
   /**
    * Pulls a visitor instance for visiting child clauses of a query
    *

--- a/lucene/core/src/test/org/apache/lucene/search/TestQueryVisitor.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestQueryVisitor.java
@@ -330,4 +330,41 @@ public class TestQueryVisitor extends LuceneTestCase {
     assertThat(minimumTermSet, equalTo(expected2));
   }
 
+  public void testMetadataSet() {
+    QueryVisitor visitor = new QueryVisitor() {
+      private final Map<String, Object> metadataStore = new HashMap<>();
+      @Override
+      public void addOrUpdateMetadata(String metadataTag, Object metadata) {
+        metadataStore.put(metadataTag, metadata);
+      }
+
+      @Override
+      public boolean addMetadata(String metadataTag, Object metadata) {
+        if (metadataStore.get(metadataTag) != null) {
+          return false;
+        }
+
+        metadataStore.put(metadataTag, metadata);
+
+        return true;
+      }
+      @Override
+      public Object getMetadata(String metadataTag) {
+        return metadataStore.get(metadataTag);
+      }
+    };
+
+    visitor.addOrUpdateMetadata("FOO_BAR1", "PROPERTY_VAL_1");
+    visitor.addOrUpdateMetadata("FOO_BAR2", 5);
+    visitor.addOrUpdateMetadata("FOO_BAR3", this);
+
+    assertEquals(visitor.getMetadata("FOO_BAR1"), "PROPERTY_VAL_1");
+    assertEquals(visitor.getMetadata("FOO_BAR2"), 5);
+    assertEquals(visitor.getMetadata("FOO_BAR3"), this);
+    assertEquals(visitor.getMetadata("FOO_BAR4"), null);
+
+    assertEquals(visitor.addMetadata("FOO_BAR5", 7.7), true);
+    assertEquals(visitor.addMetadata("FOO_BAR2", 8), false);
+    assertEquals(visitor.getMetadata("FOO_BAR2"), 5);
+  }
 }


### PR DESCRIPTION
This commit introduces the notion of state to QueryVisitor API, thus
allowing queries to pass metadata across the entire query tree. This
can allow things like upper queries making intelligent decisions
for cases like IndexOrDocValuesQuery, or cases where a sorted
index can benefit from a sorted index query.
