### PR TITLE
LUCENE-8933: Use expectThrows instead of expected.

### DIFF
--- a/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/dict/UserDictionaryTest.java
+++ b/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/dict/UserDictionaryTest.java
@@ -79,18 +79,24 @@ public class UserDictionaryTest extends LuceneTestCase {
     assertNotNull(dictionary);
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test
   public void testReadInvalid1() throws IOException {
     // the concatenated segment must be the same as the surface form
     String invalidEntry = "日経新聞,日本 経済 新聞,ニホン ケイザイ シンブン,カスタム名詞";
-    UserDictionary dictionary = UserDictionary.open(new StringReader(invalidEntry));
+    RuntimeException e = expectThrows(RuntimeException.class,
+        "RuntimeException should be thrown when passed an invalid dictionary entry.",
+        () -> UserDictionary.open(new StringReader(invalidEntry)));
+    assertTrue(e.getMessage().contains("does not match the surface form"));
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test
   public void testReadInvalid2() throws IOException {
     // the concatenated segment must be the same as the surface form
     String invalidEntry = "日本経済新聞,日経 新聞,ニッケイ シンブン,カスタム名詞";
-    UserDictionary dictionary = UserDictionary.open(new StringReader(invalidEntry));
+    RuntimeException e = expectThrows(RuntimeException.class,
+        "RuntimeException should be thrown when passed an invalid dictionary entry.",
+        () -> UserDictionary.open(new StringReader(invalidEntry)));
+    assertTrue(e.getMessage().contains("does not match the surface form"));
   }
 
 }


### PR DESCRIPTION
Use `LuceneTestCase#expectThrows()` instead of `expected`.