### PR TITLE
[LUCENE-9019] Patch for making some variable names more consistent with the other parts of the code.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene80/Lucene80DocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene80/Lucene80DocValuesProducer.java
@@ -569,20 +569,20 @@ final class Lucene80DocValuesProducer extends DocValuesProducer implements Close
             }
           };
         } else if (entry.gcd != 1) {
-          final long gcd = entry.gcd;
-          final long minValue = entry.minValue;
+          final long mul = entry.gcd;
+          final long delta = entry.minValue;
           return new LongValues() {
             @Override
             public long get(long index) {
-              return values.get(index) * gcd + minValue;
+              return values.get(index) * mul + delta;
             }
           };
         } else if (entry.minValue != 0) {
-          final long minValue = entry.minValue;
+          final long delta = entry.minValue;
           return new LongValues() {
             @Override
             public long get(long index) {
-              return values.get(index) + minValue;
+              return values.get(index) + delta;
             }
           };
         } else {

--- a/lucene/core/src/java/org/apache/lucene/index/NumericDocValuesFieldUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/NumericDocValuesFieldUpdates.java
@@ -87,8 +87,8 @@ final class NumericDocValuesFieldUpdates extends DocValuesFieldUpdates {
 
   @Override
   synchronized void add(int doc, long value) {
-    int add = add(doc);
-    values.set(add, value-minValue);
+    int index = add(doc);
+    values.set(index, value-minValue);
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentInfo.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentInfo.java
@@ -276,8 +276,8 @@ public final class SegmentInfo {
    *  segment. */
   public void addFiles(Collection<String> files) {
     checkFileNames(files);
-    for (String f : files) {
-      setFiles.add(namedForThisSegment(f));
+    for (String file : files) {
+      setFiles.add(namedForThisSegment(file));
     }
   }
 


### PR DESCRIPTION
[LUCENE-9019] Patch for making some variable names more consistent with the other parts of the code.

Hello, we're developing an automated system that detects inconsistent variable names in a large software project. Our system checks if each variable name is consistent with other variables in the project in its usage pattern, and proposes correct candidates if inconsistency is detected. This is a part of academic research that we hope to publish soon, but as a part of the evaluation, we applied our systems to your projects and got a few interesting results. We carefully reviewed our system output and manually created a patch to correct a few variable names. We would be delighted if this patch is found to be useful. If you have a question or suggestion regarding this patch, we'd happily
answer. Thank you.

P.S. our patch is purely for readability purposes and does not change any functionality. A couple of issues that we've noticed were left untouched. For example, mixed use of variable names "len" and "length" were fairly widespread, but we have only corrected a few notable instances to minimize our impact.