### PR TITLE
SOLR-13855: DistributedZkUpdateProcessor needs to propagate finish()

### DIFF
--- a/solr/core/src/java/org/apache/solr/update/processor/DistributedUpdateProcessor.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/DistributedUpdateProcessor.java
@@ -1089,15 +1089,25 @@ public class DistributedUpdateProcessor extends UpdateRequestProcessor {
   }
 
   @Override
-  public void finish() throws IOException {
-    assertNotFinished();
+  public final void finish() throws IOException {
+    assert ! finished : "lifecycle sanity check";
+    finished = true;
+
+    boolean dropCmd = doDistribFinish();
+    //nocommit
+//    if (dropCmd) {
+//      return;
+//    }
 
     super.finish();
   }
 
-  protected void assertNotFinished() {
-    assert ! finished : "lifecycle sanity check";
-    finished = true;
+  /**
+   * @return true if the command should be "dropped" (don't propagate).
+   */
+  protected boolean doDistribFinish() throws IOException {
+    // no-op for derived classes to implement
+    return false;
   }
 
   /**

--- a/solr/core/src/java/org/apache/solr/update/processor/DistributedUpdateProcessor.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/DistributedUpdateProcessor.java
@@ -1093,21 +1093,13 @@ public class DistributedUpdateProcessor extends UpdateRequestProcessor {
     assert ! finished : "lifecycle sanity check";
     finished = true;
 
-    boolean dropCmd = doDistribFinish();
-    //nocommit
-//    if (dropCmd) {
-//      return;
-//    }
+    doDistribFinish();
 
     super.finish();
   }
 
-  /**
-   * @return true if the command should be "dropped" (don't propagate).
-   */
-  protected boolean doDistribFinish() throws IOException {
+  protected void doDistribFinish() throws IOException {
     // no-op for derived classes to implement
-    return false;
   }
 
   /**

--- a/solr/core/src/java/org/apache/solr/update/processor/DistributedZkUpdateProcessor.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/DistributedZkUpdateProcessor.java
@@ -1046,7 +1046,7 @@ public class DistributedZkUpdateProcessor extends DistributedUpdateProcessor {
   }
 
   // TODO: optionally fail if n replicas are not reached...
-  protected boolean doDistribFinish() {
+  protected void doDistribFinish() {
     clusterState = zkController.getClusterState();
 
     boolean shouldUpdateTerms = isLeader && isIndexChanged;
@@ -1189,11 +1189,6 @@ public class DistributedZkUpdateProcessor extends DistributedUpdateProcessor {
       throw new DistributedUpdatesAsyncException(errorsForClient);
     }
 
-    if (nodes == null) {
-      return false; // do not drop, therefore propagate finish()
-    } else {
-      return true; // drop this command since we've distributed it
-    }
   }
 
   /**


### PR DESCRIPTION
Passes tests.  There's a nocommit comment on wether a distributed scenario should not propagate the finish() call.  It was not in the past (checked via null "nodes" field), but I think it should always propagate because even if "nodes" is null processAdd might pass on through a particular document if it's local to the shard receiving the request.  @yonik WDYT?