### PR TITLE
SOLR-13705 Double-checked locking bug is fixed.

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/admin/SecurityConfHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/SecurityConfHandler.java
@@ -260,22 +260,25 @@ public abstract class SecurityConfHandler extends RequestHandlerBase implements 
 
   @Override
   public Collection<Api> getApis() {
-    if (apis == null) {
+    Collection<Api> syncedApis = apis;
+    if (syncedApis == null) {
       synchronized (this) {
-        if (apis == null) {
-          Collection<Api> apis = new ArrayList<>();
+        syncedApis = apis;
+        if (syncedApis == null) {
+          syncedApis = new ArrayList<>();
+          apis = syncedApis;
           final SpecProvider authcCommands = Utils.getSpec("cluster.security.authentication.Commands");
           final SpecProvider authzCommands = Utils.getSpec("cluster.security.authorization.Commands");
-          apis.add(new ReqHandlerToApi(this, Utils.getSpec("cluster.security.authentication")));
-          apis.add(new ReqHandlerToApi(this, Utils.getSpec("cluster.security.authorization")));
+          syncedApis.add(new ReqHandlerToApi(this, Utils.getSpec("cluster.security.authentication")));
+          syncedApis.add(new ReqHandlerToApi(this, Utils.getSpec("cluster.security.authorization")));
           SpecProvider authcSpecProvider = () -> {
             AuthenticationPlugin authcPlugin = cores.getAuthenticationPlugin();
-            return authcPlugin != null && authcPlugin instanceof SpecProvider ?
+            return authcPlugin instanceof SpecProvider ?
                 ((SpecProvider) authcPlugin).getSpec() :
                 authcCommands.getSpec();
           };
 
-          apis.add(new ReqHandlerToApi(this, authcSpecProvider) {
+          syncedApis.add(new ReqHandlerToApi(this, authcSpecProvider) {
             @Override
             public synchronized Map<String, JsonSchemaValidator> getCommandSchema() {
               //it is possible that the Authentication plugin is modified since the last call. invalidate the
@@ -288,11 +291,11 @@ public abstract class SecurityConfHandler extends RequestHandlerBase implements 
 
           SpecProvider authzSpecProvider = () -> {
             AuthorizationPlugin authzPlugin = cores.getAuthorizationPlugin();
-            return authzPlugin != null && authzPlugin instanceof SpecProvider ?
+            return authzPlugin instanceof SpecProvider ?
                 ((SpecProvider) authzPlugin).getSpec() :
                 authzCommands.getSpec();
           };
-          apis.add(new ApiBag.ReqHandlerToApi(this, authzSpecProvider) {
+          syncedApis.add(new ApiBag.ReqHandlerToApi(this, authzSpecProvider) {
             @Override
             public synchronized Map<String, JsonSchemaValidator> getCommandSchema() {
               //it is possible that the Authorization plugin is modified since the last call. invalidate the
@@ -303,11 +306,11 @@ public abstract class SecurityConfHandler extends RequestHandlerBase implements 
             }
           });
 
-          this.apis = ImmutableList.copyOf(apis);
+          syncedApis = ImmutableList.copyOf(syncedApis);
         }
       }
     }
-    return this.apis;
+    return syncedApis;
   }
 
   @Override

--- a/solr/core/src/java/org/apache/solr/util/configuration/SSLConfigurationsFactory.java
+++ b/solr/core/src/java/org/apache/solr/util/configuration/SSLConfigurationsFactory.java
@@ -28,14 +28,17 @@ public class SSLConfigurationsFactory {
    * @return Configurations object
    */
   static public SSLConfigurations current() {
-    if (currentConfigurations == null) {
+    SSLConfigurations syncedCurrentConfigurations = currentConfigurations;
+    if (syncedCurrentConfigurations == null) {
       synchronized (SSLConfigurationsFactory.class) {
-        if (currentConfigurations == null) {
-          currentConfigurations = getInstance();
+        syncedCurrentConfigurations = currentConfigurations;
+        if (syncedCurrentConfigurations == null) {
+          syncedCurrentConfigurations = getInstance();
+          currentConfigurations = syncedCurrentConfigurations;
         }
       }
     }
-    return currentConfigurations;
+    return syncedCurrentConfigurations;
   }
 
   private static SSLConfigurations getInstance() {


### PR DESCRIPTION
# Description

Using double-checked locking for the lazy initialization of any other type of primitive or mutable object risks a second thread using an uninitialized or partially initialized member while the first thread is still creating it, and crashing the program.

# Solution

Double-checked locking bug is fixed to prevent it.

# Tests

No need to write extra tests. Existing tests should not fail after this implementation.

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I am authorized to contribute this code to the ASF and have removed any code I do not have a license to distribute.
- [X] I have developed this patch against the `master` branch.
- [X] I have run `ant precommit` and the appropriate test suite.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
