### PR TITLE
SOLR-13739: Improve performance on huge schema updates

### DIFF
--- a/solr/core/src/java/org/apache/solr/rest/ManagedResource.java
+++ b/solr/core/src/java/org/apache/solr/rest/ManagedResource.java
@@ -18,6 +18,7 @@ package org.apache.solr.rest;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
+import java.util.Collection;
 import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -79,7 +80,7 @@ public abstract class ManagedResource {
    * Called once during core initialization to get the managed
    * data loaded from storage and notify observers.
    */
-  public void loadManagedDataAndNotify(List<ManagedResourceObserver> observers) 
+  public void loadManagedDataAndNotify(Collection<ManagedResourceObserver> observers) 
       throws SolrException {
 
     // load managed data from storage
@@ -101,8 +102,7 @@ public abstract class ManagedResource {
    * reload the core to get updates applied to the analysis components that
    * depend on the ManagedResource data.
    */
-  @SuppressWarnings("unchecked")
-  protected void notifyObserversDuringInit(NamedList<?> args, List<ManagedResourceObserver> observers)
+  protected void notifyObserversDuringInit(NamedList<?> args, Collection<ManagedResourceObserver> observers)
       throws SolrException {
 
     if (observers == null || observers.isEmpty())

--- a/solr/core/src/java/org/apache/solr/rest/RestManager.java
+++ b/solr/core/src/java/org/apache/solr/rest/RestManager.java
@@ -16,6 +16,8 @@
  */
 package org.apache.solr.rest;
 
+import static org.apache.solr.common.util.Utils.fromJSONString;
+
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
@@ -25,6 +27,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -50,8 +53,6 @@ import org.restlet.routing.Router;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.solr.common.util.Utils.fromJSONString;
-
 /**
  * Supports runtime mapping of REST API endpoints to ManagedResource 
  * implementations; endpoints can be registered at either the /schema
@@ -76,7 +77,7 @@ public class RestManager {
   private static class ManagedResourceRegistration {
     String resourceId;
     Class<? extends ManagedResource> implClass;
-    List<ManagedResourceObserver> observers = new ArrayList<>();
+    Set<ManagedResourceObserver> observers = new LinkedHashSet<>();
 
     private ManagedResourceRegistration(String resourceId,
                                         Class<? extends ManagedResource> implClass, 
@@ -229,7 +230,7 @@ public class RestManager {
       }
       
       // there may be a RestManager, in which case, we want to add this new ManagedResource immediately
-      if (initializedRestManager != null) {
+      if (initializedRestManager != null && initializedRestManager.getManagedResourceOrNull(resourceId) == null) {
         initializedRestManager.addRegisteredResource(registered.get(resourceId));
       }
     }    


### PR DESCRIPTION
Affects schemas containing ResourceLoaderAware components, increases
creation of a new collection with a huge schema by a factor 60 to 100.

<!--
Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

Please provide a short description of the changes you're making with this pull request.

# Solution

Please provide a short description of the approach taken to implement your solution.

# Tests

Please describe the tests you've developed or run to confirm this patch implements the feature or solves the problem.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I am authorized to contribute this code to the ASF and have removed any code I do not have a license to distribute.
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
