### PR TITLE
Add temporal unit to warmupTime in ref guide

### DIFF
--- a/solr/solr-ref-guide/src/performance-statistics-reference.adoc
+++ b/solr/solr-ref-guide/src/performance-statistics-reference.adoc
@@ -193,7 +193,7 @@ The following statistics are available for each of the caches mentioned above:
 |inserts |Number of inserts into the cache.
 |lookups |Number of lookups against the cache.
 |size |Number of entries in the cache at that particular instance.
-|warmupTime |Warm-up time for the registered index searcher. This time is taken in account for the “auto-warming” of caches.
+|warmupTime |Warm-up time for the registered index searcher in milliseconds. This time is taken in account for the “auto-warming” of caches.
 |===
 
 When eviction by heap usage is enabled, the following additional statistics are available for the Query Result Cache:


### PR DESCRIPTION
I haven't created a Solr Ticket for this minor change, if really necessary, I can and would update PR and commit message.

# Description

Wanted to know the unit of warmUpTime, but it was not included.

# Solution

Added it, so other people don't have to dig.

# Tests

None, but you can quickly verify by checking source.
https://github.com/apache/lucene-solr/search?l=Java&q=warmupTime

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I am authorized to contribute this code to the ASF and have removed any code I do not have a license to distribute.
- [X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [X] I have developed this patch against the `master` branch.
- [ ] I have run `ant precommit` and the appropriate test suite.
- [ ] I have added tests for my changes.
- [X] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
