### PR TITLE
Remove solr.jetty.https.port when SSL is not used

### DIFF
--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -2034,7 +2034,7 @@ function start_solr() {
   fi
 
   # If SSL-related system props are set, add them to SOLR_OPTS
-  if [ "$SOLR_SSL_ENABLED" ]; then
+  if [ "$SOLR_SSL_ENABLED" == "true"  ]; then
     # If using SSL and solr.jetty.https.port not set explicitly, use the jetty.port
     SSL_PORT_PROP="-Dsolr.jetty.https.port=$SOLR_PORT"
     SOLR_OPTS+=($SOLR_SSL_OPTS "$SSL_PORT_PROP")


### PR DESCRIPTION
It appears the start script is sending `-Dsolr.jetty.https.port=8180` even if SSL is not enabled.  Changing the condition to `"$SOLR_SSL_ENABLED" == "true" ` will remove the unnecessary confusing parameter when SSL is not enabled.

<!--
Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

Please provide a short description of the changes you're making with this pull request.

# Solution

Please provide a short description of the approach taken to implement your solution.

# Tests

Please describe the tests you've developed or run to confirm this patch implements the feature or solves the problem.

# Checklist

Please review the following and check all that apply:

- [ ] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I am authorized to contribute this code to the ASF and have removed any code I do not have a license to distribute.
- [ ] I have developed this patch against the `master` branch.
- [ ] I have run `ant precommit` and the appropriate test suite.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the Ref Guide (for Solr changes only).
