### PR TITLE
SOLR-13866: Override getSolrMetricsContext in DirectUpdateHandler2

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -123,6 +123,9 @@ Bug Fixes
 
 * SOLR-9802: Fix grouping failure for date field in solrcloud (Erick Erickson, Munendra S N, Vitaly Lavrov)
 
+* SOLR-13866: Fix bug introduced by SOLR-13677 that caused DirectUpdateHandler2 stats to not be available via /admin/plugins
+  handler (Tomás Fernández Löbbe)
+
 Other Changes
 ---------------------
 

--- a/solr/core/src/java/org/apache/solr/update/DirectUpdateHandler2.java
+++ b/solr/core/src/java/org/apache/solr/update/DirectUpdateHandler2.java
@@ -1014,5 +1014,10 @@ public class DirectUpdateHandler2 extends UpdateHandler implements SolrCoreState
   public CommitTracker getSoftCommitTracker() {
     return softCommitTracker;
   }
+  
+  @Override
+  public SolrMetricsContext getSolrMetricsContext() {
+    return solrMetricsContext;
+  }
 
 }


### PR DESCRIPTION
From the Jira description:
> DUH2 stats not populated in PluginInfoHandler: I believe this is related to the changes in SOLR-13677. DirectUpdateHandler2 seems to be missing to implement SolrMetricsContext getSolrMetricsContext(), which causes SolrInfoBean.getMetricsSnapshot() to be null