### PR TITLE
LUCENE-8833: Add a #load() method to IndexInput to allow preloading file content into physical memory

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/blocktree/FieldReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/blocktree/FieldReader.java
@@ -25,7 +25,6 @@ import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.store.ByteArrayDataInput;
-import org.apache.lucene.store.ByteBufferIndexInput;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.Accountables;
@@ -98,7 +97,7 @@ public final class FieldReader extends Terms implements Accountable {
           isFSTOffHeap = ((this.docCount != this.sumDocFreq) || openedFromWriter == false);
           break;
         case AUTO:
-          isFSTOffHeap = ((this.docCount != this.sumDocFreq) || openedFromWriter == false) && indexIn instanceof ByteBufferIndexInput;
+          isFSTOffHeap = ((this.docCount != this.sumDocFreq) || openedFromWriter == false) &&  indexIn.load(); // NOCOMMIT - should we do this should we do it all the time?
           break;
         default:
           throw new IllegalStateException("unknown enum constant: " + fstLoadMode);

--- a/lucene/core/src/java/org/apache/lucene/store/BufferedChecksumIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/BufferedChecksumIndexInput.java
@@ -79,4 +79,9 @@ public class BufferedChecksumIndexInput extends ChecksumIndexInput {
   public IndexInput slice(String sliceDescription, long offset, long length) throws IOException {
     throw new UnsupportedOperationException();
   }
+
+  @Override
+  public boolean load() {
+    return main.load();
+  }
 }

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBufferIndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBufferIndexInput.java
@@ -21,6 +21,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
 
 /**
  * Base IndexInput implementation that uses an array
@@ -490,5 +491,15 @@ public abstract class ByteBufferIndexInput extends IndexInput implements RandomA
     protected ByteBufferIndexInput buildSlice(String sliceDescription, long ofs, long length) {
       return super.buildSlice(sliceDescription, this.offset + ofs, length);
     }
+  }
+
+  @Override
+  public boolean load() {
+    for (ByteBuffer buffer : buffers) {
+      if (buffer instanceof MappedByteBuffer) {
+        ((MappedByteBuffer) buffer).load();
+      }
+    }
+    return true;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/store/IndexInput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/IndexInput.java
@@ -157,4 +157,13 @@ public abstract class IndexInput extends DataInput implements Cloneable,Closeabl
       };
     }
   }
+
+  /**
+   * Tries to load the {@link IndexInput} content into physical memory and returns <code>true</code> if the operation
+   * was successful.
+   * This method is optional and will return <code>false</code> by default.
+   */
+  public boolean load() {
+    return false;
+  }
 }

