### PR TITLE
SOLR-13775: Add note about permissions to "PR Template"

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -35,6 +35,7 @@ Please review the following and check all that apply:
 - [ ] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
 - [ ] I have created a Jira issue and added the issue ID to my pull request title.
 - [ ] I am authorized to contribute this code to the ASF and have removed any code I do not have a license to distribute.
+- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
 - [ ] I have developed this patch against the `master` branch.
 - [ ] I have run `ant precommit` and the appropriate test suite.
 - [ ] I have added tests for my changes.


### PR DESCRIPTION
# Description

By default, when a Solr contributor creates their own fork, only they
have access to that fork.  This creates a bit of a roadblock when users
contribute PRs from these forks - others can't build off of their work -
something that is done often with patches.  An initial user might
contribute a feature, a committer might add tests or change formatting,
etc.

# Solution

This change introduces a bullet point to our PR checklist to nudge users
towards making their PR branches more open.

# Tests
N/A

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I am authorized to contribute this code to the ASF and have removed any code I do not have a license to distribute.
- [x] I have developed this patch against the `master` branch.
- [ ] I have run `ant precommit` and the appropriate test suite.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
