### PR TITLE
SOLR-13773: Prometheus Exporter GC and Heap options

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -161,7 +161,7 @@ Improvements
 
 * SOLR-9658: Max idle time support for SolrCache implementations. (hoss, ab)
 
-* SOLR-13773: Add Prometheus Exporter GC and Heap options. (Houston Putman)
+* SOLR-13773: Add Prometheus Exporter GC and Heap options. (Houston Putman via Anshum Gupta, David Smiley)
 
 Bug Fixes
 ----------------------

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -161,6 +161,8 @@ Improvements
 
 * SOLR-9658: Max idle time support for SolrCache implementations. (hoss, ab)
 
+* SOLR-13773: Add Prometheus Exporter GC and Heap options. (Houston Putman)
+
 Bug Fixes
 ----------------------
 

--- a/solr/contrib/prometheus-exporter/bin/solr-exporter
+++ b/solr/contrib/prometheus-exporter/bin/solr-exporter
@@ -104,7 +104,23 @@ do
   CLASSPATH="$CLASSPATH":"$JAR"
 done
 
-EXTRA_JVM_ARGUMENTS="-Xmx512m -Dlog4j.configurationFile=file:"$BASEDIR"/../../server/resources/log4j2-console.xml"
+# Memory settings
+JAVA_MEM_OPTS=
+if [ -z "$SOLR_HEAP" ] && [ -n "$SOLR_JAVA_MEM" ]; then
+  JAVA_MEM_OPTS="$SOLR_JAVA_MEM"
+else
+  SOLR_HEAP="${SOLR_HEAP:-512m}"
+  JAVA_MEM_OPTS="-Xms$SOLR_HEAP -Xmx$SOLR_HEAP"
+fi
+
+# define default GC_TUNE
+if [ -z ${GC_TUNE+x} ]; then
+    GC_TUNE='-XX:+UseG1GC'
+else
+    GC_TUNE="$GC_TUNE"
+fi
+
+EXTRA_JVM_ARGUMENTS="-Dlog4j.configurationFile=file:"$BASEDIR"/../../server/resources/log4j2-console.xml"
 
 # For Cygwin, switch paths to Windows format before running java
 if $cygwin; then
@@ -115,7 +131,10 @@ if $cygwin; then
   [ -n "$REPO" ] && REPO=`cygpath --path --windows "$REPO"`
 fi
 
-exec "$JAVACMD" $JAVA_OPTS \
+exec "$JAVACMD" \
+  $JAVA_MEM_OPTS \
+  $GC_TUNE \
+  $JAVA_OPTS \
   $EXTRA_JVM_ARGUMENTS \
   -classpath "$CLASSPATH" \
   -Dapp.name="solr-exporter" \

--- a/solr/contrib/prometheus-exporter/bin/solr-exporter
+++ b/solr/contrib/prometheus-exporter/bin/solr-exporter
@@ -106,11 +106,11 @@ done
 
 # Memory settings
 JAVA_MEM_OPTS=
-if [ -z "$SOLR_HEAP" ] && [ -n "$SOLR_JAVA_MEM" ]; then
-  JAVA_MEM_OPTS="$SOLR_JAVA_MEM"
+if [ -z "$JAVA_HEAP" ] && [ -n "$JAVA_MEM" ]; then
+  JAVA_MEM_OPTS="$JAVA_MEM"
 else
-  SOLR_HEAP="${SOLR_HEAP:-512m}"
-  JAVA_MEM_OPTS="-Xms$SOLR_HEAP -Xmx$SOLR_HEAP"
+  JAVA_HEAP="${JAVA_HEAP:-512m}"
+  JAVA_MEM_OPTS="-Xms$JAVA_HEAP -Xmx$JAVA_HEAP"
 fi
 
 # define default GC_TUNE

--- a/solr/contrib/prometheus-exporter/bin/solr-exporter.cmd
+++ b/solr/contrib/prometheus-exporter/bin/solr-exporter.cmd
@@ -63,8 +63,8 @@ set BASEDIR=%~dp0..
 
 :repoSetup
 
