### PR TITLE
LUCENE-8150: Remove references to `segments.gen`.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/DirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DirectoryReader.java
@@ -292,7 +292,6 @@ public abstract class DirectoryReader extends BaseCompositeReader<LeafReader> {
       final String fileName = files[i];
 
       if (fileName.startsWith(IndexFileNames.SEGMENTS) &&
-          !fileName.equals(IndexFileNames.OLD_SEGMENTS_GEN) &&
           SegmentInfos.generationFromSegmentsFileName(fileName) < currentGen) {
 
         SegmentInfos sis = null;

--- a/lucene/core/src/java/org/apache/lucene/index/IndexFileDeleter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexFileDeleter.java
@@ -154,7 +154,7 @@ final class IndexFileDeleter implements Closeable {
           // Add this file to refCounts with initial count 0:
           getRefCount(fileName);
           
-          if (fileName.startsWith(IndexFileNames.SEGMENTS) && !fileName.equals(IndexFileNames.OLD_SEGMENTS_GEN)) {
+          if (fileName.startsWith(IndexFileNames.SEGMENTS)) {
             
             // This is a commit (segments or segments_N), and
             // it's valid (<= the max gen).  Load it, then
@@ -269,7 +269,7 @@ final class IndexFileDeleter implements Closeable {
     Map<String,Long> maxPerSegmentGen = new HashMap<>();
 
     for(String fileName : files) {
-      if (fileName.equals(IndexFileNames.OLD_SEGMENTS_GEN) || fileName.equals(IndexWriter.WRITE_LOCK_NAME)) {
+      if (fileName.equals(IndexWriter.WRITE_LOCK_NAME)) {
         // do nothing
       } else if (fileName.startsWith(IndexFileNames.SEGMENTS)) {
         try {

--- a/lucene/core/src/java/org/apache/lucene/index/IndexFileNames.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexFileNames.java
@@ -48,9 +48,6 @@ public final class IndexFileNames {
   /** Name of pending index segment file */
   public static final String PENDING_SEGMENTS = "pending_segments";
 
-  /** Name of the generation reference file name */
-  public static final String OLD_SEGMENTS_GEN = "segments.gen";
-
   /**
    * Computes the full file name from base, extension and generation. If the
    * generation is -1, the file name is null. If it's 0, the file name is

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
@@ -126,6 +126,9 @@ public final class SegmentInfos implements Cloneable, Iterable<SegmentCommitInfo
   public static final int VERSION_74 = 9;
   static final int VERSION_CURRENT = VERSION_74;
 
+  /** Name of the generation reference file name */
+  private static final String OLD_SEGMENTS_GEN = "segments.gen";
+
   /** Used to name new segments. */
   public long counter;
   
@@ -187,7 +190,9 @@ public final class SegmentInfos implements Cloneable, Iterable<SegmentCommitInfo
   public static long getLastCommitGeneration(String[] files) {
     long max = -1;
     for (String file : files) {
-      if (file.startsWith(IndexFileNames.SEGMENTS) && !file.equals(IndexFileNames.OLD_SEGMENTS_GEN)) {
+      if (file.startsWith(IndexFileNames.SEGMENTS) &&
+          // skipping this file here helps deliver the right exception when opening an old index
+          file.startsWith(OLD_SEGMENTS_GEN) == false) {
         long gen = generationFromSegmentsFileName(file);
         if (gen > max) {
           max = gen;
@@ -246,7 +251,9 @@ public final class SegmentInfos implements Cloneable, Iterable<SegmentCommitInfo
    * return it.
    */
   public static long generationFromSegmentsFileName(String fileName) {
-    if (fileName.equals(IndexFileNames.SEGMENTS)) {
+    if (fileName.equals(OLD_SEGMENTS_GEN)) {
+      throw new IllegalArgumentException("\"" + OLD_SEGMENTS_GEN + "\" is not a valid segment file name since 4.0");
+    } else if (fileName.equals(IndexFileNames.SEGMENTS)) {
       return 0;
     } else if (fileName.startsWith(IndexFileNames.SEGMENTS)) {
       return Long.parseLong(fileName.substring(1+IndexFileNames.SEGMENTS.length()),

--- a/lucene/replicator/src/java/org/apache/lucene/replicator/IndexReplicationHandler.java
+++ b/lucene/replicator/src/java/org/apache/lucene/replicator/IndexReplicationHandler.java
@@ -108,7 +108,7 @@ public class IndexReplicationHandler implements ReplicationHandler {
     }
     
     String segmentsFile = files.remove(files.size() - 1);
-    if (!segmentsFile.startsWith(IndexFileNames.SEGMENTS) || segmentsFile.equals(IndexFileNames.OLD_SEGMENTS_GEN)) {
+    if (!segmentsFile.startsWith(IndexFileNames.SEGMENTS)) {
       throw new IllegalStateException("last file to copy+sync must be segments_N but got " + segmentsFile
           + "; check your Revision implementation!");
     }


### PR DESCRIPTION
This file isn't used anymore since 4.0, so I tried to contain references to
`segments.gen` to the minimum that is required to get the right exception when
opening a too old index.