### PR TITLE
SOLR-13816: Move eDisMax params from private interface to public constants

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/ExtendedDismaxQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/ExtendedDismaxQParser.java
@@ -83,27 +83,7 @@ public class ExtendedDismaxQParser extends QParser {
   
   /** shorten the class references for utilities */
   private static interface DMP extends DisMaxParams {
-    /**
-     * User fields. The fields that can be used by the end user to create field-specific queries.
-     */
-    public static String UF = "uf";
-    
-    /**
-     * Lowercase Operators. If set to true, 'or' and 'and' will be considered OR and AND, otherwise
-     * lowercase operators will be considered terms to search for.
-     */
-    public static String LOWERCASE_OPS = "lowercaseOperators";
-
-    /**
-     * Multiplicative boost. Boost functions which scores are going to be multiplied to the score
-     * of the main query (instead of just added, like with bf)
-     */
-    public static String MULT_BOOST = "boost";
-
-    /**
-     * If set to true, stopwords are removed from the query.
-     */
-    public static String STOPWORDS = "stopwords";
+    /* :NOOP */
   }
   
   private ExtendedDismaxConfiguration config;

--- a/solr/solrj/src/java/org/apache/solr/common/params/DisMaxParams.java
+++ b/solr/solrj/src/java/org/apache/solr/common/params/DisMaxParams.java
@@ -79,4 +79,26 @@ public interface DisMaxParams {
   
   /** query and init param for field list */
   public static String GEN = "gen";
+
+  /**
+   * User fields. The fields that can be used by the end user to create field-specific queries.
+   */
+  public static String UF = "uf";
+    
+  /**
+   * Lowercase Operators. If set to true, 'or' and 'and' will be considered OR and AND, otherwise
+   * lowercase operators will be considered terms to search for.
+   */
+  public static String LOWERCASE_OPS = "lowercaseOperators";
+
+  /**
+   * Multiplicative boost. Boost functions which scores are going to be multiplied to the score
+   * of the main query (instead of just added, like with bf)
+   */
+  public static String MULT_BOOST = "boost";
+
+  /**
+   * If set to true, stopwords are removed from the query.
+   */
+  public static String STOPWORDS = "stopwords";
 }


### PR DESCRIPTION
# Description

`DisMaxParams` contains many eDisMax query string parameters and makes them publicly available so that consuming code does not need to rely on "magic strings".  Several of these parameters are missing (but are currently being supplied to the `ExtendedDismaxQParser` by a private interface).

# Solution

Move the missing parameters from the private static interface `DMP` into the `DixMaxParams` class so that they are publicly accessible to consuming code.

# Tests

None.  This is simply an implementation detail - it is moving the definition of 4 static strings up one layer in a class hierarchy.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I am authorized to contribute this code to the ASF and have removed any code I do not have a license to distribute.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [ ] I have run `ant precommit` and the appropriate test suite.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