-IF NOT "%SOLR_HEAP%"=="" set SOLR_JAVA_MEM=-Xms%SOLR_HEAP% -Xmx%SOLR_HEAP%
-IF "%SOLR_JAVA_MEM%"=="" set SOLR_JAVA_MEM=-Xms512m -Xmx512m
+IF NOT "%JAVA_HEAP%"=="" set JAVA_MEM=-Xms%JAVA_HEAP% -Xmx%JAVA_HEAP%
+IF "%JAVA_MEM%"=="" set JAVA_MEM=-Xms512m -Xmx512m
 IF "%GC_TUNE%"=="" set GC_TUNE=-XX:+UseG1GC
 
 if "%JAVACMD%"=="" set JAVACMD=java
@@ -72,13 +72,13 @@ if "%JAVACMD%"=="" set JAVACMD=java
 if "%REPO%"=="" set REPO=%BASEDIR%\lib
 
 set CLASSPATH=%REPO%\*;%BASEDIR%\..\..\dist\solrj-lib\*;%BASEDIR%\..\..\dist\*;%BASEDIR%\lucene-libs\*;%BASEDIR%\..\..\server\solr-webapp\webapp\WEB-INF\lib\*
-set EXTRA_JVM_ARGUMENTS=-Xmx512m -Dlog4j.configurationFile=file:///%BASEDIR%\..\..\server\resources\log4j2-console.xml
+set EXTRA_JVM_ARGUMENTS=-Dlog4j.configurationFile=file:///%BASEDIR%\..\..\server\resources\log4j2-console.xml
 goto endInit
 
 @REM Reaching here means variables are defined and arguments have been captured
 :endInit
 
-%JAVACMD% %SOLR_JAVA_MEM% %GC_TUNE% %JAVA_OPTS% %EXTRA_JVM_ARGUMENTS% -classpath "%CLASSPATH_PREFIX%;%CLASSPATH%" -Dapp.name="solr-exporter" -Dapp.repo="%REPO%" -Dbasedir="%BASEDIR%" org.apache.solr.prometheus.exporter.SolrExporter %CMD_LINE_ARGS%
+%JAVACMD% %JAVA_MEM% %GC_TUNE% %JAVA_OPTS% %EXTRA_JVM_ARGUMENTS% -classpath "%CLASSPATH_PREFIX%;%CLASSPATH%" -Dapp.name="solr-exporter" -Dapp.repo="%REPO%" -Dbasedir="%BASEDIR%" org.apache.solr.prometheus.exporter.SolrExporter %CMD_LINE_ARGS%
 if ERRORLEVEL 1 goto error
 goto end
 

--- a/solr/contrib/prometheus-exporter/bin/solr-exporter.cmd
+++ b/solr/contrib/prometheus-exporter/bin/solr-exporter.cmd
@@ -63,6 +63,9 @@ set BASEDIR=%~dp0..
 
 :repoSetup
 
+IF NOT "%SOLR_HEAP%"=="" set SOLR_JAVA_MEM=-Xms%SOLR_HEAP% -Xmx%SOLR_HEAP%
+IF "%SOLR_JAVA_MEM%"=="" set SOLR_JAVA_MEM=-Xms512m -Xmx512m
+IF "%GC_TUNE%"=="" set GC_TUNE=-XX:+UseG1GC
 
 if "%JAVACMD%"=="" set JAVACMD=java
 
@@ -75,7 +78,7 @@ goto endInit
 @REM Reaching here means variables are defined and arguments have been captured
 :endInit
 
