### PR TITLE
LUCENE-8896: Override default implementation of IntersectVisitor#visit(DocIDSetBuilder, byte[]) for several queries

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -165,6 +165,9 @@ Optimizations
 * LUCENE-8885: Optimise BKD reader by exploiting cardinality information stored
   on leaves. (Ignacio Vera)
 
+* LUCENE-8896: Override default implementation of IntersectVisitor#visit(DocIDSetBuilder, byte[])
+  for several queries. (Ignacio Vera)
+
 Test Framework
 
 * LUCENE-8825: CheckHits now display the shard index in case of mismatch

--- a/lucene/core/src/java/org/apache/lucene/document/LatLonPointDistanceQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LatLonPointDistanceQuery.java
@@ -288,14 +288,14 @@ final class LatLonPointDistanceQuery extends Query {
 
           @Override
           public void visit(int docID, byte[] packedValue) {
-            if (matches(packedValue) == true) {
+            if (matches(packedValue) == false) {
               visit(docID);
             }
           }
 
           @Override
           public void visit(DocIdSetIterator iterator, byte[] packedValue) throws IOException {
-            if (matches(packedValue) == true) {
+            if (matches(packedValue) == false) {
               int docID;
               while ((docID = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
                 visit(docID);
@@ -308,19 +308,19 @@ final class LatLonPointDistanceQuery extends Query {
             if (Arrays.compareUnsigned(packedValue, 0, Integer.BYTES, maxLat, 0, Integer.BYTES) > 0 ||
                 Arrays.compareUnsigned(packedValue, 0, Integer.BYTES, minLat, 0, Integer.BYTES) < 0) {
               // latitude out of bounding box range
-              return true;
+              return false;
             }
 
             if ((Arrays.compareUnsigned(packedValue, Integer.BYTES, Integer.BYTES + Integer.BYTES, maxLon, 0, Integer.BYTES) > 0 ||
                 Arrays.compareUnsigned(packedValue, Integer.BYTES, Integer.BYTES + Integer.BYTES, minLon, 0, Integer.BYTES) < 0)
                 && Arrays.compareUnsigned(packedValue, Integer.BYTES, Integer.BYTES + Integer.BYTES, minLon2, 0, Integer.BYTES) < 0) {
               // longitude out of bounding box range
-              return true;
+              return false;
             }
 
             int docLatitude = NumericUtils.sortableBytesToInt(packedValue, 0);
             int docLongitude = NumericUtils.sortableBytesToInt(packedValue, Integer.BYTES);
-            if (!distancePredicate.test(docLatitude, docLongitude)) {
+            if (distancePredicate.test(docLatitude, docLongitude)) {
               return true;
             }
             return false;

--- a/lucene/core/src/java/org/apache/lucene/document/LatLonPointDistanceQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LatLonPointDistanceQuery.java
@@ -256,14 +256,14 @@ final class LatLonPointDistanceQuery extends Query {
 
           @Override
           public void visit(int docID, byte[] packedValue) {
-            if (matches(packedValue) == true) {
+            if (matches(packedValue)) {
               visit(docID);
             }
           }
 
           @Override
           public void visit(DocIdSetIterator iterator, byte[] packedValue) throws IOException {
-            if (matches(packedValue) == true) {
+            if (matches(packedValue)) {
               int docID;
               while ((docID = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
                 visit(docID);

--- a/lucene/core/src/java/org/apache/lucene/document/LatLonPointInPolygonQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LatLonPointInPolygonQuery.java
@@ -142,7 +142,7 @@ final class LatLonPointInPolygonQuery extends Query {
                            @Override
                            public void visit(int docID, byte[] packedValue) {
                              if (polygonPredicate.test(NumericUtils.sortableBytesToInt(packedValue, 0),
-                                                       NumericUtils.sortableBytesToInt(packedValue, Integer.BYTES)) == true) {
+                                                       NumericUtils.sortableBytesToInt(packedValue, Integer.BYTES))) {
                                visit(docID);
                              }
                            }
@@ -150,7 +150,7 @@ final class LatLonPointInPolygonQuery extends Query {
                            @Override
                            public void visit(DocIdSetIterator iterator, byte[] packedValue) throws IOException {
                              if (polygonPredicate.test(NumericUtils.sortableBytesToInt(packedValue, 0),
-                                                       NumericUtils.sortableBytesToInt(packedValue, Integer.BYTES)) == true) {
+                                                       NumericUtils.sortableBytesToInt(packedValue, Integer.BYTES))) {
                                int docID;
                                while ((docID = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
                                  visit(docID);

--- a/lucene/core/src/java/org/apache/lucene/document/LatLonPointInPolygonQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LatLonPointInPolygonQuery.java
@@ -31,6 +31,7 @@ import org.apache.lucene.index.PointValues.IntersectVisitor;
 import org.apache.lucene.index.PointValues.Relation;
 import org.apache.lucene.search.ConstantScoreScorer;
 import org.apache.lucene.search.ConstantScoreWeight;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
@@ -141,8 +142,19 @@ final class LatLonPointInPolygonQuery extends Query {
                            @Override
                            public void visit(int docID, byte[] packedValue) {
                              if (polygonPredicate.test(NumericUtils.sortableBytesToInt(packedValue, 0),
-                                                       NumericUtils.sortableBytesToInt(packedValue, Integer.BYTES))) {
-                               adder.add(docID);
+                                                       NumericUtils.sortableBytesToInt(packedValue, Integer.BYTES)) == true) {
+                               visit(docID);
+                             }
+                           }
+
+                           @Override
+                           public void visit(DocIdSetIterator iterator, byte[] packedValue) throws IOException {
+                             if (polygonPredicate.test(NumericUtils.sortableBytesToInt(packedValue, 0),
+                                                       NumericUtils.sortableBytesToInt(packedValue, Integer.BYTES)) == true) {
+                               int docID;
+                               while ((docID = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+                                 visit(docID);
+                               }
                              }
                            }
 

--- a/lucene/core/src/java/org/apache/lucene/document/RangeFieldQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/RangeFieldQuery.java
@@ -275,20 +275,34 @@ abstract class RangeFieldQuery extends Query {
       private IntersectVisitor getIntersectVisitor(DocIdSetBuilder result) {
         return new IntersectVisitor() {
           DocIdSetBuilder.BulkAdder adder;
+
           @Override
           public void grow(int count) {
             adder = result.grow(count);
           }
+
           @Override
           public void visit(int docID) throws IOException {
             adder.add(docID);
           }
+
           @Override
           public void visit(int docID, byte[] leaf) throws IOException {
-            if (queryType.matches(ranges, leaf, numDims, bytesPerDim)) {
-              adder.add(docID);
+            if (queryType.matches(ranges, leaf, numDims, bytesPerDim) == true) {
+              visit(docID);
             }
           }
+
+          @Override
+          public void visit(DocIdSetIterator iterator, byte[] leaf) throws IOException {
+            if (queryType.matches(ranges, leaf, numDims, bytesPerDim) == true) {
+              int docID;
+              while ((docID = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+                visit(docID);
+              }
+            }
+          }
+
           @Override
           public Relation compare(byte[] minPackedValue, byte[] maxPackedValue) {
             return queryType.compare(ranges, minPackedValue, maxPackedValue, numDims, bytesPerDim);

--- a/lucene/core/src/java/org/apache/lucene/document/RangeFieldQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/RangeFieldQuery.java
@@ -288,14 +288,14 @@ abstract class RangeFieldQuery extends Query {
 
           @Override
           public void visit(int docID, byte[] leaf) throws IOException {
-            if (queryType.matches(ranges, leaf, numDims, bytesPerDim) == true) {
+            if (queryType.matches(ranges, leaf, numDims, bytesPerDim)) {
               visit(docID);
             }
           }
 
           @Override
           public void visit(DocIdSetIterator iterator, byte[] leaf) throws IOException {
-            if (queryType.matches(ranges, leaf, numDims, bytesPerDim) == true) {
+            if (queryType.matches(ranges, leaf, numDims, bytesPerDim)) {
               int docID;
               while ((docID = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
                 visit(docID);

--- a/lucene/core/src/java/org/apache/lucene/search/PointInSetQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PointInSetQuery.java
@@ -206,14 +206,14 @@ public abstract class PointInSetQuery extends Query implements Accountable {
 
     @Override
     public void visit(int docID, byte[] packedValue) {
-     if (matches(packedValue) == true) {
+     if (matches(packedValue)) {
        visit(docID);
      }
     }
 
     @Override
     public void visit(DocIdSetIterator iterator, byte[] packedValue) throws IOException {
-      if (matches(packedValue) == true) {
+      if (matches(packedValue)) {
         int docID;
         while ((docID = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
           visit(docID);

--- a/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
@@ -168,14 +168,14 @@ public abstract class PointRangeQuery extends Query {
 
           @Override
           public void visit(int docID, byte[] packedValue) {
-            if (matches(packedValue) == true) {
+            if (matches(packedValue)) {
               visit(docID);
             }
           }
 
           @Override
           public void visit(DocIdSetIterator iterator, byte[] packedValue) throws IOException {
-            if (matches(packedValue) == true) {
+            if (matches(packedValue)) {
               int docID;
               while ((docID = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
                 visit(docID);

--- a/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
@@ -130,20 +130,34 @@ public abstract class PointRangeQuery extends Query {
 
           @Override
           public void visit(int docID, byte[] packedValue) {
+            if (matches(packedValue) == true) {
+              visit(docID);
+            }
+          }
+
+          @Override
+          public void visit(DocIdSetIterator iterator, byte[] packedValue) throws IOException {
+            if (matches(packedValue) == true) {
+              int docID;
+              while ((docID = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+                visit(docID);
+              }
+            }
+          }
+
+          private boolean matches(byte[] packedValue) {
             for(int dim=0;dim<numDims;dim++) {
               int offset = dim*bytesPerDim;
               if (Arrays.compareUnsigned(packedValue, offset, offset + bytesPerDim, lowerPoint, offset, offset + bytesPerDim) < 0) {
                 // Doc's value is too low, in this dimension
-                return;
+                return false;
               }
               if (Arrays.compareUnsigned(packedValue, offset, offset + bytesPerDim, upperPoint, offset, offset + bytesPerDim) > 0) {
                 // Doc's value is too high, in this dimension
-                return;
+                return false;
               }
             }
-
-            // Doc is in-bounds
-            adder.add(docID);
+            return true;
           }
 
           @Override
@@ -186,21 +200,34 @@ public abstract class PointRangeQuery extends Query {
 
           @Override
           public void visit(int docID, byte[] packedValue) {
+            if (matches(packedValue) == true) {
+              visit(docID);
+            }
+          }
+
+          @Override
+          public void visit(DocIdSetIterator iterator, byte[] packedValue) throws IOException {
+            if (matches(packedValue) == true) {
+              int docID;
+              while ((docID = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+                visit(docID);
+              }
+            }
+          }
+
+          private boolean matches(byte[] packedValue) {
             for(int dim=0;dim<numDims;dim++) {
               int offset = dim*bytesPerDim;
               if (Arrays.compareUnsigned(packedValue, offset, offset + bytesPerDim, lowerPoint, offset, offset + bytesPerDim) < 0) {
                 // Doc's value is too low, in this dimension
-                result.clear(docID);
-                cost[0]--;
-                return;
+                return true;
               }
               if (Arrays.compareUnsigned(packedValue, offset, offset + bytesPerDim, upperPoint, offset, offset + bytesPerDim) > 0) {
                 // Doc's value is too high, in this dimension
-                result.clear(docID);
-                cost[0]--;
-                return;
+                return true;
               }
             }
+            return false;
           }
 
           @Override

--- a/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PointRangeQuery.java
@@ -200,14 +200,14 @@ public abstract class PointRangeQuery extends Query {
 
           @Override
           public void visit(int docID, byte[] packedValue) {
-            if (matches(packedValue) == true) {
+            if (matches(packedValue) == false) {
               visit(docID);
             }
           }
 
           @Override
           public void visit(DocIdSetIterator iterator, byte[] packedValue) throws IOException {
-            if (matches(packedValue) == true) {
+            if (matches(packedValue) == false) {
               int docID;
               while ((docID = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
                 visit(docID);
@@ -220,14 +220,14 @@ public abstract class PointRangeQuery extends Query {
               int offset = dim*bytesPerDim;
               if (Arrays.compareUnsigned(packedValue, offset, offset + bytesPerDim, lowerPoint, offset, offset + bytesPerDim) < 0) {
                 // Doc's value is too low, in this dimension
-                return true;
+                return false;
               }
               if (Arrays.compareUnsigned(packedValue, offset, offset + bytesPerDim, upperPoint, offset, offset + bytesPerDim) > 0) {
                 // Doc's value is too high, in this dimension
-                return true;
+                return false;
               }
             }
-            return false;
+            return true;
           }
 
           @Override

--- a/lucene/core/src/test/org/apache/lucene/search/TestPointQueries.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestPointQueries.java
@@ -1727,35 +1727,30 @@ public class TestPointQueries extends LuceneTestCase {
     IndexReader r = DirectoryReader.open(w);
     IndexSearcher s = newSearcher(r, false);
     assertEquals(zeroCount, s.count(IntPoint.newSetQuery("int", 0)));
-    assertEquals(zeroCount, s.count(IntPoint.newRangeQuery("int", 0, 0)));
     assertEquals(zeroCount, s.count(IntPoint.newSetQuery("int", 0, -7)));
     assertEquals(zeroCount, s.count(IntPoint.newSetQuery("int", 7, 0)));
     assertEquals(10000-zeroCount, s.count(IntPoint.newSetQuery("int", 1)));
     assertEquals(0, s.count(IntPoint.newSetQuery("int", 2)));
 
     assertEquals(zeroCount, s.count(LongPoint.newSetQuery("long", 0)));
-    assertEquals(zeroCount, s.count(LongPoint.newRangeQuery("long", 0, 0)));
     assertEquals(zeroCount, s.count(LongPoint.newSetQuery("long", 0, -7)));
     assertEquals(zeroCount, s.count(LongPoint.newSetQuery("long", 7, 0)));
     assertEquals(10000-zeroCount, s.count(LongPoint.newSetQuery("long", 1)));
     assertEquals(0, s.count(LongPoint.newSetQuery("long", 2)));
 
     assertEquals(zeroCount, s.count(FloatPoint.newSetQuery("float", 0)));
-    assertEquals(zeroCount, s.count(FloatPoint.newRangeQuery("float", 0, 0)));
     assertEquals(zeroCount, s.count(FloatPoint.newSetQuery("float", 0, -7)));
     assertEquals(zeroCount, s.count(FloatPoint.newSetQuery("float", 7, 0)));
     assertEquals(10000-zeroCount, s.count(FloatPoint.newSetQuery("float", 1)));
     assertEquals(0, s.count(FloatPoint.newSetQuery("float", 2)));
 
     assertEquals(zeroCount, s.count(DoublePoint.newSetQuery("double", 0)));
-    assertEquals(zeroCount, s.count(DoublePoint.newRangeQuery("double", 0, 0)));
     assertEquals(zeroCount, s.count(DoublePoint.newSetQuery("double", 0, -7)));
     assertEquals(zeroCount, s.count(DoublePoint.newSetQuery("double", 7, 0)));
     assertEquals(10000-zeroCount, s.count(DoublePoint.newSetQuery("double", 1)));
     assertEquals(0, s.count(DoublePoint.newSetQuery("double", 2)));
 
     assertEquals(zeroCount, s.count(BinaryPoint.newSetQuery("bytes", new byte[] {0})));
-    assertEquals(zeroCount, s.count(BinaryPoint.newRangeQuery("bytes", new byte[] {0}, new byte[] {0})));
     assertEquals(zeroCount, s.count(BinaryPoint.newSetQuery("bytes", new byte[] {0}, new byte[] {-7})));
     assertEquals(zeroCount, s.count(BinaryPoint.newSetQuery("bytes", new byte[] {7}, new byte[] {0})));
     assertEquals(10000-zeroCount, s.count(BinaryPoint.newSetQuery("bytes", new byte[] {1})));

--- a/lucene/core/src/test/org/apache/lucene/search/TestPointQueries.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestPointQueries.java
@@ -1727,34 +1727,98 @@ public class TestPointQueries extends LuceneTestCase {
     IndexReader r = DirectoryReader.open(w);
     IndexSearcher s = newSearcher(r, false);
     assertEquals(zeroCount, s.count(IntPoint.newSetQuery("int", 0)));
+    assertEquals(zeroCount, s.count(IntPoint.newRangeQuery("int", 0, 0)));
     assertEquals(zeroCount, s.count(IntPoint.newSetQuery("int", 0, -7)));
     assertEquals(zeroCount, s.count(IntPoint.newSetQuery("int", 7, 0)));
     assertEquals(10000-zeroCount, s.count(IntPoint.newSetQuery("int", 1)));
     assertEquals(0, s.count(IntPoint.newSetQuery("int", 2)));
 
     assertEquals(zeroCount, s.count(LongPoint.newSetQuery("long", 0)));
+    assertEquals(zeroCount, s.count(LongPoint.newRangeQuery("long", 0, 0)));
     assertEquals(zeroCount, s.count(LongPoint.newSetQuery("long", 0, -7)));
     assertEquals(zeroCount, s.count(LongPoint.newSetQuery("long", 7, 0)));
     assertEquals(10000-zeroCount, s.count(LongPoint.newSetQuery("long", 1)));
     assertEquals(0, s.count(LongPoint.newSetQuery("long", 2)));
 
     assertEquals(zeroCount, s.count(FloatPoint.newSetQuery("float", 0)));
+    assertEquals(zeroCount, s.count(FloatPoint.newRangeQuery("float", 0, 0)));
     assertEquals(zeroCount, s.count(FloatPoint.newSetQuery("float", 0, -7)));
     assertEquals(zeroCount, s.count(FloatPoint.newSetQuery("float", 7, 0)));
     assertEquals(10000-zeroCount, s.count(FloatPoint.newSetQuery("float", 1)));
     assertEquals(0, s.count(FloatPoint.newSetQuery("float", 2)));
 
     assertEquals(zeroCount, s.count(DoublePoint.newSetQuery("double", 0)));
+    assertEquals(zeroCount, s.count(DoublePoint.newRangeQuery("double", 0, 0)));
     assertEquals(zeroCount, s.count(DoublePoint.newSetQuery("double", 0, -7)));
     assertEquals(zeroCount, s.count(DoublePoint.newSetQuery("double", 7, 0)));
     assertEquals(10000-zeroCount, s.count(DoublePoint.newSetQuery("double", 1)));
     assertEquals(0, s.count(DoublePoint.newSetQuery("double", 2)));
 
     assertEquals(zeroCount, s.count(BinaryPoint.newSetQuery("bytes", new byte[] {0})));
+    assertEquals(zeroCount, s.count(BinaryPoint.newRangeQuery("bytes", new byte[] {0}, new byte[] {0})));
     assertEquals(zeroCount, s.count(BinaryPoint.newSetQuery("bytes", new byte[] {0}, new byte[] {-7})));
     assertEquals(zeroCount, s.count(BinaryPoint.newSetQuery("bytes", new byte[] {7}, new byte[] {0})));
     assertEquals(10000-zeroCount, s.count(BinaryPoint.newSetQuery("bytes", new byte[] {1})));
     assertEquals(0, s.count(BinaryPoint.newSetQuery("bytes", new byte[] {2})));
+
+    w.close();
+    r.close();
+    dir.close();
+  }
+
+  public void testPointRangeQueryManyEqualValues() throws Exception {
+    Directory dir = newDirectory();
+    IndexWriterConfig iwc = newIndexWriterConfig();
+    iwc.setCodec(getCodec());
+    IndexWriter w = new IndexWriter(dir, iwc);
+
+    int cardinality = TestUtil.nextInt(random(), 2, 20);
+
+    int zeroCount = 0;
+    int oneCount = 0;
+    for(int i=0;i<10000;i++) {
+      int x = random().nextInt(cardinality);
+      if (x == 0) {
+        zeroCount++;
+      } else if (x == 1) {
+        oneCount++;
+      }
+      Document doc = new Document();
+      doc.add(new IntPoint("int", x));
+      doc.add(new LongPoint("long", (long) x));
+      doc.add(new FloatPoint("float", (float) x));
+      doc.add(new DoublePoint("double", (double) x));
+      doc.add(new BinaryPoint("bytes", new byte[] {(byte) x}));
+      w.addDocument(doc);
+    }
+
+    IndexReader r = DirectoryReader.open(w);
+    IndexSearcher s = newSearcher(r, false);
+
+    assertEquals(zeroCount, s.count(IntPoint.newRangeQuery("int", 0, 0)));
+    assertEquals(oneCount, s.count(IntPoint.newRangeQuery("int", 1, 1)));
+    assertEquals(zeroCount + oneCount, s.count(IntPoint.newRangeQuery("int", 0, 1)));
+    assertEquals(10000 - zeroCount - oneCount, s.count(IntPoint.newRangeQuery("int", 2, cardinality)));
+
+    assertEquals(zeroCount, s.count(LongPoint.newRangeQuery("long", 0, 0)));
+    assertEquals(oneCount, s.count(LongPoint.newRangeQuery("long", 1, 1)));
+    assertEquals(zeroCount + oneCount, s.count(LongPoint.newRangeQuery("long", 0, 1)));
+    assertEquals(10000 - zeroCount - oneCount, s.count(LongPoint.newRangeQuery("long", 2, cardinality)));
+
+    assertEquals(zeroCount, s.count(FloatPoint.newRangeQuery("float", 0, 0)));
+    assertEquals(oneCount, s.count(FloatPoint.newRangeQuery("float", 1, 1)));
+    assertEquals(zeroCount + oneCount, s.count(FloatPoint.newRangeQuery("float", 0, 1)));
+    assertEquals(10000 - zeroCount - oneCount, s.count(FloatPoint.newRangeQuery("float", 2, cardinality)));
+
+    assertEquals(zeroCount, s.count(DoublePoint.newRangeQuery("double", 0, 0)));
+    assertEquals(oneCount, s.count(DoublePoint.newRangeQuery("double", 1, 1)));
+    assertEquals(zeroCount + oneCount, s.count(DoublePoint.newRangeQuery("double", 0, 1)));
+    assertEquals(10000 - zeroCount - oneCount, s.count(DoublePoint.newRangeQuery("double", 2, cardinality)));
+
+    assertEquals(zeroCount, s.count(BinaryPoint.newRangeQuery("bytes", new byte[] {0}, new byte[] {0})));
+    assertEquals(oneCount, s.count(BinaryPoint.newRangeQuery("bytes", new byte[] {1}, new byte[] {1})));
+    assertEquals(zeroCount + oneCount, s.count(BinaryPoint.newRangeQuery("bytes", new byte[] {0}, new byte[] {1})));
+    assertEquals(10000 - zeroCount - oneCount, s.count(BinaryPoint.newRangeQuery("bytes", new byte[] {2}, new byte[] {(byte) cardinality})));
 
     w.close();
     r.close();

--- a/lucene/sandbox/src/java/org/apache/lucene/document/LatLonShapeQuery.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/document/LatLonShapeQuery.java
@@ -116,14 +116,14 @@ abstract class LatLonShapeQuery extends Query {
 
           @Override
           public void visit(int docID, byte[] t) throws IOException {
-            if (queryMatches(t, scratchTriangle, QueryRelation.INTERSECTS) == true) {
+            if (queryMatches(t, scratchTriangle, QueryRelation.INTERSECTS)) {
               visit(docID);
             }
           }
 
           @Override
           public void visit(DocIdSetIterator iterator, byte[] t) throws IOException {
-            if (queryMatches(t, scratchTriangle, QueryRelation.INTERSECTS) == true) {
+            if (queryMatches(t, scratchTriangle, QueryRelation.INTERSECTS)) {
               int docID;
               while ((docID = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
                 visit(docID);
@@ -167,7 +167,7 @@ abstract class LatLonShapeQuery extends Query {
             boolean queryMatches = queryMatches(t, scratchTriangle, queryRelation);
             int docID;
             while ((docID = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
-              if (queryMatches == true) {
+              if (queryMatches) {
                 intersect.set(docID);
               } else {
                 disjoint.set(docID);

--- a/lucene/sandbox/src/test/org/apache/lucene/document/BaseLatLonShapeTestCase.java
+++ b/lucene/sandbox/src/test/org/apache/lucene/document/BaseLatLonShapeTestCase.java
@@ -49,6 +49,7 @@ import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.LuceneTestCase;
+import org.apache.lucene.util.TestUtil;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.randomBoolean;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.randomIntBetween;
@@ -249,6 +250,24 @@ public abstract class BaseLatLonShapeTestCase extends LuceneTestCase {
 
     Object[] shapes = new Object[numShapes];
     Arrays.fill(shapes, theShape);
+
+    verify(shapes);
+  }
+
+  // Force low cardinality leaves
+  public void testLowCardinalityShapeManyTimes() throws Exception {
+    int numShapes = atLeast(500);
+    int cardinality = TestUtil.nextInt(random(), 2, 20);
+
+    Object[] diffShapes = new Object[cardinality];
+    for (int i = 0; i < cardinality; i++) {
+      diffShapes[i] = nextShape();
+    }
+
+    Object[] shapes = new Object[numShapes];
+    for (int i = 0; i < numShapes; i++) {
+      shapes[i] =  diffShapes[random().nextInt(cardinality)];
+    }
 
     verify(shapes);
   }

--- a/lucene/test-framework/src/java/org/apache/lucene/geo/BaseGeoPointTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/geo/BaseGeoPointTestCase.java
@@ -414,6 +414,29 @@ public abstract class BaseGeoPointTestCase extends LuceneTestCase {
     verify(lats, lons);
   }
 
+  // A particularly tricky adversary for BKD tree:
+  public void testLowCardinality() throws Exception {
+    int numPoints = atLeast(1000);
+    int cardinality = TestUtil.nextInt(random(), 2, 20);
+
+    double[] diffLons  = new double[cardinality];
+    double[] diffLats = new double[cardinality];
+    for (int i = 0; i< cardinality; i++) {
+      diffLats[i] = nextLatitude();
+      diffLons[i] = nextLongitude();
+    }
+
+    double[] lats = new double[numPoints];
+    double[] lons = new double[numPoints];
+    for (int i = 0; i < numPoints; i++) {
+      int index = random().nextInt(cardinality);
+      lats[i] = diffLats[index];
+      lons[i] = diffLons[index];
+    }
+
+    verify(lats, lons);
+  }
+
   public void testAllLatEqual() throws Exception {
     int numPoints = atLeast(10000);
     double lat = nextLatitude();

--- a/lucene/test-framework/src/java/org/apache/lucene/search/BaseRangeFieldQueryTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/search/BaseRangeFieldQueryTestCase.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.search;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -38,6 +39,7 @@ import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.LuceneTestCase;
+import org.apache.lucene.util.TestUtil;
 
 /**
  * Abstract class to do basic tests for a RangeField query. Testing rigor inspired by {@code BaseGeoPointTestCase}
@@ -77,6 +79,33 @@ public abstract class BaseRangeFieldQueryTestCase extends LuceneTestCase {
 
   public void testMultiValued() throws Exception {
     doTestRandom(10000, true);
+  }
+
+  public void testAllEqual() throws Exception {
+    int numDocs = atLeast(10000);
+    int dimensions = dimension();
+    Range[][] ranges = new Range[numDocs][];
+    Range[] theRange =  new Range[] {nextRange(dimensions)};
+    Arrays.fill(ranges, theRange);
+    verify(ranges);
+  }
+
+  // Force low cardinality leaves
+  public void testLowCardinality() throws Exception {
+    int numDocs = atLeast(10000);
+    int dimensions = dimension();
+
+    int cardinality = TestUtil.nextInt(random(), 2, 20);
+    Range[][] diffRanges =  new Range[cardinality][];
+    for (int i = 0; i < cardinality; i++) {
+      diffRanges[i] =  new Range[] {nextRange(dimensions)};
+    }
+
+    Range[][] ranges = new Range[numDocs][];
+    for (int i = 0; i < numDocs; i++) {
+      ranges[i] =  diffRanges[random().nextInt(cardinality)];
+    }
+    verify(ranges);
   }
 
   private void doTestRandom(int count, boolean multiValued) throws Exception {


### PR DESCRIPTION
The following queries have been implemented:

- LatLonShapeQuery

- RangeFieldQuery

- LatLonPointInPolygonQuery

- LatLonPointDistanceQuery

- PointRangeQuery

- PointInSetQuery