### PR TITLE
LUCENE-8810: Honor MaxClausesCount in BooleanQuery During Flattening

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/BooleanQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanQuery.java
@@ -453,23 +453,28 @@ public class BooleanQuery extends Query implements Iterable<BooleanClause> {
       BooleanQuery.Builder builder = new BooleanQuery.Builder();
       builder.setMinimumNumberShouldMatch(minimumNumberShouldMatch);
       boolean actuallyRewritten = false;
-      for (BooleanClause clause : clauses) {
-        if (clause.getOccur() == Occur.SHOULD && clause.getQuery() instanceof BooleanQuery) {
-          BooleanQuery innerQuery = (BooleanQuery) clause.getQuery();
-          if (innerQuery.isPureDisjunction()) {
-            actuallyRewritten = true;
-            for (BooleanClause innerClause : innerQuery.clauses()) {
-              builder.add(innerClause);
+      try {
+        for (BooleanClause clause : clauses) {
+          if (clause.getOccur() == Occur.SHOULD && clause.getQuery() instanceof BooleanQuery) {
+            BooleanQuery innerQuery = (BooleanQuery) clause.getQuery();
+            if (innerQuery.isPureDisjunction()) {
+              actuallyRewritten = true;
+              for (BooleanClause innerClause : innerQuery.clauses()) {
+                builder.add(innerClause);
+              }
+            } else {
+              builder.add(clause);
             }
           } else {
             builder.add(clause);
           }
-        } else {
-          builder.add(clause);
         }
-      }
-      if (actuallyRewritten) {
-        return builder.build();
+        if (actuallyRewritten) {
+          return builder.build();
+        }
+      } catch (IndexSearcher.TooManyClauses tooManyClauses) {
+        // No-op : Do not flatten if the new query will exceed the
+        // maximum count of clauses
       }
     }
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestBooleanQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestBooleanQuery.java
@@ -73,6 +73,21 @@ public class TestBooleanQuery extends LuceneTestCase {
     assertEquals(bq1.build(), bq2.build());
   }
 
+  public void testFlattenInnerDisjunctionsWithMoreThan1024Terms() throws IOException {
+    IndexSearcher searcher = newSearcher(new MultiReader());
+
+    BooleanQuery.Builder builder1024 = new BooleanQuery.Builder();
+    for(int i = 0; i < 1024; i++) {
+      builder1024.add(new TermQuery(new Term("foo", "bar-" + i)), Occur.SHOULD);
+    }
+    Query inner = builder1024.build();
+    Query query = new BooleanQuery.Builder()
+        .add(inner, Occur.SHOULD)
+        .add(new TermQuery(new Term("foo", "baz")), Occur.SHOULD)
+        .build();
+    searcher.rewrite(query);
+  }
+
   public void testEqualityDoesNotDependOnOrder() {
     TermQuery[] queries = new TermQuery[] {
         new TermQuery(new Term("foo", "bar")),


### PR DESCRIPTION
BooleanQuery will always try to flatten nested clauses during
rewrite. However, this can cause the maximum number of clauses
to be violated by the new query. This commit disables flattening
in the specific case.