### PR TITLE
LUCENE-9022: Never cache GlobalOrdinalsWithScoreQuery

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -64,6 +64,8 @@ Other
 
 * LUCENE-8768: Fix Javadocs build in Java 11. (Namgyu Kim)
 
+* LUCENE-8062: GlobalOrdinalsWithScoreQuery is no longer eligible for query caching. (Jim Ferenczi)
+
 ======================= Lucene 8.4.0 =======================
 
 API Changes

--- a/lucene/join/src/java/org/apache/lucene/search/join/GlobalOrdinalsWithScoreQuery.java
+++ b/lucene/join/src/java/org/apache/lucene/search/join/GlobalOrdinalsWithScoreQuery.java
@@ -190,6 +190,13 @@ final class GlobalOrdinalsWithScoreQuery extends Query implements Accountable {
       }
     }
 
+    @Override
+    public boolean isCacheable(LeafReaderContext ctx) {
+      // disable caching because this query relies on a top reader context
+      // and holds a bitset of matching ordinals that cannot be accounted in
+      // the memory used by the cache
+      return false;
+    }
   }
 
   final static class OrdinalMapScorer extends BaseGlobalOrdinalScorer {


### PR DESCRIPTION
Today we disable caching for GlobalOrdinalsQuery (https://issues.apache.org/jira/browse/LUCENE-8062) but not GlobalOrdinalsWithScoreQuery. However the GlobalOrdinalsWithScoreQuery is sometimes executed in a filter context (despite the name, e.g. when min/max are provided) so we should protect this query for the same reasons invoked in LUCENE-8062.
