### PR TITLE
Shared PQ Based Early Termination for Concurrent Search

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/document/FeatureSortField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/FeatureSortField.java
@@ -160,5 +160,10 @@ final class FeatureSortField extends SortField {
     public int compareTop(int doc) throws IOException {
       return Float.compare(topValue, getValueForDoc(doc));
     }
+
+    @Override
+    public Float leafValue(int docID) throws IOException {
+      return getValueForDoc(docID);
+    }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/document/LatLonPointDistanceComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LatLonPointDistanceComparator.java
@@ -217,6 +217,12 @@ class LatLonPointDistanceComparator extends FieldComparator<Double> implements L
     return minValue;
   }
 
+  //TODO: Implement this
+  @Override
+  public Double leafValue(int docID) throws IOException {
+    throw new UnsupportedOperationException("This comparator does not support getting leaf values");
+  }
+
   // second half of the haversin calculation, used to convert results from haversin1 (used internally
   // for sorting) for display purposes.
   static double haversin2(double partial) {

--- a/lucene/core/src/java/org/apache/lucene/search/Collector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/Collector.java
@@ -77,4 +77,12 @@ public interface Collector {
    * Indicates what features are required from the scorer.
    */
   ScoreMode scoreMode();
+
+  /**
+   * Indicates that input has ended for the collector. This allows the collector to perform
+   * post processing (if any).
+   */
+  default void postProcess() {
+    // No-op
+  }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/EarlyTerminatingFieldCollectorManager.java
+++ b/lucene/core/src/java/org/apache/lucene/search/EarlyTerminatingFieldCollectorManager.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.search;
+
+import java.util.Collection;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.apache.lucene.search.TopFieldCollector.EMPTY_SCOREDOCS;
+
+/**
+ * CollectorManager which allows early termination across multiple slices
+ * when the index sort key and the query sort key are the same
+ */
+public class EarlyTerminatingFieldCollectorManager implements CollectorManager<TopFieldCollector, TopFieldDocs> {
+  private final Sort sort;
+  private final int numHits;
+  private final int totalHitsThreshold;
+  private final AtomicInteger globalTotalHits;
+  private final ReentrantLock lock;
+  private int numCollectors;
+
+  private final ConcurrentLinkedQueue<TopFieldCollector.EarlyTerminatingFieldCollector> mergeableCollectors;
+  private FieldValueHitQueue globalHitQueue;
+  private FieldValueHitQueue.Entry bottom;
+  // We do not make this Atomic since it will be sought under a lock
+  private int queueSlotCounter;
+  private final AtomicBoolean mergeStarted;
+  public final AtomicBoolean mergeCompleted;
+
+  public EarlyTerminatingFieldCollectorManager(Sort sort, int numHits, int totalHitsThreshold) {
+    this.sort = sort;
+    this.numHits = numHits;
+    this.totalHitsThreshold = totalHitsThreshold;
+    this.globalTotalHits = new AtomicInteger();
+    this.lock = new ReentrantLock();
+    this.mergeStarted = new AtomicBoolean();
+    this.mergeCompleted = new AtomicBoolean();
+    this.mergeableCollectors = new ConcurrentLinkedQueue();
+    this.globalHitQueue = null;
+  }
+
+  @Override
+  public TopFieldCollector.EarlyTerminatingFieldCollector newCollector() {
+    ++numCollectors;
+
+    return new TopFieldCollector.EarlyTerminatingFieldCollector(sort, FieldValueHitQueue.create(sort.fields, numHits), numHits,
+        totalHitsThreshold, this, globalTotalHits);
+  }
+
+  @Override
+  public TopFieldDocs reduce(Collection<TopFieldCollector> collectors) {
+
+    if (globalHitQueue == null) {
+      final TopFieldDocs[] topDocs = new TopFieldDocs[collectors.size()];
+      int i = 0;
+      for (TopFieldCollector collector : collectors) {
+        topDocs[i++] = collector.topDocs();
+      }
+      return TopDocs.merge(sort, 0, numHits, topDocs);
+    }
+
+    ScoreDoc[] results = populateResults(globalHitQueue.size());
+
+    return newTopDocs(results);
+  }
+
+  public int compareAndUpdateBottom(int docBase, int doc, Object value) {
+
+    try {
+      lock.lock();
+
+      // If not enough hits are accumulated, add this hit to the global hit queue
+      if (globalHitQueue.size() < numHits) {
+        FieldValueHitQueue.Entry newEntry = new FieldValueHitQueue.Entry(queueSlotCounter++, (doc + docBase), value);
+        bottom = (FieldValueHitQueue.Entry) globalHitQueue.add(newEntry);
+        return 1;
+      }
+
+      FieldComparator[] comparators = globalHitQueue.getComparators();
+      int[] reverseMul = globalHitQueue.getReverseMul();
+      Object bottomValues = bottom.values;
+      Object[] valuesArray;
+      Object[] bottomValuesArray;
+
+      if (comparators.length > 1) {
+        assert value instanceof Object[];
+        valuesArray = (Object[]) value;
+
+        assert bottomValues instanceof Object[];
+        bottomValuesArray = (Object[]) bottomValues;
+      } else {
+        valuesArray = new Object[1];
+        valuesArray[0] = value;
+
+        bottomValuesArray = new Object[1];
+        bottomValuesArray[0] = bottomValues;
+      }
+
+      int cmp;
+      int i = 0;
+      for (FieldComparator comparator : comparators) {
+        cmp = reverseMul[i] * comparator.compareValues(bottomValuesArray[i], valuesArray[i]);
+        ++i;
+
+        if (cmp != 0) {
+          if (cmp > 0) {
+            updateBottom(docBase, doc, value);
+          }
+
+          return cmp;
+        }
+      }
+
+      // For equal values, we choose the lower docID
+      if ((doc + docBase) < bottom.doc) {
+        updateBottom(docBase, doc, value);
+
+        // Return a value greater than 0 to signify replacement
+        return 1;
+      }
+
+      return 0;
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  private final void updateBottom(int docBase, int doc, Object values) {
+    bottom.doc = docBase + doc;
+    bottom.values = values;
+    bottom = (FieldValueHitQueue.Entry) globalHitQueue.updateTop();
+
+    assert bottom != null;
+  }
+
+  FieldValueHitQueue.Entry addCollectorToGlobalQueue(TopFieldCollector.EarlyTerminatingFieldCollector fieldCollector, int docBase) {
+    FieldValueHitQueue queue = fieldCollector.queue;
+
+    try {
+      lock.lock();
+      if (globalHitQueue == null) {
+        this.globalHitQueue = FieldValueHitQueue.createValuesComparingQueue(sort.fields, numHits);
+      }
+
+      FieldValueHitQueue.Entry entry = (FieldValueHitQueue.Entry) queue.pop();
+      while (entry != null) {
+        if (queueSlotCounter > numHits) {
+          throw new IllegalStateException("Global number exceeds number of hits. Current hit number " + queueSlotCounter + " numHits " + numHits);
+        }
+
+
+        if (globalHitQueue.size() > numHits) {
+          throw new IllegalStateException("WTF?");
+        }
+
+        // If hit count was already achieved, return this entry
+        if (globalHitQueue.size() == numHits) {
+          return entry;
+        }
+
+        FieldValueHitQueue.Entry newEntry = new FieldValueHitQueue.Entry(queueSlotCounter++, (entry.doc + docBase), entry.values);
+
+        bottom = (FieldValueHitQueue.Entry) globalHitQueue.add(newEntry);
+
+        entry = (FieldValueHitQueue.Entry) queue.pop();
+      }
+    } finally {
+      lock.unlock();
+    }
+
+    return null;
+  }
+
+  private ScoreDoc[] populateResults(int howMany) {
+    ScoreDoc[] results = new ScoreDoc[howMany];
+    // avoid casting if unnecessary.
+    for (int i = howMany - 1; i >= 0; i--) {
+      results[i] = globalHitQueue.fillFields((FieldValueHitQueue.Entry) globalHitQueue.pop());
+    }
+
+    return results;
+  }
+
+  protected TopFieldDocs newTopDocs(ScoreDoc[] results) {
+    if (results == null) {
+      results = EMPTY_SCOREDOCS;
+    }
+
+    //TODO: atris -- Is the relation correct, since we are early terminating?
+    return new TopFieldDocs(new TotalHits(results.length, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO), results, globalHitQueue.getFields());
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/search/FieldComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FieldComparator.java
@@ -219,6 +219,11 @@ public abstract class FieldComparator<T> {
     public int compareTop(int doc) throws IOException {
       return Double.compare(topValue, getValueForDoc(doc));
     }
+
+    @Override
+    public Double leafValue(int docID) throws IOException {
+      return getValueForDoc(docID);
+    }
   }
 
   /** Parses field's values as float (using {@link
@@ -278,6 +283,11 @@ public abstract class FieldComparator<T> {
     @Override
     public int compareTop(int doc) throws IOException {
       return Float.compare(topValue, getValueForDoc(doc));
+    }
+
+    @Override
+    public Float leafValue(int docID) throws IOException {
+      return getValueForDoc(docID);
     }
   }
 
@@ -341,6 +351,11 @@ public abstract class FieldComparator<T> {
     public int compareTop(int doc) throws IOException {
       return Integer.compare(topValue, getValueForDoc(doc));
     }
+
+    @Override
+    public Integer leafValue(int docID) throws IOException {
+      return getValueForDoc(docID);
+    }
   }
 
   /** Parses field's values as long (using {@link
@@ -400,6 +415,11 @@ public abstract class FieldComparator<T> {
     @Override
     public int compareTop(int doc) throws IOException {
       return Long.compare(topValue, getValueForDoc(doc));
+    }
+
+    @Override
+    public Long leafValue(int docID) throws IOException {
+      return getValueForDoc(docID);
     }
   }
 
@@ -484,6 +504,11 @@ public abstract class FieldComparator<T> {
       assert !Float.isNaN(docValue);
       return Float.compare(docValue, topValue);
     }
+
+    @Override
+    public Float leafValue(int docID) throws IOException {
+      return scorer.score();
+    }
   }
 
   /** Sorts by ascending docID */
@@ -543,6 +568,11 @@ public abstract class FieldComparator<T> {
     public int compareTop(int doc) {
       int docValue = docBase + doc;
       return Integer.compare(topValue, docValue);
+    }
+
+    @Override
+    public Integer leafValue(int docID) throws IOException {
+      return docBase + docID;
     }
 
     @Override
@@ -684,6 +714,11 @@ public abstract class FieldComparator<T> {
       } else {
         return -1;
       }
+    }
+
+    @Override
+    public Integer leafValue(int docID) throws IOException {
+      return getOrdForDoc(docID);
     }
 
     @Override
@@ -927,5 +962,10 @@ public abstract class FieldComparator<T> {
 
     @Override
     public void setScorer(Scorable scorer) {}
+
+    @Override
+    public BytesRef leafValue(int docID) throws IOException {
+      return getValueForDoc(docID);
+    }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -726,6 +726,7 @@ public class IndexSearcher {
         }
       }
     }
+    collector.postProcess();
   }
 
   /** Expert: called to re-write queries into primitive queries.

--- a/lucene/core/src/java/org/apache/lucene/search/LeafFieldComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/LeafFieldComparator.java
@@ -51,7 +51,7 @@ import java.io.IOException;
  * @see FieldComparator
  * @lucene.experimental
  */
-public interface LeafFieldComparator {
+public interface LeafFieldComparator<T> {
 
   /**
    * Set the bottom slot, ie the "weakest" (sorted last)
@@ -116,4 +116,7 @@ public interface LeafFieldComparator {
    * obtain the current hit's score, if necessary. */
   void setScorer(Scorable scorer) throws IOException;
 
+  /** Publishes feature values for the given docID
+   */
+  T leafValue(int doc) throws IOException;
 }

--- a/lucene/core/src/java/org/apache/lucene/search/MultiLeafFieldComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiLeafFieldComparator.java
@@ -89,4 +89,15 @@ final class MultiLeafFieldComparator implements LeafFieldComparator {
     }
   }
 
+  @Override
+  public Object leafValue(int docID) throws IOException {
+    Object[] valuesArray = new Object[comparators.length];
+
+    for (int i = 0; i < comparators.length; i++) {
+      valuesArray[i] = comparators[i].leafValue(docID);
+    }
+
+    return valuesArray;
+  }
+
 }

--- a/lucene/core/src/java/org/apache/lucene/search/TopDocsCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TopDocsCollector.java
@@ -17,7 +17,6 @@
 package org.apache.lucene.search;
 
 
-
 import org.apache.lucene.util.PriorityQueue;
 
 /**

--- a/lucene/core/src/test/org/apache/lucene/search/TestEarlyTerminationFieldCM.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestEarlyTerminationFieldCM.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.search;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import com.carrotsearch.randomizedtesting.generators.RandomPicks;
+import org.apache.lucene.analysis.MockAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.MockRandomMergePolicy;
+import org.apache.lucene.index.RandomIndexWriter;
+import org.apache.lucene.index.SerialMergeScheduler;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.LuceneTestCase;
+import org.apache.lucene.util.NamedThreadFactory;
+import org.apache.lucene.util.TestUtil;
+
+public class TestEarlyTerminationFieldCM extends LuceneTestCase {
+  private int numDocs;
+  private List<String> terms;
+  private Directory dir;
+  private final Sort sort = new Sort(new SortField("ndv1", SortField.Type.LONG));
+  private RandomIndexWriter iw;
+  private IndexReader reader;
+  private static final int FORCE_MERGE_MAX_SEGMENT_COUNT = 5;
+
+  private Document randomDocument() {
+    final Document doc = new Document();
+    doc.add(new NumericDocValuesField("ndv1", random().nextInt(10)));
+    doc.add(new NumericDocValuesField("ndv2", random().nextInt(10)));
+    doc.add(new StringField("s", RandomPicks.randomFrom(random(), terms), Field.Store.YES));
+    return doc;
+  }
+
+  private void createRandomIndex(boolean singleSortedSegment) throws IOException {
+    dir = newDirectory();
+    numDocs = TestUtil.nextInt(random(), 20, 50);
+    final int numTerms = TestUtil.nextInt(random(), 1, numDocs / 5);
+    Set<String> randomTerms = new HashSet<>();
+    while (randomTerms.size() < numTerms) {
+      randomTerms.add(TestUtil.randomSimpleString(random()));
+    }
+    terms = new ArrayList<>(randomTerms);
+    final long seed = random().nextLong();
+    final IndexWriterConfig iwc = newIndexWriterConfig(new MockAnalyzer(new Random(seed)));
+    if (iwc.getMergePolicy() instanceof MockRandomMergePolicy) {
+      // MockRandomMP randomly wraps the leaf readers which makes merging angry
+      iwc.setMergePolicy(newTieredMergePolicy());
+    }
+    iwc.setMergeScheduler(new SerialMergeScheduler()); // for reproducible tests
+    iwc.setIndexSort(sort);
+    iw = new RandomIndexWriter(new Random(seed), dir, iwc);
+    iw.setDoRandomForceMerge(false); // don't do this, it may happen anyway with MockRandomMP
+    for (int i = 0; i < numDocs; ++i) {
+      final Document doc = randomDocument();
+      iw.addDocument(doc);
+      if (i == numDocs / 2 || (i != numDocs - 1 && random().nextInt(8) == 0)) {
+        iw.commit();
+      }
+    }
+    if (singleSortedSegment) {
+      iw.forceMerge(1);
+    }
+    else if (random().nextBoolean()) {
+      iw.forceMerge(FORCE_MERGE_MAX_SEGMENT_COUNT);
+    }
+    reader = iw.getReader();
+    if (reader.numDocs() == 0) {
+      iw.addDocument(new Document());
+      reader.close();
+      reader = iw.getReader();
+    }
+  }
+
+  private void createStaticIndex() throws IOException {
+    dir = newDirectory();
+    numDocs = TestUtil.nextInt(random(), 20, 50);
+    final long seed = random().nextLong();
+    final IndexWriterConfig iwc = newIndexWriterConfig(new MockAnalyzer(new Random(seed)));
+    iwc.setIndexSort(sort);
+    iw = new RandomIndexWriter(new Random(seed), dir, iwc);
+
+    for (int i = 0; i < numDocs; ++i) {
+      final Document doc = new Document();
+      doc.add(new StringField("s1", "foo1", Field.Store.YES));
+      doc.add(new StringField("s2", "foo2", Field.Store.YES));
+      iw.addDocument(doc);
+      if (i == numDocs / 5) {
+        iw.commit();
+      }
+    }
+
+    // One document with a special value
+    final Document doc = new Document();
+    doc.add(new StringField("s3", "foo3", Field.Store.YES));
+
+    iw.addDocument(doc);
+
+    reader = iw.getReader();
+  }
+
+  private void closeIndex() throws IOException {
+    reader.close();
+    iw.close();
+    dir.close();
+  }
+
+  public void testGlobalStateEarlyTermination() throws IOException {
+    createRandomIndex(false);
+    ExecutorService service = new ThreadPoolExecutor(4, 4, 0L, TimeUnit.MILLISECONDS,
+        new LinkedBlockingQueue<Runnable>(),
+        new NamedThreadFactory("TestGlobalStateCMEarlyTermination"));
+    final IndexSearcher searcher = new SmallSliceSizeIndexSearcher(reader, service);
+    final int numHits = TestUtil.nextInt(random(), 2, 5);
+    final int totalHitsThreshold = TestUtil.nextInt(random(), 1, (numHits - 1));
+
+    final EarlyTerminatingFieldCollectorManager collectorManager = new EarlyTerminatingFieldCollectorManager(sort, numHits, totalHitsThreshold);
+    final TopFieldCollector collector1 = TopFieldCollector.create(sort, numHits, null, totalHitsThreshold);
+
+    final Query query;
+    if (random().nextBoolean()) {
+      query = new TermQuery(new Term("s", RandomPicks.randomFrom(random(), terms)));
+    } else {
+      query = new MatchAllDocsQuery();
+    }
+    TopDocs td2 = searcher.search(query, collectorManager);
+    searcher.search(query, collector1);
+    TopDocs td1 = collector1.topDocs();
+
+    assertTrue("Values were different " + td2.totalHits.value + " " + td1.scoreDocs.length,
+        td2.totalHits.value >= td1.scoreDocs.length);
+    assertTrue(td2.totalHits.value <= reader.maxDoc());
+    CheckHits.checkEqual(query, td1.scoreDocs, td2.scoreDocs);
+    closeIndex();
+    service.shutdown();
+  }
+
+  public void testGlobalStateSingleSegmentEarlyTermination() throws IOException {
+    createRandomIndex(true);
+    ExecutorService service = new ThreadPoolExecutor(4, 4, 0L, TimeUnit.MILLISECONDS,
+        new LinkedBlockingQueue<Runnable>(),
+        new NamedThreadFactory("TestGlobalStateCMEarlyTermination"));
+    final IndexSearcher searcher = new SmallSliceSizeIndexSearcher(reader, service);
+    final int numHits = TestUtil.nextInt(random(), 1, numDocs);
+    final int totalHitsThreshold = TestUtil.nextInt(random(), 1, (numHits - 1) > 0 ? (numHits -1) : 2);
+
+    final EarlyTerminatingFieldCollectorManager collectorManager = new EarlyTerminatingFieldCollectorManager(sort, numHits, totalHitsThreshold);
+    final TopFieldCollector collector1 = TopFieldCollector.create(sort, numHits, null, Integer.MAX_VALUE);
+
+    final Query query;
+    if (random().nextBoolean()) {
+      query = new TermQuery(new Term("s", RandomPicks.randomFrom(random(), terms)));
+    } else {
+      query = new MatchAllDocsQuery();
+    }
+    TopDocs td2 = searcher.search(query, collectorManager);
+    searcher.search(query, collector1);
+    TopDocs td1 = collector1.topDocs();
+
+    assertFalse(collector1.isEarlyTerminated());
+    assertTrue(td2.totalHits.value >= td1.scoreDocs.length);
+    assertTrue(td2.totalHits.value <= reader.maxDoc());
+    CheckHits.checkEqual(query, td1.scoreDocs, td2.scoreDocs);
+    closeIndex();
+    service.shutdown();
+  }
+
+  public void testOneDocumentHasHigherScoreThanAll() throws IOException {
+    createStaticIndex();
+    ExecutorService service = new ThreadPoolExecutor(4, 4, 0L, TimeUnit.MILLISECONDS,
+        new LinkedBlockingQueue<Runnable>(),
+        new NamedThreadFactory("TestGlobalStateCMEarlyTermination"));
+    final IndexSearcher searcher = new SmallSliceSizeIndexSearcher(reader, service);
+    final int numHits = TestUtil.nextInt(random(), 1, numDocs);
+    final int totalHitsThreshold = TestUtil.nextInt(random(), 1, (numHits - 1) > 0 ? (numHits - 1) : 2);
+
+    final EarlyTerminatingFieldCollectorManager collectorManager = new EarlyTerminatingFieldCollectorManager(sort, numHits, totalHitsThreshold);
+    final TopFieldCollector collector1 = TopFieldCollector.create(sort, numHits, null, Integer.MAX_VALUE);
+
+    BooleanQuery.Builder builder = new BooleanQuery.Builder();
+    builder.add(new TermQuery(new Term("s1", "foo1")), BooleanClause.Occur.MUST);
+    builder.add(new TermQuery(new Term("s2", "foo2")), BooleanClause.Occur.SHOULD);
+    Query query = builder.build();
+    TopDocs td2 = searcher.search(query, collectorManager);
+    searcher.search(query, collector1);
+    TopDocs td1 = collector1.topDocs();
+
+    assertFalse(collector1.isEarlyTerminated());
+    assertTrue("Values did not match " + td1.totalHits.value + " " + td1.scoreDocs.length,
+        td2.totalHits.value >= td1.scoreDocs.length);
+    assertTrue(td2.totalHits.value <= reader.maxDoc());
+    CheckHits.checkEqual(query, td1.scoreDocs, td2.scoreDocs);
+    closeIndex();
+    service.shutdown();
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/search/TestElevationComparator.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestElevationComparator.java
@@ -194,6 +194,11 @@ class ElevationComparatorSource extends FieldComparatorSource {
 
         @Override
         public void setScorer(Scorable scorer) {}
+
+        @Override
+        public Integer leafValue(int docID) throws IOException {
+          return docVal(docID);
+        }
       };
     }
 
@@ -211,7 +216,6 @@ class ElevationComparatorSource extends FieldComparatorSource {
      public Integer value(int slot) {
        return Integer.valueOf(values[slot]);
      }
-
 
    };
  }

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/ValueSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/ValueSource.java
@@ -442,5 +442,10 @@ public abstract class ValueSource {
       final double docValue = docVals.doubleVal(doc);
       return Double.compare(topValue, docValue);
     }
+
+    @Override
+    public Double leafValue(int docID) throws IOException {
+      return docVals.doubleVal(docID);
+    }
   }
 }

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/Geo3DPointDistanceComparator.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/Geo3DPointDistanceComparator.java
@@ -150,6 +150,11 @@ class Geo3DPointDistanceComparator extends FieldComparator<Double> implements Le
     return Double.compare(topValue, computeMinimumDistance(doc));
   }
 
+  @Override
+  public Double leafValue(int docID) throws IOException {
+    return computeMinimumDistance(docID);
+  }
+
   double computeMinimumDistance(final int doc) throws IOException {
     if (doc > currentDocs.docID()) {
       currentDocs.advance(doc);

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/Geo3DPointOutsideDistanceComparator.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/Geo3DPointOutsideDistanceComparator.java
@@ -121,6 +121,11 @@ class Geo3DPointOutsideDistanceComparator extends FieldComparator<Double> implem
     return Double.compare(topValue, computeMinimumDistance(doc));
   }
 
+  @Override
+  public Double leafValue(int docID) throws IOException {
+    return computeMinimumDistance(docID);
+  }
+
   double computeMinimumDistance(final int doc) throws IOException {
     if (doc > currentDocs.docID()) {
       currentDocs.advance(doc);

--- a/lucene/test-framework/src/java/org/apache/lucene/search/SmallSliceSizeIndexSearcher.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/search/SmallSliceSizeIndexSearcher.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.search;
+
+import java.util.List;
+import java.util.concurrent.Executor;
+
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReaderContext;
+
+/**
+ * An {@link IndexSearcher} that has a smaller size limit for slices, allowing higher slice count with lesser
+ * number of documents
+ */
+public class SmallSliceSizeIndexSearcher extends IndexSearcher {
+
+  private static final int MAX_DOCS_PER_SLICE = 10;
+  private static final int MAX_SEGMENTS_PER_SLICE = 5;
+
+  /** Creates a searcher searching the provided index. Search on individual
+   *  segments will be run in the provided {@link Executor}.
+   * @see IndexSearcher#IndexSearcher(IndexReader, Executor) */
+  public SmallSliceSizeIndexSearcher(IndexReader r, Executor executor) {
+    super(r, executor);
+  }
+
+  @Override
+  protected LeafSlice[] slices(List<LeafReaderContext> leaves) {
+    return slices(leaves, MAX_DOCS_PER_SLICE, MAX_SEGMENTS_PER_SLICE);
+  }
+
+}

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryElevationComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryElevationComponent.java
@@ -1220,6 +1220,11 @@ public class QueryElevationComponent extends SearchComponent implements SolrCore
           final int docValue = docVal(doc);
           return topVal - docValue;  // values will be small enough that there is no overflow concern
         }
+
+        @Override
+        public Integer leafValue(int docID) throws IOException {
+          return docVal(docID);
+        }
       };
     }
   }

--- a/solr/core/src/java/org/apache/solr/schema/RandomSortField.java
+++ b/solr/core/src/java/org/apache/solr/schema/RandomSortField.java
@@ -154,6 +154,11 @@ public class RandomSortField extends FieldType {
           // values will be positive... no overflow possible.
           return topVal - hash(doc+seed);
         }
+
+        @Override
+        public Integer leafValue(int docID) throws IOException {
+          return hash(docID + seed);
+        }
       };
     }
   };


### PR DESCRIPTION
NOCOMMIT.

This is a WIP PR which implements a shared PQ based early termination. Each collector collects independently into a thread local PQ and updates a global count of hits (which will be refactored post merging of LUCENE-8939).

Once enough hits are accumulated, a global PQ is populated by all collectors and then the global PQ serves as the benchmark to filter further hits.

Several optimizations have been performed, such as non blocking building of global PQ, no reduce operation performed during CollectorManager.reduce but rather, returning results directly from the global PQ.

I need some eyes on the overall logic, and especially at two points: 1) Across segment values comparison and 2) Local to global DocID mapping during interactions of thread local PQs and global PQ. I am pretty sure there is a bug in either of the two, so would really appreciate a deep look.