--- a/lucene/core/src/java/org/apache/lucene/store/MMapDirectory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/MMapDirectory.java
@@ -91,7 +91,6 @@ import org.apache.lucene.util.SuppressForbidden;
  */
 public class MMapDirectory extends FSDirectory {
   private boolean useUnmapHack = UNMAP_SUPPORTED;
-  private boolean preload;
 
   /** 
    * Default max chunk size.
@@ -203,24 +202,6 @@ public class MMapDirectory extends FSDirectory {
   }
   
   /**
-   * Set to {@code true} to ask mapped pages to be loaded
-   * into physical memory on init. The behavior is best-effort 
-   * and operating system dependent.
-   * @see MappedByteBuffer#load
-   */
-  public void setPreload(boolean preload) {
-    this.preload = preload;
-  }
-  
-  /**
-   * Returns {@code true} if mapped pages should be loaded.
-   * @see #setPreload
-   */
-  public boolean getPreload() {
-    return preload;
-  }
-  
-  /**
    * Returns the current mmap chunk size.
    * @see #MMapDirectory(Path, LockFactory, int)
    */
@@ -266,9 +247,6 @@ public class MMapDirectory extends FSDirectory {
         buffer = fc.map(MapMode.READ_ONLY, offset + bufferStart, bufSize);
       } catch (IOException ioe) {
         throw convertMapFailedIOException(ioe, resourceDescription, bufSize);
-      }
-      if (preload) {
-        buffer.load();
       }
       buffers[bufNr] = buffer;
       bufferStart += bufSize;

--- a/lucene/core/src/test/org/apache/lucene/index/TestLazyProxSkipping.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestLazyProxSkipping.java
@@ -179,53 +179,58 @@ public class TestLazyProxSkipping extends LuceneTestCase {
     // Simply extends IndexInput in a way that we are able to count the number
     // of invocations of seek()
     class SeeksCountingStream extends IndexInput {
-          private IndexInput input;      
-          
-          
-          SeeksCountingStream(IndexInput input) {
-              super("SeekCountingStream(" + input + ")");
-              this.input = input;
-          }      
-                
-          @Override
-          public byte readByte() throws IOException {
-              return this.input.readByte();
-          }
-    
-          @Override
-          public void readBytes(byte[] b, int offset, int len) throws IOException {
-              this.input.readBytes(b, offset, len);        
-          }
-    
-          @Override
-          public void close() throws IOException {
-              this.input.close();
-          }
-    
-          @Override
-          public long getFilePointer() {
-              return this.input.getFilePointer();
-          }
-    
-          @Override
-          public void seek(long pos) throws IOException {
-              TestLazyProxSkipping.this.seeksCounter++;
-              this.input.seek(pos);
-          }
-    
-          @Override
-          public long length() {
-              return this.input.length();
-          }
-          
-          @Override
-          public SeeksCountingStream clone() {
-              return new SeeksCountingStream(this.input.clone());
-          }
+        private IndexInput input;
 
-          @Override
-          public IndexInput slice(String sliceDescription, long offset, long length) throws IOException {
-            return new SeeksCountingStream(this.input.slice(sliceDescription, offset, length));
-          }
+
+        SeeksCountingStream(IndexInput input) {
+            super("SeekCountingStream(" + input + ")");
+            this.input = input;
+        }
+
+        @Override
+        public byte readByte() throws IOException {
+            return this.input.readByte();
+        }
+
+        @Override
+        public void readBytes(byte[] b, int offset, int len) throws IOException {
+            this.input.readBytes(b, offset, len);
+        }
+
+        @Override
+        public void close() throws IOException {
+            this.input.close();
+        }
+
+        @Override
+        public long getFilePointer() {
+            return this.input.getFilePointer();
+        }
+
+        @Override
+        public void seek(long pos) throws IOException {
+            TestLazyProxSkipping.this.seeksCounter++;
+            this.input.seek(pos);
+        }
+
+        @Override
+        public long length() {
+            return this.input.length();
+        }
+
+        @Override
+        public SeeksCountingStream clone() {
+            return new SeeksCountingStream(this.input.clone());
+        }
+
+        @Override
+        public IndexInput slice(String sliceDescription, long offset, long length) throws IOException {
+          return new SeeksCountingStream(this.input.slice(sliceDescription, offset, length));
+        }
+
+        @Override
+        public boolean load() {
+          return this.input.load();
+        }
     }
 }

--- a/lucene/core/src/test/org/apache/lucene/store/TestMmapDirectory.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestMmapDirectory.java
@@ -32,8 +32,17 @@ public class TestMmapDirectory extends BaseDirectoryTestCase {
 
   @Override
   protected Directory getDirectory(Path path) throws IOException {
-    MMapDirectory m = new MMapDirectory(path);
-    m.setPreload(random().nextBoolean());
+    MMapDirectory m = new MMapDirectory(path) {
+      @Override
+      public IndexInput openInput(String name, IOContext context) throws IOException {
+        IndexInput indexInput = super.openInput(name, context);
+        if (random().nextBoolean()) {
+          boolean load = indexInput.load();
+          assert load;
+        }
+        return indexInput;
+      }
+    };
     return m;
   }
   

--- a/lucene/test-framework/src/java/org/apache/lucene/store/MockIndexInputWrapper.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/store/MockIndexInputWrapper.java
@@ -223,5 +223,10 @@ public class MockIndexInputWrapper extends IndexInput {
   public String toString() {
     return "MockIndexInputWrapper(" + delegate + ")";
   }
+
+  @Override
+  public boolean load() {
+    return delegate.load();
+  }
 }
 

--- a/solr/core/src/java/org/apache/solr/core/MMapDirectoryFactory.java
+++ b/solr/core/src/java/org/apache/solr/core/MMapDirectoryFactory.java
@@ -21,6 +21,8 @@ import java.lang.invoke.MethodHandles;
 import java.nio.file.Path;
 
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.LockFactory; // javadocs
 import org.apache.lucene.store.MMapDirectory;
 import org.apache.solr.common.params.SolrParams;
@@ -35,7 +37,8 @@ import org.slf4j.LoggerFactory;
  * Can set the following parameters:
  * <ul>
  *  <li>unmap -- See {@link MMapDirectory#setUseUnmap(boolean)}</li>
- *  <li>preload -- See {@link MMapDirectory#setPreload(boolean)}</li>
+ *  <li>preload -- Set to {@code true} to ask mapped pages to be loaded into physical memory on init.
+ *  he behavior is best-effort and operating system dependent.</li>
  *  <li>maxChunkSize -- The Max chunk size.  See {@link MMapDirectory#MMapDirectory(Path, LockFactory, int)}</li>
  * </ul>
  *
@@ -61,13 +64,23 @@ public class MMapDirectoryFactory extends StandardDirectoryFactory {
   @Override
   protected Directory create(String path, LockFactory lockFactory, DirContext dirContext) throws IOException {
     // we pass NoLockFactory, because the real lock factory is set later by injectLockFactory:
-    MMapDirectory mapDirectory = new MMapDirectory(new File(path).toPath(), lockFactory, maxChunk);
+    final boolean preloadIndexInput = this.preload;
+    MMapDirectory mapDirectory = new MMapDirectory(new File(path).toPath(), lockFactory, maxChunk) {
+      @Override
+      public IndexInput openInput(String name, IOContext context) throws IOException {
+        IndexInput indexInput = super.openInput(name, context);
+        if (preloadIndexInput) {
+          boolean load = indexInput.load();
+          assert load;
+        }
+        return indexInput;
+      }
+    };
     try {
       mapDirectory.setUseUnmap(unmapHack);
     } catch (IllegalArgumentException e) {
       log.warn("Unmap not supported on this JVM, continuing on without setting unmap", e);
     }
-    mapDirectory.setPreload(preload);
     return mapDirectory;
   }
   


### PR DESCRIPTION
Today we have an all or nothing option on MMapDirectory to preload the contents
of the file into physical memory. Yet, with recent efforts moving datastructures
to disk if they can be accessed efficiently can benefit from a per IndexInput API
to make better decisions for defaults if the index is mmapped.
