### PR TITLE
LUCENE-8911: Backport LUCENE-8778 (improved analysis SPI name handling) to 8.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ pom.xml
 .pydevproject
 __pycache__
 /dev-tools/scripts/scripts.iml
+

--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,3 @@ pom.xml
 .pydevproject
 __pycache__
 /dev-tools/scripts/scripts.iml
-

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -119,7 +119,11 @@ Improvements
 
 * LUCENE-8793: Luke enhanced UI for CustomAnalyzer: show detailed analysis steps. (Jun Ohtani via Tomoko Uchida)
 
+* LUCENE-8874: Show SPI names instead of class names in Luke Analysis tab. (Tomoko Uchida)
+
 * LUCENE-8855: Add Accountable to some Query implementations (ab, Adrien Grand)
+
+* LUCENE-8894: Add APIs to find SPI names for Tokenizer/CharFilter/TokenFilter factory classes. (Tomoko Uchida)
 
 Optimizations
 
@@ -161,6 +165,9 @@ Other
 * LUCENE-8861: Script to find open Github PRs that needs attention (janhoy)
 
 * LUCENE-8852: ReleaseWizard tool for release managers (janhoy)
+
+* LUCENE-8778: Define analyzer SPI names as static final fields and document the names in Javadocs.
+  (Tomoko Uchida, Uwe Schindler)
 
 * LUCENE-8838: Remove support for Steiner points on Tessellator. (Ignacio Vera)
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -4,7 +4,17 @@ For more information on past and future Lucene versions, please see:
 http://s.apache.org/luceneversions
 
 ======================= Lucene 8.3.0 =======================
-(No Changes)
+
+Improvements
+
+* LUCENE-8874: Show SPI names instead of class names in Luke Analysis tab. (Tomoko Uchida)
+
+* LUCENE-8894: Add APIs to find SPI names for Tokenizer/CharFilter/TokenFilter factory classes. (Tomoko Uchida)
+
+Other
+
+* LUCENE-8778 LUCENE-8911: Define analyzer SPI names as static final fields and document the names in Javadocs.
+  (Tomoko Uchida, Uwe Schindler)
 
 ======================= Lucene 8.2.0 =======================
 
@@ -119,11 +129,7 @@ Improvements
 
 * LUCENE-8793: Luke enhanced UI for CustomAnalyzer: show detailed analysis steps. (Jun Ohtani via Tomoko Uchida)
 
-* LUCENE-8874: Show SPI names instead of class names in Luke Analysis tab. (Tomoko Uchida)
-
 * LUCENE-8855: Add Accountable to some Query implementations (ab, Adrien Grand)
-
-* LUCENE-8894: Add APIs to find SPI names for Tokenizer/CharFilter/TokenFilter factory classes. (Tomoko Uchida)
 
 Optimizations
 
@@ -165,9 +171,6 @@ Other
 * LUCENE-8861: Script to find open Github PRs that needs attention (janhoy)
 
 * LUCENE-8852: ReleaseWizard tool for release managers (janhoy)
-
-* LUCENE-8778: Define analyzer SPI names as static final fields and document the names in Javadocs.
-  (Tomoko Uchida, Uwe Schindler)
 
 * LUCENE-8838: Remove support for Steiner points on Tessellator. (Ignacio Vera)
 

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/ar/ArabicNormalizationFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/ar/ArabicNormalizationFilterFactory.java
@@ -33,8 +33,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * &lt;/fieldType&gt;</pre>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class ArabicNormalizationFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "arabicNormalization";
 
   /** Creates a new ArabicNormalizationFilterFactory */
   public ArabicNormalizationFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/ar/ArabicStemFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/ar/ArabicStemFilterFactory.java
@@ -34,8 +34,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * &lt;/fieldType&gt;</pre>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class ArabicStemFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "arabicStem";
 
   /** Creates a new ArabicStemFilterFactory */
   public ArabicStemFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/bg/BulgarianStemFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/bg/BulgarianStemFilterFactory.java
