### PR TITLE
LUCENE-9001: Fix race condition in SetOnce

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/SetOnce.java
+++ b/lucene/core/src/java/org/apache/lucene/util/SetOnce.java
@@ -38,7 +38,7 @@ public final class SetOnce<T> implements Cloneable {
   }
 
   /** Holding object and marking that it was already set */
-  private final class Wrapper {
+  private static final class Wrapper<T> {
     private T object;
 
     private Wrapper(T object) {
@@ -46,14 +46,14 @@ public final class SetOnce<T> implements Cloneable {
     }
   }
 
-  private final AtomicReference<Wrapper> set;
+  private final AtomicReference<Wrapper<T>> set;
   
   /**
    * A default constructor which does not set the internal object, and allows
    * setting it by calling {@link #set(Object)}.
    */
   public SetOnce() {
-    set = new AtomicReference();
+    set = new AtomicReference<>();
   }
 
   /**
@@ -65,7 +65,7 @@ public final class SetOnce<T> implements Cloneable {
    * @see #set(Object)
    */
   public SetOnce(T obj) {
-    set = new AtomicReference(new Wrapper(obj));
+    set = new AtomicReference<>(new Wrapper<>(obj));
   }
   
   /** Sets the given object. If the object has already been set, an exception is thrown. */
@@ -80,12 +80,12 @@ public final class SetOnce<T> implements Cloneable {
    * @return true if object was set successfully, false otherwise
    * */
   public final boolean trySet(T obj) {
-    return set.compareAndSet(null, new Wrapper(obj));
+    return set.compareAndSet(null, new Wrapper<>(obj));
   }
   
   /** Returns the object set by {@link #set(Object)}. */
   public final T get() {
-    Wrapper wrapper = set.get();
+    Wrapper<T> wrapper = set.get();
     return wrapper == null ? null : wrapper.object;
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/util/SetOnce.java
+++ b/lucene/core/src/java/org/apache/lucene/util/SetOnce.java
@@ -16,7 +16,7 @@
  */
 package org.apache.lucene.util;
 
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 
 /**
@@ -36,16 +36,24 @@ public final class SetOnce<T> implements Cloneable {
       super("The object cannot be set twice!");
     }
   }
-  
-  private volatile T obj = null;
-  private final AtomicBoolean set;
+
+  /** Holding object and marking that it was already set */
+  private final class Wrapper {
+    private T object;
+
+    private Wrapper(T object) {
+      this.object = object;
+    }
+  }
+
+  private final AtomicReference<Wrapper> set;
   
   /**
    * A default constructor which does not set the internal object, and allows
    * setting it by calling {@link #set(Object)}.
    */
   public SetOnce() {
-    set = new AtomicBoolean(false);
+    set = new AtomicReference();
   }
 
   /**
@@ -57,21 +65,27 @@ public final class SetOnce<T> implements Cloneable {
    * @see #set(Object)
    */
   public SetOnce(T obj) {
-    this.obj = obj;
-    set = new AtomicBoolean(true);
+    set = new AtomicReference(new Wrapper(obj));
   }
   
   /** Sets the given object. If the object has already been set, an exception is thrown. */
   public final void set(T obj) {
-    if (set.compareAndSet(false, true)) {
-      this.obj = obj;
-    } else {
+    if (!trySet(obj)) {
       throw new AlreadySetException();
     }
+  }
+
+  /** Sets the given object if none was set before.
+   *
+   * @return true if object was set successfully, false otherwise
+   * */
+  public final boolean trySet(T obj) {
+    return set.compareAndSet(null, new Wrapper(obj));
   }
   
   /** Returns the object set by {@link #set(Object)}. */
   public final T get() {
-    return obj;
+    Wrapper wrapper = set.get();
+    return wrapper == null ? null : wrapper.object;
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/util/TestSetOnce.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestSetOnce.java
@@ -69,6 +69,15 @@ public class TestSetOnce extends LuceneTestCase {
     assertEquals(5, set.get().intValue());
     set.set(7);
   }
+
+  @Test
+  public void testTrySet() {
+    SetOnce<Integer> set = new SetOnce<>();
+    assertTrue(set.trySet(5));
+    assertEquals(5, set.get().intValue());
+    assertFalse(set.trySet(7));
+    assertEquals(5, set.get().intValue());
+  }
   
   @Test
   public void testSetMultiThreaded() throws Exception {


### PR DESCRIPTION
# Description

This change fixes race condition in SetOnce class that can cause code like below throw `NullPointerException`
```java
SetOnce<String> setOnce = new SetOnce<>();
new Thread(() -> setOnce.set("thread")).start();
try{
    setOnce.set("main");
} catch (SetOnce.AlreadySetException e){
    setOnce.get().hashCode(); //possible NPE!
}
```
It also adds `boolean trySet(T obj)` method that doesn't throw exception when something was set before, it returns false in that case.

# Solution

`AtomicBoolean` and `volatile T obj` was replaced with single `AtomicReference` that serves both purposes: checking if something was set and actually storing object. That way update is atomic - no race condition can occur.
`Wrapper` is used to allow null object to be stored, the same way it was possible before.

# Tests

All tests from `TestSetOnce` pass, I've also added test for `trySet` method

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I am authorized to contribute this code to the ASF and have removed any code I do not have a license to distribute.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
