### PR TITLE
LUCENE-8979: Code Cleanup: Use entryset for map iteration wherever possible. - part 2

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -211,7 +211,7 @@ Other
 
 * LUCENE-8758: QuadPrefixTree: removed levelS and levelN fields which weren't used. (Amish Shah)
 
-* LUCENE-8975: Code Cleanup: Use entryset for map iteration wherever possible.
+* LUCENE-8975: Code Cleanup: Use entryset for map iteration wherever possible. (Koen De Groote)
 
 * LUCENE-8993, LUCENE-8807: Changed all repository and download references in build files
   to HTTPS. (Uwe Schindler)
@@ -220,6 +220,8 @@ Other
 
 * LUCENE-8999: LuceneTestCase.expectThrows now propogates assert/assumption failures up to the test
   w/o wrapping in a new assertion failure unless the caller has explicitly expected them (hossman)
+
+* LUCENE-8979: Code Cleanup: Use entryset for map iteration wherever possible. - Part 2 (Koen De Groote)
 
 ======================= Lucene 8.2.0 =======================
 

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/query/QueryAutoStopWordAnalyzer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/query/QueryAutoStopWordAnalyzer.java
@@ -200,10 +200,12 @@ public final class QueryAutoStopWordAnalyzer extends AnalyzerWrapper {
    */
   public Term[] getStopWords() {
     List<Term> allStopWords = new ArrayList<>();
-    for (String fieldName : stopWordsPerField.keySet()) {
-      Set<String> stopWords = stopWordsPerField.get(fieldName);
+    for (Map.Entry<String, Set<String>> entry : stopWordsPerField.entrySet()) {
+      String field = entry.getKey();
+      Set<String> stopWords = entry.getValue();
+
       for (String text : stopWords) {
-        allStopWords.add(new Term(fieldName, text));
+        allStopWords.add(new Term(field, text));
       }
     }
     return allStopWords.toArray(new Term[allStopWords.size()]);

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/utils/Config.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/utils/Config.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.StringTokenizer;
 
@@ -276,8 +277,9 @@ public class Config {
     // log changes in values
     if (valByRound.size() > 0) {
       sb.append(": ");
-      for (final String name : valByRound.keySet()) {
-        Object a = valByRound.get(name);
+      for (final Map.Entry<String, Object> entry : valByRound.entrySet()) {
+        final String name = entry.getKey();
+        Object a = entry.getValue();
         if (a instanceof int[]) {
           int ai[] = (int[]) a;
           int n1 = (roundNumber - 1) % ai.length;
@@ -388,9 +390,8 @@ public class Config {
       return "";
     }
     StringBuilder sb = new StringBuilder();
-    for (final String name : colForValByRound.keySet()) {
-      String colName = colForValByRound.get(name);
-      sb.append(" ").append(colName);
+    for (final String colName : colForValByRound.values()) {
+      sb.append(' ').append(colName);
     }
     return sb.toString();
   }
@@ -403,15 +404,17 @@ public class Config {
       return "";
     }
     StringBuilder sb = new StringBuilder();
-    for (final String name : colForValByRound.keySet()) {
-      String colName = colForValByRound.get(name);
+    for (final Map.Entry<String, String> entry : colForValByRound.entrySet()) {
+      String colName = entry.getValue();
       String template = " " + colName;
       if (roundNum < 0) {
         // just append blanks
         sb.append(Format.formatPaddLeft("-", template));
       } else {
+        String valByRoundName = entry.getKey();
+
         // append actual values, for that round
-        Object a = valByRound.get(name);
+        Object a = valByRound.get(valByRoundName);
         if (a instanceof int[]) {
           int ai[] = (int[]) a;
           int n = roundNum % ai.length;

--- a/lucene/core/src/java/org/apache/lucene/search/BooleanQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanQuery.java
@@ -506,10 +506,13 @@ public class BooleanQuery extends Query implements Iterable<BooleanClause> {
 
   @Override
   public void visit(QueryVisitor visitor) {
-    for (BooleanClause.Occur occur : clauseSets.keySet()) {
-      if (clauseSets.get(occur).size() > 0) {
-        QueryVisitor v = visitor.getSubVisitor(occur, this);
-        for (Query q : clauseSets.get(occur)) {
+    for (Map.Entry<Occur, Collection<Query>> entry : clauseSets.entrySet()) {
+      Occur clauseOccur = entry.getKey();
+      Collection<Query> clauseQueries = entry.getValue();
+
+      if (clauseQueries.size() > 0) {
+        QueryVisitor v = visitor.getSubVisitor(clauseOccur, this);
+        for (Query q : clauseQueries) {
           q.visit(v);
         }
       }

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/MultipassTermFilteredPresearcher.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/MultipassTermFilteredPresearcher.java
@@ -113,8 +113,8 @@ public class MultipassTermFilteredPresearcher extends TermFilteredPresearcher {
     @Override
     public Query build() {
       Map<String, BytesRef[]> collectedTerms = new HashMap<>();
-      for (String field : terms.keySet()) {
-        collectedTerms.put(field, convertHash(terms.get(field)));
+      for (Map.Entry<String, BytesRefHash> entry : terms.entrySet()) {
+        collectedTerms.put(entry.getKey(), convertHash(entry.getValue()));
       }
       BooleanQuery.Builder parent = new BooleanQuery.Builder();
       for (int i = 0; i < passes; i++) {

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/TermFilteredPresearcher.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/TermFilteredPresearcher.java
@@ -225,8 +225,8 @@ public class TermFilteredPresearcher extends Presearcher {
       @Override
       public Query build() {
         BooleanQuery.Builder builder = new BooleanQuery.Builder();
-        for (String field : terms.keySet()) {
-          builder.add(new TermInSetQuery(field, terms.get(field)), BooleanClause.Occur.SHOULD);
+        for (Map.Entry<String, List<BytesRef>> entry : terms.entrySet()) {
+          builder.add(new TermInSetQuery(entry.getKey(), entry.getValue()), BooleanClause.Occur.SHOULD);
         }
         return builder.build();
       }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/MultiPhraseQueryNodeBuilder.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/flexible/standard/builders/MultiPhraseQueryNodeBuilder.java
@@ -18,6 +18,7 @@ package org.apache.lucene.queryparser.flexible.standard.builders;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.TreeMap;
 
 import org.apache.lucene.index.Term;
@@ -67,12 +68,9 @@ public class MultiPhraseQueryNodeBuilder implements StandardQueryBuilder {
 
       }
 
-      for (int positionIncrement : positionTermMap.keySet()) {
-        List<Term> termList = positionTermMap.get(positionIncrement);
-
-        phraseQueryBuilder.add(termList.toArray(new Term[termList.size()]),
-            positionIncrement);
-
+      for (Map.Entry<Integer, List<Term>> entry : positionTermMap.entrySet()) {
+        List<Term> termList = entry.getValue();
+        phraseQueryBuilder.add(termList.toArray(new Term[termList.size()]), entry.getKey());
       }
 
     }

--- a/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/StandardObjects.java
+++ b/lucene/spatial3d/src/java/org/apache/lucene/spatial3d/geom/StandardObjects.java
@@ -77,8 +77,8 @@ class StandardObjects {
    classRegsitry.put(GeoExactCircle.class, 37);
    classRegsitry.put(GeoS2Shape.class, 38);
 
-   for (Class<?> clazz : classRegsitry.keySet()){
-     codeRegsitry.put(classRegsitry.get(clazz), clazz);
+   for (Map.Entry<Class<?>, Integer> entry : classRegsitry.entrySet()){
+     codeRegsitry.put(entry.getValue(), entry.getKey());
    }
   }
 }

--- a/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/ContextQuery.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/suggest/document/ContextQuery.java
@@ -156,15 +156,15 @@ public class ContextQuery extends CompletionQuery implements Accountable {
   public String toString(String field) {
     StringBuilder buffer = new StringBuilder();
     BytesRefBuilder scratch = new BytesRefBuilder();
-    for (IntsRef context : contexts.keySet()) {
+    for (Map.Entry<IntsRef, ContextMetaData> entry : contexts.entrySet()) {
       if (buffer.length() != 0) {
         buffer.append(",");
       } else {
         buffer.append("contexts");
         buffer.append(":[");
       }
-      buffer.append(Util.toBytesRef(context, scratch).utf8ToString());
-      ContextMetaData metaData = contexts.get(context);
+      buffer.append(Util.toBytesRef(entry.getKey(), scratch).utf8ToString());
+      ContextMetaData metaData = entry.getValue();
       if (metaData.exact == false) {
         buffer.append("*");
       }

--- a/lucene/tools/src/java/org/apache/lucene/dependencies/GetMavenDependenciesTask.java
+++ b/lucene/tools/src/java/org/apache/lucene/dependencies/GetMavenDependenciesTask.java
@@ -312,10 +312,10 @@ public class GetMavenDependenciesTask extends Task {
     // Delay adding shared compile-scope dependencies until after all have been processed,
     // so dependency sharing is limited to a depth of one.
     Map<String,SortedSet<ExternalDependency>> sharedDependencies = new HashMap<>();
-    for (String module : interModuleExternalCompileScopeDependencies.keySet()) {
+    for (Map.Entry<String, Set<String>> entry : interModuleExternalCompileScopeDependencies.entrySet()) {
       TreeSet<ExternalDependency> deps = new TreeSet<>();
-      sharedDependencies.put(module, deps);
-      Set<String> moduleDependencies = interModuleExternalCompileScopeDependencies.get(module);
+      sharedDependencies.put(entry.getKey(), deps);
+      Set<String> moduleDependencies = entry.getValue();
       if (null != moduleDependencies) {
         for (String otherArtifactId : moduleDependencies) {
           SortedSet<ExternalDependency> otherExtDeps = allExternalDependencies.get(otherArtifactId); 
@@ -329,13 +329,14 @@ public class GetMavenDependenciesTask extends Task {
         }
       }
     }
-    for (String module : interModuleExternalTestScopeDependencies.keySet()) {
+    for (Map.Entry<String, Set<String>> entry : interModuleExternalTestScopeDependencies.entrySet()) {
+      String module = entry.getKey();
       SortedSet<ExternalDependency> deps = sharedDependencies.get(module);
       if (null == deps) {
         deps = new TreeSet<>();
         sharedDependencies.put(module, deps);
       }
-      Set<String> moduleDependencies = interModuleExternalTestScopeDependencies.get(module);
+      Set<String> moduleDependencies = entry.getValue();
       if (null != moduleDependencies) {
         for (String otherArtifactId : moduleDependencies) {
           int testScopePos = otherArtifactId.indexOf(":test");
@@ -362,13 +363,14 @@ public class GetMavenDependenciesTask extends Task {
         }
       }
     }
-    for (String module : sharedDependencies.keySet()) {
+    for (Map.Entry<String, SortedSet<ExternalDependency>> entry : sharedDependencies.entrySet()) {
+      String module = entry.getKey();
       SortedSet<ExternalDependency> deps = allExternalDependencies.get(module);
       if (null == deps) {
         deps = new TreeSet<>();
         allExternalDependencies.put(module, deps);
       }
-      for (ExternalDependency dep : sharedDependencies.get(module)) {
+      for (ExternalDependency dep : entry.getValue()) {
         String dependencyCoordinate = dep.groupId + ":" + dep.artifactId;
         if (globalOptionalExternalDependencies.contains(dependencyCoordinate)
             || (perModuleOptionalExternalDependencies.containsKey(module)
@@ -439,9 +441,10 @@ public class GetMavenDependenciesTask extends Task {
    * dependencies.
    */
   private void appendAllInternalDependencies(StringBuilder builder) {
-    for (String artifactId : internalCompileScopeDependencies.keySet()) {
+    for (Map.Entry<String, SortedSet<String>> entry : internalCompileScopeDependencies.entrySet()) {
+      String artifactId = entry.getKey();
       List<String> exclusions = new ArrayList<>();
-      exclusions.addAll(internalCompileScopeDependencies.get(artifactId));
+      exclusions.addAll(entry.getValue());
       SortedSet<ExternalDependency> extDeps = allExternalDependencies.get(artifactId);
       if (null != extDeps) {
         for (ExternalDependency externalDependency : extDeps) {

--- a/solr/contrib/analytics/src/java/org/apache/solr/analytics/AnalyticsRequestManager.java
+++ b/solr/contrib/analytics/src/java/org/apache/solr/analytics/AnalyticsRequestManager.java
@@ -179,9 +179,9 @@ public class AnalyticsRequestManager {
     ungroupedReductionManager.exportData();
 
     output.writeInt(groupingManagers.size());
-    for (String groupingName : groupingManagers.keySet()) {
-      output.writeUTF(groupingName);
-      groupingManagers.get(groupingName).exportShardData(output);
+    for (Map.Entry<String, AnalyticsGroupingManager> entry : groupingManagers.entrySet()) {
+      output.writeUTF(entry.getKey());
+      entry.getValue().exportShardData(output);
     }
   }
 

--- a/solr/contrib/prometheus-exporter/src/java/org/apache/solr/prometheus/collector/MetricSamples.java
+++ b/solr/contrib/prometheus-exporter/src/java/org/apache/solr/prometheus/collector/MetricSamples.java
@@ -53,13 +53,14 @@ public class MetricSamples {
   }
 
   public void addAll(MetricSamples other) {
-    for (String key : other.samplesByMetricName.keySet()) {
+    for (Map.Entry<String, Collector.MetricFamilySamples> entry : other.samplesByMetricName.entrySet()) {
+      String key = entry.getKey();
       if (this.samplesByMetricName.containsKey(key)) {
-        for (Collector.MetricFamilySamples.Sample sample : other.samplesByMetricName.get(key).samples) {
+        for (Collector.MetricFamilySamples.Sample sample : entry.getValue().samples) {
           addSampleIfMetricExists(key, sample);
         }
       } else {
-        this.samplesByMetricName.put(key, other.samplesByMetricName.get(key));
+        this.samplesByMetricName.put(key, entry.getValue());
       }
     }
   }

--- a/solr/contrib/velocity/src/java/org/apache/solr/response/VelocityResponseWriter.java
+++ b/solr/contrib/velocity/src/java/org/apache/solr/response/VelocityResponseWriter.java
@@ -235,8 +235,9 @@ public class VelocityResponseWriter implements QueryResponseWriter, SolrCoreAwar
         </queryResponseWriter>
 */
     // Custom tools can override any of the built-in tools provided above, by registering one with the same name
-    for(String name : customTools.keySet()) {
-      Object customTool = SolrCore.createInstance(customTools.get(name), Object.class, "VrW custom tool: " + name, request.getCore(), request.getCore().getResourceLoader());
+    for(Map.Entry<String, String> entry : customTools.entrySet()) {
+      String name = entry.getKey();
+      Object customTool = SolrCore.createInstance(entry.getValue(), Object.class, "VrW custom tool: " + name, request.getCore(), request.getCore().getResourceLoader());
       if (customTool instanceof LocaleConfig) {
         ((LocaleConfig)customTool).configure(toolConfig);
       }

--- a/solr/core/src/java/org/apache/solr/client/solrj/embedded/JettySolrRunner.java
+++ b/solr/core/src/java/org/apache/solr/client/solrj/embedded/JettySolrRunner.java
@@ -371,14 +371,12 @@ public class JettySolrRunner {
 
         debugFilter = root.addFilter(DebugFilter.class, "*", EnumSet.of(DispatcherType.REQUEST) );
         extraFilters = new LinkedList<>();
-        for (Class<? extends Filter> filterClass : config.extraFilters.keySet()) {
-          extraFilters.add(root.addFilter(filterClass, config.extraFilters.get(filterClass),
-              EnumSet.of(DispatcherType.REQUEST)));
+        for (Map.Entry<Class<? extends Filter>, String> entry : config.extraFilters.entrySet()) {
+          extraFilters.add(root.addFilter(entry.getKey(), entry.getValue(), EnumSet.of(DispatcherType.REQUEST)));
         }
 
-        for (ServletHolder servletHolder : config.extraServlets.keySet()) {
-          String pathSpec = config.extraServlets.get(servletHolder);
-          root.addServlet(servletHolder, pathSpec);
+        for (Map.Entry<ServletHolder, String> entry : config.extraServlets.entrySet()) {
+          root.addServlet(entry.getKey(), entry.getValue());
         }
         dispatchFilter = root.getServletHandler().newFilterHolder(Source.EMBEDDED);
         dispatchFilter.setHeldClass(SolrDispatchFilter.class);

--- a/solr/core/src/java/org/apache/solr/cloud/OverseerTaskProcessor.java
+++ b/solr/core/src/java/org/apache/solr/cloud/OverseerTaskProcessor.java
@@ -352,10 +352,10 @@ public class OverseerTaskProcessor implements Runnable, Closeable {
 
   private void cleanUpWorkQueue() throws KeeperException, InterruptedException {
     synchronized (completedTasks) {
-      for (String id : completedTasks.keySet()) {
-        workQueue.remove(completedTasks.get(id));
+      for (Map.Entry<String, QueueEvent> entry : completedTasks.entrySet()) {
+        workQueue.remove(entry.getValue());
         synchronized (runningZKTasks) {
-          runningZKTasks.remove(id);
+          runningZKTasks.remove(entry.getKey());
         }
       }
       completedTasks.clear();

--- a/solr/core/src/java/org/apache/solr/cloud/ZkShardTerms.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ZkShardTerms.java
@@ -482,9 +482,10 @@ public class ZkShardTerms implements AutoCloseable{
 
       HashMap<String, Long> newValues = new HashMap<>(values);
       long leaderTerm = newValues.get(leader);
-      for (String key : newValues.keySet()) {
+      for (Map.Entry<String, Long> entry : newValues.entrySet()) {
+        String key = entry.getKey();
         if (replicasNeedingRecovery.contains(key)) foundReplicasInLowerTerms = true;
-        if (Objects.equals(newValues.get(key), leaderTerm)) {
+        if (Objects.equals(entry.getValue(), leaderTerm)) {
           if(skipIncreaseTermOf(key, replicasNeedingRecovery)) {
             changed = true;
           } else {

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/DeleteReplicaCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/DeleteReplicaCmd.java
@@ -145,9 +145,10 @@ public class DeleteReplicaCmd implements Cmd {
       }
     }
 
-    for (Slice shardSlice: shardToReplicasMapping.keySet()) {
+    for (Map.Entry<Slice, Set<String>> entry : shardToReplicasMapping.entrySet()) {
+      Slice shardSlice = entry.getKey();
       String shardId = shardSlice.getName();
-      Set<String> replicas = shardToReplicasMapping.get(shardSlice);
+      Set<String> replicas = entry.getValue();
       //callDeleteReplica on all replicas
       for (String replica: replicas) {
         log.debug("Deleting replica {}  for shard {} based on count {}", replica, shardId, count);

--- a/solr/core/src/java/org/apache/solr/handler/admin/CoreAdminHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/CoreAdminHandler.java
@@ -242,10 +242,10 @@ public class CoreAdminHandler extends RequestHandlerBase implements PermissionNa
     Map<String, String> coreParams = new HashMap<>();
 
     // standard core create parameters
-    for (String param : paramToProp.keySet()) {
-      String value = params.get(param, null);
+    for (Map.Entry<String, String> entry : paramToProp.entrySet()) {
+      String value = params.get(entry.getKey(), null);
       if (StringUtils.isNotEmpty(value)) {
-        coreParams.put(paramToProp.get(param), value);
+        coreParams.put(entry.getValue(), value);
       }
     }
 

--- a/solr/core/src/java/org/apache/solr/handler/component/TermsComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/TermsComponent.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import org.apache.lucene.index.IndexReaderContext;
@@ -504,14 +505,15 @@ public class TermsComponent extends SearchComponent {
       TermsResponse termsResponse = new TermsResponse(terms);
 
       // loop though each field and add each term+freq to map
-      for (String key : fieldmap.keySet()) {
-        HashMap<String, TermsResponse.Term> termmap = fieldmap.get(key);
-        List<TermsResponse.Term> termlist = termsResponse.getTerms(key);
+      for (Map.Entry<String, HashMap<String, TermsResponse.Term>> entry : fieldmap.entrySet()) {
+        List<TermsResponse.Term> termlist = termsResponse.getTerms(entry.getKey());
 
         // skip this field if there are no terms
         if (termlist == null) {
           continue;
         }
+
+        HashMap<String, TermsResponse.Term> termmap = entry.getValue();
 
         // loop though each term
         for (TermsResponse.Term tc : termlist) {
@@ -552,13 +554,13 @@ public class TermsComponent extends SearchComponent {
       }
 
       // loop through each field we want terms from
-      for (String key : fieldmap.keySet()) {
+      for (Map.Entry<String, HashMap<String, TermsResponse.Term>> entry : fieldmap.entrySet()) {
         NamedList<Object> fieldTerms = new NamedList<>();
         TermsResponse.Term[] data = null;
         if (sort) {
-          data = getCountSorted(fieldmap.get(key));
+          data = getCountSorted(entry.getValue());
         } else {
-          data = getLexSorted(fieldmap.get(key));
+          data = getLexSorted(entry.getValue());
         }
 
         boolean includeTotalTermFreq = params.getBool(TermsParams.TERMS_TTF, false);
@@ -575,7 +577,7 @@ public class TermsComponent extends SearchComponent {
           }
         }
 
-        response.add(key, fieldTerms);
+        response.add(entry.getKey(), fieldTerms);
       }
 
       return response;

--- a/solr/core/src/java/org/apache/solr/handler/loader/CSVLoaderBase.java
+++ b/solr/core/src/java/org/apache/solr/handler/loader/CSVLoaderBase.java
@@ -30,6 +30,7 @@ import org.apache.solr.internal.csv.CSVStrategy;
 import org.apache.solr.internal.csv.CSVParser;
 import org.apache.commons.io.IOUtils;
 
+import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.List;
 import java.util.HashMap;
@@ -380,9 +381,8 @@ abstract class CSVLoaderBase extends ContentStreamLoader {
     }
 
     // add any literals
-    for (String fname : literals.keySet()) {
-      String val = literals.get(fname);
-      doc.addField(fname, val);
+    for (Map.Entry<String, String> entry : literals.entrySet()) {
+      doc.addField(entry.getKey(), entry.getValue());
     }
     if (rowId != null){
       doc.addField(rowId, line + rowIdOffset);

--- a/solr/core/src/java/org/apache/solr/response/PHPSerializedResponseWriter.java
+++ b/solr/core/src/java/org/apache/solr/response/PHPSerializedResponseWriter.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.Map;
 
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
@@ -137,16 +138,18 @@ class PHPSerializedWriter extends JSONWriter {
     }
 
     writeMapOpener(single.size() + multi.size());
-    for(String fname: single.keySet()){
-      Object val = single.get(fname);
+    for(Map.Entry<String, Object> entry : single.entrySet()){
+      String fname = entry.getKey();
+      Object val = entry.getValue();
       writeKey(fname, true);
       writeVal(fname, val);
     }
     
-    for(String fname: multi.keySet()){
+    for(Map.Entry<String, Object> entry : multi.entrySet()){
+      String fname = entry.getKey();
       writeKey(fname, true);
 
-      Object val = multi.get(fname);
+      Object val = entry.getValue();
       if (!(val instanceof Collection)) {
         // should never be reached if multivalued fields are stored as a Collection
         // so I'm assuming a size of 1 just to wrap the single value

--- a/solr/core/src/java/org/apache/solr/rest/RestManager.java
+++ b/solr/core/src/java/org/apache/solr/rest/RestManager.java
@@ -768,11 +768,12 @@ public class RestManager {
     }      
     
     int numAttached = 0;
-    for (String resourceId : managed.keySet()) {
+    for (Map.Entry<String, ManagedResource> entry : managed.entrySet()) {
+      String resourceId = entry.getKey();
       if (resourceId.startsWith(routerPath)) {
         // the way restlet works is you attach a path w/o the routerPath
         String path = resourceId.substring(routerPath.length());
-        attachManagedResource(managed.get(resourceId), path, router);
+        attachManagedResource(entry.getValue(), path, router);
         ++numAttached;
       }
     }

--- a/solr/core/src/java/org/apache/solr/rest/schema/analysis/ManagedSynonymFilterFactory.java
+++ b/solr/core/src/java/org/apache/solr/rest/schema/analysis/ManagedSynonymFilterFactory.java
@@ -142,7 +142,8 @@ public class ManagedSynonymFilterFactory extends BaseManagedTokenFilterFactory {
       synonymMappings = new TreeMap<>();
       if (managedData != null) {
         Map<String,Object> storedSyns = (Map<String,Object>)managedData;
-        for (String key : storedSyns.keySet()) {
+        for (Map.Entry<String, Object> entry : storedSyns.entrySet()) {
+          String key = entry.getKey();
 
           String caseKey = applyCaseSetting(ignoreCase, key);
           CasePreservedSynonymMappings cpsm = synonymMappings.get(caseKey);
@@ -153,7 +154,7 @@ public class ManagedSynonymFilterFactory extends BaseManagedTokenFilterFactory {
           
           // give the nature of our JSON parsing solution, we really have
           // no guarantees on what is in the file
-          Object mapping = storedSyns.get(key);
+          Object mapping = entry.getValue();
           if (!(mapping instanceof List)) {
             throw new SolrException(ErrorCode.SERVER_ERROR, 
                 "Invalid synonym file format! Expected a list of synonyms for "+key+
@@ -161,7 +162,7 @@ public class ManagedSynonymFilterFactory extends BaseManagedTokenFilterFactory {
           }
                     
           Set<String> sortedVals = new TreeSet<>();
-          sortedVals.addAll((List<String>)storedSyns.get(key));          
+          sortedVals.addAll((List<String>) entry.getValue());
           cpsm.mappings.put(key, sortedVals);        
         }
       }
@@ -269,8 +270,8 @@ public class ManagedSynonymFilterFactory extends BaseManagedTokenFilterFactory {
     protected Map<String,Set<String>> getStoredView() {
       Map<String,Set<String>> storedView = new TreeMap<>();
       for (CasePreservedSynonymMappings cpsm : synonymMappings.values()) {
-        for (String key : cpsm.mappings.keySet()) {
-          storedView.put(key, cpsm.mappings.get(key));
+        for (Map.Entry<String, Set<String>> entry : cpsm.mappings.entrySet()) {
+          storedView.put(entry.getKey(), entry.getValue());
         }
       }
       return storedView;
@@ -366,10 +367,10 @@ public class ManagedSynonymFilterFactory extends BaseManagedTokenFilterFactory {
     public void parse(Reader in) throws IOException, ParseException {
       boolean ignoreCase = synonymManager.getIgnoreCase();
       for (CasePreservedSynonymMappings cpsm : synonymManager.synonymMappings.values()) {
-        for (String term : cpsm.mappings.keySet()) {
-          for (String mapping : cpsm.mappings.get(term)) {
+        for (Map.Entry<String, Set<String>> entry : cpsm.mappings.entrySet()) {
+          for (String mapping : entry.getValue()) {
             // apply the case setting to match the behavior of the SynonymMap builder
-            CharsRef casedTerm = analyze(synonymManager.applyCaseSetting(ignoreCase, term), new CharsRefBuilder());
+            CharsRef casedTerm = analyze(synonymManager.applyCaseSetting(ignoreCase, entry.getKey()), new CharsRefBuilder());
             CharsRef casedMapping = analyze(synonymManager.applyCaseSetting(ignoreCase, mapping), new CharsRefBuilder());
             add(casedTerm, casedMapping, false);
           }          

--- a/solr/core/src/java/org/apache/solr/schema/FileExchangeRateProvider.java
+++ b/solr/core/src/java/org/apache/solr/schema/FileExchangeRateProvider.java
@@ -148,9 +148,9 @@ public class FileExchangeRateProvider implements ExchangeRateProvider {
   @Override
   public Set<String> listAvailableCurrencies() {
     Set<String> currencies = new HashSet<>();
-    for(String from : rates.keySet()) {
-      currencies.add(from);
-      for(String to : rates.get(from).keySet()) {
+    for(Map.Entry<String, Map<String, Double>> entry : rates.entrySet()) {
+      currencies.add(entry.getKey());
+      for(String to : entry.getValue().keySet()) {
         currencies.add(to);
       }
     }

--- a/solr/core/src/java/org/apache/solr/search/grouping/distributed/requestfactory/TopGroupsShardRequestFactory.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/distributed/requestfactory/TopGroupsShardRequestFactory.java
@@ -65,8 +65,7 @@ public class TopGroupsShardRequestFactory implements ShardRequestFactory {
   private ShardRequest[] createRequestForSpecificShards(ResponseBuilder rb) {
     // Determine all unique shards to query for TopGroups
     Set<String> uniqueShards = new HashSet<>();
-    for (String command : rb.searchGroupToShards.keySet()) {
-      Map<SearchGroup<BytesRef>, Set<String>> groupsToShard = rb.searchGroupToShards.get(command);
+    for (Map<SearchGroup<BytesRef>, Set<String>> groupsToShard : rb.searchGroupToShards.values()) {
       for (Set<String> shards : groupsToShard.values()) {
         uniqueShards.addAll(shards);
       }

--- a/solr/core/src/java/org/apache/solr/search/grouping/distributed/responseprocessor/SearchGroupShardResponseProcessor.java
+++ b/solr/core/src/java/org/apache/solr/search/grouping/distributed/responseprocessor/SearchGroupShardResponseProcessor.java
@@ -107,7 +107,8 @@ public class SearchGroupShardResponseProcessor implements ShardResponseProcessor
       @SuppressWarnings("unchecked")
       NamedList<NamedList> firstPhaseResult = (NamedList<NamedList>) srsp.getSolrResponse().getResponse().get("firstPhase");
       final Map<String, SearchGroupsFieldCommandResult> result = serializer.transformToNative(firstPhaseResult, groupSort, withinGroupSort, srsp.getShard());
-      for (String field : commandSearchGroups.keySet()) {
+      for (Map.Entry<String, List<Collection<SearchGroup<BytesRef>>>> entry : commandSearchGroups.entrySet()) {
+        String field = entry.getKey();
         final SearchGroupsFieldCommandResult firstPhaseCommandResult = result.get(field);
 
         final Integer groupCount = firstPhaseCommandResult.getGroupCount();
@@ -122,7 +123,7 @@ public class SearchGroupShardResponseProcessor implements ShardResponseProcessor
           continue;
         }
 
-        commandSearchGroups.get(field).add(searchGroups);
+        entry.getValue().add(searchGroups);
         for (SearchGroup<BytesRef> searchGroup : searchGroups) {
           Map<SearchGroup<BytesRef>, Set<String>> map = tempSearchGroupToShards.get(field);
           Set<String> shards = map.get(searchGroup);
@@ -137,8 +138,9 @@ public class SearchGroupShardResponseProcessor implements ShardResponseProcessor
     }
     rb.totalHitCount = hitCountDuringFirstPhase;
     rb.firstPhaseElapsedTime = maxElapsedTime;
-    for (String groupField : commandSearchGroups.keySet()) {
-      List<Collection<SearchGroup<BytesRef>>> topGroups = commandSearchGroups.get(groupField);
+    for (Map.Entry<String, List<Collection<SearchGroup<BytesRef>>>> entry : commandSearchGroups.entrySet()) {
+      String groupField = entry.getKey();
+      List<Collection<SearchGroup<BytesRef>>> topGroups = entry.getValue();
       Collection<SearchGroup<BytesRef>> mergedTopGroups = SearchGroup.merge(topGroups, groupSortSpec.getOffset(), groupSortSpec.getCount(), groupSort);
       if (mergedTopGroups == null) {
         continue;

--- a/solr/core/src/java/org/apache/solr/update/processor/AddSchemaFieldsUpdateProcessorFactory.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/AddSchemaFieldsUpdateProcessorFactory.java
@@ -424,11 +424,12 @@ public class AddSchemaFieldsUpdateProcessorFactory extends UpdateRequestProcesso
           builder.append("]");
           builder.append("\nCopyFields to be added to the schema: [");
           isFirst = true;
-          for (String fieldName : newCopyFields.keySet()) {
+          for (Map.Entry<String, Map<Integer, List<CopyFieldDef>>> entry : newCopyFields.entrySet()) {
+            String fieldName = entry.getKey();
             builder.append(isFirst ? "" : ",");
             isFirst = false;
             builder.append("source=").append(fieldName).append("{");
-            for (List<CopyFieldDef> copyFieldDefList : newCopyFields.get(fieldName).values()) {
+            for (List<CopyFieldDef> copyFieldDefList : entry.getValue().values()) {
               for (CopyFieldDef copyFieldDef : copyFieldDefList) {
                 builder.append("{dest=").append(copyFieldDef.getDest(fieldName));
                 builder.append(", maxChars=").append(copyFieldDef.getMaxChars()).append("}");
@@ -445,10 +446,11 @@ public class AddSchemaFieldsUpdateProcessorFactory extends UpdateRequestProcesso
           try {
             IndexSchema newSchema = oldSchema.addFields(newFields, Collections.emptyMap(), false);
             // Add copyFields
-            for (String srcField : newCopyFields.keySet()) {
-              for (Integer maxChars : newCopyFields.get(srcField).keySet()) {
-                newSchema = newSchema.addCopyFields(srcField, 
-                  newCopyFields.get(srcField).get(maxChars).stream().map(f -> f.getDest(srcField)).collect(Collectors.toList()), 
+            for (Map.Entry<String, Map<Integer, List<CopyFieldDef>>> entry : newCopyFields.entrySet()) {
+              String srcField = entry.getKey();
+              for (Integer maxChars : entry.getValue().keySet()) {
+                newSchema = newSchema.addCopyFields(srcField,
+                    entry.getValue().get(maxChars).stream().map(f -> f.getDest(srcField)).collect(Collectors.toList()),
                   maxChars);
               }
             }

--- a/solr/core/src/java/org/apache/solr/update/processor/CloneFieldUpdateProcessorFactory.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/CloneFieldUpdateProcessorFactory.java
@@ -458,8 +458,8 @@ public class CloneFieldUpdateProcessorFactory
           destMap.put(resolvedDest, destField);
         }
 
-        for (String dest : destMap.keySet()) {
-          doc.put(dest, destMap.get(dest));
+        for (Map.Entry<String, SolrInputField> entry : destMap.entrySet()) {
+          doc.put(entry.getKey(), entry.getValue());
         }
         super.processAdd(cmd);
       }

--- a/solr/core/src/java/org/apache/solr/util/SimplePostTool.java
+++ b/solr/core/src/java/org/apache/solr/util/SimplePostTool.java
@@ -709,9 +709,9 @@ public class SimplePostTool {
    * @return true if this is a supported content type
    */
   protected boolean typeSupported(String type) {
-    for(String key : mimeMap.keySet()) {
-      if(mimeMap.get(key).equals(type)) {
-        if(fileTypes.contains(key))
+    for(Map.Entry<String, String> entry : mimeMap.entrySet()) {
+      if(entry.getValue().equals(type)) {
+        if(fileTypes.contains(entry.getKey()))
           return true;
       }
     }

--- a/solr/core/src/java/org/apache/solr/util/SolrPluginUtils.java
+++ b/solr/core/src/java/org/apache/solr/util/SolrPluginUtils.java
@@ -900,12 +900,12 @@ public class SolrPluginUtils {
         Alias a = aliases.get(field);
 
         List<Query> disjuncts = new ArrayList<>();
-        for (String f : a.fields.keySet()) {
+        for (Map.Entry<String, Float> entry : a.fields.entrySet()) {
 
-          Query sub = getFieldQuery(f,queryText,quoted, false);
+          Query sub = getFieldQuery(entry.getKey(),queryText,quoted, false);
           if (null != sub) {
-            if (null != a.fields.get(f)) {
-              sub = new BoostQuery(sub, a.fields.get(f));
+            if (null != entry.getValue()) {
+              sub = new BoostQuery(sub, entry.getValue());
             }
             disjuncts.add(sub);
           }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/BaseCloudSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/BaseCloudSolrClient.java
@@ -746,8 +746,8 @@ public abstract class BaseCloudSolrClient extends SolrClient {
         throw toThrow;
       }
     }
-    for (String updateType: versions.keySet()) {
-      condensed.add(updateType, versions.get(updateType));
+    for (Map.Entry<String, NamedList> entry : versions.entrySet()) {
+      condensed.add(entry.getKey(), entry.getValue());
     }
     condensed.add("responseHeader", cheader);
     return condensed;

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/CloudSolrStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/CloudSolrStream.java
@@ -359,9 +359,9 @@ public class CloudSolrStream extends TupleStream implements Expressible {
     }
 
     // Check collection case insensitive
-    for(String collectionMapKey : collectionsMap.keySet()) {
-      if(collectionMapKey.equalsIgnoreCase(collectionName)) {
-        return collectionsMap.get(collectionMapKey).getActiveSlicesArr();
+    for(Entry<String, DocCollection> entry : collectionsMap.entrySet()) {
+      if(entry.getKey().equalsIgnoreCase(collectionName)) {
+        return entry.getValue().getActiveSlicesArr();
       }
     }
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/DeepRandomStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/DeepRandomStream.java
@@ -298,9 +298,9 @@ public class DeepRandomStream extends TupleStream implements Expressible {
     }
 
     // Check collection case insensitive
-    for(String collectionMapKey : collectionsMap.keySet()) {
-      if(collectionMapKey.equalsIgnoreCase(collectionName)) {
-        return collectionsMap.get(collectionMapKey).getActiveSlicesArr();
+    for(Entry<String, DocCollection> entry : collectionsMap.entrySet()) {
+      if(entry.getKey().equalsIgnoreCase(collectionName)) {
+        return entry.getValue().getActiveSlicesArr();
       }
     }
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/FeaturesSelectionStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/FeaturesSelectionStream.java
@@ -424,8 +424,8 @@ public class FeaturesSelectionStream extends TupleStream implements Expressible{
       params.add(DISTRIB, "false");
       params.add("fq","{!igain}");
 
-      for(String key : paramsMap.keySet()) {
-        params.add(key, paramsMap.get(key));
+      for(Map.Entry<String, String> entry : paramsMap.entrySet()) {
+        params.add(entry.getKey(), entry.getValue());
       }
 
       params.add("outcome", outcome);

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/SignificantTermsStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/SignificantTermsStream.java
@@ -315,10 +315,10 @@ public class SignificantTermsStream extends TupleStream implements Expressible{
 
         List<Map> maps = new ArrayList();
 
-        for(String term : mergeFreqs.keySet() ) {
-          int[] freqs = mergeFreqs.get(term);
+        for(Map.Entry<String, int[]> entry : mergeFreqs.entrySet()) {
+          int[] freqs = entry.getValue();
           Map map = new HashMap();
-          map.put("term", term);
+          map.put("term", entry.getKey());
           map.put("background", freqs[0]);
           map.put("foreground", freqs[1]);
 
@@ -389,8 +389,8 @@ public class SignificantTermsStream extends TupleStream implements Expressible{
       params.add(DISTRIB, "false");
       params.add("fq","{!significantTerms}");
 
-      for(String key : paramsMap.keySet()) {
-        params.add(key, paramsMap.get(key));
+      for(Map.Entry<String, String> entry : paramsMap.entrySet()) {
+        params.add(entry.getKey(), entry.getValue());
       }
 
       params.add("minDocFreq", Float.toString(minDocFreq));

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/StatsStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/StatsStream.java
@@ -305,16 +305,16 @@ public class StatsStream extends TupleStream implements Expressible  {
       }
     }
 
-    for(String field : m.keySet()) {
+    for(Entry<String, List<String>> entry : m.entrySet()) {
       StringBuilder buf = new StringBuilder();
-      List<String> stats = m.get(field);
+      List<String> stats = entry.getValue();
       buf.append("{!");
 
       for(String stat : stats) {
         buf.append(stat).append("=").append("true ");
       }
 
-      buf.append("}").append(field);
+      buf.append("}").append(entry.getKey());
       params.add("stats.field", buf.toString());
     }
   }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/TextLogitStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/TextLogitStream.java
@@ -627,8 +627,8 @@ public class TextLogitStream extends TupleStream implements Expressible {
       params.add("terms", TextLogitStream.toString(terms));
       params.add("idfs", TextLogitStream.toString(idfs));
 
-      for(String key : paramsMap.keySet()) {
-        params.add(key, paramsMap.get(key));
+      for(Entry<String, String> entry : paramsMap.entrySet()) {
+        params.add(entry.getKey(), entry.getValue());
       }
 
       if(weights != null) {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/ZplotStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/ZplotStream.java
@@ -197,9 +197,9 @@ public class ZplotStream extends TupleStream implements Expressible {
       //Handle the vectors
       for (int i = 0; i < numTuples; i++) {
         Tuple tuple = new Tuple(new HashMap());
-        for (String key : evaluated.keySet()) {
-          List l = (List) evaluated.get(key);
-          tuple.put(key, l.get(i));
+        for (Map.Entry<String, Object> entry : evaluated.entrySet()) {
+          List l = (List) entry.getValue();
+          tuple.put(entry.getKey(), l.get(i));
         }
 
         outTuples.add(tuple);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/LUCENE-8979

It appears not all instances were picked up by the previous sweep, which is strange as it's all automated. I'm hoping this is all of them.

Some simple cleanup. No need to spend company/personal time reviewing this, would be good if someone had some spare time. If you don't, feel free to close this tab.

It's a very simple PR: just changing keySet() to entrySet() when possible. In general just the better choice. Only really a performance gain when going over a TreeMap(as I recall at least), but in general a good idea to consistent with it.

A small move in TermsComponent.java, there's no point in doing the method call to populate the field and then the very next thing that happens is an unrelated check that potentially forces a `continue`, rendering the call pointless for that iteration.

All tests have run locally and succeeded.

Sorry about doing this twice, I don't get how these weren't picked up the first time.