@@ -33,9 +33,13 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.1.0
+ * @lucene.spi {@value #NAME}
  */
 public class BulgarianStemFilterFactory extends TokenFilterFactory {
-  
+
+  /** SPI name */
+  public static final String NAME = "bulgarianStem";
+
   /** Creates a new BulgarianStemFilterFactory */
   public BulgarianStemFilterFactory(Map<String,String> args) {
     super(args);

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/bn/BengaliNormalizationFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/bn/BengaliNormalizationFilterFactory.java
@@ -32,8 +32,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 7.1.0
+ * @lucene.spi {@value #NAME}
  */
 public class BengaliNormalizationFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "bengaliNormalization";
 
   public BengaliNormalizationFilterFactory(Map<String,String> args) {
     super(args);

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/bn/BengaliStemFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/bn/BengaliStemFilterFactory.java
@@ -32,8 +32,12 @@ import java.util.Map;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 7.1.0
+ * @lucene.spi {@value #NAME}
  */
 public class BengaliStemFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "bengaliStem";
 
   public BengaliStemFilterFactory(Map<String,String> args) {
     super(args);

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/br/BrazilianStemFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/br/BrazilianStemFilterFactory.java
@@ -34,8 +34,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * &lt;/fieldType&gt;</pre>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class BrazilianStemFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "brazilianStem";
   
   /** Creates a new BrazilianStemFilterFactory */
   public BrazilianStemFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/charfilter/HTMLStripCharFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/charfilter/HTMLStripCharFilterFactory.java
@@ -35,8 +35,13 @@ import java.util.regex.Pattern;
  * &lt;/fieldType&gt;</pre>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class HTMLStripCharFilterFactory extends CharFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "htmlStrip";
+
   final Set<String> escapedTags;
   static final Pattern TAG_NAME_PATTERN = Pattern.compile("[^\\s,]+");
   

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/charfilter/MappingCharFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/charfilter/MappingCharFilterFactory.java
@@ -40,9 +40,13 @@ import org.apache.lucene.analysis.util.ResourceLoaderAware;
  * &lt;/fieldType&gt;</pre>
  *
  * @since Solr 1.4
+ * @lucene.spi {@value #NAME}
  */
 public class MappingCharFilterFactory extends CharFilterFactory implements
     ResourceLoaderAware {
+
+  /** SPI name */
+  public static final String NAME = "mapping";
 
   protected NormalizeCharMap normMap;
   private final String mapping;

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/cjk/CJKBigramFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/cjk/CJKBigramFilterFactory.java
@@ -36,8 +36,13 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.6.0
+ * @lucene.spi {@value #NAME}
  */
 public class CJKBigramFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "cjkBigram";
+
   final int flags;
   final boolean outputUnigrams;
 

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/cjk/CJKWidthFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/cjk/CJKWidthFilterFactory.java
@@ -34,8 +34,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.6.0
+ * @lucene.spi {@value #NAME}
  */
 public class CJKWidthFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "cjkWidth";
   
   /** Creates a new CJKWidthFilterFactory */
   public CJKWidthFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/ckb/SoraniNormalizationFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/ckb/SoraniNormalizationFilterFactory.java
@@ -32,8 +32,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 4.7.0
+ * @lucene.spi {@value #NAME}
  */
 public class SoraniNormalizationFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "soraniNormalization";
 
   /** Creates a new SoraniNormalizationFilterFactory */
   public SoraniNormalizationFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/ckb/SoraniStemFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/ckb/SoraniStemFilterFactory.java
@@ -33,8 +33,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 4.7.0
+ * @lucene.spi {@value #NAME}
  */
 public class SoraniStemFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "soraniStem";
 
   /** Creates a new SoraniStemFilterFactory */
   public SoraniStemFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/commongrams/CommonGramsFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/commongrams/CommonGramsFilterFactory.java
@@ -39,9 +39,14 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * &lt;/fieldType&gt;</pre>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class CommonGramsFilterFactory extends TokenFilterFactory implements ResourceLoaderAware {
-  // TODO: shared base class for Stop/Keep/CommonGrams? 
+
+  /** SPI name */
+  public static final String NAME = "commonGrams";
+
+  // TODO: shared base class for Stop/Keep/CommonGrams?
   private CharArraySet commonWords;
   private final String commonWordFiles;
   private final String format;

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/commongrams/CommonGramsQueryFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/commongrams/CommonGramsQueryFilterFactory.java
@@ -34,8 +34,11 @@ import org.apache.lucene.analysis.TokenStream;
  * &lt;/fieldType&gt;</pre>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class CommonGramsQueryFilterFactory extends CommonGramsFilterFactory {
+
+  public static final String NAME = "commonGramsQuery";
 
   /** Creates a new CommonGramsQueryFilterFactory */
   public CommonGramsQueryFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/compound/DictionaryCompoundWordTokenFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/compound/DictionaryCompoundWordTokenFilterFactory.java
@@ -38,8 +38,13 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * &lt;/fieldType&gt;</pre>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class DictionaryCompoundWordTokenFilterFactory extends TokenFilterFactory implements ResourceLoaderAware {
+
+  /** SPI name */
+  public static final String NAME = "dictionaryCompoundWord";
+
   private CharArraySet dictionary;
   private final String dictFile;
   private final int minWordSize;

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/compound/HyphenationCompoundWordTokenFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/compound/HyphenationCompoundWordTokenFilterFactory.java
@@ -58,8 +58,13 @@ import org.xml.sax.InputSource;
  *
  * @see HyphenationCompoundWordTokenFilter
  * @since 3.1.0
+ * @lucene.spi {@value #NAME}
  */
 public class HyphenationCompoundWordTokenFilterFactory extends TokenFilterFactory implements ResourceLoaderAware {
+
+  /** SPI name */
+  public static final String NAME = "hyphenationCompoundWord";
+
   private CharArraySet dictionary;
   private HyphenationTree hyphenator;
   private final String dictFile;

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/core/DecimalDigitFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/core/DecimalDigitFilterFactory.java
@@ -32,8 +32,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 5.4.0
+ * @lucene.spi {@value #NAME}
  */
 public class DecimalDigitFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "decimalDigit";
   
   /** Creates a new DecimalDigitFilterFactory */
   public DecimalDigitFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/core/FlattenGraphFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/core/FlattenGraphFilterFactory.java
@@ -27,8 +27,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *
  * @lucene.experimental
  * @since 6.4.0
+ * @lucene.spi {@value #NAME}
  */
 public class FlattenGraphFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "flattenGraph";
 
   /** Creates a new FlattenGraphFilterFactory */
   public FlattenGraphFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/core/KeywordTokenizerFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/core/KeywordTokenizerFactory.java
@@ -40,8 +40,13 @@ import static org.apache.lucene.analysis.standard.StandardTokenizer.MAX_TOKEN_LE
  * </ul>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class KeywordTokenizerFactory extends TokenizerFactory {
+
+  /** SPI name */
+  public static final String NAME = "keyword";
+
   private final int maxTokenLen;
   
   /** Creates a new KeywordTokenizerFactory */

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/core/LetterTokenizerFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/core/LetterTokenizerFactory.java
@@ -42,8 +42,13 @@ import static org.apache.lucene.analysis.standard.StandardTokenizer.MAX_TOKEN_LE
  * </ul>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class LetterTokenizerFactory extends TokenizerFactory {
+
+  /** SPI name */
+  public static final String NAME = "letter";
+
   private final int maxTokenLen;
 
   /** Creates a new LetterTokenizerFactory */

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/core/LowerCaseFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/core/LowerCaseFilterFactory.java
@@ -33,8 +33,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * &lt;/fieldType&gt;</pre>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class LowerCaseFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "lowercase";
   
   /** Creates a new LowerCaseFilterFactory */
   public LowerCaseFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/core/StopFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/core/StopFilterFactory.java
@@ -71,8 +71,13 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * </ul>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class StopFilterFactory extends TokenFilterFactory implements ResourceLoaderAware {
+
+  /** SPI name */
+  public static final String NAME = "stop";
+
   public static final String FORMAT_WORDSET = "wordset";
   public static final String FORMAT_SNOWBALL = "snowball";
   

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/core/TypeTokenFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/core/TypeTokenFilterFactory.java
@@ -39,8 +39,13 @@ import java.util.Set;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.6.0
+ * @lucene.spi {@value #NAME}
  */
 public class TypeTokenFilterFactory extends TokenFilterFactory implements ResourceLoaderAware {
+
+  /** SPI name */
+  public static final String NAME = "type";
+
   private final boolean useWhitelist;
   private final String stopTypesFiles;
   private Set<String> stopTypes;

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/core/UpperCaseFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/core/UpperCaseFilterFactory.java
@@ -37,8 +37,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * when you require uppercase tokens.  Use the {@link LowerCaseFilterFactory} for 
  * general search matching
  * @since 4.7.0
+ * @lucene.spi {@value #NAME}
  */
 public class UpperCaseFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "uppercase";
   
   /** Creates a new UpperCaseFilterFactory */
   public UpperCaseFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/core/WhitespaceTokenizerFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/core/WhitespaceTokenizerFactory.java
@@ -47,8 +47,13 @@ import static org.apache.lucene.analysis.standard.StandardTokenizer.MAX_TOKEN_LE
  * </ul>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class WhitespaceTokenizerFactory extends TokenizerFactory {
+
+  /** SPI name */
+  public static final String NAME = "whitespace";
+
   public static final String RULE_JAVA = "java";
   public static final String RULE_UNICODE = "unicode";
   private static final Collection<String> RULE_NAMES = Arrays.asList(RULE_JAVA, RULE_UNICODE);

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/cz/CzechStemFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/cz/CzechStemFilterFactory.java
@@ -33,8 +33,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.1.0
+ * @lucene.spi {@value #NAME}
  */
 public class CzechStemFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "czechStem";
   
   /** Creates a new CzechStemFilterFactory */
   public CzechStemFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/de/GermanLightStemFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/de/GermanLightStemFilterFactory.java
@@ -33,8 +33,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.1.0
+ * @lucene.spi {@value #NAME}
  */
 public class GermanLightStemFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "germanLightStem";
   
   /** Creates a new GermanLightStemFilterFactory */
   public GermanLightStemFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/de/GermanMinimalStemFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/de/GermanMinimalStemFilterFactory.java
@@ -33,8 +33,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.1.0
+ * @lucene.spi {@value #NAME}
  */
 public class GermanMinimalStemFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "germanMinimalStem";
   
   /** Creates a new GermanMinimalStemFilterFactory */
   public GermanMinimalStemFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/de/GermanNormalizationFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/de/GermanNormalizationFilterFactory.java
@@ -33,8 +33,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre> 
  * @since 3.6.0
+ * @lucene.spi {@value #NAME}
  */
 public class GermanNormalizationFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "germanNormalization";
 
   /** Creates a new GermanNormalizationFilterFactory */
   public GermanNormalizationFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/de/GermanStemFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/de/GermanStemFilterFactory.java
@@ -34,8 +34,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * &lt;/fieldType&gt;</pre>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class GermanStemFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "germanStem";
   
   /** Creates a new GermanStemFilterFactory */
   public GermanStemFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/el/GreekLowerCaseFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/el/GreekLowerCaseFilterFactory.java
@@ -33,8 +33,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * &lt;/fieldType&gt;</pre>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class GreekLowerCaseFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "greekLowerCase";
  
   /** Creates a new GreekLowerCaseFilterFactory */
   public GreekLowerCaseFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/el/GreekStemFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/el/GreekStemFilterFactory.java
@@ -33,8 +33,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.1.0
+ * @lucene.spi {@value #NAME}
  */
 public class GreekStemFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "greekStem";
 
   /** Creates a new GreekStemFilterFactory */
   public GreekStemFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/en/EnglishMinimalStemFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/en/EnglishMinimalStemFilterFactory.java
@@ -33,8 +33,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.1.0
+ * @lucene.spi {@value #NAME}
  */
 public class EnglishMinimalStemFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "englishMinimalStem";
   
   /** Creates a new EnglishMinimalStemFilterFactory */
   public EnglishMinimalStemFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/en/EnglishPossessiveFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/en/EnglishPossessiveFilterFactory.java
@@ -33,8 +33,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.1.0
+ * @lucene.spi {@value #NAME}
  */
 public class EnglishPossessiveFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "englishPossessive";
   
   /** Creates a new EnglishPossessiveFilterFactory */
   public EnglishPossessiveFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/en/KStemFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/en/KStemFilterFactory.java
@@ -34,8 +34,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.3.0
+ * @lucene.spi {@value #NAME}
  */
 public class KStemFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "kStem";
 
   /** Creates a new KStemFilterFactory */
   public KStemFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/en/PorterStemFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/en/PorterStemFilterFactory.java
@@ -34,8 +34,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * &lt;/fieldType&gt;</pre>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class PorterStemFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "porterStem";
   
   /** Creates a new PorterStemFilterFactory */
   public PorterStemFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/es/SpanishLightStemFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/es/SpanishLightStemFilterFactory.java
@@ -33,8 +33,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.1.0
+ * @lucene.spi {@value #NAME}
  */
 public class SpanishLightStemFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "spanishLightStem";
   
   /** Creates a new SpanishLightStemFilterFactory */
   public SpanishLightStemFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/fa/PersianCharFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/fa/PersianCharFilterFactory.java
@@ -33,8 +33,12 @@ import org.apache.lucene.analysis.util.CharFilterFactory;
  * &lt;/fieldType&gt;</pre>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class PersianCharFilterFactory extends CharFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "persian";
 
   /** Creates a new PersianCharFilterFactory */
   public PersianCharFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/fa/PersianNormalizationFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/fa/PersianNormalizationFilterFactory.java
@@ -34,8 +34,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * &lt;/fieldType&gt;</pre>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class PersianNormalizationFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "persianNormalization";
   
   /** Creates a new PersianNormalizationFilterFactory */
   public PersianNormalizationFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/fi/FinnishLightStemFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/fi/FinnishLightStemFilterFactory.java
@@ -33,8 +33,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.1.0
+ * @lucene.spi {@value #NAME}
  */
 public class FinnishLightStemFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "finnishLightStem";
   
   /** Creates a new FinnishLightStemFilterFactory */
   public FinnishLightStemFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/fr/FrenchLightStemFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/fr/FrenchLightStemFilterFactory.java
@@ -34,8 +34,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.1.0
+ * @lucene.spi {@value #NAME}
  */
 public class FrenchLightStemFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "frenchLightStem";
   
   /** Creates a new FrenchLightStemFilterFactory */
   public FrenchLightStemFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/fr/FrenchMinimalStemFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/fr/FrenchMinimalStemFilterFactory.java
@@ -34,8 +34,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.1.0
+ * @lucene.spi {@value #NAME}
  */
 public class FrenchMinimalStemFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "frenchMinimalStem";
   
   /** Creates a new FrenchMinimalStemFilterFactory */
   public FrenchMinimalStemFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/ga/IrishLowerCaseFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/ga/IrishLowerCaseFilterFactory.java
@@ -32,8 +32,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.6.0
+ * @lucene.spi {@value #NAME}
  */
 public class IrishLowerCaseFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "irishLowerCase";
 
   /** Creates a new IrishLowerCaseFilterFactory */
   public IrishLowerCaseFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/gl/GalicianMinimalStemFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/gl/GalicianMinimalStemFilterFactory.java
@@ -33,8 +33,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.6.0
+ * @lucene.spi {@value #NAME}
  */
 public class GalicianMinimalStemFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "galicianMinimalStem";
   
   /** Creates a new GalicianMinimalStemFilterFactory */
   public GalicianMinimalStemFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/gl/GalicianStemFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/gl/GalicianStemFilterFactory.java
@@ -33,8 +33,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.1.0
+ * @lucene.spi {@value #NAME}
  */
 public class GalicianStemFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "galicianStem";
   
   /** Creates a new GalicianStemFilterFactory */
   public GalicianStemFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hi/HindiNormalizationFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hi/HindiNormalizationFilterFactory.java
@@ -32,8 +32,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.1.0
+ * @lucene.spi {@value #NAME}
  */
 public class HindiNormalizationFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "hindiNormalization";
   
   /** Creates a new HindiNormalizationFilterFactory */
   public HindiNormalizationFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hi/HindiStemFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hi/HindiStemFilterFactory.java
@@ -32,8 +32,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.1.0
+ * @lucene.spi {@value #NAME}
  */
 public class HindiStemFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "hindiStem";
   
   /** Creates a new HindiStemFilterFactory */
   public HindiStemFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hu/HungarianLightStemFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hu/HungarianLightStemFilterFactory.java
@@ -33,8 +33,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.1.0
+ * @lucene.spi {@value #NAME}
  */
 public class HungarianLightStemFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "hungarianLightStem";
   
   /** Creates a new HungarianLightStemFilterFactory */
   public HungarianLightStemFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/HunspellStemFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/HunspellStemFilterFactory.java
@@ -49,8 +49,13 @@ import org.apache.lucene.util.IOUtils;
  * See <a href="http://wiki.apache.org/solr/Hunspell">http://wiki.apache.org/solr/Hunspell</a>
  * @lucene.experimental
  * @since 3.5.0
+ * @lucene.spi {@value #NAME}
  */
 public class HunspellStemFilterFactory extends TokenFilterFactory implements ResourceLoaderAware {
+
+  /** SPI name */
+  public static final String NAME = "hunspellStem";
+
   private static final String PARAM_DICTIONARY    = "dictionary";
   private static final String PARAM_AFFIX         = "affix";
   // NOTE: this one is currently unused?:

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/id/IndonesianStemFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/id/IndonesianStemFilterFactory.java
@@ -33,8 +33,13 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.1.0
+ * @lucene.spi {@value #NAME}
  */
 public class IndonesianStemFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "indonesianStem";
+
   private final boolean stemDerivational;
 
   /** Creates a new IndonesianStemFilterFactory */

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/in/IndicNormalizationFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/in/IndicNormalizationFilterFactory.java
@@ -32,8 +32,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.1.0
+ * @lucene.spi {@value #NAME}
  */
 public class IndicNormalizationFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "indicNormalization";
   
   /** Creates a new IndicNormalizationFilterFactory */
   public IndicNormalizationFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/it/ItalianLightStemFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/it/ItalianLightStemFilterFactory.java
@@ -33,8 +33,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre> 
  * @since 3.1.0
+ * @lucene.spi {@value #NAME}
  */
 public class ItalianLightStemFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "italianLightStem";
   
   /** Creates a new ItalianLightStemFilterFactory */
   public ItalianLightStemFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/lv/LatvianStemFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/lv/LatvianStemFilterFactory.java
@@ -33,8 +33,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.2.0
+ * @lucene.spi {@value #NAME}
  */
 public class LatvianStemFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "latvianStem";
   
   /** Creates a new LatvianStemFilterFactory */
   public LatvianStemFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/minhash/MinHashFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/minhash/MinHashFilterFactory.java
@@ -25,8 +25,13 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
 /**
  * {@link TokenFilterFactory} for {@link MinHashFilter}.
  * @since 6.2.0
+ * @lucene.spi {@value #NAME}
  */
 public class MinHashFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "minHash";
+
   private int hashCount = MinHashFilter.DEFAULT_HASH_COUNT;
   
   private int bucketCount = MinHashFilter.DEFAULT_BUCKET_COUNT;

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/ASCIIFoldingFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/ASCIIFoldingFilterFactory.java
@@ -33,8 +33,13 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * &lt;/fieldType&gt;</pre>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class ASCIIFoldingFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "asciiFolding";
+
   private static final String PRESERVE_ORIGINAL = "preserveOriginal";
 
   private final boolean preserveOriginal;

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/CapitalizationFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/CapitalizationFilterFactory.java
@@ -56,8 +56,13 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * &lt;/fieldType&gt;</pre>
  *
  * @since solr 1.3
+ * @lucene.spi {@value #NAME}
  */
 public class CapitalizationFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "capitalization";
+
   public static final String KEEP = "keep";
   public static final String KEEP_IGNORE_CASE = "keepIgnoreCase";
   public static final String OK_PREFIX = "okPrefix";

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/CodepointCountFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/CodepointCountFilterFactory.java
@@ -32,8 +32,13 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 4.5.1
+ * @lucene.spi {@value #NAME}
  */
 public class CodepointCountFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "codepointCount";
+
   final int min;
   final int max;
   public static final String MIN_KEY = "min";

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/ConcatenateGraphFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/ConcatenateGraphFilterFactory.java
@@ -44,8 +44,12 @@ import org.apache.lucene.util.automaton.TooComplexToDeterminizeException;
  * </ul>
  * @see ConcatenateGraphFilter
  * @since 7.4.0
+ * @lucene.spi {@value #NAME}
  */
 public class ConcatenateGraphFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "concatenateGraph";
 
   private boolean preserveSep;
   private boolean preservePositionIncrements;

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/ConditionalTokenFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/ConditionalTokenFilterFactory.java
@@ -32,8 +32,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * Abstract parent class for analysis factories that create {@link ConditionalTokenFilter} instances
  *
  * @since 7.4.0
+ * @lucene.spi {@value #NAME}
  */
 public abstract class ConditionalTokenFilterFactory extends TokenFilterFactory implements ResourceLoaderAware {
+
+  /** SPI name */
+  public static final String NAME = "conditional";
 
   private List<TokenFilterFactory> innerFilters;
 

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/DateRecognizerFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/DateRecognizerFilterFactory.java
@@ -42,8 +42,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * format of the system. The {@code locale} is optional and if omitted the filter will be created with
  * {@link Locale#ENGLISH}.
  * @since 5.5.0
+ * @lucene.spi {@value #NAME}
  */
 public class DateRecognizerFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "dateRecognizer";
 
   public static final String DATE_PATTERN = "datePattern";
   public static final String LOCALE = "locale";

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/DelimitedTermFrequencyTokenFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/DelimitedTermFrequencyTokenFilterFactory.java
@@ -32,8 +32,13 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 7.0.0
+ * @lucene.spi {@value #NAME}
  */
 public class DelimitedTermFrequencyTokenFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "delimitedTermFrequency";
+
   public static final String DELIMITER_ATTR = "delimiter";
 
   private final char delimiter;

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/FingerprintFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/FingerprintFilterFactory.java
@@ -32,8 +32,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * {@link FingerprintFilter} for an explanation of its use.
  * </pre>
  * @since 5.4.0
+ * @lucene.spi {@value #NAME}
  */
 public class FingerprintFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "fingerprint";
 
   public static final String MAX_OUTPUT_TOKEN_SIZE_KEY = "maxOutputTokenSize";
   public static final String SEPARATOR_KEY = "separator";

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/FixBrokenOffsetsFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/FixBrokenOffsetsFilterFactory.java
@@ -25,8 +25,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
 /**
  * Factory for {@link FixBrokenOffsetsFilter}.
  * @since 7.0.0
+ * @lucene.spi {@value #NAME}
  */
 public class FixBrokenOffsetsFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "fixBrokenOffsets";
 
   /** Sole constructor */
   public FixBrokenOffsetsFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/HyphenatedWordsFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/HyphenatedWordsFilterFactory.java
@@ -33,8 +33,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * &lt;/fieldType&gt;</pre>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class HyphenatedWordsFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "hyphenatedWords";
   
   /** Creates a new HyphenatedWordsFilterFactory */
   public HyphenatedWordsFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/KeepWordFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/KeepWordFilterFactory.java
@@ -37,8 +37,13 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * &lt;/fieldType&gt;</pre>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class KeepWordFilterFactory extends TokenFilterFactory implements ResourceLoaderAware {
+
+  /** SPI name */
+  public static final String NAME = "keepWord";
+
   private final boolean ignoreCase;
   private final String wordFiles;
   private CharArraySet words;

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/KeywordMarkerFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/KeywordMarkerFilterFactory.java
@@ -37,8 +37,13 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.1.0
+ * @lucene.spi {@value #NAME}
  */
 public class KeywordMarkerFilterFactory extends TokenFilterFactory implements ResourceLoaderAware {
+
+  /** SPI name */
+  public static final String NAME = "keywordMarker";
+
   public static final String PROTECTED_TOKENS = "protected";
   public static final String PATTERN = "pattern";
   private final String wordFiles;

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/KeywordRepeatFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/KeywordRepeatFilterFactory.java
@@ -29,8 +29,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * later in the analysis chain will be in the document twice. Therefore, consider adding
  * {@link RemoveDuplicatesTokenFilterFactory} later in the analysis chain.
  * @since 4.3.0
+ * @lucene.spi {@value #NAME}
  */
 public final class KeywordRepeatFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "keywordRepeat";
   
   /** Creates a new KeywordRepeatFilterFactory */
   public KeywordRepeatFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/LengthFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/LengthFilterFactory.java
@@ -33,8 +33,13 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * &lt;/fieldType&gt;</pre>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class LengthFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "length";
+
   final int min;
   final int max;
   public static final String MIN_KEY = "min";

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/LimitTokenCountFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/LimitTokenCountFilterFactory.java
@@ -35,8 +35,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * The {@code consumeAllTokens} property is optional and defaults to {@code false}.  
  * See {@link LimitTokenCountFilter} for an explanation of its use.
  * @since 3.1.0
+ * @lucene.spi {@value #NAME}
  */
 public class LimitTokenCountFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "limitTokenCount";
 
   public static final String MAX_TOKEN_COUNT_KEY = "maxTokenCount";
   public static final String CONSUME_ALL_TOKENS_KEY = "consumeAllTokens";

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/LimitTokenOffsetFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/LimitTokenOffsetFilterFactory.java
@@ -34,8 +34,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * <p>
  * The {@code consumeAllTokens} property is optional and defaults to {@code false}.
  * @since 5.2.0
+ * @lucene.spi {@value #NAME}
  */
 public class LimitTokenOffsetFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "limitTokenOffset";
 
   public static final String MAX_START_OFFSET = "maxStartOffset";
   public static final String CONSUME_ALL_TOKENS_KEY = "consumeAllTokens";

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/LimitTokenPositionFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/LimitTokenPositionFilterFactory.java
@@ -34,8 +34,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * The {@code consumeAllTokens} property is optional and defaults to {@code false}.  
  * See {@link LimitTokenPositionFilter} for an explanation of its use.
  * @since 4.3.0
+ * @lucene.spi {@value #NAME}
  */
 public class LimitTokenPositionFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "limitTokenPosition";
 
   public static final String MAX_TOKEN_POSITION_KEY = "maxTokenPosition";
   public static final String CONSUME_ALL_TOKENS_KEY = "consumeAllTokens";

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/ProtectedTermFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/ProtectedTermFilterFactory.java
@@ -77,8 +77,11 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * <p>See related {@link org.apache.lucene.analysis.custom.CustomAnalyzer.Builder#whenTerm(Predicate)}
  *
  * @since 7.4.0
+ * @lucene.spi {@value #NAME}
  */
 public class ProtectedTermFilterFactory extends ConditionalTokenFilterFactory implements ResourceLoaderAware {
+
+  public static final String NAME = "protectedTerm";
 
   public static final String PROTECTED_TERMS = "protected";
   public static final char FILTER_ARG_SEPARATOR = '.';

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/RemoveDuplicatesTokenFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/RemoveDuplicatesTokenFilterFactory.java
@@ -33,8 +33,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * &lt;/fieldType&gt;</pre>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class RemoveDuplicatesTokenFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "removeDuplicates";
   
   /** Creates a new RemoveDuplicatesTokenFilterFactory */
   public RemoveDuplicatesTokenFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/ScandinavianFoldingFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/ScandinavianFoldingFilterFactory.java
@@ -32,8 +32,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 4.4.0
+ * @lucene.spi {@value #NAME}
  */
 public class ScandinavianFoldingFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "scandinavianFolding";
 
   public ScandinavianFoldingFilterFactory(Map<String,String> args) {
     super(args);

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/ScandinavianNormalizationFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/ScandinavianNormalizationFilterFactory.java
@@ -32,8 +32,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 4.4.0
+ * @lucene.spi {@value #NAME}
  */
 public class ScandinavianNormalizationFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "scandinavianNormalization";
 
   public ScandinavianNormalizationFilterFactory(Map<String, String> args) {
     super(args);

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/StemmerOverrideFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/StemmerOverrideFilterFactory.java
@@ -37,8 +37,13 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.1.0
+ * @lucene.spi {@value #NAME}
  */
 public class StemmerOverrideFilterFactory extends TokenFilterFactory implements ResourceLoaderAware {
+
+  /** SPI name */
+  public static final String NAME = "stemmerOverride";
+
   private StemmerOverrideMap dictionary;
   private final String dictionaryFiles;
   private final boolean ignoreCase;

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/TrimFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/TrimFilterFactory.java
@@ -35,8 +35,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * @see TrimFilter
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class TrimFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "trim";
   
   /** Creates a new TrimFilterFactory */
   public TrimFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/TruncateTokenFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/TruncateTokenFilterFactory.java
@@ -37,8 +37,12 @@ import java.util.Map;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 4.8.0
+ * @lucene.spi {@value #NAME}
  */
 public class TruncateTokenFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "truncate";
 
   public static final String PREFIX_LENGTH_KEY = "prefixLength";
   private final byte prefixLength;

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/TypeAsSynonymFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/TypeAsSynonymFilterFactory.java
@@ -38,8 +38,13 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * the emitted synonym will have text "_type_&lt;URL&gt;".
  *
  * @since 7.3.0
+ * @lucene.spi {@value #NAME}
  */
 public class TypeAsSynonymFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "typeAsSynonym";
+
   private final String prefix;
 
   public TypeAsSynonymFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/WordDelimiterFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/WordDelimiterFilterFactory.java
@@ -54,9 +54,14 @@ import static org.apache.lucene.analysis.miscellaneous.WordDelimiterFilter.*;
  * the search time analyzer.
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 @Deprecated
 public class WordDelimiterFilterFactory extends TokenFilterFactory implements ResourceLoaderAware {
+
+  /** SPI name */
+  public static final String NAME = "wordDelimiter";
+
   public static final String PROTECTED_TOKENS = "protected";
   public static final String TYPES = "types";
 

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/WordDelimiterGraphFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/miscellaneous/WordDelimiterGraphFilterFactory.java
@@ -49,8 +49,13 @@ import static org.apache.lucene.analysis.miscellaneous.WordDelimiterIterator.*;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 6.5.0
+ * @lucene.spi {@value #NAME}
  */
 public class WordDelimiterGraphFilterFactory extends TokenFilterFactory implements ResourceLoaderAware {
+
+  /** SPI name */
+  public static final String NAME = "wordDelimiterGraph";
+
   public static final String PROTECTED_TOKENS = "protected";
   public static final String TYPES = "types";
   public static final String OFFSETS = "adjustOffsets";

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/ngram/EdgeNGramFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/ngram/EdgeNGramFilterFactory.java
@@ -34,8 +34,13 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * &lt;/fieldType&gt;</pre>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class EdgeNGramFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "edgeNGram";
+
   private final int maxGramSize;
   private final int minGramSize;
   private final boolean preserveOriginal;

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/ngram/EdgeNGramTokenizerFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/ngram/EdgeNGramTokenizerFactory.java
@@ -33,8 +33,13 @@ import java.util.Map;
  * &lt;/fieldType&gt;</pre>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class EdgeNGramTokenizerFactory extends TokenizerFactory {
+
+  /** SPI name */
+  public static final String NAME = "edgeNGram";
+
   private final int maxGramSize;
   private final int minGramSize;
 

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/ngram/NGramFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/ngram/NGramFilterFactory.java
@@ -34,8 +34,13 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * &lt;/fieldType&gt;</pre>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class NGramFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "nGram";
+
   private final int maxGramSize;
   private final int minGramSize;
   private final boolean preserveOriginal;

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/ngram/NGramTokenizerFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/ngram/NGramTokenizerFactory.java
@@ -35,8 +35,13 @@ import java.util.Map;
  * &lt;/fieldType&gt;</pre>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class NGramTokenizerFactory extends TokenizerFactory {
+
+  /** SPI name */
+  public static final String NAME = "nGram";
+
   private final int maxGramSize;
   private final int minGramSize;
 

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/no/NorwegianLightStemFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/no/NorwegianLightStemFilterFactory.java
@@ -36,8 +36,12 @@ import static org.apache.lucene.analysis.no.NorwegianLightStemmer.NYNORSK;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.6.0
+ * @lucene.spi {@value #NAME}
  */
 public class NorwegianLightStemFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "norwegianLightStem";
   
   private final int flags;
   

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/no/NorwegianMinimalStemFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/no/NorwegianMinimalStemFilterFactory.java
@@ -36,8 +36,12 @@ import static org.apache.lucene.analysis.no.NorwegianLightStemmer.NYNORSK;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.6.0
+ * @lucene.spi {@value #NAME}
  */
 public class NorwegianMinimalStemFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "norwegianMinimalStem";
   
   private final int flags;
   

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/path/PathHierarchyTokenizerFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/path/PathHierarchyTokenizerFactory.java
@@ -68,8 +68,13 @@ import org.apache.lucene.util.AttributeFactory;
  * </pre>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class PathHierarchyTokenizerFactory extends TokenizerFactory {
+
+  /** SPI name */
+  public static final String NAME = "pathHierarchy";
+
   private final char delimiter;
   private final char replacement;
   private final boolean reverse;

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/pattern/PatternCaptureGroupFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/pattern/PatternCaptureGroupFilterFactory.java
@@ -35,8 +35,13 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *
  * @see PatternCaptureGroupTokenFilter
  * @since 4.4.0
+ * @lucene.spi {@value #NAME}
  */
 public class PatternCaptureGroupFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "patternCaptureGroup";
+
   private Pattern pattern;
   private boolean preserveOriginal = true;
   

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/pattern/PatternReplaceCharFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/pattern/PatternReplaceCharFilterFactory.java
@@ -35,8 +35,13 @@ import org.apache.lucene.analysis.util.CharFilterFactory;
  * &lt;/fieldType&gt;</pre>
  * 
  * @since Solr 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class PatternReplaceCharFilterFactory extends CharFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "patternReplace";
+
   private final Pattern pattern;
   private final String replacement;
 

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/pattern/PatternReplaceFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/pattern/PatternReplaceFilterFactory.java
@@ -38,8 +38,13 @@ import java.util.regex.Pattern;
  * @see PatternReplaceFilter
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class PatternReplaceFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "patternReplace";
+
   final Pattern pattern;
   final String replacement;
   final boolean replaceAll;

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/pattern/PatternTokenizerFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/pattern/PatternTokenizerFactory.java
@@ -57,8 +57,13 @@ import org.apache.lucene.util.AttributeFactory;
  * 
  * @see PatternTokenizer
  * @since solr1.2
+ * @lucene.spi {@value #NAME}
  */
 public class PatternTokenizerFactory extends TokenizerFactory {
+
+  /** SPI name */
+  public static final String NAME = "pattern";
+
   public static final String PATTERN = "pattern";
   public static final String GROUP = "group";
  

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/pattern/SimplePatternSplitTokenizerFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/pattern/SimplePatternSplitTokenizerFactory.java
@@ -55,8 +55,13 @@ import org.apache.lucene.util.automaton.RegExp;
  * @see SimplePatternSplitTokenizer
  *
  * @since 6.5.0
+ * @lucene.spi {@value #NAME}
  */
 public class SimplePatternSplitTokenizerFactory extends TokenizerFactory {
+
+  /** SPI name */
+  public static final String NAME = "simplePatternSplit";
+
   public static final String PATTERN = "pattern";
   private final Automaton dfa;
   private final int maxDeterminizedStates;

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/pattern/SimplePatternTokenizerFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/pattern/SimplePatternTokenizerFactory.java
@@ -55,8 +55,13 @@ import org.apache.lucene.util.automaton.RegExp;
  * @see SimplePatternTokenizer
  *
  * @since 6.5.0
+ * @lucene.spi {@value #NAME}
  */
 public class SimplePatternTokenizerFactory extends TokenizerFactory {
+
+  /** SPI name */
+  public static final String NAME = "simplePattern";
+
   public static final String PATTERN = "pattern";
   private final Automaton dfa;
   private final int maxDeterminizedStates;

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/payloads/DelimitedPayloadTokenFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/payloads/DelimitedPayloadTokenFilterFactory.java
@@ -35,8 +35,13 @@ import java.util.Map;
  * &lt;/fieldType&gt;</pre>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class DelimitedPayloadTokenFilterFactory extends TokenFilterFactory implements ResourceLoaderAware {
+
+  /** SPI name */
+  public static final String NAME = "delimitedPayload";
+
   public static final String ENCODER_ATTR = "encoder";
   public static final String DELIMITER_ATTR = "delimiter";
 

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/payloads/NumericPayloadTokenFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/payloads/NumericPayloadTokenFilterFactory.java
@@ -32,8 +32,13 @@ import java.util.Map;
  * &lt;/fieldType&gt;</pre>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class NumericPayloadTokenFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "numericPayload";
+
   private final float payload;
   private final String typeMatch;
   

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/payloads/TokenOffsetPayloadTokenFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/payloads/TokenOffsetPayloadTokenFilterFactory.java
@@ -33,8 +33,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * &lt;/fieldType&gt;</pre>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class TokenOffsetPayloadTokenFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "tokenOffsetPayload";
   
   /** Creates a new TokenOffsetPayloadTokenFilterFactory */
   public TokenOffsetPayloadTokenFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/payloads/TypeAsPayloadTokenFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/payloads/TypeAsPayloadTokenFilterFactory.java
@@ -33,8 +33,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * &lt;/fieldType&gt;</pre>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class TypeAsPayloadTokenFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "typeAsPayload";
   
   /** Creates a new TypeAsPayloadTokenFilterFactory */
   public TypeAsPayloadTokenFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/pt/PortugueseLightStemFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/pt/PortugueseLightStemFilterFactory.java
@@ -33,8 +33,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.1.0
+ * @lucene.spi {@value #NAME}
  */
 public class PortugueseLightStemFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "portugueseLightStem";
   
   /** Creates a new PortugueseLightStemFilterFactory */
   public PortugueseLightStemFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/pt/PortugueseMinimalStemFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/pt/PortugueseMinimalStemFilterFactory.java
@@ -33,8 +33,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.1.0
+ * @lucene.spi {@value #NAME}
  */
 public class PortugueseMinimalStemFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "portugueseMinimalStem";
   
   /** Creates a new PortugueseMinimalStemFilterFactory */
   public PortugueseMinimalStemFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/pt/PortugueseStemFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/pt/PortugueseStemFilterFactory.java
@@ -33,8 +33,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.1.0
+ * @lucene.spi {@value #NAME}
  */
 public class PortugueseStemFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "portugueseStem";
   
   /** Creates a new PortugueseStemFilterFactory */
   public PortugueseStemFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/reverse/ReverseStringFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/reverse/ReverseStringFilterFactory.java
@@ -33,8 +33,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * &lt;/fieldType&gt;</pre>
  *
  * @since solr 1.4
+ * @lucene.spi {@value #NAME}
  */
 public class ReverseStringFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "reverseString";
   
   /** Creates a new ReverseStringFilterFactory */
   public ReverseStringFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/ru/RussianLightStemFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/ru/RussianLightStemFilterFactory.java
@@ -33,8 +33,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.1.0
+ * @lucene.spi {@value #NAME}
  */
 public class RussianLightStemFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "russianLightStem";
   
   /** Creates a new RussianLightStemFilterFactory */
   public RussianLightStemFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/shingle/FixedShingleFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/shingle/FixedShingleFilterFactory.java
@@ -33,8 +33,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * </ul>
  *
  * @since 7.4.0
+ * @lucene.spi {@value #NAME}
  */
 public class FixedShingleFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "fixedShingle";
 
   private final int shingleSize;
   private final String tokenSeparator;

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/shingle/ShingleFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/shingle/ShingleFilterFactory.java
@@ -34,8 +34,13 @@ import java.util.Map;
  * &lt;/fieldType&gt;</pre>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class ShingleFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "shingle";
+
   private final int minShingleSize;
   private final int maxShingleSize;
   private final boolean outputUnigrams;

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/snowball/SnowballPorterFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/snowball/SnowballPorterFilterFactory.java
@@ -43,8 +43,13 @@ import org.tartarus.snowball.SnowballProgram;
  * &lt;/fieldType&gt;</pre>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class SnowballPorterFilterFactory extends TokenFilterFactory implements ResourceLoaderAware {
+
+  /** SPI name */
+  public static final String NAME = "snowballPorter";
+
   public static final String PROTECTED_TOKENS = "protected";
 
   private final String language;

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/sr/SerbianNormalizationFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/sr/SerbianNormalizationFilterFactory.java
@@ -35,8 +35,13 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre> 
  * @since 5.0.0
+ * @lucene.spi {@value #NAME}
  */
 public class SerbianNormalizationFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "serbianNormalization";
+
   final String haircut;
 
   /** Creates a new SerbianNormalizationFilterFactory */

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/standard/ClassicFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/standard/ClassicFilterFactory.java
@@ -33,8 +33,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.1.0
+ * @lucene.spi {@value #NAME}
  */
 public class ClassicFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "classic";
   
   /** Creates a new ClassicFilterFactory */
   public ClassicFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/standard/ClassicTokenizerFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/standard/ClassicTokenizerFactory.java
@@ -32,8 +32,13 @@ import java.util.Map;
  * &lt;/fieldType&gt;</pre>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class ClassicTokenizerFactory extends TokenizerFactory {
+
+  /** SPI name */
+  public static final String NAME = "classic";
+
   private final int maxTokenLength;
 
   /** Creates a new ClassicTokenizerFactory */

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/standard/StandardTokenizerFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/standard/StandardTokenizerFactory.java
@@ -32,8 +32,13 @@ import java.util.Map;
  * &lt;/fieldType&gt;</pre> 
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class StandardTokenizerFactory extends TokenizerFactory {
+
+  /** SPI name */
+  public static final String NAME = "standard";
+
   private final int maxTokenLength;
   
   /** Creates a new StandardTokenizerFactory */

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/standard/UAX29URLEmailTokenizerFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/standard/UAX29URLEmailTokenizerFactory.java
@@ -32,8 +32,13 @@ import java.util.Map;
  * &lt;/fieldType&gt;</pre> 
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class UAX29URLEmailTokenizerFactory extends TokenizerFactory {
+
+  /** SPI name */
+  public static final String NAME = "uaX29UrlEmail";
+
   private final int maxTokenLength;
 
   /** Creates a new UAX29URLEmailTokenizerFactory */

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/sv/SwedishLightStemFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/sv/SwedishLightStemFilterFactory.java
@@ -33,8 +33,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.1.0
+ * @lucene.spi {@value #NAME}
  */
 public class SwedishLightStemFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "swedishLightStem";
   
   /** Creates a new SwedishLightStemFilterFactory */
   public SwedishLightStemFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/SynonymFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/SynonymFilterFactory.java
@@ -78,9 +78,14 @@ import org.apache.lucene.analysis.util.TokenizerFactory;
  * use {@link FlattenGraphFilterFactory} at index time (not at search time) as well.
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 @Deprecated
 public class SynonymFilterFactory extends TokenFilterFactory implements ResourceLoaderAware {
+
+  /** SPI name */
+  public static final String NAME = "synonym";
+
   private final boolean ignoreCase;
   private final String tokenizerFactory;
   private final String synonyms;

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/SynonymGraphFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/SynonymGraphFilterFactory.java
@@ -74,8 +74,13 @@ import org.apache.lucene.analysis.util.TokenizerFactory;
  *
  * @lucene.experimental
  * @since 6.4.0
+ * @lucene.spi {@value #NAME}
  */
 public class SynonymGraphFilterFactory extends TokenFilterFactory implements ResourceLoaderAware {
+
+  /** SPI name */
+  public static final String NAME = "synonymGraph";
+
   private final boolean ignoreCase;
   private final String tokenizerFactory;
   private final String synonyms;

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/th/ThaiTokenizerFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/th/ThaiTokenizerFactory.java
@@ -33,8 +33,12 @@ import org.apache.lucene.util.AttributeFactory;
  * &lt;/fieldType&gt;</pre>
  *
  * @since 4.10.0
+ * @lucene.spi {@value #NAME}
  */
 public class ThaiTokenizerFactory extends TokenizerFactory {
+
+  /** SPI name */
+  public static final String NAME = "thai";
   
   /** Creates a new ThaiTokenizerFactory */
   public ThaiTokenizerFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/tr/ApostropheFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/tr/ApostropheFilterFactory.java
@@ -33,8 +33,12 @@ import java.util.Map;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 4.8.0
+ * @lucene.spi {@value #NAME}
  */
 public class ApostropheFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "apostrophe";
 
   public ApostropheFilterFactory(Map<String, String> args) {
     super(args);

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/tr/TurkishLowerCaseFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/tr/TurkishLowerCaseFilterFactory.java
@@ -32,8 +32,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.1.0
+ * @lucene.spi {@value #NAME}
  */
 public class TurkishLowerCaseFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "turkishLowerCase";
   
   /** Creates a new TurkishLowerCaseFilterFactory */
   public TurkishLowerCaseFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/AbstractAnalysisFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/AbstractAnalysisFactory.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -357,5 +358,22 @@ public abstract class AbstractAnalysisFactory {
       return ((String) field.get(null));
       }
     throw new IllegalStateException("No SPI name defined.");
+  }
+
+  /**
+   * Generate legacy SPI name derived from the class name.
+   * @return the SPI name
+   */
+  @Deprecated
+  static String generateLegacySPIName(Class<? extends AbstractAnalysisFactory> service, String[] suffixes) {
+    final String clazzName = service.getSimpleName();
+    String name = null;
+    for (String suffix : suffixes) {
+      if (clazzName.endsWith(suffix)) {
+        name = clazzName.substring(0, clazzName.length() - suffix.length()).toLowerCase(Locale.ROOT);
+        break;
+      }
+    }
+    return name;
   }
 }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/AbstractAnalysisFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/AbstractAnalysisFactory.java
@@ -21,6 +21,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
@@ -32,6 +34,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -335,5 +338,24 @@ public abstract class AbstractAnalysisFactory {
 
   public void setExplicitLuceneMatchVersion(boolean isExplicitLuceneMatchVersion) {
     this.isExplicitLuceneMatchVersion = isExplicitLuceneMatchVersion;
+  }
+
+  /**
+   * Looks up SPI name (static "NAME" field) with appropriate modifiers.
+   * Also it must be a String class and declared in the concrete class.
+   * @return the SPI name
+   * @throws NoSuchFieldException - if the "NAME" field is not defined.
+   * @throws IllegalAccessException - if the "NAME" field is inaccessible.
+   * @throws IllegalStateException - if the "NAME" field does not have appropriate modifiers or isn't a String field.
+   */
+  static String lookupSPIName(Class<? extends AbstractAnalysisFactory> service) throws NoSuchFieldException, IllegalAccessException, IllegalStateException {
+    final Field field = service.getField("NAME");
+    int modifier = field.getModifiers();
+    if (Modifier.isStatic(modifier) && Modifier.isFinal(modifier) &&
+        field.getType().equals(String.class) &&
+        Objects.equals(field.getDeclaringClass(), service)) {
+      return ((String) field.get(null));
+      }
+    throw new IllegalStateException("No SPI name defined.");
   }
 }

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/AnalysisSPILoader.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/AnalysisSPILoader.java
@@ -18,14 +18,15 @@ package org.apache.lucene.analysis.util;
 
 
 import java.lang.reflect.InvocationTargetException;
-import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.LinkedHashMap;
 import java.util.Set;
 import java.util.ServiceConfigurationError;
+import java.util.regex.Pattern;
 
 import org.apache.lucene.util.SPIClassIterator;
 
@@ -36,24 +37,17 @@ import org.apache.lucene.util.SPIClassIterator;
 public final class AnalysisSPILoader<S extends AbstractAnalysisFactory> {
 
   private volatile Map<String,Class<? extends S>> services = Collections.emptyMap();
+  private volatile Set<String> originalNames = Collections.emptySet();
   private final Class<S> clazz;
-  private final String[] suffixes;
-  
+
+  private static final Pattern SERVICE_NAME_PATTERN = Pattern.compile("^[a-zA-Z][a-zA-Z0-9_]+$");
+
   public AnalysisSPILoader(Class<S> clazz) {
-    this(clazz, new String[] { clazz.getSimpleName() });
+    this(clazz, null);
   }
 
-  public AnalysisSPILoader(Class<S> clazz, ClassLoader loader) {
-    this(clazz, new String[] { clazz.getSimpleName() }, loader);
-  }
-
-  public AnalysisSPILoader(Class<S> clazz, String[] suffixes) {
-    this(clazz, suffixes, null);
-  }
-  
-  public AnalysisSPILoader(Class<S> clazz, String[] suffixes, ClassLoader classloader) {
+  public AnalysisSPILoader(Class<S> clazz, ClassLoader classloader) {
     this.clazz = clazz;
-    this.suffixes = suffixes;
     // if clazz' classloader is not a parent of the given one, we scan clazz's classloader, too:
     final ClassLoader clazzClassloader = clazz.getClassLoader();
     if (classloader == null) {
@@ -64,7 +58,7 @@ public final class AnalysisSPILoader<S extends AbstractAnalysisFactory> {
     }
     reload(classloader);
   }
-  
+
   /** 
    * Reloads the internal SPI list from the given {@link ClassLoader}.
    * Changes to the service list are visible after the method ends, all
@@ -78,22 +72,27 @@ public final class AnalysisSPILoader<S extends AbstractAnalysisFactory> {
    */
   public synchronized void reload(ClassLoader classloader) {
     Objects.requireNonNull(classloader, "classloader");
-    final LinkedHashMap<String,Class<? extends S>> services =
-      new LinkedHashMap<>(this.services);
+    final LinkedHashMap<String,Class<? extends S>> services = new LinkedHashMap<>(this.services);
+    final LinkedHashSet<String> originalNames = new LinkedHashSet<>(this.originalNames);
     final SPIClassIterator<S> loader = SPIClassIterator.get(clazz, classloader);
     while (loader.hasNext()) {
       final Class<? extends S> service = loader.next();
-      final String clazzName = service.getSimpleName();
       String name = null;
-      for (String suffix : suffixes) {
-        if (clazzName.endsWith(suffix)) {
-          name = clazzName.substring(0, clazzName.length() - suffix.length()).toLowerCase(Locale.ROOT);
-          break;
+      String originalName = null;
+      Throwable cause = null;
+      try {
+        originalName = AbstractAnalysisFactory.lookupSPIName(service);
+        name = originalName.toLowerCase(Locale.ROOT);
+        if (!isValidName(originalName)) {
+          throw new ServiceConfigurationError("The name " + originalName + " for " + service.getName() +
+              " is invalid: Allowed characters are (English) alphabet, digits, and underscore. It should be started with an alphabet.");
         }
+      } catch (NoSuchFieldException | IllegalAccessException | IllegalStateException e) {
+        cause = e;
       }
       if (name == null) {
         throw new ServiceConfigurationError("The class name " + service.getName() +
-          " has wrong suffix, allowed are: " + Arrays.toString(suffixes));
+            " has no service name field: [public static final String NAME]", cause);
       }
       // only add the first one for each name, later services will be ignored
       // this allows to place services before others in classpath to make 
@@ -105,11 +104,26 @@ public final class AnalysisSPILoader<S extends AbstractAnalysisFactory> {
       // When changing this be careful to allow reload()!
       if (!services.containsKey(name)) {
         services.put(name, service);
+        // preserve (case-sensitive) original name for reference
+        originalNames.add(originalName);
       }
     }
+
+    // make sure that the number of lookup keys is same to the number of original names.
+    // in fact this constraint should be met in existence checks of the lookup map key,
+    // so this is more like an assertion rather than a status check.
+    if (services.keySet().size() != originalNames.size()) {
+      throw new ServiceConfigurationError("Service lookup key set is inconsistent with original name set!");
+    }
+
     this.services = Collections.unmodifiableMap(services);
+    this.originalNames = Collections.unmodifiableSet(originalNames);
   }
-  
+
+  private boolean isValidName(String name) {
+    return SERVICE_NAME_PATTERN.matcher(name).matches();
+  }
+
   public S newInstance(String name, Map<String,String> args) {
     final Class<? extends S> service = lookupClass(name);
     return newFactoryClassInstance(service, args);
@@ -127,7 +141,7 @@ public final class AnalysisSPILoader<S extends AbstractAnalysisFactory> {
   }
 
   public Set<String> availableServices() {
-    return services.keySet();
+    return originalNames;
   }  
   
   /** Creates a new instance of the given {@link AbstractAnalysisFactory} by invoking the constructor, passing the given argument map. */

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/AnalysisSPILoader.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/AnalysisSPILoader.java
@@ -18,6 +18,7 @@ package org.apache.lucene.analysis.util;
 
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Locale;
@@ -39,15 +40,21 @@ public final class AnalysisSPILoader<S extends AbstractAnalysisFactory> {
   private volatile Map<String,Class<? extends S>> services = Collections.emptyMap();
   private volatile Set<String> originalNames = Collections.emptySet();
   private final Class<S> clazz;
+  private final String[] suffixes;
 
   private static final Pattern SERVICE_NAME_PATTERN = Pattern.compile("^[a-zA-Z][a-zA-Z0-9_]+$");
 
   public AnalysisSPILoader(Class<S> clazz) {
-    this(clazz, null);
+    this(clazz, new String[] { clazz.getSimpleName() });
   }
 
-  public AnalysisSPILoader(Class<S> clazz, ClassLoader classloader) {
+  public AnalysisSPILoader(Class<S> clazz, String[] suffixes) {
+    this(clazz, suffixes, null);
+  }
+
+  public AnalysisSPILoader(Class<S> clazz, String[] suffixes, ClassLoader classloader) {
     this.clazz = clazz;
+    this.suffixes = suffixes;
     // if clazz' classloader is not a parent of the given one, we scan clazz's classloader, too:
     final ClassLoader clazzClassloader = clazz.getClassLoader();
     if (classloader == null) {
@@ -79,7 +86,6 @@ public final class AnalysisSPILoader<S extends AbstractAnalysisFactory> {
       final Class<? extends S> service = loader.next();
       String name = null;
       String originalName = null;
-      Throwable cause = null;
       try {
         originalName = AbstractAnalysisFactory.lookupSPIName(service);
         name = originalName.toLowerCase(Locale.ROOT);
@@ -88,12 +94,10 @@ public final class AnalysisSPILoader<S extends AbstractAnalysisFactory> {
               " is invalid: Allowed characters are (English) alphabet, digits, and underscore. It should be started with an alphabet.");
         }
       } catch (NoSuchFieldException | IllegalAccessException | IllegalStateException e) {
-        cause = e;
+        // just ignore on Lucene 8.x.
+        // we should properly handle these exceptions from Lucene 9.0.
       }
-      if (name == null) {
-        throw new ServiceConfigurationError("The class name " + service.getName() +
-            " has no service name field: [public static final String NAME]", cause);
-      }
+
       // only add the first one for each name, later services will be ignored
       // this allows to place services before others in classpath to make 
       // them used instead of others
@@ -102,11 +106,24 @@ public final class AnalysisSPILoader<S extends AbstractAnalysisFactory> {
       // Allowing it may get confusing on collisions, as different packages
       // could contain same factory class, which is a naming bug!
       // When changing this be careful to allow reload()!
-      if (!services.containsKey(name)) {
+      if (name != null && !services.containsKey(name)) {
         services.put(name, service);
         // preserve (case-sensitive) original name for reference
         originalNames.add(originalName);
       }
+
+      // register legacy spi name for backwards compatibility.
+      String legacyName = AbstractAnalysisFactory.generateLegacySPIName(service, suffixes);
+      if (legacyName == null) {
+        throw new ServiceConfigurationError("The class name " + service.getName() +
+            " has wrong suffix, allowed are: " + Arrays.toString(suffixes));
+      }
+      if (!services.containsKey(legacyName)) {
+        services.put(legacyName, service);
+        // also register this to original name set for reference
+        originalNames.add(legacyName);
+      }
+
     }
 
     // make sure that the number of lookup keys is same to the number of original names.

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/CharFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/CharFilterFactory.java
@@ -49,6 +49,15 @@ public abstract class CharFilterFactory extends AbstractAnalysisFactory {
     return loader.availableServices();
   }
 
+  /** looks up a SPI name for the specified char filter factory */
+  public static String findSPIName(Class<? extends CharFilterFactory> serviceClass) {
+    try {
+      return lookupSPIName(serviceClass);
+    } catch (NoSuchFieldException | IllegalAccessException | IllegalStateException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
   /** 
    * Reloads the factory list from the given {@link ClassLoader}.
    * Changes to the factories are visible after the method ends, all

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/ElisionFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/ElisionFilterFactory.java
@@ -37,8 +37,13 @@ import org.apache.lucene.analysis.fr.FrenchAnalyzer;
  * &lt;/fieldType&gt;</pre>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class ElisionFilterFactory extends TokenFilterFactory implements ResourceLoaderAware {
+
+  /** SPI name */
+  public static final String NAME = "elision";
+
   private final String articlesFile;
   private final boolean ignoreCase;
   private CharArraySet articles;

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/TokenFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/TokenFilterFactory.java
@@ -31,9 +31,8 @@ import org.apache.lucene.analysis.TokenStream;
 public abstract class TokenFilterFactory extends AbstractAnalysisFactory {
 
   private static final AnalysisSPILoader<TokenFilterFactory> loader =
-      new AnalysisSPILoader<>(TokenFilterFactory.class,
-          new String[] { "TokenFilterFactory", "FilterFactory" });
-  
+      new AnalysisSPILoader<>(TokenFilterFactory.class);
+
   /** looks up a tokenfilter by name from context classpath */
   public static TokenFilterFactory forName(String name, Map<String,String> args) {
     return loader.newInstance(name, args);
@@ -48,7 +47,16 @@ public abstract class TokenFilterFactory extends AbstractAnalysisFactory {
   public static Set<String> availableTokenFilters() {
     return loader.availableServices();
   }
-  
+
+  /** looks up a SPI name for the specified token filter factory */
+  public static String findSPIName(Class<? extends TokenFilterFactory> serviceClass) {
+    try {
+      return lookupSPIName(serviceClass);
+    } catch (NoSuchFieldException | IllegalAccessException | IllegalStateException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
   /** 
    * Reloads the factory list from the given {@link ClassLoader}.
    * Changes to the factories are visible after the method ends, all

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/TokenFilterFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/TokenFilterFactory.java
@@ -31,7 +31,8 @@ import org.apache.lucene.analysis.TokenStream;
 public abstract class TokenFilterFactory extends AbstractAnalysisFactory {
 
   private static final AnalysisSPILoader<TokenFilterFactory> loader =
-      new AnalysisSPILoader<>(TokenFilterFactory.class);
+      new AnalysisSPILoader<>(TokenFilterFactory.class,
+          new String[] { "TokenFilterFactory", "FilterFactory" });
 
   /** looks up a tokenfilter by name from context classpath */
   public static TokenFilterFactory forName(String name, Map<String,String> args) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/TokenizerFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/util/TokenizerFactory.java
@@ -49,7 +49,16 @@ public abstract class TokenizerFactory extends AbstractAnalysisFactory {
   public static Set<String> availableTokenizers() {
     return loader.availableServices();
   }
-  
+
+  /** looks up a SPI name for the specified tokenizer factory */
+  public static String findSPIName(Class<? extends TokenizerFactory> serviceClass) {
+    try {
+      return lookupSPIName(serviceClass);
+    } catch (NoSuchFieldException | IllegalAccessException | IllegalStateException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
   /** 
    * Reloads the factory list from the given {@link ClassLoader}.
    * Changes to the factories are visible after the method ends, all

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/wikipedia/WikipediaTokenizerFactory.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/wikipedia/WikipediaTokenizerFactory.java
@@ -33,8 +33,13 @@ import org.apache.lucene.util.AttributeFactory;
  * &lt;/fieldType&gt;</pre>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class WikipediaTokenizerFactory extends TokenizerFactory {
+
+  /** SPI name */
+  public static final String NAME = "wikipedia";
+
   public static final String TOKEN_OUTPUT = "tokenOutput";
   public static final String UNTOKENIZED_TYPES = "untokenizedTypes";
 

--- a/lucene/analysis/common/src/test/META-INF/services/org.apache.lucene.analysis.util.CharFilterFactory
+++ b/lucene/analysis/common/src/test/META-INF/services/org.apache.lucene.analysis.util.CharFilterFactory
@@ -1,0 +1,17 @@
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+org.apache.lucene.analysis.util.MockNameLackingCharFilterFactory
+org.apache.lucene.analysis.util.MockNameMismatchedCharFilterFactory

--- a/lucene/analysis/common/src/test/META-INF/services/org.apache.lucene.analysis.util.TokenFilterFactory
+++ b/lucene/analysis/common/src/test/META-INF/services/org.apache.lucene.analysis.util.TokenFilterFactory
@@ -1,0 +1,17 @@
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+org.apache.lucene.analysis.util.MockNameLackingFilterFactory
+org.apache.lucene.analysis.util.MockNameMismatchedFilterFactory

--- a/lucene/analysis/common/src/test/META-INF/services/org.apache.lucene.analysis.util.TokenizerFactory
+++ b/lucene/analysis/common/src/test/META-INF/services/org.apache.lucene.analysis.util.TokenizerFactory
@@ -1,0 +1,17 @@
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+org.apache.lucene.analysis.util.MockNameLackingTokenizerFactory
+org.apache.lucene.analysis.util.MockNameMismatchedTokenizerFactory

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/util/MockNameLackingCharFilterFactory.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/util/MockNameLackingCharFilterFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.analysis.util;
+
+import java.io.Reader;
+import java.util.Map;
+
+/** Fake char filter factory for tests. */
+public class MockNameLackingCharFilterFactory extends CharFilterFactory {
+
+  public MockNameLackingCharFilterFactory(Map<String, String> args) {
+    super(args);
+  }
+
+  @Override
+  public Reader create(Reader input) {
+    return input;
+  }
+
+}

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/util/MockNameLackingFilterFactory.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/util/MockNameLackingFilterFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.analysis.util;
+
+import java.util.Map;
+
+import org.apache.lucene.analysis.TokenStream;
+
+/** Fake token filter factory for tests. */
+public class MockNameLackingFilterFactory extends TokenFilterFactory {
+
+  public MockNameLackingFilterFactory(Map<String, String> args) {
+    super(args);
+  }
+
+  @Override
+  public TokenStream create(TokenStream input) {
+    return input;
+  }
+
+}

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/util/MockNameLackingTokenizerFactory.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/util/MockNameLackingTokenizerFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.analysis.util;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.util.AttributeFactory;
+
+/** Fake tokenizer factory for tests. */
+public class MockNameLackingTokenizerFactory extends TokenizerFactory {
+
+  public MockNameLackingTokenizerFactory(Map<String, String> args) {
+    super(args);
+  }
+
+  @Override
+  public Tokenizer create(AttributeFactory factory) {
+    return new Tokenizer() {
+      @Override
+      public boolean incrementToken() throws IOException {
+        return false;
+      }
+    };
+  }
+}

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/util/MockNameMismatchedCharFilterFactory.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/util/MockNameMismatchedCharFilterFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.analysis.util;
+
+import java.io.Reader;
+import java.util.Map;
+
+/** Fake token filter factory for tests. */
+public class MockNameMismatchedCharFilterFactory extends CharFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "mock";
+
+  public MockNameMismatchedCharFilterFactory(Map<String, String> args) {
+    super(args);
+  }
+
+  @Override
+  public Reader create(Reader input) {
+    return input;
+  }
+
+}

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/util/MockNameMismatchedFilterFactory.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/util/MockNameMismatchedFilterFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.analysis.util;
+
+import java.util.Map;
+
+import org.apache.lucene.analysis.TokenStream;
+
+/** Fake token filter factory for tests. */
+public class MockNameMismatchedFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "mock";
+
+  public MockNameMismatchedFilterFactory(Map<String, String> args) {
+    super(args);
+  }
+
+  @Override
+  public TokenStream create(TokenStream input) {
+    return input;
+  }
+
+}

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/util/MockNameMismatchedTokenizerFactory.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/util/MockNameMismatchedTokenizerFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.analysis.util;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.util.AttributeFactory;
+
+/** Fake tokenizer factory for tests. */
+public class MockNameMismatchedTokenizerFactory extends TokenizerFactory {
+
+  /** SPI name */
+  public static final String NAME = "mock";
+
+  public MockNameMismatchedTokenizerFactory(Map<String, String> args) {
+    super(args);
+  }
+  
+  @Override
+  public Tokenizer create(AttributeFactory factory) {
+    return new Tokenizer() {
+      @Override
+      public boolean incrementToken() throws IOException {
+        return false;
+      }
+    };
+  }
+}

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/util/TestAbstractAnalysisFactory.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/util/TestAbstractAnalysisFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.analysis.util;
+
+import org.apache.lucene.analysis.charfilter.HTMLStripCharFilterFactory;
+import org.apache.lucene.analysis.core.LowerCaseFilterFactory;
+import org.apache.lucene.analysis.core.WhitespaceTokenizerFactory;
+import org.apache.lucene.util.LuceneTestCase;
+
+public class TestAbstractAnalysisFactory extends LuceneTestCase {
+
+  public void testLookupTokenizerSPIName() throws NoSuchFieldException, IllegalAccessException {
+    assertEquals("whitespace", AbstractAnalysisFactory.lookupSPIName(WhitespaceTokenizerFactory.class));
+    assertEquals("whitespace", TokenizerFactory.findSPIName(WhitespaceTokenizerFactory.class));
+  }
+
+  public void testLookupCharFilterSPIName() throws NoSuchFieldException, IllegalAccessException {
+    assertEquals("htmlStrip", AbstractAnalysisFactory.lookupSPIName(HTMLStripCharFilterFactory.class));
+    assertEquals("htmlStrip", CharFilterFactory.findSPIName(HTMLStripCharFilterFactory.class));
+  }
+
+  public void testLookupTokenFilterSPIName() throws NoSuchFieldException, IllegalAccessException{
+    assertEquals("lowercase", AbstractAnalysisFactory.lookupSPIName(LowerCaseFilterFactory.class));
+    assertEquals("lowercase", TokenFilterFactory.findSPIName(LowerCaseFilterFactory.class));
+  }
+}

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/util/TestAnalysisSPILoader.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/util/TestAnalysisSPILoader.java
@@ -30,7 +30,7 @@ import org.apache.lucene.util.Version;
 public class TestAnalysisSPILoader extends LuceneTestCase {
   
   private Map<String,String> versionArgOnly() {
-    return new HashMap<String,String>() {{
+    return new HashMap<String, String>() {{
       put("luceneMatchVersion", Version.LATEST.toString());
     }};
   }
@@ -113,7 +113,7 @@ public class TestAnalysisSPILoader extends LuceneTestCase {
   
   public void testAvailableTokenFilters() {
     assertTrue(TokenFilterFactory.availableTokenFilters().contains("lowercase"));
-    assertTrue(TokenFilterFactory.availableTokenFilters().contains("removeduplicates"));
+    assertTrue(TokenFilterFactory.availableTokenFilters().contains("removeDuplicates"));
   }
   
   public void testLookupCharFilter() {
@@ -149,6 +149,6 @@ public class TestAnalysisSPILoader extends LuceneTestCase {
   }
   
   public void testAvailableCharFilters() {
-    assertTrue(CharFilterFactory.availableCharFilters().contains("htmlstrip"));
+    assertTrue(CharFilterFactory.availableCharFilters().contains("htmlStrip"));
   }
 }

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/util/TestAnalysisSPILoader.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/util/TestAnalysisSPILoader.java
@@ -39,6 +39,10 @@ public class TestAnalysisSPILoader extends LuceneTestCase {
     assertSame(WhitespaceTokenizerFactory.class, TokenizerFactory.forName("Whitespace", versionArgOnly()).getClass());
     assertSame(WhitespaceTokenizerFactory.class, TokenizerFactory.forName("WHITESPACE", versionArgOnly()).getClass());
     assertSame(WhitespaceTokenizerFactory.class, TokenizerFactory.forName("whitespace", versionArgOnly()).getClass());
+
+    assertSame(MockNameLackingTokenizerFactory.class, TokenizerFactory.forName("mocknamelacking", versionArgOnly()).getClass());
+    assertSame(MockNameMismatchedTokenizerFactory.class, TokenizerFactory.forName("mocknamemismatched", versionArgOnly()).getClass());
+    assertSame(MockNameMismatchedTokenizerFactory.class, TokenizerFactory.forName("mock", versionArgOnly()).getClass());
   }
   
   public void testBogusLookupTokenizer() {
@@ -55,6 +59,10 @@ public class TestAnalysisSPILoader extends LuceneTestCase {
     assertSame(WhitespaceTokenizerFactory.class, TokenizerFactory.lookupClass("Whitespace"));
     assertSame(WhitespaceTokenizerFactory.class, TokenizerFactory.lookupClass("WHITESPACE"));
     assertSame(WhitespaceTokenizerFactory.class, TokenizerFactory.lookupClass("whitespace"));
+
+    assertSame(MockNameLackingTokenizerFactory.class, TokenizerFactory.lookupClass("mocknamelacking"));
+    assertSame(MockNameMismatchedTokenizerFactory.class, TokenizerFactory.lookupClass("mocknamemismatched"));
+    assertSame(MockNameMismatchedTokenizerFactory.class, TokenizerFactory.lookupClass("mock"));
   }
   
   public void testBogusLookupTokenizerClass() {
@@ -69,6 +77,10 @@ public class TestAnalysisSPILoader extends LuceneTestCase {
   
   public void testAvailableTokenizers() {
     assertTrue(TokenizerFactory.availableTokenizers().contains("whitespace"));
+
+    assertTrue(TokenizerFactory.availableTokenizers().contains("mocknamelacking"));
+    assertTrue(TokenizerFactory.availableTokenizers().contains("mocknamemismatched"));
+    assertTrue(TokenizerFactory.availableTokenizers().contains("mock"));
   }
   
   public void testLookupTokenFilter() {
@@ -79,6 +91,10 @@ public class TestAnalysisSPILoader extends LuceneTestCase {
     assertSame(RemoveDuplicatesTokenFilterFactory.class, TokenFilterFactory.forName("RemoveDuplicates", versionArgOnly()).getClass());
     assertSame(RemoveDuplicatesTokenFilterFactory.class, TokenFilterFactory.forName("REMOVEDUPLICATES", versionArgOnly()).getClass());
     assertSame(RemoveDuplicatesTokenFilterFactory.class, TokenFilterFactory.forName("removeduplicates", versionArgOnly()).getClass());
+
+    assertSame(MockNameLackingFilterFactory.class, TokenFilterFactory.forName("mocknamelacking", versionArgOnly()).getClass());
+    assertSame(MockNameMismatchedFilterFactory.class, TokenFilterFactory.forName("mocknamemismatched", versionArgOnly()).getClass());
+    assertSame(MockNameMismatchedFilterFactory.class, TokenFilterFactory.forName("mock", versionArgOnly()).getClass());
   }
   
   public void testBogusLookupTokenFilter() {
@@ -99,6 +115,10 @@ public class TestAnalysisSPILoader extends LuceneTestCase {
     assertSame(RemoveDuplicatesTokenFilterFactory.class, TokenFilterFactory.lookupClass("RemoveDuplicates"));
     assertSame(RemoveDuplicatesTokenFilterFactory.class, TokenFilterFactory.lookupClass("REMOVEDUPLICATES"));
     assertSame(RemoveDuplicatesTokenFilterFactory.class, TokenFilterFactory.lookupClass("removeduplicates"));
+
+    assertSame(MockNameLackingFilterFactory.class, TokenFilterFactory.lookupClass("mocknamelacking"));
+    assertSame(MockNameMismatchedFilterFactory.class, TokenFilterFactory.lookupClass("mocknamemismatched"));
+    assertSame(MockNameMismatchedFilterFactory.class, TokenFilterFactory.lookupClass("mock"));
   }
   
   public void testBogusLookupTokenFilterClass() {
@@ -114,12 +134,20 @@ public class TestAnalysisSPILoader extends LuceneTestCase {
   public void testAvailableTokenFilters() {
     assertTrue(TokenFilterFactory.availableTokenFilters().contains("lowercase"));
     assertTrue(TokenFilterFactory.availableTokenFilters().contains("removeDuplicates"));
+
+    assertTrue(TokenFilterFactory.availableTokenFilters().contains("mocknamelacking"));
+    assertTrue(TokenFilterFactory.availableTokenFilters().contains("mocknamemismatched"));
+    assertTrue(TokenFilterFactory.availableTokenFilters().contains("mock"));
   }
   
   public void testLookupCharFilter() {
     assertSame(HTMLStripCharFilterFactory.class, CharFilterFactory.forName("HTMLStrip", versionArgOnly()).getClass());
     assertSame(HTMLStripCharFilterFactory.class, CharFilterFactory.forName("HTMLSTRIP", versionArgOnly()).getClass());
     assertSame(HTMLStripCharFilterFactory.class, CharFilterFactory.forName("htmlstrip", versionArgOnly()).getClass());
+
+    assertSame(MockNameLackingCharFilterFactory.class, CharFilterFactory.forName("mocknamelacking", versionArgOnly()).getClass());
+    assertSame(MockNameMismatchedCharFilterFactory.class, CharFilterFactory.forName("mocknamemismatched", versionArgOnly()).getClass());
+    assertSame(MockNameMismatchedCharFilterFactory.class, CharFilterFactory.forName("mock", versionArgOnly()).getClass());
   }
   
   public void testBogusLookupCharFilter() {
@@ -136,6 +164,10 @@ public class TestAnalysisSPILoader extends LuceneTestCase {
     assertSame(HTMLStripCharFilterFactory.class, CharFilterFactory.lookupClass("HTMLStrip"));
     assertSame(HTMLStripCharFilterFactory.class, CharFilterFactory.lookupClass("HTMLSTRIP"));
     assertSame(HTMLStripCharFilterFactory.class, CharFilterFactory.lookupClass("htmlstrip"));
+
+    assertSame(MockNameLackingCharFilterFactory.class, CharFilterFactory.lookupClass("mocknamelacking"));
+    assertSame(MockNameMismatchedCharFilterFactory.class, CharFilterFactory.lookupClass("mocknamemismatched"));
+    assertSame(MockNameMismatchedCharFilterFactory.class, CharFilterFactory.lookupClass("mock"));
   }
   
   public void testBogusLookupCharFilterClass() {
@@ -150,5 +182,9 @@ public class TestAnalysisSPILoader extends LuceneTestCase {
   
   public void testAvailableCharFilters() {
     assertTrue(CharFilterFactory.availableCharFilters().contains("htmlStrip"));
+
+    assertTrue(CharFilterFactory.availableCharFilters().contains("mocknamelacking"));
+    assertTrue(CharFilterFactory.availableCharFilters().contains("mocknamemismatched"));
+    assertTrue(CharFilterFactory.availableCharFilters().contains("mock"));
   }
 }

--- a/lucene/analysis/icu/src/java/org/apache/lucene/analysis/icu/ICUFoldingFilterFactory.java
+++ b/lucene/analysis/icu/src/java/org/apache/lucene/analysis/icu/ICUFoldingFilterFactory.java
@@ -35,8 +35,13 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.1.0
+ * @lucene.spi {@value #NAME}
  */
 public class ICUFoldingFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "icuFolding";
+
   private final Normalizer2 normalizer;
 
   /** Creates a new ICUFoldingFilterFactory */

--- a/lucene/analysis/icu/src/java/org/apache/lucene/analysis/icu/ICUNormalizer2CharFilterFactory.java
+++ b/lucene/analysis/icu/src/java/org/apache/lucene/analysis/icu/ICUNormalizer2CharFilterFactory.java
@@ -43,8 +43,13 @@ import org.apache.lucene.analysis.util.CharFilterFactory;
  * @see FilteredNormalizer2
  *
  * @since 4.10.0
+ * @lucene.spi {@value #NAME}
  */
 public class ICUNormalizer2CharFilterFactory extends CharFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "icuNormalizer2";
+
   private final Normalizer2 normalizer;
 
   /** Creates a new ICUNormalizer2CharFilterFactory */

--- a/lucene/analysis/icu/src/java/org/apache/lucene/analysis/icu/ICUNormalizer2FilterFactory.java
+++ b/lucene/analysis/icu/src/java/org/apache/lucene/analysis/icu/ICUNormalizer2FilterFactory.java
@@ -42,8 +42,13 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * @see Normalizer2
  * @see FilteredNormalizer2
  * @since 3.1.0
+ * @lucene.spi {@value #NAME}
  */
 public class ICUNormalizer2FilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "icuNormalizer2";
+
   private final Normalizer2 normalizer;
 
   /** Creates a new ICUNormalizer2FilterFactory */

--- a/lucene/analysis/icu/src/java/org/apache/lucene/analysis/icu/ICUTransformFilterFactory.java
+++ b/lucene/analysis/icu/src/java/org/apache/lucene/analysis/icu/ICUTransformFilterFactory.java
@@ -34,8 +34,13 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * </ul>
  * @see Transliterator
  * @since 3.1.0
+ * @lucene.spi {@value #NAME}
  */
 public class ICUTransformFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "icuTransform";
+
   private final Transliterator transliterator;
   
   // TODO: add support for custom rules

--- a/lucene/analysis/icu/src/java/org/apache/lucene/analysis/icu/segmentation/ICUTokenizerFactory.java
+++ b/lucene/analysis/icu/src/java/org/apache/lucene/analysis/icu/segmentation/ICUTokenizerFactory.java
@@ -74,8 +74,13 @@ import com.ibm.icu.text.RuleBasedBreakIterator;
  * &lt;/fieldType&gt;</pre>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class ICUTokenizerFactory extends TokenizerFactory implements ResourceLoaderAware {
+
+  /** SPI name */
+  public static final String NAME = "icu";
+
   static final String RULEFILES = "rulefiles";
   private final Map<Integer,String> tailored;
   private ICUTokenizerConfig config;

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/JapaneseBaseFormFilterFactory.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/JapaneseBaseFormFilterFactory.java
@@ -33,8 +33,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * &lt;/fieldType&gt;
  * </pre>
  * @since 3.6.0
+ * @lucene.spi {@value #NAME}
  */
 public class JapaneseBaseFormFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "japaneseBaseForm";
 
   /** Creates a new JapaneseBaseFormFilterFactory */
   public JapaneseBaseFormFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/JapaneseIterationMarkCharFilterFactory.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/JapaneseIterationMarkCharFilterFactory.java
@@ -33,8 +33,12 @@ import org.apache.lucene.analysis.util.CharFilterFactory;
  * &lt;/fieldType&gt;</pre>
  *
  * @since 4.0.0
+ * @lucene.spi {@value #NAME}
  */
 public class JapaneseIterationMarkCharFilterFactory extends CharFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "japaneseIterationMark";
 
   private static final String NORMALIZE_KANJI_PARAM = "normalizeKanji";
   private static final String NORMALIZE_KANA_PARAM = "normalizeKana";

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/JapaneseKatakanaStemFilterFactory.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/JapaneseKatakanaStemFilterFactory.java
@@ -34,8 +34,13 @@ import java.util.Map;
  * &lt;/fieldType&gt;
  * </pre>
  * @since 3.6.0
+ * @lucene.spi {@value #NAME}
  */
 public class JapaneseKatakanaStemFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "japaneseKatakanaStem";
+
   private static final String MINIMUM_LENGTH_PARAM = "minimumLength";
   private final int minimumLength;
   

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/JapaneseNumberFilterFactory.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/JapaneseNumberFilterFactory.java
@@ -37,8 +37,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * It is important that punctuation is not discarded by the tokenizer so use
  * {@code discardPunctuation="false"} in your {@link JapaneseTokenizerFactory}.
  * @since 6.0.0
+ * @lucene.spi {@value #NAME}
  */
 public class JapaneseNumberFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "japaneseNumber";
 
   public JapaneseNumberFilterFactory(Map<String, String> args) {
     super(args);

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/JapanesePartOfSpeechStopFilterFactory.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/JapanesePartOfSpeechStopFilterFactory.java
@@ -40,8 +40,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * &lt;/fieldType&gt;
  * </pre>
  * @since 3.6.0
+ * @lucene.spi {@value #NAME}
  */
 public class JapanesePartOfSpeechStopFilterFactory extends TokenFilterFactory implements ResourceLoaderAware {
+
+  public static final String NAME = "japanesePartOfSpeechStop";
+
   private final String stopTagFiles;
   private Set<String> stopTags;
 

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/JapaneseReadingFormFilterFactory.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/JapaneseReadingFormFilterFactory.java
@@ -34,8 +34,13 @@ import java.util.Map;
  * &lt;/fieldType&gt;
  * </pre>
  * @since 3.6.0
+ * @lucene.spi {@value #NAME}
  */
 public class JapaneseReadingFormFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "japaneseReadingForm";
+
   private static final String ROMAJI_PARAM = "useRomaji";
   private final boolean useRomaji;
   

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/JapaneseTokenizerFactory.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/JapaneseTokenizerFactory.java
@@ -78,8 +78,13 @@ import org.apache.lucene.analysis.util.ResourceLoaderAware;
  * modes, but it makes the most sense to use them with NORMAL mode.
  *
  * @since 3.6.0
+ * @lucene.spi {@value #NAME}
  */
 public class JapaneseTokenizerFactory extends TokenizerFactory implements ResourceLoaderAware {
+
+  /** SPI name */
+  public static final String NAME = "japanese";
+
   private static final String MODE = "mode";
 
   private static final String USER_DICT_PATH = "userDictionary";

--- a/lucene/analysis/morfologik/src/java/org/apache/lucene/analysis/morfologik/MorfologikFilterFactory.java
+++ b/lucene/analysis/morfologik/src/java/org/apache/lucene/analysis/morfologik/MorfologikFilterFactory.java
@@ -49,8 +49,13 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * 
  * @see <a href="http://morfologik.blogspot.com/">Morfologik web site</a>
  * @since 4.0.0
+ * @lucene.spi {@value #NAME}
  */
 public class MorfologikFilterFactory extends TokenFilterFactory implements ResourceLoaderAware {
+
+  /** SPI name */
+  public static final String NAME = "morfologik";
+
   /** Dictionary resource attribute (should have {@code ".dict"} suffix), loaded from {@link ResourceLoader}. */
   public static final String DICTIONARY_ATTRIBUTE = "dictionary";
 

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/KoreanNumberFilterFactory.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/KoreanNumberFilterFactory.java
@@ -37,8 +37,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * It is important that punctuation is not discarded by the tokenizer so use
  * {@code discardPunctuation="false"} in your {@link KoreanTokenizerFactory}.
  * @since 8.2.0
+ * @lucene.spi {@value #NAME}
  */
 public class KoreanNumberFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "koreanNumber";
 
   public KoreanNumberFilterFactory(Map<String, String> args) {
     super(args);

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/KoreanPartOfSpeechStopFilterFactory.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/KoreanPartOfSpeechStopFilterFactory.java
@@ -43,8 +43,13 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * @lucene.experimental
  *
  * @since 7.4.0
+ * @lucene.spi {@value #NAME}
  */
 public class KoreanPartOfSpeechStopFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "koreanPartOfSpeechStop";
+
   private Set<POS.Tag> stopTags;
 
   /** Creates a new KoreanPartOfSpeechStopFilterFactory */

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/KoreanReadingFormFilterFactory.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/KoreanReadingFormFilterFactory.java
@@ -34,8 +34,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * @lucene.experimental
  *
  * @since 7.4.0
+ * @lucene.spi {@value #NAME}
  */
 public class KoreanReadingFormFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "koreanReadingForm";
 
   /** Creates a new KoreanReadingFilterFactory */
   public KoreanReadingFormFilterFactory(Map<String,String> args) {

--- a/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/KoreanTokenizerFactory.java
+++ b/lucene/analysis/nori/src/java/org/apache/lucene/analysis/ko/KoreanTokenizerFactory.java
@@ -62,8 +62,13 @@ import org.apache.lucene.analysis.ko.KoreanTokenizer.DecompoundMode;
  * @lucene.experimental
  *
  * @since 7.4.0
+ * @lucene.spi {@value #NAME}
  */
 public class KoreanTokenizerFactory extends TokenizerFactory implements ResourceLoaderAware {
+
+  /** SPI name */
+  public static final String NAME = "korean";
+
   private static final String USER_DICT_PATH = "userDictionary";
   private static final String USER_DICT_ENCODING = "userDictionaryEncoding";
   private static final String DECOMPOUND_MODE = "decompoundMode";

--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPChunkerFilterFactory.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPChunkerFilterFactory.java
@@ -39,8 +39,13 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 7.3.0
+ * @lucene.spi {@value #NAME}
  */
 public class OpenNLPChunkerFilterFactory extends TokenFilterFactory implements ResourceLoaderAware {
+
+  /** SPI name */
+  public static final String NAME = "openNlpChunker";
+
   public static final String CHUNKER_MODEL = "chunkerModel";
 
   private final String chunkerModelFile;

--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPLemmatizerFilterFactory.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPLemmatizerFilterFactory.java
@@ -43,8 +43,13 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 7.3.0
+ * @lucene.spi {@value #NAME}
  */
 public class OpenNLPLemmatizerFilterFactory extends TokenFilterFactory implements ResourceLoaderAware {
+
+  /** SPI name */
+  public static final String NAME = "openNlpLemmatizer";
+
   public static final String DICTIONARY = "dictionary";
   public static final String LEMMATIZER_MODEL = "lemmatizerModel";
 

--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPPOSFilterFactory.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPPOSFilterFactory.java
@@ -37,8 +37,13 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 7.3.0
+ * @lucene.spi {@value #NAME}
  */
 public class OpenNLPPOSFilterFactory extends TokenFilterFactory implements ResourceLoaderAware {
+
+  /** SPI name */
+  public static final String NAME = "openNlppos";
+
   public static final String POS_TAGGER_MODEL = "posTaggerModel";
 
   private final String posTaggerModelFile;

--- a/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPTokenizerFactory.java
+++ b/lucene/analysis/opennlp/src/java/org/apache/lucene/analysis/opennlp/OpenNLPTokenizerFactory.java
@@ -38,8 +38,13 @@ import org.apache.lucene.util.AttributeFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 7.3.0
+ * @lucene.spi {@value #NAME}
  */
 public class OpenNLPTokenizerFactory extends TokenizerFactory implements ResourceLoaderAware {
+
+  /** SPI name */
+  public static final String NAME = "openNlp";
+
   public static final String SENTENCE_MODEL = "sentenceModel";
   public static final String TOKENIZER_MODEL = "tokenizerModel";
 

--- a/lucene/analysis/phonetic/src/java/org/apache/lucene/analysis/phonetic/BeiderMorseFilterFactory.java
+++ b/lucene/analysis/phonetic/src/java/org/apache/lucene/analysis/phonetic/BeiderMorseFilterFactory.java
@@ -40,8 +40,13 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *   &lt;/analyzer&gt;
  * &lt;/fieldType&gt;</pre>
  * @since 3.6.0
+ * @lucene.spi {@value #NAME}
  */
 public class BeiderMorseFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "beiderMorse";
+
   private final PhoneticEngine engine;
   private final LanguageSet languageSet;
   

--- a/lucene/analysis/phonetic/src/java/org/apache/lucene/analysis/phonetic/DaitchMokotoffSoundexFilterFactory.java
+++ b/lucene/analysis/phonetic/src/java/org/apache/lucene/analysis/phonetic/DaitchMokotoffSoundexFilterFactory.java
@@ -43,8 +43,13 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *
  * @lucene.experimental
  * @since 5.0.0
+ * @lucene.spi {@value #NAME}
  */
 public class DaitchMokotoffSoundexFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "daitchMokotoffSoundex";
+
   /** parameter name: true if encoded tokens should be added as synonyms */
   public static final String INJECT = "inject"; // boolean
 

--- a/lucene/analysis/phonetic/src/java/org/apache/lucene/analysis/phonetic/DoubleMetaphoneFilterFactory.java
+++ b/lucene/analysis/phonetic/src/java/org/apache/lucene/analysis/phonetic/DoubleMetaphoneFilterFactory.java
@@ -33,9 +33,14 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * &lt;/fieldType&gt;</pre>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class DoubleMetaphoneFilterFactory extends TokenFilterFactory
 {
+
+  /** SPI name */
+  public static final String NAME = "doubleMetaphone";
+
   /** parameter name: true if encoded tokens should be added as synonyms */
   public static final String INJECT = "inject"; 
   /** parameter name: restricts the length of the phonetic code */

--- a/lucene/analysis/phonetic/src/java/org/apache/lucene/analysis/phonetic/PhoneticFilterFactory.java
+++ b/lucene/analysis/phonetic/src/java/org/apache/lucene/analysis/phonetic/PhoneticFilterFactory.java
@@ -64,8 +64,13 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * @see PhoneticFilter
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class PhoneticFilterFactory extends TokenFilterFactory implements ResourceLoaderAware {
+
+  /** SPI name */
+  public static final String NAME = "phonetic";
+
   /** parameter name: either a short name or a full class name */
   public static final String ENCODER = "encoder";
   /** parameter name: true if encoded tokens should be added as synonyms */

--- a/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/HMMChineseTokenizerFactory.java
+++ b/lucene/analysis/smartcn/src/java/org/apache/lucene/analysis/cn/smart/HMMChineseTokenizerFactory.java
@@ -32,8 +32,12 @@ import org.apache.lucene.util.AttributeFactory;
  * @lucene.experimental
  *
  * @since 4.10.0
+ * @lucene.spi {@value #NAME}
  */
 public final class HMMChineseTokenizerFactory extends TokenizerFactory {
+
+  /** SPI name */
+  public static final String NAME = "hmmChinese";
 
   /** Creates a new HMMChineseTokenizerFactory */
   public HMMChineseTokenizerFactory(Map<String,String> args) {

--- a/lucene/analysis/stempel/src/java/org/apache/lucene/analysis/stempel/StempelPolishStemFilterFactory.java
+++ b/lucene/analysis/stempel/src/java/org/apache/lucene/analysis/stempel/StempelPolishStemFilterFactory.java
@@ -26,8 +26,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
 /**
  * Factory for {@link StempelFilter} using a Polish stemming table.
  * @since 3.1.0
+ * @lucene.spi {@value #NAME}
  */
-public class StempelPolishStemFilterFactory extends TokenFilterFactory {  
+public class StempelPolishStemFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "stempelPolishStem";
   
   /** Creates a new StempelPolishStemFilterFactory */
   public StempelPolishStemFilterFactory(Map<String,String> args) {

--- a/lucene/common-build.xml
+++ b/lucene/common-build.xml
@@ -2203,6 +2203,8 @@ ${ant.project.name}.test.dependencies=${test.classpath.list}
           description="WARNING: This API is experimental and might change in incompatible ways in the next release."/>
         <tag name="lucene.internal"
         description="NOTE: This API is for internal purposes only and might change in incompatible ways in the next release."/>
+        <tag name="lucene.spi"
+        description="SPI Name (Note: This is case-insensitive. e.g., if the name is 'htmlStrip', 'htmlstrip' can be used when looking up the service):" scope="types"/>
         <link offline="true" packagelistLoc="${javadoc.dir}"/>
         <link offline="true" href="${javadoc.link}" packagelistLoc="${javadoc.packagelist.dir}/java8"/>
         <bottom><![CDATA[

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/analysis/AnalysisChainDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/analysis/AnalysisChainDialogFactory.java
@@ -37,6 +37,9 @@ import java.awt.Window;
 import java.io.IOException;
 
 import org.apache.lucene.analysis.custom.CustomAnalyzer;
+import org.apache.lucene.analysis.util.CharFilterFactory;
+import org.apache.lucene.analysis.util.TokenFilterFactory;
+import org.apache.lucene.analysis.util.TokenizerFactory;
 import org.apache.lucene.luke.app.desktop.Preferences;
 import org.apache.lucene.luke.app.desktop.PreferencesFactory;
 import org.apache.lucene.luke.app.desktop.util.DialogOpener;
@@ -109,7 +112,7 @@ public class AnalysisChainDialogFactory implements DialogOpener.DialogFactory {
     c.weighty = 0.5;
     panel.add(new JLabel(MessageUtils.getLocalizedMessage("analysis.dialog.chain.label.charfilters")), c);
 
-    String[] charFilters = analyzer.getCharFilterFactories().stream().map(f -> f.getClass().getName()).toArray(String[]::new);
+    String[] charFilters = analyzer.getCharFilterFactories().stream().map(f -> CharFilterFactory.findSPIName(f.getClass())).toArray(String[]::new);
     JList<String> charFilterList = new JList<>(charFilters);
     charFilterList.setVisibleRowCount(charFilters.length == 0 ? 1 : Math.min(charFilters.length, 5));
     c.gridx = 1;
@@ -124,7 +127,7 @@ public class AnalysisChainDialogFactory implements DialogOpener.DialogFactory {
     c.weighty = 0.1;
     panel.add(new JLabel(MessageUtils.getLocalizedMessage("analysis.dialog.chain.label.tokenizer")), c);
 
-    String tokenizer = analyzer.getTokenizerFactory().getClass().getName();
+    String tokenizer = TokenizerFactory.findSPIName(analyzer.getTokenizerFactory().getClass());
     JTextField tokenizerTF = new JTextField(tokenizer);
     tokenizerTF.setColumns(30);
     tokenizerTF.setEditable(false);
@@ -142,7 +145,7 @@ public class AnalysisChainDialogFactory implements DialogOpener.DialogFactory {
     c.weighty = 0.5;
     panel.add(new JLabel(MessageUtils.getLocalizedMessage("analysis.dialog.chain.label.tokenfilters")), c);
 
-    String[] tokenFilters = analyzer.getTokenFilterFactories().stream().map(f -> f.getClass().getName()).toArray(String[]::new);
+    String[] tokenFilters = analyzer.getTokenFilterFactories().stream().map(f -> TokenFilterFactory.findSPIName(f.getClass())).toArray(String[]::new);
     JList<String> tokenFilterList = new JList<>(tokenFilters);
     tokenFilterList.setVisibleRowCount(tokenFilters.length == 0 ? 1 : Math.min(tokenFilters.length, 5));
     tokenFilterList.setMinimumSize(new Dimension(300, 25));

--- a/lucene/luke/src/java/org/apache/lucene/luke/models/analysis/AnalysisImpl.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/models/analysis/AnalysisImpl.java
@@ -247,7 +247,7 @@ public final class AnalysisImpl implements Analysis {
           Reader readerForWriteOut = new StringReader(charFilteredSource);
           readerForWriteOut = charFilterFactory.create(readerForWriteOut);
           charFilteredSource = writeCharStream(readerForWriteOut);
-          charfilteredTexts.add(new CharfilteredText(readerForWriteOut.getClass().getName(), charFilteredSource));
+          charfilteredTexts.add(new CharfilteredText(CharFilterFactory.findSPIName(charFilterFactory.getClass()), charFilteredSource));
         }
         reader = cs;
       }
@@ -259,13 +259,14 @@ public final class AnalysisImpl implements Analysis {
       ((Tokenizer)tokenStream).setReader(reader);
       List<Token> tokens = new ArrayList<>();
       List<AttributeSource> attributeSources = analyzeTokenStream(tokenStream, tokens);
-      namedTokens.add(new NamedTokens(tokenStream.getClass().getName(), tokens));
+      namedTokens.add(new NamedTokens(TokenizerFactory.findSPIName(tokenizerFactory.getClass()), tokens));
+
       ListBasedTokenStream listBasedTokenStream = new ListBasedTokenStream(tokenStream, attributeSources);
       for (TokenFilterFactory tokenFilterFactory : tokenFilterFactories) {
         tokenStream = tokenFilterFactory.create(listBasedTokenStream);
         tokens = new ArrayList<>();
         attributeSources = analyzeTokenStream(tokenStream, tokens);
-        namedTokens.add(new NamedTokens(tokenStream.getClass().getName(), tokens));
+        namedTokens.add(new NamedTokens(TokenFilterFactory.findSPIName(tokenFilterFactory.getClass()), tokens));
         try {
           listBasedTokenStream.close();
         } catch (IOException e) {

--- a/lucene/luke/src/test/org/apache/lucene/luke/models/analysis/AnalysisImplTest.java
+++ b/lucene/luke/src/test/org/apache/lucene/luke/models/analysis/AnalysisImplTest.java
@@ -165,12 +165,12 @@ public class AnalysisImplTest extends LuceneTestCase {
     assertNotNull(result);
     assertNotNull(result.getCharfilteredTexts());
     assertEquals(1,result.getCharfilteredTexts().size());
-    assertEquals("org.apache.lucene.analysis.charfilter.HTMLStripCharFilter", result.getCharfilteredTexts().get(0).getName());
+    assertEquals("htmlStrip", result.getCharfilteredTexts().get(0).getName());
 
     assertNotNull(result.getNamedTokens());
     assertEquals(2, result.getNamedTokens().size());
     //FIXME check each namedTokensList
-    assertEquals("org.apache.lucene.analysis.core.KeywordTokenizer", result.getNamedTokens().get(0).getName());
-    assertEquals("org.apache.lucene.analysis.core.LowerCaseFilter", result.getNamedTokens().get(1).getName());
+    assertEquals("keyword", result.getNamedTokens().get(0).getName());
+    assertEquals("lowercase", result.getNamedTokens().get(1).getName());
   }
 }

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/analyzing/SuggestStopFilterFactory.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/analyzing/SuggestStopFilterFactory.java
@@ -71,8 +71,13 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  *  </li>
  * </ul>
  * @since 5.0.0
+ * @lucene.spi {@value #NAME}
  */
-  public class SuggestStopFilterFactory extends TokenFilterFactory implements ResourceLoaderAware {
+public class SuggestStopFilterFactory extends TokenFilterFactory implements ResourceLoaderAware {
+
+  /** SPI name */
+  public static final String NAME = "suggestStop";
+
   /** the default format, one word per line, whole line comments start with "#" */
   public static final String FORMAT_WORDSET = "wordset";
   /** multiple words may be specified on each line, trailing comments start with "&#124;" */

--- a/solr/core/src/java/org/apache/solr/analysis/LowerCaseTokenizerFactory.java
+++ b/solr/core/src/java/org/apache/solr/analysis/LowerCaseTokenizerFactory.java
@@ -41,9 +41,13 @@ import static org.apache.lucene.analysis.standard.StandardTokenizer.MAX_TOKEN_LE
  * else {@link CharTokenizer}::DEFAULT_MAX_WORD_LEN</li>
  * </ul>
  * @deprecated Use {@link org.apache.lucene.analysis.core.LetterTokenizerFactory} and {@link LowerCaseFilterFactory}
+ * @lucene.spi {@value #NAME}
  */
 @Deprecated
 public class LowerCaseTokenizerFactory extends TokenizerFactory {
+
+  /** SPI name */
+  public static final String NAME = "lowercase";
 
   private final int maxTokenLen;
 

--- a/solr/core/src/java/org/apache/solr/analysis/ReversedWildcardFilterFactory.java
+++ b/solr/core/src/java/org/apache/solr/analysis/ReversedWildcardFilterFactory.java
@@ -61,8 +61,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
  * &lt;/fieldType&gt;</pre>
  *
  * @since 3.1
+ * @lucene.spi {@value #NAME}
  */
 public class ReversedWildcardFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "reversedWildcard";
   
   private char markerChar = ReverseStringFilter.START_OF_HEADING_MARKER;
   private boolean withOriginal;

--- a/solr/core/src/java/org/apache/solr/rest/schema/analysis/ManagedStopFilterFactory.java
+++ b/solr/core/src/java/org/apache/solr/rest/schema/analysis/ManagedStopFilterFactory.java
@@ -29,8 +29,12 @@ import org.apache.solr.rest.ManagedResource;
  * TokenFilterFactory that uses the ManagedWordSetResource implementation
  * for managing stop words using the REST API.
  * @since 4.8.0
+ * @lucene.spi {@value #NAME}
  */
 public class ManagedStopFilterFactory extends BaseManagedTokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "managedStop";
 
   // this only gets changed once during core initialization and not every
   // time an update is made to the underlying managed word set.

--- a/solr/core/src/java/org/apache/solr/rest/schema/analysis/ManagedSynonymFilterFactory.java
+++ b/solr/core/src/java/org/apache/solr/rest/schema/analysis/ManagedSynonymFilterFactory.java
@@ -55,9 +55,13 @@ import org.slf4j.LoggerFactory;
  * @deprecated Use {@link ManagedSynonymGraphFilterFactory} instead, but be sure to also
  * use {@link FlattenGraphFilterFactory} at index time (not at search time) as well.
  * @since 4.8.0
+ * @lucene.spi {@value #NAME}
  */
 @Deprecated
 public class ManagedSynonymFilterFactory extends BaseManagedTokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "managedSynonym";
   
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   

--- a/solr/core/src/java/org/apache/solr/rest/schema/analysis/ManagedSynonymGraphFilterFactory.java
+++ b/solr/core/src/java/org/apache/solr/rest/schema/analysis/ManagedSynonymGraphFilterFactory.java
@@ -51,8 +51,12 @@ import org.slf4j.LoggerFactory;
  * TokenFilterFactory and ManagedResource implementation for 
  * doing CRUD on synonyms using the REST API.
  * @since 7.0.0
+ * @lucene.spi {@value #NAME}
  */
 public class ManagedSynonymGraphFilterFactory extends BaseManagedTokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "managedSynonymGraph";
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 

--- a/solr/core/src/test/org/apache/solr/handler/tagger/WordLengthTaggingFilterFactory.java
+++ b/solr/core/src/test/org/apache/solr/handler/tagger/WordLengthTaggingFilterFactory.java
@@ -30,7 +30,13 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * @lucene.spi {@value #NAME}
+ */
 public class WordLengthTaggingFilterFactory extends TokenFilterFactory {
+
+  /** SPI name */
+  public static final String NAME = "wordLengthTagging";
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 


### PR DESCRIPTION
# Description

Backport LUCENE-8778 to 8.x and also keep legacy look-up algorithm for backwards compatibility.
See also: https://issues.apache.org/jira/browse/LUCENE-8911

# Solution

Make it possible to load analysis factories by both of new/legacy SPI names.

# Tests

I added tests for the following cases:
- A factory lacks the NAME field: the loader registers the legacy name only.
- A factory has the NAME field but it does not match to the legacy name, which is derived from the class name: the loader registers both of NAME and legacy name.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I am authorized to contribute this code to the ASF and have removed any code I do not have a license to distribute.
- ~~[] I have developed this patch against the `master` branch.~~
- [x] I have run `ant precommit` and the appropriate test suite.
- [x] I have added tests for my changes.
- ~~[] I have added documentation for the Ref Guide (for Solr changes only).~~
