### PR TITLE
LUCENE-9024 Optimize IntroSelector to use median of medians

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/IntroSelector.java
+++ b/lucene/core/src/java/org/apache/lucene/util/IntroSelector.java
@@ -36,29 +36,30 @@ public abstract class IntroSelector extends Selector {
     return medianOfMediansSelect(from, to-1, k);
   }
 
-  int medianOfMediansSelect(int from, int to, int k) {
+  int medianOfMediansSelect(int left, int right, int k) {
     int pivotIndex;
     do {
-      if (from == to) {
-        return from;
+      // Defensive check, this is also checked in the calling
+      // method. Including here so this method can be used
+      // as a self contained quickSelect implementation.
+      if (left == right) {
+        return left;
       }
-      pivotIndex = pivot(from, to);
-      setPivot(pivotIndex);
-      pivotIndex = partition(from, to, k, pivotIndex);
-      setPivot(pivotIndex);
+      pivotIndex = pivot(left, right);
+      pivotIndex = partition(left, right, k, pivotIndex);
       if (k == pivotIndex) {
         return k;
       } else if (k < pivotIndex) {
-        to = pivotIndex-1;
+        right = pivotIndex-1;
       } else {
-        from = pivotIndex+1;
+        left = pivotIndex+1;
       }
-    } while (from != to);
-    setPivot(pivotIndex);
+    } while (left != right);
     return pivotIndex;
   }
 
-  private int partition(int left, int right, int n, int pivotIndex) {
+  private int partition(int left, int right, int k, int pivotIndex) {
+    setPivot(pivotIndex);
     swap(pivotIndex, right);
     int storeIndex = left;
     for (int i = left; i < right; i++) {
@@ -75,10 +76,10 @@ public abstract class IntroSelector extends Selector {
       }
     }
     swap(right, storeIndexEq);
-    if (n < storeIndex) {
+    if (k < storeIndex) {
       return storeIndex;
-    } else if (n <= storeIndexEq) {
-      return n;
+    } else if (k <= storeIndexEq) {
+      return k;
     }
     return storeIndexEq;
   }
@@ -102,6 +103,9 @@ public abstract class IntroSelector extends Selector {
     return medianOfMediansSelect(left, to, mid);
   }
 
+  // selects the median of a group of at most five elements,
+  // implemented using insertion sort. Efficient due to
+  // bounded nature of data set.
   private int partition5(int left, int right) {
     int i = left + 1;
     while( i <= right) {
@@ -112,7 +116,7 @@ public abstract class IntroSelector extends Selector {
       }
       i++;
     }
-    return (left + right) / 2;
+    return (left + right) >>> 1;
   }
 
   private void quickSelect(int from, int to, int k, int maxDepth) {

--- a/lucene/core/src/java/org/apache/lucene/util/IntroSelector.java
+++ b/lucene/core/src/java/org/apache/lucene/util/IntroSelector.java
@@ -34,7 +34,11 @@ public abstract class IntroSelector extends Selector {
   }
 
   int slowSelect(int from, int to, int k) {
-    int pivotIndex = 0;
+    return medianOfMediansSelect(from, to-1, k);
+  }
+
+  int medianOfMediansSelect(int from, int to, int k) {
+    int pivotIndex;
     do {
       if (from == to) {
         return from;
@@ -96,7 +100,7 @@ public abstract class IntroSelector extends Selector {
     }
     int mid = ((right - left) / 10) + left + 1;
     int to = left + ((right - left)/5);
-    return slowSelect(left, to, mid);
+    return medianOfMediansSelect(left, to, mid);
   }
 
   private int partition5(int left, int right) {

--- a/lucene/core/src/java/org/apache/lucene/util/IntroSelector.java
+++ b/lucene/core/src/java/org/apache/lucene/util/IntroSelector.java
@@ -33,26 +33,83 @@ public abstract class IntroSelector extends Selector {
     quickSelect(from, to, k, maxDepth);
   }
 
-  // heap sort
-  // TODO: use median of median instead to have linear worst-case rather than
-  // n*log(n)
-  void slowSelect(int from, int to, int k) {
-    new Sorter() {
-
-      @Override
-      protected void swap(int i, int j) {
-        IntroSelector.this.swap(i, j);
+  int slowSelect(int from, int to, int k) {
+    int pivotIndex = 0;
+    do {
+      if (from == to) {
+        return from;
       }
-
-      @Override
-      protected int compare(int i, int j) {
-        return IntroSelector.this.compare(i, j);
+      pivotIndex = pivot(from, to);
+      setPivot(pivotIndex);
+      pivotIndex = partition(from, to, k, pivotIndex);
+      setPivot(pivotIndex);
+      if (k == pivotIndex) {
+        return k;
+      } else if (k < pivotIndex) {
+        to = pivotIndex-1;
+      } else {
+        from = pivotIndex+1;
       }
+    } while (from != to);
+    setPivot(pivotIndex);
+    return pivotIndex;
+  }
 
-      public void sort(int from, int to) {
-        heapSort(from, to);
+  private int partition(int left, int right, int n, int pivotIndex) {
+    swap(pivotIndex, right);
+    int storeIndex = left;
+    for (int i = left; i < right; i++) {
+      if (comparePivot(i) > 0) {
+        swap(storeIndex, i);
+        storeIndex++;
       }
-    }.sort(from, to);
+    }
+    int storeIndexEq = storeIndex;
+    for (int i = storeIndex; i < right; i++) {
+      if (comparePivot(i) == 0) {
+        swap(storeIndexEq, i);
+        storeIndexEq++;
+      }
+    }
+    swap(right, storeIndexEq);
+    if (n < storeIndex) {
+      return storeIndex;
+    } else if (n <= storeIndexEq) {
+      return n;
+    }
+    return storeIndexEq;
+  }
+
+  private int pivot(int left, int right) {
+    if (right - left < 5) {
+      int pivotIndex = partition5(left, right);
+      return pivotIndex;
+    }
+
+    for (int i = left; i <= right; i=i+5) {
+      int subRight = i + 4;
+      if (subRight > right) {
+        subRight = right;
+      }
+      int median5 = partition5(i, subRight);
+      swap(median5, left + ((i-left)/5));
+    }
+    int mid = ((right - left) / 10) + left + 1;
+    int to = left + ((right - left)/5);
+    return slowSelect(left, to, mid);
+  }
+
+  private int partition5(int left, int right) {
+    int i = left + 1;
+    while( i <= right) {
+      int j = i;
+      while (j > left && compare(j-1,j)>0) {
+        swap(j-1, j);
+        j--;
+      }
+      i++;
+    }
+    return (left + right) / 2;
   }
 
   private void quickSelect(int from, int to, int k, int maxDepth) {

--- a/lucene/core/src/java/org/apache/lucene/util/IntroSelector.java
+++ b/lucene/core/src/java/org/apache/lucene/util/IntroSelector.java
@@ -37,7 +37,6 @@ public abstract class IntroSelector extends Selector {
   }
 
   int medianOfMediansSelect(int left, int right, int k) {
-    int pivotIndex;
     do {
       // Defensive check, this is also checked in the calling
       // method. Including here so this method can be used
@@ -45,7 +44,7 @@ public abstract class IntroSelector extends Selector {
       if (left == right) {
         return left;
       }
-      pivotIndex = pivot(left, right);
+      int pivotIndex = pivot(left, right);
       pivotIndex = partition(left, right, k, pivotIndex);
       if (k == pivotIndex) {
         return k;
@@ -55,7 +54,7 @@ public abstract class IntroSelector extends Selector {
         left = pivotIndex+1;
       }
     } while (left != right);
-    return pivotIndex;
+    return left;
   }
 
   private int partition(int left, int right, int k, int pivotIndex) {

--- a/lucene/core/src/java/org/apache/lucene/util/IntroSelector.java
+++ b/lucene/core/src/java/org/apache/lucene/util/IntroSelector.java
@@ -20,9 +20,8 @@ import java.util.Comparator;
 
 /** Implementation of the quick select algorithm.
  *  <p>It uses the median of the first, middle and last values as a pivot and
- *  falls back to a heap sort when the number of recursion levels exceeds
- *  {@code 2 lg(n)}, as a consequence it runs in linear time on average and in
- *  {@code n log(n)} time in the worst case.</p>
+ *  falls back to a median of medians when the number of recursion levels exceeds
+ *  {@code 2 lg(n)}, as a consequence it runs in linear time on average.</p>
  *  @lucene.internal */
 public abstract class IntroSelector extends Selector {
 

--- a/lucene/core/src/test/org/apache/lucene/util/TestIntroSelector.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestIntroSelector.java
@@ -36,7 +36,7 @@ public class TestIntroSelector extends LuceneTestCase {
     final int from = random().nextInt(5);
     final int to = from + TestUtil.nextInt(random(), 1, 10000);
     final int max = random().nextBoolean() ? random().nextInt(100) : random().nextInt(100000);
-    Integer[] arr = new Integer[from + to + random().nextInt(5)];
+    Integer[] arr = new Integer[to + random().nextInt(5)];
     for (int i = 0; i < arr.length; ++i) {
       arr[i] = TestUtil.nextInt(random(), 0, max);
     }

--- a/lucene/core/src/test/org/apache/lucene/util/TestIntroSelector.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestIntroSelector.java
@@ -17,7 +17,6 @@
 package org.apache.lucene.util;
 
 import java.util.Arrays;
-import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -40,44 +39,7 @@ public class TestIntroSelector extends LuceneTestCase {
         .map(String::valueOf)
         .collect(Collectors.joining(", "));
   }
-  public void testSpecialSlowSelect() {
 
-    int testCount = 10000;
-    for (int counter = 0; counter < testCount; counter++) {
-      int len = 400; //new Random().nextInt(25);
-      Integer[] toSort = new Integer[len];
-
-      for (int i = 0; i < len; i++) {
-        toSort[i] = new Random().nextInt(len);
-      }
-
-      Integer[] sorted = toSort.clone();
-      Arrays.sort(sorted);
-
-      IntroSelector selector = new IntroSelector() {
-        Integer pivot;
-        @Override
-        protected void swap(int i, int j) {
-          ArrayUtil.swap(toSort, i, j);
-        }
-        @Override
-        protected void setPivot(int i) {
-          pivot = toSort[i];
-        }
-        @Override
-        protected int comparePivot(int j) {
-          return pivot.compareTo(toSort[j]);
-        }
-      };
-
-      int k = new Random().nextInt(len);
-
-      selector.slowSelect(0, len-1, k);
-      int actual = toSort[k];
-      int expected = sorted[k];
-      assertEquals(actual, expected);
-    }
-  }
 
   private void doTestSelect(boolean slow) {
     final int from = random().nextInt(5);
@@ -94,19 +56,15 @@ public class TestIntroSelector extends LuceneTestCase {
 
     Integer[] actual = arr.clone();
     IntroSelector selector = new IntroSelector() {
-
       Integer pivot;
-
       @Override
       protected void swap(int i, int j) {
         ArrayUtil.swap(actual, i, j);
       }
-
       @Override
       protected void setPivot(int i) {
         pivot = actual[i];
       }
-
       @Override
       protected int comparePivot(int j) {
         return pivot.compareTo(actual[j]);
@@ -118,7 +76,6 @@ public class TestIntroSelector extends LuceneTestCase {
     } else {
       selector.select(from, to, k);
     }
-
     assertEquals(expected[k], actual[k]);
 
     for (int i = 0; i < actual.length; ++i) {
@@ -130,6 +87,7 @@ public class TestIntroSelector extends LuceneTestCase {
         assertTrue(actual[i].intValue() >= actual[k].intValue());
       }
     }
+
   }
 
 }

--- a/lucene/core/src/test/org/apache/lucene/util/TestIntroSelector.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestIntroSelector.java
@@ -17,8 +17,6 @@
 package org.apache.lucene.util;
 
 import java.util.Arrays;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class TestIntroSelector extends LuceneTestCase {
 
@@ -33,13 +31,6 @@ public class TestIntroSelector extends LuceneTestCase {
       doTestSelect(true);
     }
   }
-
-  public static String format(Integer[] arr) {
-    return Stream.of(arr)
-        .map(String::valueOf)
-        .collect(Collectors.joining(", "));
-  }
-
 
   private void doTestSelect(boolean slow) {
     final int from = random().nextInt(5);
@@ -56,28 +47,31 @@ public class TestIntroSelector extends LuceneTestCase {
 
     Integer[] actual = arr.clone();
     IntroSelector selector = new IntroSelector() {
+
       Integer pivot;
+
       @Override
       protected void swap(int i, int j) {
         ArrayUtil.swap(actual, i, j);
       }
+
       @Override
       protected void setPivot(int i) {
         pivot = actual[i];
       }
+
       @Override
       protected int comparePivot(int j) {
         return pivot.compareTo(actual[j]);
       }
     };
-
     if (slow) {
       selector.slowSelect(from, to, k);
     } else {
       selector.select(from, to, k);
     }
-    assertEquals(expected[k], actual[k]);
 
+    assertEquals(expected[k], actual[k]);
     for (int i = 0; i < actual.length; ++i) {
       if (i < from || i >= to) {
         assertSame(arr[i], actual[i]);
@@ -87,7 +81,6 @@ public class TestIntroSelector extends LuceneTestCase {
         assertTrue(actual[i].intValue() >= actual[k].intValue());
       }
     }
-
   }
 
 }

--- a/lucene/core/src/test/org/apache/lucene/util/TestIntroSelector.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestIntroSelector.java
@@ -17,6 +17,9 @@
 package org.apache.lucene.util;
 
 import java.util.Arrays;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class TestIntroSelector extends LuceneTestCase {
 
@@ -29,6 +32,50 @@ public class TestIntroSelector extends LuceneTestCase {
   public void testSlowSelect() {
     for (int iter = 0; iter < 100; ++iter) {
       doTestSelect(true);
+    }
+  }
+
+  public static String format(Integer[] arr) {
+    return Stream.of(arr)
+        .map(String::valueOf)
+        .collect(Collectors.joining(", "));
+  }
+  public void testSpecialSlowSelect() {
+
+    int testCount = 10000;
+    for (int counter = 0; counter < testCount; counter++) {
+      int len = 400; //new Random().nextInt(25);
+      Integer[] toSort = new Integer[len];
+
+      for (int i = 0; i < len; i++) {
+        toSort[i] = new Random().nextInt(len);
+      }
+
+      Integer[] sorted = toSort.clone();
+      Arrays.sort(sorted);
+
+      IntroSelector selector = new IntroSelector() {
+        Integer pivot;
+        @Override
+        protected void swap(int i, int j) {
+          ArrayUtil.swap(toSort, i, j);
+        }
+        @Override
+        protected void setPivot(int i) {
+          pivot = toSort[i];
+        }
+        @Override
+        protected int comparePivot(int j) {
+          return pivot.compareTo(toSort[j]);
+        }
+      };
+
+      int k = new Random().nextInt(len);
+
+      selector.slowSelect(0, len-1, k);
+      int actual = toSort[k];
+      int expected = sorted[k];
+      assertEquals(actual, expected);
     }
   }
 
@@ -65,6 +112,7 @@ public class TestIntroSelector extends LuceneTestCase {
         return pivot.compareTo(actual[j]);
       }
     };
+
     if (slow) {
       selector.slowSelect(from, to, k);
     } else {
@@ -72,6 +120,7 @@ public class TestIntroSelector extends LuceneTestCase {
     }
 
     assertEquals(expected[k], actual[k]);
+
     for (int i = 0; i < actual.length; ++i) {
       if (i < from || i >= to) {
         assertSame(arr[i], actual[i]);


### PR DESCRIPTION
# Description

Today, `IntroSelector.slowSelect` falls back to a heap sort; This PR moves that implementation to use a median of medians approach, suggested by a TODO in the code.
 
# Solution

Implemented a median of medians algorithm.

# Tests

I didn't add any new tests for this as I believe the current test cases, `TestIntroSelector`, should cover the basic functionality. However, one thing I'd like input on: Today, `select(int from, int to, int k)`, the `to` parameter is _exclusive_. Since it's also a specified parameter in the test, the test never checks the case where the full array should be used. `doTestSelect` has a call to `Arrays.sort(expected, from, to);`, but `to` will never be the last index in the array because the size of the array is allocated to `from + to + random().nextInt(5)`, so the actual size of the array will be a minimum of `from + to`.

I'd be happy to address this problem in this PR, or in a subsequent PR if that's preferred. 

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I am authorized to contribute this code to the ASF and have removed any code I do not have a license to distribute.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
