### PR TITLE
SOLR-13760 - restore viability of date math in TRA start property

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/TimeRoutedAlias.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/TimeRoutedAlias.java
@@ -355,7 +355,11 @@ public class TimeRoutedAlias extends RoutedAlias {
     // Although this is also checked later, we need to check it here too to handle the case in Dimensional Routed
     // aliases where one can legally have zero collections for a newly encountered category and thus the loop later
     // can't catch this.
-    Instant startTime = parseRouteKey(start);
+
+    // SOLR-13760
+    // todo: we might want to think about converting datemath start times to an instant when the first collection
+    //  is created...
+    Instant startTime = DateMathParser.parseMath(new Date(), start).toInstant();
     if (docTimestamp.isBefore(startTime)) {
       throw new SolrException(BAD_REQUEST, "The document couldn't be routed because " + docTimestamp +
           " is before the start time for this alias " +start+")");

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/TimeRoutedAlias.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/TimeRoutedAlias.java
@@ -24,12 +24,14 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -47,6 +49,7 @@ import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.MapSolrParams;
 import org.apache.solr.common.params.RequiredSolrParams;
+import org.apache.solr.core.SolrCore;
 import org.apache.solr.update.AddUpdateCommand;
 import org.apache.solr.update.processor.RoutedAliasUpdateProcessor;
 import org.apache.solr.util.DateMathParser;
@@ -356,10 +359,30 @@ public class TimeRoutedAlias extends RoutedAlias {
     // aliases where one can legally have zero collections for a newly encountered category and thus the loop later
     // can't catch this.
 
-    // SOLR-13760
-    // todo: we might want to think about converting datemath start times to an instant when the first collection
-    //  is created...
-    Instant startTime = DateMathParser.parseMath(new Date(), start).toInstant();
+    // SOLR-13760 - we need to fix the date math to a specific instant when the first document arrives.
+    // If we don't do this DRA's with a time dimension have variable start times across the other dimensions
+    // and logic gets much to complicated, and depends too much on queries to zookeeper. This keeps life simpler.
+    // I have to admit I'm not terribly fond of the mutation during a validate method however.
+    Instant startTime;
+    try {
+      startTime = Instant.parse(start);
+    } catch (DateTimeParseException e) {
+      startTime = DateMathParser.parseMath(new Date(), start).toInstant();
+      SolrCore core = cmd.getReq().getCore();
+      ZkStateReader zkStateReader = core.getCoreContainer().getZkController().zkStateReader;
+      Aliases aliases = zkStateReader.getAliases();
+      Map<String, String> props = new HashMap<>(aliases.getCollectionAliasProperties(aliasName));
+      start = DateTimeFormatter.ISO_INSTANT.format(startTime);
+      props.put(ROUTER_START, start);
+
+      // This could race, but it only occurs when the alias is first used and the values produced
+      // should all be identical and who wins won't matter (baring cases of Date Math involving seconds,
+      // which is pretty far fetched). Putting this in a separate thread to ensure that any failed
+      // races don't cause documents to get rejected.
+      core.runAsync(() -> zkStateReader.aliasesManager.applyModificationAndExportToZk(
+          (a) -> aliases.cloneWithCollectionAliasProperties(aliasName, props)));
+
+    }
     if (docTimestamp.isBefore(startTime)) {
       throw new SolrException(BAD_REQUEST, "The document couldn't be routed because " + docTimestamp +
           " is before the start time for this alias " +start+")");

--- a/solr/core/src/test/org/apache/solr/update/processor/DimensionalRoutedAliasUpdateProcessorTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/DimensionalRoutedAliasUpdateProcessorTest.java
@@ -686,7 +686,8 @@ public class DimensionalRoutedAliasUpdateProcessorTest extends RoutedAliasUpdate
       final Object errors = resp.getResponseHeader().get("errors"); // Tolerant URP
       assertTrue(errors != null && errors.toString().contains(errorMsg));
     } catch (SolrException e) {
-      assertTrue(e.getMessage().contains(errorMsg));
+      String message = e.getMessage();
+      assertTrue("expected message to contain" + errorMsg + " but message was " + message , message.contains(errorMsg));
     }
     numDocsDeletedOrFailed++;
   }

--- a/solr/core/src/test/org/apache/solr/update/processor/TimeRoutedAliasUpdateProcessorTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/TimeRoutedAliasUpdateProcessorTest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collections;
@@ -53,6 +54,10 @@ import org.apache.solr.common.util.Utils;
 import org.apache.solr.update.UpdateCommand;
 import org.apache.solr.util.DateMathParser;
 import org.apache.solr.util.LogLevel;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.data.Stat;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -61,6 +66,7 @@ import org.slf4j.LoggerFactory;
 
 import static org.apache.solr.client.solrj.RoutedAliasTypes.TIME;
 import static org.apache.solr.cloud.api.collections.RoutedAlias.ROUTED_ALIAS_NAME_CORE_PROP;
+import static org.apache.solr.cloud.api.collections.TimeRoutedAlias.ROUTER_START;
 import static org.apache.solr.common.cloud.ZkStateReader.COLLECTIONS_ZKNODE;
 import static org.apache.solr.common.cloud.ZkStateReader.COLLECTION_PROPS_ZKNODE;
 
@@ -710,11 +716,16 @@ public class TimeRoutedAliasUpdateProcessorTest extends RoutedAliasUpdateProcess
 
   @Test
   public void testDateMathInStart() throws Exception {
+    ClusterStateProvider clusterStateProvider = solrClient.getClusterStateProvider();
+    Class<? extends ClusterStateProvider> aClass = clusterStateProvider.getClass();
+    System.out.println("CSPROVIDER:" + aClass);
 
     // This test prevents recurrence of SOLR-13760
 
     String configName = getSaferTestName();
     createConfigSet(configName);
+    CountDownLatch aliasUpdate = new CountDownLatch(1);
+    monitorAlias(aliasUpdate);
 
     // each collection has 4 shards with 3 replicas for 12 possible destinations
     // 4 of which are leaders, and 8 of which should fail this test.
@@ -725,11 +736,44 @@ public class TimeRoutedAliasUpdateProcessorTest extends RoutedAliasUpdateProcess
             .setMaxShardsPerNode(numReplicas))
         .process(solrClient);
 
+    aliasUpdate.await();
+    if (BaseHttpClusterStateProvider.class.isAssignableFrom(aClass)) {
+      ((BaseHttpClusterStateProvider)clusterStateProvider).resolveAlias(getAlias(), true);
+    }
+    aliasUpdate = new CountDownLatch(1);
+    monitorAlias(aliasUpdate);
+
     ModifiableSolrParams params = params();
     String nowDay = DateTimeFormatter.ISO_INSTANT.format(DateMathParser.parseMath(new Date(), "2019-09-14T01:00:00Z").toInstant());
     assertUpdateResponse(add(alias, Arrays.asList(
         sdoc("id", "1", "timestamp_dt", nowDay)), // should not cause preemptive creation of 10-28 now
         params));
+
+    // this process should have lead to the modification of the start time for the alias, converting it into
+    // a parsable date, removing the DateMath
+
+    // what we test next happens in a separate thread, so we have to give it some time to happen
+    aliasUpdate.await();
+    if (BaseHttpClusterStateProvider.class.isAssignableFrom(aClass)) {
+      ((BaseHttpClusterStateProvider)clusterStateProvider).resolveAlias(getAlias(), true);
+    }
+
+    String hopeFullyModified = clusterStateProvider.getAliasProperties(getAlias()).get(ROUTER_START);
+    try {
+      Instant.parse(hopeFullyModified);
+    } catch (DateTimeParseException e) {
+      fail(ROUTER_START + " should not have any date math by this point and parse as an instant. Using "+ aClass +" Found:" + hopeFullyModified);
+    }
+  }
+
+  private void monitorAlias(CountDownLatch aliasUpdate) throws KeeperException, InterruptedException {
+    Stat stat = new Stat();
+    zkClient().getData("/aliases.json", new Watcher() {
+      @Override
+      public void process(WatchedEvent watchedEvent) {
+        aliasUpdate.countDown();
+      }
+    }, stat, true);
   }
 
   /**


### PR DESCRIPTION
<!--
Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

Fix Date math parsing for TRA start

# Solution

Invoke the DateMathParser.parseMath method rather than using the parseRouteKey method.

# Tests

Added a test that fails without the fix to ensure support for date math is not lost again.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I am authorized to contribute this code to the ASF and have removed any code I do not have a license to distribute.
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [x] I have added tests for my changes.
- [x] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
