### PR TITLE
LUCENE-8978: Maximal Of Minimum Scores Based Concurrent Early Termination

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/BottomValueChecker.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BottomValueChecker.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.search;
+
+/**
+ * Maintains the bottom value across multiple collectors
+ */
+abstract class BottomValueChecker {
+  /** Maintains global bottom score as the maximum of all bottom scores */
+  private static class MaximumBottomScoreChecker extends BottomValueChecker {
+    private volatile float maxMinScore;
+
+    @Override
+    public void updateThreadLocalBottomValue(float value) {
+      if (value <= maxMinScore) {
+        return;
+      }
+      synchronized (this) {
+        if (value > maxMinScore) {
+          maxMinScore = value;
+        }
+      }
+    }
+
+    @Override
+    public float getBottomValue() {
+      return maxMinScore;
+    }
+  }
+
+  public static BottomValueChecker createMaxBottomScoreChecker() {
+    return new MaximumBottomScoreChecker();
+  }
+
+  public abstract void updateThreadLocalBottomValue(float value);
+  public abstract float getBottomValue();
+}

--- a/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
+++ b/lucene/core/src/java/org/apache/lucene/search/IndexSearcher.java
@@ -468,9 +468,12 @@ public class IndexSearcher {
 
       private final HitsThresholdChecker hitsThresholdChecker = (executor == null || leafSlices.length <= 1) ? HitsThresholdChecker.create(TOTAL_HITS_THRESHOLD) :
           HitsThresholdChecker.createShared(TOTAL_HITS_THRESHOLD);
+
+      private final BottomValueChecker bottomValueChecker = BottomValueChecker.createMaxBottomScoreChecker();
+
       @Override
       public TopScoreDocCollector newCollector() throws IOException {
-        return TopScoreDocCollector.create(cappedNumHits, after, hitsThresholdChecker);
+        return TopScoreDocCollector.create(cappedNumHits, after, hitsThresholdChecker, bottomValueChecker);
       }
 
       @Override

--- a/lucene/core/src/java/org/apache/lucene/search/TopScoreDocCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TopScoreDocCollector.java
@@ -283,10 +283,14 @@ public abstract class TopScoreDocCollector extends TopDocsCollector<ScoreDoc> {
           || (pqTop != null && pqTop.score != Float.NEGATIVE_INFINITY))) { // -Infinity is the score of sentinels
       // since we tie-break on doc id and collect in doc id order, we can require
       // the next float
-      float bottomScore = Math.nextUp(pqTop.score);
+      float bottomScore = Float.NEGATIVE_INFINITY;
 
-      if (bottomValueChecker != null) {
-        bottomValueChecker.updateThreadLocalBottomValue(pqTop.score);
+      if (pqTop != null && pqTop.score != Float.NEGATIVE_INFINITY) {
+        bottomScore = Math.nextUp(pqTop.score);
+
+        if (bottomValueChecker != null) {
+          bottomValueChecker.updateThreadLocalBottomValue(pqTop.score);
+        }
       }
 
       // Global bottom can only be greater than or equal to the local bottom score

--- a/lucene/core/src/java/org/apache/lucene/search/TopScoreDocCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TopScoreDocCollector.java
@@ -279,13 +279,13 @@ public abstract class TopScoreDocCollector extends TopDocsCollector<ScoreDoc> {
 
   protected void updateMinCompetitiveScore(Scorable scorer) throws IOException {
     if (hitsThresholdChecker.isThresholdReached()
-          && pqTop != null
-          && pqTop.score != Float.NEGATIVE_INFINITY) { // -Infinity is the score of sentinels
+          && ((bottomValueChecker != null && bottomValueChecker.getBottomValue() > 0)
+          || (pqTop != null && pqTop.score != Float.NEGATIVE_INFINITY))) { // -Infinity is the score of sentinels
       // since we tie-break on doc id and collect in doc id order, we can require
       // the next float
       float bottomScore = Math.nextUp(pqTop.score);
 
-      if (bottomValueChecker != null && bottomValueChecker.getBottomValue() > 0) {
+      if (bottomValueChecker != null) {
         bottomValueChecker.updateThreadLocalBottomValue(pqTop.score);
       }
 

--- a/lucene/core/src/java/org/apache/lucene/search/TopScoreDocCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TopScoreDocCollector.java
@@ -49,8 +49,9 @@ public abstract class TopScoreDocCollector extends TopDocsCollector<ScoreDoc> {
 
   private static class SimpleTopScoreDocCollector extends TopScoreDocCollector {
 
-    SimpleTopScoreDocCollector(int numHits, HitsThresholdChecker hitsThresholdChecker) {
-      super(numHits, hitsThresholdChecker);
+    SimpleTopScoreDocCollector(int numHits, HitsThresholdChecker hitsThresholdChecker,
+                               BottomValueChecker bottomValueChecker) {
+      super(numHits, hitsThresholdChecker, bottomValueChecker);
     }
 
     @Override
@@ -100,8 +101,9 @@ public abstract class TopScoreDocCollector extends TopDocsCollector<ScoreDoc> {
     private final ScoreDoc after;
     private int collectedHits;
 
-    PagingTopScoreDocCollector(int numHits, ScoreDoc after, HitsThresholdChecker hitsThresholdChecker) {
-      super(numHits, hitsThresholdChecker);
+    PagingTopScoreDocCollector(int numHits, ScoreDoc after, HitsThresholdChecker hitsThresholdChecker,
+                               BottomValueChecker bottomValueChecker) {
+      super(numHits, hitsThresholdChecker, bottomValueChecker);
       this.after = after;
       this.collectedHits = 0;
     }
@@ -195,10 +197,11 @@ public abstract class TopScoreDocCollector extends TopDocsCollector<ScoreDoc> {
    * objects.
    */
   public static TopScoreDocCollector create(int numHits, ScoreDoc after, int totalHitsThreshold) {
-    return create(numHits, after, HitsThresholdChecker.create(totalHitsThreshold));
+    return create(numHits, after, HitsThresholdChecker.create(totalHitsThreshold), null);
   }
 
-  static TopScoreDocCollector create(int numHits, ScoreDoc after, HitsThresholdChecker hitsThresholdChecker) {
+  static TopScoreDocCollector create(int numHits, ScoreDoc after, HitsThresholdChecker hitsThresholdChecker,
+                                     BottomValueChecker bottomValueChecker) {
 
     if (numHits <= 0) {
       throw new IllegalArgumentException("numHits must be > 0; please use TotalHitCountCollector if you just need the total hit count");
@@ -209,9 +212,9 @@ public abstract class TopScoreDocCollector extends TopDocsCollector<ScoreDoc> {
     }
 
     if (after == null) {
-      return new SimpleTopScoreDocCollector(numHits, hitsThresholdChecker);
+      return new SimpleTopScoreDocCollector(numHits, hitsThresholdChecker, bottomValueChecker);
     } else {
-      return new PagingTopScoreDocCollector(numHits, after, hitsThresholdChecker);
+      return new PagingTopScoreDocCollector(numHits, after, hitsThresholdChecker, bottomValueChecker);
     }
   }
 
@@ -223,10 +226,11 @@ public abstract class TopScoreDocCollector extends TopDocsCollector<ScoreDoc> {
     return new CollectorManager<>() {
 
       private final HitsThresholdChecker hitsThresholdChecker = HitsThresholdChecker.createShared(totalHitsThreshold);
+      private final BottomValueChecker bottomValueChecker = BottomValueChecker.createMaxBottomScoreChecker();
 
       @Override
       public TopScoreDocCollector newCollector() throws IOException {
-        return TopScoreDocCollector.create(numHits, after, hitsThresholdChecker);
+        return TopScoreDocCollector.create(numHits, after, hitsThresholdChecker, bottomValueChecker);
       }
 
       @Override
@@ -244,9 +248,11 @@ public abstract class TopScoreDocCollector extends TopDocsCollector<ScoreDoc> {
 
   ScoreDoc pqTop;
   final HitsThresholdChecker hitsThresholdChecker;
+  final BottomValueChecker bottomValueChecker;
 
   // prevents instantiation
-  TopScoreDocCollector(int numHits, HitsThresholdChecker hitsThresholdChecker) {
+  TopScoreDocCollector(int numHits, HitsThresholdChecker hitsThresholdChecker,
+                       BottomValueChecker bottomValueChecker) {
     super(new HitQueue(numHits, true));
     assert hitsThresholdChecker != null;
 
@@ -254,6 +260,7 @@ public abstract class TopScoreDocCollector extends TopDocsCollector<ScoreDoc> {
     // that at this point top() is already initialized.
     pqTop = pq.top();
     this.hitsThresholdChecker = hitsThresholdChecker;
+    this.bottomValueChecker = bottomValueChecker;
   }
 
   @Override
@@ -276,7 +283,20 @@ public abstract class TopScoreDocCollector extends TopDocsCollector<ScoreDoc> {
           && pqTop.score != Float.NEGATIVE_INFINITY) { // -Infinity is the score of sentinels
       // since we tie-break on doc id and collect in doc id order, we can require
       // the next float
-      scorer.setMinCompetitiveScore(Math.nextUp(pqTop.score));
+      float bottomScore = Math.nextUp(pqTop.score);
+
+      if (bottomValueChecker != null && bottomValueChecker.getBottomValue() > 0) {
+        bottomValueChecker.updateThreadLocalBottomValue(pqTop.score);
+      }
+
+      // Global bottom can only be greater than or equal to the local bottom score
+      // The updating of global bottom score for this hit before getting here should
+      // ensure that
+      if (bottomValueChecker != null && bottomValueChecker.getBottomValue() > bottomScore) {
+        bottomScore = bottomValueChecker.getBottomValue();
+      }
+
+      scorer.setMinCompetitiveScore(bottomScore);
       totalHitsRelation = TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO;
     }
   }

--- a/lucene/core/src/test/org/apache/lucene/search/TestTopDocsCollector.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestTopDocsCollector.java
@@ -29,9 +29,15 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.MultiTerms;
 import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.RandomIndexWriter;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.LineFileDocs;
 import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.NamedThreadFactory;
 
@@ -114,7 +120,7 @@ public class TestTopDocsCollector extends LuceneTestCase {
     return tdc;
   }
 
-  private TopDocs doConcurrentSearchWithThreshold(int numResults, int threshold) throws IOException {
+  private TopDocs doConcurrentSearchWithThreshold(int numResults, int threshold, IndexReader reader) throws IOException {
     Query q = new MatchAllDocsQuery();
     ExecutorService service = new ThreadPoolExecutor(4, 4, 0L, TimeUnit.MILLISECONDS,
         new LinkedBlockingQueue<Runnable>(),
@@ -339,7 +345,7 @@ public class TestTopDocsCollector extends LuceneTestCase {
     w.close();
 
     TopDocsCollector collector = doSearchWithThreshold(5, 10);
-    TopDocs tdc = doConcurrentSearchWithThreshold(5, 10);
+    TopDocs tdc = doConcurrentSearchWithThreshold(5, 10, reader);
     TopDocs tdc2 = collector.topDocs();
 
     CheckHits.checkEqual(q, tdc.scoreDocs, tdc2.scoreDocs);
@@ -390,6 +396,48 @@ public class TestTopDocsCollector extends LuceneTestCase {
       assertEquals(4, topDocs.totalHits.value);
       assertEquals(totalHitsThreshold < 4, scorer.minCompetitiveScore != null);
       assertEquals(new TotalHits(4, totalHitsThreshold < 4 ? TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO : TotalHits.Relation.EQUAL_TO), topDocs.totalHits);
+    }
+
+    reader.close();
+    dir.close();
+  }
+
+  public void testGlobalScore() throws Exception {
+    Directory dir = newDirectory();
+    RandomIndexWriter writer = new RandomIndexWriter(random(), dir);
+    try (LineFileDocs docs = new LineFileDocs(random())) {
+      int numDocs = atLeast(100);
+      for (int i = 0; i < numDocs; i++) {
+        writer.addDocument(docs.nextDoc());
+      }
+    }
+
+    IndexReader reader = writer.getReader();
+    writer.close();
+
+    final IndexSearcher s = newSearcher(reader);
+    Terms terms = MultiTerms.getTerms(reader, "body");
+    int termCount = 0;
+    TermsEnum termsEnum = terms.iterator();
+    while(termsEnum.next() != null) {
+      termCount++;
+    }
+    assertTrue(termCount > 0);
+
+    // Target ~10 terms to search:
+    double chance = 10.0 / termCount;
+    termsEnum = terms.iterator();
+    while(termsEnum.next() != null) {
+      if (random().nextDouble() <= chance) {
+        BytesRef term = BytesRef.deepCopyOf(termsEnum.term());
+        Query query = new TermQuery(new Term("body", term));
+
+        TopDocsCollector collector = doSearchWithThreshold(5, 10);
+        TopDocs tdc = doConcurrentSearchWithThreshold(5, 10, reader);
+        TopDocs tdc2 = collector.topDocs();
+
+        CheckHits.checkEqual(query, tdc.scoreDocs, tdc2.scoreDocs);
+      }
     }
 
     reader.close();


### PR DESCRIPTION
This commit introduces a mechanism for early termination where,
for indices sorted by relevance, hits are collected in per thread
queue. Full PQs publish their bottom values and the maximum of
them is then used by the corresponding collectors to filter further
hits