### PR TITLE
[docs]: fixed two small errors in JavaDoc

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/DisjunctionMaxQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DisjunctionMaxQuery.java
@@ -262,9 +262,9 @@ public final class DisjunctionMaxQuery extends Query implements Iterable<Query> 
     return buffer.toString();
   }
 
-  /** Return true iff we represent the same query as o
+  /** Return true if we represent the same query as other
    * @param other another object
-   * @return true iff o is a DisjunctionMaxQuery with the same boost and the same subqueries, in the same order, as us
+   * @return true if other is a DisjunctionMaxQuery with the same boost and the same subqueries, in the same order, as us
    */
   @Override
   public boolean equals(Object other) {

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetRange.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetRange.java
@@ -113,7 +113,7 @@ class FacetRangeProcessor extends FacetProcessor<FacetRange> {
    * <ul>
    * <li>If this is a phase#1 shard request, then {@link #createRangeList} will set this value (non null)
    *     if and only if it is needed for refinement (ie: <code>hardend:false</code> &amp; <code>other</code>
-   *     that requres an end value low/high value calculation).  And it wil be included in the response</li>
+   *     that requires an end value low/high value calculation).  And it wil be included in the response</li>
    * <li>If this is a phase#2 refinement request, this variable will be used 
    *     {@link #getOrComputeActualEndForRefinement} to track the value sent with the refinement request 
    *     -- or to cache a recomputed value if the request omitted it -- for use in refining the 


### PR DESCRIPTION
I only fixed two small typo errors in the JavaDocs
