### PR TITLE
SOLR-13507: Remove support for addr parameter from the /solr/admin/zookeeper endpoint. (#759)

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -54,6 +54,9 @@ Upgrade Notes
   for existing TRA's will use the new format. Solr will handle this invisibly, but any external code that attempted to
   predict collection names in TRA's will probably need adjustment.
 
+* SOLR-13507: Support for "addr" parameter from the "/solr/admin/zookeeper" endpoint has now been removed and will no
+  longer be supported.
+
 New Features
 ----------------------
 
@@ -202,6 +205,8 @@ Other Changes
 * SOLR-12364: Add test cases for edismax boost (David Smiley, Munendra S N)
 
 * SOLR-13603: Remove usage of GroupingSpecification's deprecated methods (Munendra S N)
+
+* SOLR-13507: Remove support for "addr" parameter from the "/solr/admin/zookeeper" endpoint. (janhoy, Anshum Gupta)
 
 ==================  8.1.2 ==================
 

--- a/solr/core/src/java/org/apache/solr/handler/admin/ZookeeperInfoHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/ZookeeperInfoHandler.java
@@ -371,10 +371,9 @@ public final class ZookeeperInfoHandler extends RequestHandlerBase {
     }
 
     String path = params.get(PATH);
-    String addr = params.get("addr");
 
-    if (addr != null && addr.length() == 0) {
-      addr = null;
+    if (params.get("addr") != null) {
+      throw new SolrException(ErrorCode.BAD_REQUEST, "Illegal parameter \"addr\"");
     }
 
     String detailS = params.get("detail");
@@ -401,7 +400,7 @@ public final class ZookeeperInfoHandler extends RequestHandlerBase {
         filter = null;
     }
 
-    ZKPrinter printer = new ZKPrinter(cores.getZkController(), addr);
+    ZKPrinter printer = new ZKPrinter(cores.getZkController());
     printer.detail = detail;
     printer.dump = dump;
     boolean isGraphView = "graph".equals(params.get("view"));
@@ -429,61 +428,23 @@ public final class ZookeeperInfoHandler extends RequestHandlerBase {
     boolean detail = false;
     boolean dump = false;
 
-    String addr; // the address passed to us
     String keeperAddr; // the address we're connected to
-
-    boolean doClose;  // close the client after done if we opened it
 
     final BAOS baos = new BAOS();
     final Writer out = new OutputStreamWriter(baos,  StandardCharsets.UTF_8);
     SolrZkClient zkClient;
 
-    int level;
-    int maxData = 95;
-
     PageOfCollections page;
     PagedCollectionSupport pagingSupport;
     ZkController zkController;
 
-    public ZKPrinter(ZkController controller, String addr) throws IOException {
+    public ZKPrinter(ZkController controller) throws IOException {
       this.zkController = controller;
-      this.addr = addr;
-
-      if (addr == null) {
-        if (controller != null) {
-          // this core is zk enabled
-          keeperAddr = controller.getZkServerAddress();
-          zkClient = controller.getZkClient();
-          if (zkClient != null && zkClient.isConnected()) {
-            return;
-          } else {
-            // try a different client with this address
-            addr = keeperAddr;
-          }
-        }
-      }
-
-      keeperAddr = addr;
-      if (addr == null) {
-        writeError(404, "Zookeeper is not configured for this Solr Core. Please try connecting to an alternate zookeeper address.");
-        return;
-      }
-
-      try {
-        zkClient = new SolrZkClient(addr, 10000);
-        doClose = true;
-      } catch (Exception e) {
-        writeError(503, "Could not connect to zookeeper at '" + addr + "'\"");
-        zkClient = null;
-        return;
-      }
-
+      keeperAddr = controller.getZkServerAddress();
+      zkClient = controller.getZkClient();
     }
 
     public void close() {
-      if (doClose) {
-        zkClient.close();
-      }
       try {
         out.flush();
       } catch (Exception e) {


### PR DESCRIPTION
SOLR-13507: Remove support for addr parameter from the /solr/admin/zookeeper endpoint. (#759)

back-port from master https://github.com/anshumg/lucene-solr/commit/b7090d9c25ba430442628b0dc77c7c700cb35b33
