### PR TITLE
SOLR-13676: Reduce log verbosity in TestDistributedGrouping 

### DIFF
--- a/solr/core/src/test/org/apache/solr/TestDistributedGrouping.java
+++ b/solr/core/src/test/org/apache/solr/TestDistributedGrouping.java
@@ -231,6 +231,7 @@ public class TestDistributedGrouping extends BaseDistributedSearchTestCase {
     );
     assertEquals(SolrException.ErrorCode.BAD_REQUEST.code, exception.code());
     Assert.assertThat(exception.getMessage(), containsString("'group.offset' parameter cannot be negative"));
+    resetExceptionIgnores();
 
     query("q", "*:*",
         "group", "true",

--- a/solr/core/src/test/org/apache/solr/TestDistributedGrouping.java
+++ b/solr/core/src/test/org/apache/solr/TestDistributedGrouping.java
@@ -29,7 +29,6 @@ import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.SolrTestCaseJ4.SuppressPointFields;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.containsString;
@@ -230,7 +229,7 @@ public class TestDistributedGrouping extends BaseDistributedSearchTestCase {
         "group.query", t1 + ":kings OR " + t1 + ":eggs", "group.offset", "-1")
     );
     assertEquals(SolrException.ErrorCode.BAD_REQUEST.code, exception.code());
-    Assert.assertThat(exception.getMessage(), containsString("'group.offset' parameter cannot be negative"));
+    assertThat(exception.getMessage(), containsString("'group.offset' parameter cannot be negative"));
     resetExceptionIgnores();
 
     query("q", "*:*",

--- a/solr/core/src/test/org/apache/solr/TestDistributedGrouping.java
+++ b/solr/core/src/test/org/apache/solr/TestDistributedGrouping.java
@@ -29,7 +29,10 @@ import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.SolrTestCaseJ4.SuppressPointFields;
+import org.junit.Assert;
 import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
 
 /**
  * TODO? perhaps use:
@@ -221,12 +224,13 @@ public class TestDistributedGrouping extends BaseDistributedSearchTestCase {
         "fl", "id", "group.format", "grouped", "group.limit", "-12",
         "sort", i1 + " asc, id asc");
 
+    ignoreException("'group.offset' parameter cannot be negative");
     SolrException exception = expectThrows(SolrException.class, () -> query("q", "*:*",
         "group", "true",
         "group.query", t1 + ":kings OR " + t1 + ":eggs", "group.offset", "-1")
     );
     assertEquals(SolrException.ErrorCode.BAD_REQUEST.code, exception.code());
-    assertTrue(exception.getMessage().contains("'group.offset' parameter cannot be negative"));
+    Assert.assertThat(exception.getMessage(), containsString("'group.offset' parameter cannot be negative"));
 
     query("q", "*:*",
         "group", "true",


### PR DESCRIPTION
using ignoreException

# Description

SOLR-13404 added a test that expects Solr to fail if grouping is called with group.offset < 0. When the test runs it succeeds but the whole stack trace is printed out in the logs. 
# Solution

This small patch avoid the stack trace by using ignoreException. I also replaced an `assertTrue` with a more specific check. 

# Tests

This patch is improving a test.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I am authorized to contribute this code to the ASF and have removed any code I do not have a license to distribute.
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [x] I have added tests for my changes.
- [...] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
