### PR TITLE
SOLR-13925: including resource directory in solrj pom template

### DIFF
--- a/dev-tools/maven/solr/solrj/src/java/pom.xml.template
+++ b/dev-tools/maven/solr/solrj/src/java/pom.xml.template
@@ -47,6 +47,11 @@
   </dependencies>
   <build>
     <sourceDirectory>${module-path}</sourceDirectory>
+    <resources>
+      <resource>
+        <directory>${module-path}/../resources</directory>
+      </resource>
+    </resources>
     <testSourceDirectory/>
     <plugins>
       <plugin>


### PR DESCRIPTION
# Description

Updating the pom template for the solrj module to include resources such as clusterstate.json. 

# Solution

See description.

# Tests

No unit tests, wasn't evident how I could include a test of the maven artifacts. 

# Checklist

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I am authorized to contribute this code to the ASF and have removed any code I do not have a license to distribute.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [ ] I have run `ant precommit` and the appropriate test suite.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
