### PR TITLE
SOLR-11724: Fix for 'Cdcr Bootstrapping does not cause ''index copying'' to follower nodes on Target' BUG 

### DIFF
--- a/solr/core/src/test/org/apache/solr/cloud/cdcr/CdcrBootstrapTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/cdcr/CdcrBootstrapTest.java
@@ -241,6 +241,58 @@ public class CdcrBootstrapTest extends SolrTestCaseJ4 {
     }
   }
 
+  /**
+   * This test successfully validates the follower nodes at targer copies content
+   * from their respective leaders
+   */
+  public void testBootstrapWithMultitpleReplicas() throws Exception {
+    // start the target first so that we know its zkhost
+    MiniSolrCloudCluster target = new MiniSolrCloudCluster(3, createTempDir("cdcr-target"), buildJettyConfig("/solr"));
+    try {
+      System.out.println("Target zkHost = " + target.getZkServer().getZkAddress());
+      System.setProperty("cdcr.target.zkHost", target.getZkServer().getZkAddress());
+
+      MiniSolrCloudCluster source = new MiniSolrCloudCluster(3, createTempDir("cdcr-source"), buildJettyConfig("/solr"));
+      try {
+        source.uploadConfigSet(configset("cdcr-source"), "cdcr-source");
+
+        CollectionAdminRequest.createCollection("cdcr-source", "cdcr-source", 1, 3)
+            .withProperty("solr.directoryFactory", "solr.StandardDirectoryFactory")
+            .process(source.getSolrClient());
+        source.waitForActiveCollection("cdcr-source", 1, 3);
+
+        CloudSolrClient sourceSolrClient = source.getSolrClient();
+        int docs = (TEST_NIGHTLY ? 100 : 10);
+        int numDocs = indexDocs(sourceSolrClient, "cdcr-source", docs);
+
+        QueryResponse response = sourceSolrClient.query(new SolrQuery("*:*"));
+        assertEquals("", numDocs, response.getResults().getNumFound());
+
+        // setup the target cluster
+        target.uploadConfigSet(configset("cdcr-target"), "cdcr-target");
+        CollectionAdminRequest.createCollection("cdcr-target", "cdcr-target", 1, 3)
+            .process(target.getSolrClient());
+        target.waitForActiveCollection("cdcr-target", 1, 3);
+        CloudSolrClient targetSolrClient = target.getSolrClient();
+        targetSolrClient.setDefaultCollection("cdcr-target");
+
+        CdcrTestsUtil.cdcrStart(targetSolrClient);
+        CdcrTestsUtil.cdcrStart(sourceSolrClient);
+
+        response = CdcrTestsUtil.getCdcrQueue(sourceSolrClient);
+        log.info("Cdcr queue response: " + response.getResponse());
+        long foundDocs = CdcrTestsUtil.waitForClusterToSync(numDocs, targetSolrClient);
+        assertEquals("Document mismatch on target after sync", numDocs, foundDocs);
+        assertTrue("leader followers didnt' match", CdcrTestsUtil.assertShardInSync("cdcr-target", "shard1", targetSolrClient)); // with more than 1 replica
+
+      } finally {
+        source.shutdown();
+      }
+    } finally {
+      target.shutdown();
+    }
+  }
+
   // 29-June-2018 @BadApple(bugUrl="https://issues.apache.org/jira/browse/SOLR-12028")
   @BadApple(bugUrl="https://issues.apache.org/jira/browse/SOLR-12028") // 6-Sep-2018
   @Test


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-11724

# Description

When indexing documents in to Source, bootstrapping only copies the index to leader node of shards of the collection and does not start replication to its replicas

# Solution

This change now ensures that the follower recovery request is now sent to replica. Previously this was only sent to the leader which caused issues if the replica was not hosted on the same node.

# Tests

Test case " testBootstrapWithMultitpleReplicas()" has been added. 
See results of tests here: https://issues.apache.org/jira/browse/SOLR-11724?focusedCommentId=16844254&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-16844254

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I am authorized to contribute this code to the ASF and have removed any code I do not have a license to distribute.
- [X] I have developed this patch against the `master` branch.
- [X] I have run `ant precommit` and the appropriate test suite.
- [X] I have added tests for my changes.
- [X] I have added documentation for the Ref Guide (for Solr changes only).


As a note, I did not develop the .patch linked, however it solved the replication issues I was having and I noticed that no one had submitted the patch or created a pull request for it.
