### PR TITLE
SOLR-13643: Create accessors/setters in ResponseBuilder with unit tests

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/ResponseBuilder.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/ResponseBuilder.java
@@ -497,4 +497,28 @@ public class ResponseBuilder
   public void setNextCursorMark(CursorMark nextCursorMark) {
     this.nextCursorMark = nextCursorMark;
   }
+
+  public void setDoAnalytics(boolean doAnalytics) {
+    this.doAnalytics = doAnalytics;
+  }
+
+  public boolean getDoAnalytics() {
+    return this.doAnalytics;
+  }
+
+  public void setAnalyticsRequestManager(Object analyticsRequestManager) {
+    this._analyticsRequestManager = analyticsRequestManager;
+  }
+
+  public Object getAnalyticsRequestManager() {
+    return this._analyticsRequestManager;
+  }
+
+  public void setIsOlapAnalytics(boolean isOlapAnalytics) {
+    this._isOlapAnalytics = isOlapAnalytics;
+  }
+
+  public boolean getIsOlapAnalytics() {
+    return this._isOlapAnalytics;
+  }
 }

--- a/solr/core/src/test/org/apache/solr/handler/component/ResponseBuilderTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/ResponseBuilderTest.java
@@ -26,6 +26,9 @@ import org.junit.BeforeClass;
 
 public class ResponseBuilderTest extends SolrTestCaseJ4 {
 
+  SolrQueryRequest req = req("q", "title:test");
+  SolrQueryResponse rsp = new SolrQueryResponse();
+
   @BeforeClass
   public static void beforeClass() throws Exception {
     initCore("solrconfig.xml", "schema.xml");
@@ -33,13 +36,33 @@ public class ResponseBuilderTest extends SolrTestCaseJ4 {
 
   //This test is being added to verify responseBuilder.isDistributed() exists and is visible.
   public void testIsDistrib(){
-
-    SolrQueryRequest req = req("q", "title:test");
-    SolrQueryResponse rsp = new SolrQueryResponse();
-
     ResponseBuilder responseBuilder = new ResponseBuilder(req, rsp, new ArrayList<>(0));
     assertFalse(responseBuilder.isDistributed());
-
   }
 
+  public void testDoAnalyticsAccessors() {
+    ResponseBuilder rb = new ResponseBuilder(req, rsp, new ArrayList<>(0));
+    assertFalse(rb.getDoAnalytics());
+    rb.setDoAnalytics(true);
+    assertTrue(rb.getDoAnalytics());
+    rb.setDoAnalytics(false);
+    assertFalse(rb.getDoAnalytics());
+  }
+
+  public void testIsOlapAnalyticsAccessors() {
+    ResponseBuilder rb = new ResponseBuilder(req, rsp, new ArrayList<>(0));
+    assertFalse(rb.getIsOlapAnalytics());
+    rb.setIsOlapAnalytics(true);
+    assertTrue(rb.getIsOlapAnalytics());
+    rb.setIsOlapAnalytics(false);
+    assertFalse(rb.getIsOlapAnalytics());
+  }
+
+  public void testAnalyticsRequestManagerAccessors() {
+    ResponseBuilder rb = new ResponseBuilder(req, rsp, new ArrayList<>(0));
+    assertNull(rb.getAnalyticsRequestManager());
+    rb.setAnalyticsRequestManager(this);
+    assertNotNull(rb.getAnalyticsRequestManager());
+    assertEquals(rb.getAnalyticsRequestManager(), this);
+  }
 }


### PR DESCRIPTION

# Description

Create accessors/setters in ResponseBuilder with unit tests.  Also migrate analytics rqeuest handling to use them.

# Solution

I added accessors/setters to ResponseBuilder for the analytics-related fields and unit tests.

# Tests

Unit tests are added to ResponseBuilderTest, and I create a local Solr installation with the changes and verified that analytics queries worked.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I am authorized to contribute this code to the ASF and have removed any code I do not have a license to distribute.
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [x] I have added tests for my changes.
- [x] I have added documentation for the Ref Guide (for Solr changes only).
