### PR TITLE
SOLR-13680 Auto closed resources after use which implements Closeable or AutoCloseable interface.

### DIFF
--- a/solr/core/src/java/org/apache/solr/rest/ManagedResourceStorage.java
+++ b/solr/core/src/java/org/apache/solr/rest/ManagedResourceStorage.java
@@ -496,17 +496,9 @@ public abstract class ManagedResourceStorage {
     if (inputStream == null) {
       return null;
     }
-    Object parsed = null;
-    InputStreamReader reader = null;
-    try {
-      reader = new InputStreamReader(inputStream, UTF_8);
+    Object parsed;
+    try (InputStreamReader reader = new InputStreamReader(inputStream, UTF_8)) {
       parsed = parseText(reader, resourceId);
-    } finally {
-      if (reader != null) {
-        try {
-          reader.close();
-        } catch (Exception ignore){}
-      }
     }
     
     String objectType = (parsed != null) ? parsed.getClass().getSimpleName() : "null"; 

--- a/solr/core/src/java/org/apache/solr/schema/ManagedIndexSchema.java
+++ b/solr/core/src/java/org/apache/solr/schema/ManagedIndexSchema.java
@@ -130,10 +130,11 @@ public final class ManagedIndexSchema extends IndexSchema {
           throw new SolrException(ErrorCode.SERVER_ERROR, msg);
         }
       }
-      final FileOutputStream out = new FileOutputStream(managedSchemaFile);
-      writer = new OutputStreamWriter(out, StandardCharsets.UTF_8);
-      persist(writer);
-      log.info("Upgraded to managed schema at " + managedSchemaFile.getPath());
+      try (FileOutputStream out = new FileOutputStream(managedSchemaFile)) {
+        writer = new OutputStreamWriter(out, StandardCharsets.UTF_8);
+        persist(writer);
+        log.info("Upgraded to managed schema at " + managedSchemaFile.getPath());
+      }
     } catch (IOException e) {
       final String msg = "Error persisting managed schema " + managedSchemaFile;
       log.error(msg, e);

--- a/solr/core/src/java/org/apache/solr/util/FileUtils.java
+++ b/solr/core/src/java/org/apache/solr/util/FileUtils.java
@@ -16,7 +16,12 @@
  */
 package org.apache.solr.util;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -44,15 +49,9 @@ public class FileUtils {
   }
 
   public static void copyFile(File src , File destination) throws IOException {
-    FileChannel in = null;
-    FileChannel out = null;
-    try {
-      in = new FileInputStream(src).getChannel();
-      out = new FileOutputStream(destination).getChannel();
+    try (FileChannel in = new FileInputStream(src).getChannel();
+         FileChannel out = new FileOutputStream(destination).getChannel()) {
       in.transferTo(0, in.size(), out);
-    } finally {
-      try { if (in != null) in.close(); } catch (IOException e) {}
-      try { if (out != null) out.close(); } catch (IOException e) {}
     }
   }
 
@@ -71,16 +70,9 @@ public class FileUtils {
     IOException exc = null;
     while(!success && retryCount < 5) {
       retryCount++;
-      RandomAccessFile file = null;
-      try {
-        try {
-          file = new RandomAccessFile(fullFile, "rw");
-          file.getFD().sync();
-          success = true;
-        } finally {
-          if (file != null)
-            file.close();
-        }
+      try (RandomAccessFile file = new RandomAccessFile(fullFile, "rw")) {
+        file.getFD().sync();
+        success = true;
       } catch (IOException ioe) {
         if (exc == null)
           exc = ioe;

--- a/solr/core/src/java/org/apache/solr/util/SolrCLI.java
+++ b/solr/core/src/java/org/apache/solr/util/SolrCLI.java
@@ -565,14 +565,15 @@ public class SolrCLI implements CLIO {
     if (path.startsWith("file:") && path.contains("!")) {
       String[] split = path.split("!");
       URL jar = new URL(split[0]);
-      ZipInputStream zip = new ZipInputStream(jar.openStream());
-      ZipEntry entry;
-      while ((entry = zip.getNextEntry()) != null) {
-        if (entry.getName().endsWith(".class")) {
-          String className = entry.getName().replaceAll("[$].*", "")
-              .replaceAll("[.]class", "").replace('/', '.');
-          if (className.startsWith(packageName))
-            classes.add(className);
+      try (ZipInputStream zip = new ZipInputStream(jar.openStream())) {
+        ZipEntry entry;
+        while ((entry = zip.getNextEntry()) != null) {
+          if (entry.getName().endsWith(".class")) {
+            String className = entry.getName().replaceAll("[$].*", "")
+                .replaceAll("[.]class", "").replace('/', '.');
+            if (className.startsWith(packageName))
+              classes.add(className);
+          }
         }
       }
     }

--- a/solr/core/src/test/org/apache/solr/core/TestCoreContainer.java
+++ b/solr/core/src/test/org/apache/solr/core/TestCoreContainer.java
@@ -251,18 +251,18 @@ public class TestCoreContainer extends SolrTestCaseJ4 {
     File lib = new File(tmpRoot.toFile(), "lib");
     lib.mkdirs();
 
-    JarOutputStream jar1 = new JarOutputStream(new FileOutputStream(new File(lib, "jar1.jar")));
-    jar1.putNextEntry(new JarEntry("defaultSharedLibFile"));
-    jar1.closeEntry();
-    jar1.close();
+    try (JarOutputStream jar1 = new JarOutputStream(new FileOutputStream(new File(lib, "jar1.jar")))) {
+      jar1.putNextEntry(new JarEntry("defaultSharedLibFile"));
+      jar1.closeEntry();
+    }
 
     File customLib = new File(tmpRoot.toFile(), "customLib");
     customLib.mkdirs();
 
-    JarOutputStream jar2 = new JarOutputStream(new FileOutputStream(new File(customLib, "jar2.jar")));
-    jar2.putNextEntry(new JarEntry("customSharedLibFile"));
-    jar2.closeEntry();
-    jar2.close();
+    try (JarOutputStream jar2 = new JarOutputStream(new FileOutputStream(new File(customLib, "jar2.jar")))) {
+      jar2.putNextEntry(new JarEntry("customSharedLibFile"));
+      jar2.closeEntry();
+    }
 
     final CoreContainer cc1 = init(tmpRoot, "<solr></solr>");
     try {

--- a/solr/core/src/test/org/apache/solr/core/TestDynamicLoading.java
+++ b/solr/core/src/test/org/apache/solr/core/TestDynamicLoading.java
@@ -267,19 +267,18 @@ public class TestDynamicLoading extends AbstractFullDistribZkTestBase {
 
 
   public static ByteBuffer generateZip(Class... classes) throws IOException {
-    ZipOutputStream zipOut = null;
     SimplePostTool.BAOS bos = new SimplePostTool.BAOS();
-    zipOut = new ZipOutputStream(bos);
-    zipOut.setLevel(ZipOutputStream.DEFLATED);
-    for (Class c : classes) {
-      String path = c.getName().replace('.', '/').concat(".class");
-      ZipEntry entry = new ZipEntry(path);
-      ByteBuffer b = SimplePostTool.inputStreamToByteArray(c.getClassLoader().getResourceAsStream(path));
-      zipOut.putNextEntry(entry);
-      zipOut.write(b.array(), 0, b.limit());
-      zipOut.closeEntry();
+    try (ZipOutputStream zipOut = new ZipOutputStream(bos)) {
+      zipOut.setLevel(ZipOutputStream.DEFLATED);
+      for (Class c : classes) {
+        String path = c.getName().replace('.', '/').concat(".class");
+        ZipEntry entry = new ZipEntry(path);
+        ByteBuffer b = SimplePostTool.inputStreamToByteArray(c.getClassLoader().getResourceAsStream(path));
+        zipOut.putNextEntry(entry);
+        zipOut.write(b.array(), 0, b.limit());
+        zipOut.closeEntry();
+      }
     }
-    zipOut.close();
     return bos.getByteBuffer();
   }
 

--- a/solr/core/src/test/org/apache/solr/handler/TestCSVLoader.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestCSVLoader.java
@@ -16,21 +16,24 @@
  */
 package org.apache.solr.handler;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.solr.SolrTestCaseJ4;
-import org.apache.solr.request.LocalSolrQueryRequest;
 import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.util.ContentStream;
 import org.apache.solr.common.util.ContentStreamBase;
+import org.apache.solr.request.LocalSolrQueryRequest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import java.io.*;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.util.List;
-import java.util.ArrayList;
 
 public class TestCSVLoader extends SolrTestCaseJ4 {
 
@@ -68,10 +71,8 @@ public class TestCSVLoader extends SolrTestCaseJ4 {
   }
 
   void makeFile(String contents) {
-    try {
-      Writer out = new OutputStreamWriter(new FileOutputStream(filename), StandardCharsets.UTF_8);
+    try (Writer out = new OutputStreamWriter(new FileOutputStream(filename), StandardCharsets.UTF_8)) {
       out.write(contents);
-      out.close();
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/solr/core/src/test/org/apache/solr/handler/TestReplicationHandler.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestReplicationHandler.java
@@ -1604,20 +1604,17 @@ public class TestReplicationHandler extends SolrTestCaseJ4 {
    * character copy of file using UTF-8. If port is non-null, will be substituted any time "TEST_PORT" is found.
    */
   private static void copyFile(File src, File dst, Integer port, boolean internalCompression) throws IOException {
-    BufferedReader in = new BufferedReader(new InputStreamReader(new FileInputStream(src), StandardCharsets.UTF_8));
-    Writer out = new OutputStreamWriter(new FileOutputStream(dst), StandardCharsets.UTF_8);
+    try (BufferedReader in = new BufferedReader(new InputStreamReader(new FileInputStream(src), StandardCharsets.UTF_8));
+         Writer out = new OutputStreamWriter(new FileOutputStream(dst), StandardCharsets.UTF_8)) {
 
-    for (String line = in.readLine(); null != line; line = in.readLine()) {
-
-      if (null != port)
-        line = line.replace("TEST_PORT", port.toString());
-      
-      line = line.replace("COMPRESSION", internalCompression?"internal":"false");
-
-      out.write(line);
+      for (String line = in.readLine(); null != line; line = in.readLine()) {
+        if (null != port) {
+          line = line.replace("TEST_PORT", port.toString());
+        }
+        line = line.replace("COMPRESSION", internalCompression ? "internal" : "false");
+        out.write(line);
+      }
     }
-    in.close();
-    out.close();
   }
 
   private UpdateResponse emptyUpdate(SolrClient client, String... params)

--- a/solr/core/src/test/org/apache/solr/search/function/TestFunctionQuery.java
+++ b/solr/core/src/test/org/apache/solr/search/function/TestFunctionQuery.java
@@ -51,10 +51,9 @@ public class TestFunctionQuery extends SolrTestCaseJ4 {
   void makeExternalFile(String field, String contents) {
     String dir = h.getCore().getDataDir();
     String filename = dir + "/external_" + field + "." + (start++);
-    try {
-      Writer out = new OutputStreamWriter(new FileOutputStream(filename), StandardCharsets.UTF_8);
+
+    try (Writer out = new OutputStreamWriter(new FileOutputStream(filename), StandardCharsets.UTF_8)) {
       out.write(contents);
-      out.close();
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/solr/core/src/test/org/apache/solr/servlet/CacheHeaderTest.java
+++ b/solr/core/src/test/org/apache/solr/servlet/CacheHeaderTest.java
@@ -258,9 +258,9 @@ public class CacheHeaderTest extends CacheHeaderTestBase {
   protected File makeFile(String contents, String charset) {
     try {
       File f = createTempFile("cachetest","csv").toFile();
-      Writer out = new OutputStreamWriter(new FileOutputStream(f), charset);
-      out.write(contents);
-      out.close();
+      try (Writer out = new OutputStreamWriter(new FileOutputStream(f), charset)) {
+        out.write(contents);
+      }
       return f;
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/solr/core/src/test/org/apache/solr/update/processor/TestNamedUpdateProcessors.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/TestNamedUpdateProcessors.java
@@ -149,19 +149,18 @@ public class TestNamedUpdateProcessors extends AbstractFullDistribZkTestBase {
 
 
   public static ByteBuffer generateZip(Class... classes) throws IOException {
-    ZipOutputStream zipOut = null;
     SimplePostTool.BAOS bos = new SimplePostTool.BAOS();
-    zipOut = new ZipOutputStream(bos);
-    zipOut.setLevel(ZipOutputStream.DEFLATED);
-    for (Class c : classes) {
-      String path = c.getName().replace('.', '/').concat(".class");
-      ZipEntry entry = new ZipEntry(path);
-      ByteBuffer b = SimplePostTool.inputStreamToByteArray(c.getClassLoader().getResourceAsStream(path));
-      zipOut.putNextEntry(entry);
-      zipOut.write(b.array(), 0, b.limit());
-      zipOut.closeEntry();
+    try (ZipOutputStream zipOut = new ZipOutputStream(bos)) {
+      zipOut.setLevel(ZipOutputStream.DEFLATED);
+      for (Class c : classes) {
+        String path = c.getName().replace('.', '/').concat(".class");
+        ZipEntry entry = new ZipEntry(path);
+        ByteBuffer b = SimplePostTool.inputStreamToByteArray(c.getClassLoader().getResourceAsStream(path));
+        zipOut.putNextEntry(entry);
+        zipOut.write(b.array(), 0, b.limit());
+        zipOut.closeEntry();
+      }
     }
-    zipOut.close();
     return bos.getByteBuffer();
   }
 


### PR DESCRIPTION
# Description

Files, streams or connections which implements Closeable or AutoCloseable interface should be closed after use.

# Solution

Auto closed resources after use which implements Closeable or AutoCloseable interface.

# Tests

No need to write extra tests. Existing tests should not fail after this implementation.

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I am authorized to contribute this code to the ASF and have removed any code I do not have a license to distribute.
- [X] I have developed this patch against the `master` branch.
- [X] I have run `ant precommit` and the appropriate test suite.
- [ ] I have added tests for my changes.
- [X] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