-%JAVACMD% %JAVA_OPTS% %EXTRA_JVM_ARGUMENTS% -classpath "%CLASSPATH_PREFIX%;%CLASSPATH%" -Dapp.name="solr-exporter" -Dapp.repo="%REPO%" -Dbasedir="%BASEDIR%" org.apache.solr.prometheus.exporter.SolrExporter %CMD_LINE_ARGS%
+%JAVACMD% %SOLR_JAVA_MEM% %GC_TUNE% %JAVA_OPTS% %EXTRA_JVM_ARGUMENTS% -classpath "%CLASSPATH_PREFIX%;%CLASSPATH%" -Dapp.name="solr-exporter" -Dapp.repo="%REPO%" -Dbasedir="%BASEDIR%" org.apache.solr.prometheus.exporter.SolrExporter %CMD_LINE_ARGS%
 if ERRORLEVEL 1 goto error
 goto end
 

--- a/solr/solr-ref-guide/src/monitoring-solr-with-prometheus-and-grafana.adoc
+++ b/solr/solr-ref-guide/src/monitoring-solr-with-prometheus-and-grafana.adoc
@@ -108,12 +108,28 @@ The number of seconds between collecting metrics from Solr. The `solr-exporter` 
 
 The Solr's metrics exposed by `solr-exporter` can be seen at: `\http://localhost:9983/solr/admin/metrics`.
 
+=== Environment Variable Options
+
+The start commands provided with the Prometheus Exporter support the use of custom java options through the following environment variables:
+
+`JAVA_HEAP`::
+Sets the initial (`Xms`) and max (`Xmx`) Java heap size. The default is `512m`.
+
+`JAVA_MEM`::
+Custom java memory settings (e.g. `-Xms1g -Xmx2g`). This is ignored if `JAVA_HEAP` is provided.
+
+`GC_TUNE`::
+Custom Java garbage collection settings. The default is `-XX:+UseG1GC`.
+
+`JAVA_OPTS`::
+Extra JVM options.
+
+`CLASSPATH_PREFIX`::
+Location of extra libraries to load when starting the `solr-exporter`.
+
 === Getting metrics from a secure Solr(Cloud)
 
-Your Solr(Cloud) might be secured by measures described in <<securing-solr.adoc#securing-solr,Securing Solr>>. The security configuration can be injected into `solr-exporter` using environment variables in a fashion similar to other clients using <<using-solrj.adoc#using-solrj,SolrJ>>. This is possible because the main script picks up two external environment variables and passes them on to the Java process:
-
-* `JAVA_OPTS` allows to add extra JVM options
-* `CLASSPATH_PREFIX` allows to add extra libraries
+Your Solr(Cloud) might be secured by measures described in <<securing-solr.adoc#securing-solr,Securing Solr>>. The security configuration can be injected into `solr-exporter` using environment variables in a fashion similar to other clients using <<using-solrj.adoc#using-solrj,SolrJ>>. This is possible because the main script picks up <<Environment Variable Options>>  and passes them on to the Java process.
 
 Example for a SolrCloud instance secured by <<basic-authentication-plugin.adoc#basic-authentication-plugin,Basic Authentication>>, <<enabling-ssl.adoc#enabling-ssl,SSL>> and <<zookeeper-access-control.adoc#zookeeper-access-control,ZooKeeper Access Control>>:
 


### PR DESCRIPTION
# Description

The startup options for the Prometheus Exporter are pretty sparse compared to what the Solr start script offers.

# Solution

I've added some options that mirror what Solr offers, such as:
- SOLR_HEAP
- SOLR_JAVA_MEM
- GC_TUNE

Having just the memory settings available would let us start the prometheus exporter with more than 500 Mb of heap, which right now isn't possible as the max heap is hard coded here.

# Tests

I have started the metrics-exporter locally with this script, although I do not have access to a windows host to test the `solr-exporter.cmd` script. That code came from `solr.cmd` so I would imagine that it works, however I would appreciate if someone on windows could make sure that it works as expected.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I am authorized to contribute this code to the ASF and have removed any code I do not have a license to distribute.
- [x] I have developed this patch against the `master` branch.
- [ ] I have run `ant precommit` and the appropriate test suite.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
