### PR TITLE
LUCENE-8964: Fix geojson shape parsing on string arrays in properties

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -56,6 +56,9 @@ Improvements
 * LUCENE-8937: Avoid agressive stemming on numbers in the FrenchMinimalStemmer.
   (Adrien Gallou via Tomoko Uchida)
 
+* LUCENE-8964: Fix geojson shape parsing on string arrays in properties 
+  (Alexander Reelsen)
+
 Bug fixes
 
 * LUCENE-8663: NRTCachingDirectory.slowFileExists may open a file while 

--- a/lucene/core/src/java/org/apache/lucene/geo/SimpleGeoJSONPolygonParser.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/SimpleGeoJSONPolygonParser.java
@@ -295,6 +295,8 @@ class SimpleGeoJSONPolygonParser {
         o = null;
       } else if (ch == '-' || ch == '.' || (ch >= '0' && ch <= '9')) {
         o = parseNumber();
+      } else if (ch == '"') {
+        o = parseString();
       } else {
         throw newParseException("expected another array or number while parsing array, not '" + ch + "'");
       }

--- a/lucene/core/src/test/org/apache/lucene/geo/TestPolygon.java
+++ b/lucene/core/src/test/org/apache/lucene/geo/TestPolygon.java
@@ -300,4 +300,21 @@ public class TestPolygon extends LuceneTestCase {
     Exception e = expectThrows(ParseException.class, () -> Polygon.fromGeoJSON(b.toString()));
     assertTrue(e.getMessage().contains("can only handle type FeatureCollection (if it has a single polygon geometry), Feature, Polygon or MutiPolygon, but got Point"));
   }
+
+  public void testPolygonPropertiesCanBeStringArrays() throws Exception {
+    StringBuilder b = new StringBuilder();
+    b.append("{\n");
+    b.append("  \"type\": \"Polygon\",\n");
+    b.append("  \"coordinates\": [\n");
+    b.append("    [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0],\n");
+    b.append("      [100.0, 1.0], [100.0, 0.0] ]\n");
+    b.append("  ],\n");
+    b.append("  \"properties\": {\n");
+    b.append("    \"array\": [ \"value\" ]\n");
+    b.append("  }\n");
+    b.append("}\n");
+
+    Polygon[] polygons = Polygon.fromGeoJSON(b.toString());
+    assertEquals(1, polygons.length);
+  }
 }


### PR DESCRIPTION
# Description

The builtin geo shape parser throws an exception when the properties contains an array of strings.

# Solution

Allow parsing of such arrays by reading strings.

# Tests

Add unit test has been added for this case.

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I am authorized to contribute this code to the ASF and have removed any code I do not have a license to distribute.
- [X] I have developed this patch against the `master` branch.
- [X] I have run `ant precommit` and the appropriate test suite.
- [X] I have added tests for my changes.
