### PR TITLE
SOLR-13666: Pull Request Template to sign-post to the Solr Ref Guide source

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -38,4 +38,4 @@ Please review the following and check all that apply:
 - [ ] I have developed this patch against the `master` branch.
 - [ ] I have run `ant precommit` and the appropriate test suite.
 - [ ] I have added tests for my changes.
-- [ ] I have added documentation for the Ref Guide (for Solr changes only).
+- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).


### PR DESCRIPTION
# Description

To make the "I have added documentation for the Ref Guide (for Solr changes only)" checklist item slightly more easy to action-and-tick-yes.

# Solution

Include a sign-posting link to where the ref guide source can be found and how it may be edited.