### PR TITLE
LUCENE-8918: Disallow null terms in PhraseQuery

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/PhraseQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PhraseQuery.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.lucene.codecs.lucene50.Lucene50PostingsFormat;
 import org.apache.lucene.codecs.lucene50.Lucene50PostingsReader;
@@ -109,6 +110,7 @@ public class PhraseQuery extends Query {
      * all of them.
      */
     public Builder add(Term term, int position) {
+      Objects.requireNonNull(term, "Cannot add a null term to PhraseQuery");
       if (position < 0) {
         throw new IllegalArgumentException("Positions must be >= 0, got " + position);
       }

--- a/lucene/core/src/java/org/apache/lucene/search/PhraseQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PhraseQuery.java
@@ -154,6 +154,9 @@ public class PhraseQuery extends Query {
     if (slop < 0) {
       throw new IllegalArgumentException("Slop must be >= 0, got " + slop);
     }
+    for (Term term : terms) {
+      Objects.requireNonNull(term, "Cannot add a null term to PhraseQuery");
+    }
     for (int i = 1; i < terms.length; ++i) {
       if (terms[i-1].field().equals(terms[i].field()) == false) {
         throw new IllegalArgumentException("All terms should have the same field");
@@ -187,6 +190,7 @@ public class PhraseQuery extends Query {
   private static Term[] toTerms(String field, String... termStrings) {
     Term[] terms = new Term[termStrings.length];
     for (int i = 0; i < terms.length; ++i) {
+      Objects.requireNonNull(termStrings[i], "Cannot add a null term to PhraseQuery");
       terms[i] = new Term(field, termStrings[i]);
     }
     return terms;
@@ -195,6 +199,7 @@ public class PhraseQuery extends Query {
   private static Term[] toTerms(String field, BytesRef... termBytes) {
     Term[] terms = new Term[termBytes.length];
     for (int i = 0; i < terms.length; ++i) {
+      Objects.requireNonNull(termBytes[i], "Cannot add a null term to PhraseQuery");
       terms[i] = new Term(field, termBytes[i]);
     }
     return terms;

--- a/lucene/core/src/test/org/apache/lucene/search/TestPhraseQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestPhraseQuery.java
@@ -1075,5 +1075,11 @@ public class TestPhraseQuery extends LuceneTestCase {
   public void testNullTerm() {
     NullPointerException e = expectThrows(NullPointerException.class, () -> new PhraseQuery.Builder().add(null));
     assertEquals("Cannot add a null term to PhraseQuery", e.getMessage());
+
+    e = expectThrows(NullPointerException.class, () -> new PhraseQuery("field", (BytesRef)null));
+    assertEquals("Cannot add a null term to PhraseQuery", e.getMessage());
+
+    e = expectThrows(NullPointerException.class, () -> new PhraseQuery("field", (String)null));
+    assertEquals("Cannot add a null term to PhraseQuery", e.getMessage());
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestPhraseQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestPhraseQuery.java
@@ -1071,4 +1071,9 @@ public class TestPhraseQuery extends LuceneTestCase {
     reader.close();
     dir.close();
   }
+
+  public void testNullTerm() {
+    NullPointerException e = expectThrows(NullPointerException.class, () -> new PhraseQuery.Builder().add(null));
+    assertEquals("Cannot add a null term to PhraseQuery", e.getMessage());
+  }
 }


### PR DESCRIPTION
It is currently possible to create a PhraseQuery consisting of a single `null` term,
which will then cause NullPointerExceptions deep inside postings decoding at
search time.  We should instead catch this up-front, and prevent construction of
the Query.