### PR TITLE
Update Wordnet file format description link

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/WordnetSynonymParser.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/synonym/WordnetSynonymParser.java
@@ -30,7 +30,7 @@ import org.apache.lucene.util.CharsRefBuilder;
 /**
  * Parser for wordnet prolog format
  * <p>
- * See http://wordnet.princeton.edu/man/prologdb.5WN.html for a description of the format.
+ * See https://wordnet.princeton.edu/documentation/prologdb5wn for a description of the format.
  * @lucene.experimental
  */
 // TODO: allow you to specify syntactic categories (e.g. just nouns, etc)


### PR DESCRIPTION
The link to the description of the Wordnet prolog database files seems outdated.
This change replaces it with a working link.
