### PR TITLE
SOLR-13538: Fix classcastEx in TrieDateField for atomic updates

### DIFF
--- a/solr/core/src/java/org/apache/solr/schema/AbstractEnumField.java
+++ b/solr/core/src/java/org/apache/solr/schema/AbstractEnumField.java
@@ -17,17 +17,16 @@
 
 package org.apache.solr.schema;
 
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-
-import javax.xml.xpath.XPath;
-import javax.xml.xpath.XPathConstants;
-import javax.xml.xpath.XPathExpressionException;
-import javax.xml.xpath.XPathFactory;
 
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.lucene.index.IndexableField;
@@ -314,7 +313,7 @@ public abstract class AbstractEnumField extends PrimitiveFieldType {
   
   @Override
   public Object toNativeType(Object val) {
-    if (val instanceof CharSequence || val instanceof String) {
+    if (val instanceof CharSequence) {
       final String str = val.toString();
       final Integer entry = enumMapping.enumStringToIntMap.get(str);
       if (entry != null) {

--- a/solr/core/src/java/org/apache/solr/schema/TrieDateField.java
+++ b/solr/core/src/java/org/apache/solr/schema/TrieDateField.java
@@ -97,7 +97,7 @@ public class TrieDateField extends TrieField implements DateValueFieldType {
   @Override
   public Object toNativeType(Object val) {
     if (val instanceof CharSequence) {
-      return DateMathParser.parseMath(null, (String)val);
+      return DateMathParser.parseMath(null, val.toString());
     }
     return super.toNativeType(val);
   }

--- a/solr/core/src/test/org/apache/solr/schema/DateFieldTest.java
+++ b/solr/core/src/test/org/apache/solr/schema/DateFieldTest.java
@@ -23,6 +23,7 @@ import java.util.Date;
 
 import org.apache.lucene.index.IndexableField;
 import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.common.util.ByteArrayUtf8CharSequence;
 import org.apache.solr.core.SolrConfig;
 import org.apache.solr.core.SolrResourceLoader;
 
@@ -59,6 +60,14 @@ public class DateFieldTest extends SolrTestCaseJ4 {
     // Date math
     out = f.createField(sf, "1995-12-31T23:59:59.99Z+5MINUTES");
     assertEquals(820454699990L, ((Date) f.toObject( out )).getTime() );
+  }
+
+  public void testToNativeType() {
+    FieldType ft = new TrieDateField();
+    ByteArrayUtf8CharSequence charSequence = new ByteArrayUtf8CharSequence("1995-12-31T23:59:59Z");
+
+    Date val = (Date) ft.toNativeType(charSequence);
+    assertEquals("1995-12-31T23:59:59Z", val.toInstant().toString());
   }
 
 }


### PR DESCRIPTION
* get the string from charsequence and avoid casting
