### PR TITLE
SOLR-13647 default solr.in.sh contains uncommented lines

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -62,6 +62,8 @@ Other Changes
 
 * SOLR-10288: Remove non-minified JavaScript from the webapp. (Erik Hatcher, marcussorealheis)
 
+* SOLR-13647: default solr.in.sh contains incorrect default value (John Ryan, jnyryan)
+
 
 ==================  8.3.0 ==================
 
@@ -100,8 +102,8 @@ Bug Fixes
 
 * SOLR-13206: Fix AIOOBE when group.facet is specified with group.query and return proper error code. (Marek, Munendra S N)
 
-* SOLR-11556: Backup and restore command really supports picking one of a few repositories by 
-  repository parameter (Timothy Potter via Mikhail Khludnev) 
+* SOLR-11556: Backup and restore command really supports picking one of a few repositories by
+  repository parameter (Timothy Potter via Mikhail Khludnev)
 
 Other Changes
 ----------------------

--- a/solr/bin/solr.in.sh
+++ b/solr/bin/solr.in.sh
@@ -82,7 +82,7 @@
 # Set to true to activate the JMX RMI connector to allow remote JMX client applications
 # to monitor the JVM hosting Solr; set to "false" to disable that behavior
 # (false is recommended in production environments)
-ENABLE_REMOTE_JMX_OPTS="false"
+# ENABLE_REMOTE_JMX_OPTS="false"
 
 # The script will use SOLR_PORT+10000 for the RMI_PORT or you can set it here
 # RMI_PORT=18983

--- a/solr/bin/solr.in.sh
+++ b/solr/bin/solr.in.sh
@@ -82,7 +82,7 @@
 # Set to true to activate the JMX RMI connector to allow remote JMX client applications
 # to monitor the JVM hosting Solr; set to "false" to disable that behavior
 # (false is recommended in production environments)
-ENABLE_REMOTE_JMX_OPTS="true"
+# ENABLE_REMOTE_JMX_OPTS="true"
 
 # The script will use SOLR_PORT+10000 for the RMI_PORT or you can set it here
 # RMI_PORT=18983

--- a/solr/bin/solr.in.sh
+++ b/solr/bin/solr.in.sh
@@ -82,7 +82,7 @@
 # Set to true to activate the JMX RMI connector to allow remote JMX client applications
 # to monitor the JVM hosting Solr; set to "false" to disable that behavior
 # (false is recommended in production environments)
-# ENABLE_REMOTE_JMX_OPTS="true"
+ENABLE_REMOTE_JMX_OPTS="false"
 
 # The script will use SOLR_PORT+10000 for the RMI_PORT or you can set it here
 # RMI_PORT=18983


### PR DESCRIPTION
# Description

default version of this file should be completely commented

ENABLE_REMOTE_JMX_OPTS had defaults

Issue: https://issues.apache.org/jira/browse/SOLR-13647

# Solution

Comment the line in question
