### PR TITLE
[SOLR-13663] Span Positional Range Support in XML Query Parser + test

### DIFF
--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/xml/CoreParser.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/xml/CoreParser.java
@@ -112,6 +112,10 @@ public class CoreParser implements QueryBuilder, SpanQueryBuilder {
     spanFactory.addBuilder("SpanFirst", sft);
     queryFactory.addBuilder("SpanFirst", sft);
 
+    SpanPositionRangeBuilder sprt = new SpanPositionRangeBuilder(spanFactory);
+    spanFactory.addBuilder("SpanPositionRange", sprt);
+    queryFactory.addBuilder("SpanPositionRange", sprt);
+
     SpanNotBuilder snot = new SpanNotBuilder(spanFactory);
     spanFactory.addBuilder("SpanNot", snot);
     queryFactory.addBuilder("SpanNot", snot);

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/xml/builders/SpanPositionRangeBuilder.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/xml/builders/SpanPositionRangeBuilder.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.queryparser.xml.builders;
+
+import org.apache.lucene.queryparser.xml.DOMUtils;
+import org.apache.lucene.queryparser.xml.ParserException;
+import org.apache.lucene.search.spans.SpanBoostQuery;
+import org.apache.lucene.search.spans.SpanPositionRangeQuery;
+import org.apache.lucene.search.spans.SpanQuery;
+import org.w3c.dom.Element;
+
+/**
+ * Builder for {@link SpanPositionRangeQuery}
+ */
+public class SpanPositionRangeBuilder extends SpanBuilderBase {
+
+  private final SpanQueryBuilder factory;
+
+  public SpanPositionRangeBuilder(SpanQueryBuilder factory) {
+    this.factory = factory;
+  }
+
+  @Override
+  public SpanQuery getSpanQuery(Element e) throws ParserException {
+    int start = DOMUtils.getAttribute(e, "start", 1);
+    int end = DOMUtils.getAttribute(e, "end", 1);
+    Element child = DOMUtils.getFirstChildElement(e);
+    SpanQuery q = factory.getSpanQuery(child);
+
+    SpanPositionRangeQuery query = new SpanPositionRangeQuery(q, start, end);
+
+    float boost = DOMUtils.getAttribute(e, "boost", 1.0f);
+    return new SpanBoostQuery(query, boost);
+  }
+
+}

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/xml/SpanPositionRangeQuery.xml
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/xml/SpanPositionRangeQuery.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<SpanPositionRange start="9" end="11">
+  <SpanTerm fieldName="contents">sugar</SpanTerm>
+</SpanPositionRange>  

--- a/lucene/queryparser/src/test/org/apache/lucene/queryparser/xml/TestCoreParser.java
+++ b/lucene/queryparser/src/test/org/apache/lucene/queryparser/xml/TestCoreParser.java
@@ -135,6 +135,15 @@ public class TestCoreParser extends LuceneTestCase {
     assertEquals(q, sq);
   }
 
+  public void testSpanPositionRangeQueryXML() throws Exception {
+    Query q = parse("SpanPositionRangeQuery.xml");
+    long h = searcher().search(q, 10).totalHits.value;
+    assertEquals("SpanPositionRangeQuery should produce 2 result ", 2, h);
+    SpanQuery sq = parseAsSpan("SpanPositionRangeQuery.xml");
+    dumpResults("SpanPositionRangeQuery", sq, 5);
+    assertEquals(q, sq);
+  }
+
   public void testSpanNearQueryWithoutSlopXML() throws Exception {
     Exception expectedException = new NumberFormatException("For input string: \"\"");
     try {

--- a/solr/solr-ref-guide/src/other-parsers.adoc
+++ b/solr/solr-ref-guide/src/other-parsers.adoc
@@ -1042,6 +1042,7 @@ The XmlQParser implementation uses the {solr-javadocs}/solr-core/org/apache/solr
 |<MatchAllDocsQuery> |{lucene-javadocs}/queryparser/org/apache/lucene/queryparser/xml/builders/MatchAllDocsQueryBuilder.html[MatchAllDocsQueryBuilder]
 |<RangeQuery> |{lucene-javadocs}/queryparser/org/apache/lucene/queryparser/xml/builders/RangeQueryBuilder.html[RangeQueryBuilder]
 |<SpanFirst> |{lucene-javadocs}/queryparser/org/apache/lucene/queryparser/xml/builders/SpanFirstBuilder.html[SpanFirstBuilder]
+|<SpanPositionRange> |{lucene-javadocs}/queryparser/org/apache/lucene/queryparser/xml/builders/SpanPositionRangeBuilder.html[SpanPositionRangeBuilder]
 |<SpanNear> |{lucene-javadocs}/queryparser/org/apache/lucene/queryparser/xml/builders/SpanNearBuilder.html[SpanNearBuilder]
 |<SpanNot> |{lucene-javadocs}/queryparser/org/apache/lucene/queryparser/xml/builders/SpanNotBuilder.html[SpanNotBuilder]
 |<SpanOr> |{lucene-javadocs}/queryparser/org/apache/lucene/queryparser/xml/builders/SpanOrBuilder.html[SpanOrBuilder]


### PR DESCRIPTION
<!--
Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

Currently the XML Query Parser support a vast array of span queries, including the SpanFirstQuery, but it doesn't support the generic SpanPositionRangeQuery.
< SpanPositionRange start="2" end="3">
<SpanTerm fieldName="title">prejudice</SpanTerm>
</ SpanPositionRange>
 



# Solution

Scope of this issue is to introduce the related java builder and allow the possibility to build such queries.

# Tests

org.apache.lucene.queryparser.xml.TestCoreParser#testSpanPositionRangeQueryXML

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I am authorized to contribute this code to the ASF and have removed any code I do not have a license to distribute.
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [x] I have added tests for my changes.
- [x] I have added documentation for the Ref Guide (for Solr changes only).