### PR TITLE
SOLR-13936 : expose endpoint to support changing schema without collection

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -78,6 +78,7 @@ import org.apache.solr.core.DirectoryFactory.DirContext;
 import org.apache.solr.core.backup.repository.BackupRepository;
 import org.apache.solr.core.backup.repository.BackupRepositoryFactory;
 import org.apache.solr.filestore.PackageStoreAPI;
+import org.apache.solr.handler.CoreLessSchemaHandler;
 import org.apache.solr.handler.RequestHandlerBase;
 import org.apache.solr.handler.SnapShooter;
 import org.apache.solr.handler.admin.AutoscalingHistoryHandler;
@@ -225,6 +226,7 @@ public class CoreContainer {
   protected volatile AutoscalingHistoryHandler autoscalingHistoryHandler;
 
   private PackageStoreAPI packageStoreAPI;
+  private CoreLessSchemaHandler coreLessSchemaHandler;
   private PackageLoader packageLoader;
 
 
@@ -616,8 +618,12 @@ public class CoreContainer {
     }
 
     packageStoreAPI = new PackageStoreAPI(this);
+    coreLessSchemaHandler = new CoreLessSchemaHandler(this);
     containerHandlers.getApiBag().register(new AnnotatedApi(packageStoreAPI.readAPI), Collections.EMPTY_MAP);
     containerHandlers.getApiBag().register(new AnnotatedApi(packageStoreAPI.writeAPI), Collections.EMPTY_MAP);
+    //schema endpoints
+    containerHandlers.getApiBag().register(new AnnotatedApi(coreLessSchemaHandler.write), Collections.EMPTY_MAP);
+    containerHandlers.getApiBag().register(new AnnotatedApi(coreLessSchemaHandler.read), Collections.EMPTY_MAP);
 
     metricManager = new SolrMetricManager(loader, cfg.getMetricsConfig());
     String registryName = SolrMetricManager.getRegistryName(SolrInfoBean.Group.node);

--- a/solr/core/src/java/org/apache/solr/core/SolrConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrConfig.java
@@ -166,6 +166,19 @@ public class SolrConfig extends XmlConfigFile implements MapSerializable {
   }
 
   /**
+   * Creates a configuration instance from a configuration stream.
+   * A default resource loader will be created (@see SolrResourceLoader).
+   * If the stream is null, the resource loader will open the configuration stream.
+   * If the stream is not null, no attempt to load the resource will occur (the name is not used).
+   *
+   * @param is the configuration stream
+   */
+  public SolrConfig(InputSource is)
+      throws ParserConfigurationException, IOException, SAXException {
+    this((SolrResourceLoader) null, DEFAULT_CONF_FILE, is);
+  }
+
+  /**
    * Creates a configuration instance from an instance directory, configuration name and stream.
    *
    * @param instanceDir the directory used to create the resource loader
@@ -960,6 +973,7 @@ public class SolrConfig extends XmlConfigFile implements MapSerializable {
 
   private ConfigOverlay overlay;
 
+  //@todo refactor
   public ConfigOverlay getOverlay() {
     if (overlay == null) {
       overlay = getConfigOverlay(getResourceLoader());

--- a/solr/core/src/java/org/apache/solr/handler/CoreLessSchemaHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/CoreLessSchemaHandler.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.handler;
+
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.solr.api.ApiBag;
+import org.apache.solr.api.Command;
+import org.apache.solr.api.EndPoint;
+import org.apache.solr.client.solrj.SolrRequest;
+import org.apache.solr.common.SolrException;
+import org.apache.solr.core.CoreContainer;
+import org.apache.solr.core.SolrConfig;
+import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.response.SolrQueryResponse;
+import org.apache.solr.schema.ManagedIndexSchema;
+import org.apache.solr.schema.SchemaManager;
+import org.apache.solr.security.PermissionNameProvider;
+import org.apache.solr.util.InputSourceUtil;
+import org.apache.zookeeper.data.Stat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+public class CoreLessSchemaHandler {
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private final CoreContainer coreContainer;
+  private static final String SCHEMA_NAME = "managed-schema";
+  private static final String CONFIG_PREFIX = "/configs/";
+  private static final String PATH_PREFIX = "/cluster/configset/";
+  private static final String PATH_POSTFIX_SCHEMA = "/schema";
+
+  public CoreLessSchemaHandler(CoreContainer coreContainer) {
+    this.coreContainer = coreContainer;
+  }
+
+  public final Write write = new Write();
+  public final Read read = new Read();
+
+  @EndPoint(method = SolrRequest.METHOD.GET,
+      path = {PATH_PREFIX, PATH_PREFIX + "{name}" + PATH_POSTFIX_SCHEMA},
+      permission = PermissionNameProvider.Name.SCHEMA_READ_PERM)
+  public class Read {
+    @Command()
+    public void get(SolrQueryRequest req, SolrQueryResponse rsp) throws Exception {
+      String configSetName = req.getPathTemplateValues().get("name");
+      //@todo apv remove query param ?
+      //@todo apv check get version call
+      String schemaPath = req.getParams().get("query");
+      //populating ManagedSchema
+      SolrConfig config = getSolrConfig(configSetName);
+      ManagedIndexSchema schema = getManagedSchema(configSetName, config);
+      //running operations
+      Map<String, Object> params = new SchemaManager().executeGET(schemaPath, schema, req.getParams(), coreContainer.getResourceLoader());
+      Iterator<String> iterator = params.keySet().iterator();
+      while (iterator.hasNext()) {
+        String key = iterator.next();
+        rsp.add(key, params.get(key));
+      }
+    }
+  }
+
+  @EndPoint(method = SolrRequest.METHOD.POST,
+      path = PATH_PREFIX + "{name}" + PATH_POSTFIX_SCHEMA,
+      permission = PermissionNameProvider.Name.SCHEMA_EDIT_PERM)
+  public class Write {
+    @Command()
+    public void post(SolrQueryRequest req, SolrQueryResponse rsp) throws Exception {
+      String configSetName = req.getPathTemplateValues().get("name");
+      try {
+        //populating ManagedSchema
+        SolrConfig config = getSolrConfig(configSetName);
+        ManagedIndexSchema schema = getManagedSchema(configSetName, config);
+        List errs = new SchemaManager().doCmdOperations(
+            configSetName, req.getCommands(false),
+            schema, config, req.getParams(), coreContainer.getResourceLoader(), coreContainer.getZkController());
+        if (!errs.isEmpty())
+          throw new ApiBag.ExceptionWithErrObject(SolrException.ErrorCode.BAD_REQUEST, "error processing commands", errs);
+      } catch (IOException e) {
+        throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, "Error reading input String " + e.getMessage(), e);
+      }
+    }
+  }
+
+  private ManagedIndexSchema getManagedSchema(String configSetName, SolrConfig config) {
+    String schemaNode = CONFIG_PREFIX + configSetName + "/" + SCHEMA_NAME;
+    Stat stat = new Stat();
+    InputSource schemaIS = InputSourceUtil.populate(coreContainer.getZkController().getZkClient(), schemaNode, new Stat());
+    return new ManagedIndexSchema(
+        config.luceneMatchVersion, coreContainer.getResourceLoader(), SCHEMA_NAME, schemaIS, stat.getVersion(), new Object());
+  }
+
+  private SolrConfig getSolrConfig(String configSetName) {
+    String confNode = CONFIG_PREFIX + configSetName + "/" + SolrConfig.DEFAULT_CONF_FILE;
+    InputSource confIS = InputSourceUtil.populate(coreContainer.getZkController().getZkClient(), confNode, new Stat());
+    SolrConfig config;
+    try {
+      config = new SolrConfig(confIS);
+    } catch (IOException | ParserConfigurationException | SAXException e) {
+      throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "Failed to form solrConfig", e);
+    }
+    return config;
+  }
+
+}

--- a/solr/core/src/java/org/apache/solr/handler/SchemaHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/SchemaHandler.java
@@ -18,61 +18,31 @@ package org.apache.solr.handler;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.apache.solr.api.Api;
 import org.apache.solr.api.ApiBag;
-import org.apache.solr.cloud.ZkSolrResourceLoader;
 import org.apache.solr.common.SolrException;
-import org.apache.solr.common.params.MapSolrParams;
-import org.apache.solr.common.params.SolrParams;
-import org.apache.solr.common.util.SimpleOrderedMap;
 import org.apache.solr.common.util.StrUtils;
-import org.apache.solr.common.util.Utils;
 import org.apache.solr.core.SolrCore;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.request.SolrRequestHandler;
 import org.apache.solr.response.SolrQueryResponse;
-import org.apache.solr.schema.IndexSchema;
-import org.apache.solr.schema.ManagedIndexSchema;
 import org.apache.solr.schema.SchemaManager;
-import org.apache.solr.schema.ZkIndexSchemaReader;
 import org.apache.solr.security.AuthorizationContext;
 import org.apache.solr.security.PermissionNameProvider;
 import org.apache.solr.util.plugin.SolrCoreAware;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static java.util.Collections.singletonMap;
 import static org.apache.solr.common.params.CommonParams.JSON;
-import static org.apache.solr.schema.IndexSchema.SchemaProps.Handler.COPY_FIELDS;
-import static org.apache.solr.schema.IndexSchema.SchemaProps.Handler.DYNAMIC_FIELDS;
-import static org.apache.solr.schema.IndexSchema.SchemaProps.Handler.FIELDS;
-import static org.apache.solr.schema.IndexSchema.SchemaProps.Handler.FIELD_TYPES;
 
 public class SchemaHandler extends RequestHandlerBase implements SolrCoreAware, PermissionNameProvider {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private boolean isImmutableConfigSet = false;
-
-  private static final Map<String, String> level2;
-
-  static {
-    Map s = Utils.makeMap(
-        FIELD_TYPES.nameLower, null,
-        FIELDS.nameLower, "fl",
-        DYNAMIC_FIELDS.nameLower, "fl",
-        COPY_FIELDS.nameLower, null
-    );
-
-    level2 = Collections.unmodifiableMap(s);
-  }
-
 
   @Override
   public void handleRequestBody(SolrQueryRequest req, SolrQueryResponse rsp) throws Exception {
@@ -87,7 +57,7 @@ public class SchemaHandler extends RequestHandlerBase implements SolrCoreAware, 
       }
 
       try {
-        List errs = new SchemaManager(req).performOperations();
+        List errs = new SchemaManager().doCmdOperations(req.getCommands(false), req.getCore(), req.getParams());
         if (!errs.isEmpty())
           throw new ApiBag.ExceptionWithErrObject(SolrException.ErrorCode.BAD_REQUEST,"error processing commands", errs);
       } catch (IOException e) {
@@ -111,113 +81,25 @@ public class SchemaHandler extends RequestHandlerBase implements SolrCoreAware, 
   }
 
   private void handleGET(SolrQueryRequest req, SolrQueryResponse rsp) {
+    String path = (String) req.getContext().get("path");
     try {
-      String path = (String) req.getContext().get("path");
-      switch (path) {
-        case "/schema":
-          rsp.add(IndexSchema.SCHEMA, req.getSchema().getNamedPropertyValues());
-          break;
-        case "/schema/version":
-          rsp.add(IndexSchema.VERSION, req.getSchema().getVersion());
-          break;
-        case "/schema/uniquekey":
-          rsp.add(IndexSchema.UNIQUE_KEY, req.getSchema().getUniqueKeyField().getName());
-          break;
-        case "/schema/similarity":
-          rsp.add(IndexSchema.SIMILARITY, req.getSchema().getSimilarityFactory().getNamedPropertyValues());
-          break;
-        case "/schema/name": {
-          final String schemaName = req.getSchema().getSchemaName();
-          if (null == schemaName) {
-            String message = "Schema has no name";
-            throw new SolrException(SolrException.ErrorCode.NOT_FOUND, message);
-          }
-          rsp.add(IndexSchema.NAME, schemaName);
-          break;
-        }
-        case "/schema/zkversion": {
-          int refreshIfBelowVersion = -1;
-          Object refreshParam = req.getParams().get("refreshIfBelowVersion");
-          if (refreshParam != null)
-            refreshIfBelowVersion = (refreshParam instanceof Number) ? ((Number) refreshParam).intValue()
-                : Integer.parseInt(refreshParam.toString());
-          int zkVersion = -1;
-          IndexSchema schema = req.getSchema();
-          if (schema instanceof ManagedIndexSchema) {
-            ManagedIndexSchema managed = (ManagedIndexSchema) schema;
-            zkVersion = managed.getSchemaZkVersion();
-            if (refreshIfBelowVersion != -1 && zkVersion < refreshIfBelowVersion) {
-              log.info("REFRESHING SCHEMA (refreshIfBelowVersion=" + refreshIfBelowVersion +
-                  ", currentVersion=" + zkVersion + ") before returning version!");
-              ZkSolrResourceLoader zkSolrResourceLoader = (ZkSolrResourceLoader) req.getCore().getResourceLoader();
-              ZkIndexSchemaReader zkIndexSchemaReader = zkSolrResourceLoader.getZkIndexSchemaReader();
-              managed = zkIndexSchemaReader.refreshSchemaFromZk(refreshIfBelowVersion);
-              zkVersion = managed.getSchemaZkVersion();
-            }
-          }
-          rsp.add("zkversion", zkVersion);
-          break;
-        }
-        default: {
-          List<String> parts = StrUtils.splitSmart(path, '/', true);
-          if (parts.size() > 1 && level2.containsKey(parts.get(1))) {
-            String realName = parts.get(1);
-            String fieldName = IndexSchema.nameMapping.get(realName);
-
-            String pathParam = level2.get(realName);
-            if (parts.size() > 2) {
-              req.setParams(SolrParams.wrapDefaults(new MapSolrParams(singletonMap(pathParam, parts.get(2))), req.getParams()));
-            }
-            Map propertyValues = req.getSchema().getNamedPropertyValues(realName, req.getParams());
-            Object o = propertyValues.get(fieldName);
-            if(parts.size()> 2) {
-              String name = parts.get(2);
-              if (o instanceof List) {
-                List list = (List) o;
-                for (Object obj : list) {
-                  if (obj instanceof SimpleOrderedMap) {
-                    SimpleOrderedMap simpleOrderedMap = (SimpleOrderedMap) obj;
-                    if(name.equals(simpleOrderedMap.get("name"))) {
-                      rsp.add(fieldName.substring(0, realName.length() - 1), simpleOrderedMap);
-                      return;
-                    }
-                  }
-                }
-              }
-              throw new SolrException(SolrException.ErrorCode.NOT_FOUND, "No such path " + path);
-            } else {
-              rsp.add(fieldName, o);
-            }
-            return;
-          }
-
-          throw new SolrException(SolrException.ErrorCode.NOT_FOUND, "No such path " + path);
-        }
+      Map<String, Object> params = new SchemaManager().executeGET(path, req.getSchema(), req.getParams(), req.getCore().getResourceLoader());
+      Iterator<String> iterator = params.keySet().iterator();
+      while (iterator.hasNext()) {
+        String key = iterator.next();
+        rsp.add(key, params.get(key));
       }
-
     } catch (Exception e) {
       rsp.setException(e);
     }
   }
 
-  private static Set<String> subPaths = new HashSet<>(Arrays.asList(
-      "version",
-      "uniquekey",
-      "name",
-      "similarity",
-      "defaultsearchfield",
-      "solrqueryparser",
-      "zkversion"
-  ));
-  static {
-    subPaths.addAll(level2.keySet());
-  }
 
   @Override
   public SolrRequestHandler getSubHandler(String subPath) {
     List<String> parts = StrUtils.splitSmart(subPath, '/', true);
     String prefix =  parts.get(0);
-    if(subPaths.contains(prefix)) return this;
+    if (SchemaManager.getSubPaths().contains(prefix)) return this;
 
     return null;
   }

--- a/solr/core/src/java/org/apache/solr/schema/IndexSchema.java
+++ b/solr/core/src/java/org/apache/solr/schema/IndexSchema.java
@@ -50,6 +50,7 @@ import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.queries.payloads.PayloadDecoder;
 import org.apache.lucene.search.similarities.Similarity;
 import org.apache.lucene.util.Version;
+import org.apache.solr.cloud.ZkSolrResourceLoader;
 import org.apache.solr.common.MapSerializable;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrException.ErrorCode;
@@ -615,9 +616,12 @@ public class IndexSchema {
   }
 
   protected void postReadInform() {
-    //Run the callbacks on SchemaAware now that everything else is done
-    for (SchemaAware aware : schemaAware) {
-      aware.inform(this);
+    //@todo check exclusive
+    if (loader instanceof ZkSolrResourceLoader) {
+      //Run the callbacks on SchemaAware now that everything else is done
+      for (SchemaAware aware : schemaAware) {
+        aware.inform(this);
+      }
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/schema/ManagedIndexSchema.java
+++ b/solr/core/src/java/org/apache/solr/schema/ManagedIndexSchema.java
@@ -108,6 +108,16 @@ public final class ManagedIndexSchema extends IndexSchema {
     this.schemaZkVersion = schemaZkVersion;
     this.schemaUpdateLock = schemaUpdateLock;
   }
+
+  public ManagedIndexSchema(Version luceneMatchVersion,SolrResourceLoader loader, String name, InputSource is
+      , int schemaZkVersion, Object schemaUpdateLock) {
+    super(name, is, luceneMatchVersion,loader);
+    this.isMutable = true;
+    this.managedSchemaResourceName = name;
+    this.schemaZkVersion = schemaZkVersion;
+    //@todo maybe remove lock
+    this.schemaUpdateLock = schemaUpdateLock;
+  }
   
   
   /**
@@ -1146,9 +1156,12 @@ public final class ManagedIndexSchema extends IndexSchema {
   
   @Override
   protected void postReadInform() {
-    super.postReadInform();
-    for (FieldType fieldType : fieldTypes.values()) {
-      informResourceLoaderAwareObjectsForFieldType(fieldType);
+    //@todo check exclusive
+    if (loader instanceof ZkSolrResourceLoader) {
+      super.postReadInform();
+      for (FieldType fieldType : fieldTypes.values()) {
+        informResourceLoaderAwareObjectsForFieldType(fieldType);
+      }
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/schema/SchemaManager.java
+++ b/solr/core/src/java/org/apache/solr/schema/SchemaManager.java
@@ -21,24 +21,33 @@ import java.io.InputStream;
 import java.io.StringWriter;
 import java.lang.invoke.MethodHandles;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.solr.cloud.ZkController;
 import org.apache.solr.cloud.ZkSolrResourceLoader;
 import org.apache.solr.common.SolrException;
+import org.apache.solr.common.cloud.SolrZkClient;
+import org.apache.solr.common.params.SolrParams;
+import org.apache.solr.common.util.CommandOperation;
+import org.apache.solr.common.util.SimpleOrderedMap;
+import org.apache.solr.common.util.StrUtils;
 import org.apache.solr.common.util.TimeSource;
+import org.apache.solr.common.util.Utils;
 import org.apache.solr.core.CoreDescriptor;
+import org.apache.solr.core.SolrConfig;
 import org.apache.solr.core.SolrCore;
 import org.apache.solr.core.SolrResourceLoader;
-import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.rest.BaseSolrResource;
-import org.apache.solr.common.util.CommandOperation;
 import org.apache.solr.util.TimeOut;
 import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.InputSource;
@@ -51,6 +60,10 @@ import static org.apache.solr.schema.IndexSchema.DESTINATION;
 import static org.apache.solr.schema.IndexSchema.MAX_CHARS;
 import static org.apache.solr.schema.IndexSchema.NAME;
 import static org.apache.solr.schema.IndexSchema.SOURCE;
+import static org.apache.solr.schema.IndexSchema.SchemaProps.Handler.COPY_FIELDS;
+import static org.apache.solr.schema.IndexSchema.SchemaProps.Handler.DYNAMIC_FIELDS;
+import static org.apache.solr.schema.IndexSchema.SchemaProps.Handler.FIELDS;
+import static org.apache.solr.schema.IndexSchema.SchemaProps.Handler.FIELD_TYPES;
 import static org.apache.solr.schema.IndexSchema.TYPE;
 
 /**
@@ -61,48 +74,131 @@ import static org.apache.solr.schema.IndexSchema.TYPE;
 public class SchemaManager {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  final SolrQueryRequest req;
   ManagedIndexSchema managedIndexSchema;
 
-  public SchemaManager(SolrQueryRequest req){
-    this.req = req;
+  private static final Map<String, String> level2;
+
+  static {
+    Map s = Utils.makeMap(
+        FIELD_TYPES.nameLower, null,
+        FIELDS.nameLower, "fl",
+        DYNAMIC_FIELDS.nameLower, "fl",
+        COPY_FIELDS.nameLower, null
+    );
+
+    level2 = Collections.unmodifiableMap(s);
+
   }
 
+  private static Set<String> subPaths = new HashSet<>(Arrays.asList(
+      "version",
+      "uniquekey",
+      "name",
+      "similarity",
+      "defaultsearchfield",
+      "solrqueryparser",
+      "zkversion"
+  ));
+
+  static {
+    subPaths.addAll(level2.keySet());
+
+  }
+
+  public static Set<String> getSubPaths() {
+    return subPaths;
+  }
   /**
    * Take in a JSON command set and execute them. It tries to capture as many errors
    * as possible instead of failing at the first error it encounters
    * @return List of errors. If the List is empty then the operation was successful.
    */
-  public List performOperations() throws Exception {
-    List<CommandOperation> ops = req.getCommands(false);
-    List errs = CommandOperation.captureErrors(ops);
+  public List doCmdOperations(List<CommandOperation> cmds, SolrCore core, SolrParams params) throws Exception {
+    List errs = CommandOperation.captureErrors(cmds);
     if (!errs.isEmpty()) return errs;
 
-    IndexSchema schema = req.getCore().getLatestSchema();
+    IndexSchema schema = core.getLatestSchema();
     if (schema instanceof ManagedIndexSchema && schema.isMutable()) {
-      return doOperations(ops);
+      return doOperations(cmds, core, params);
+    } else {
+      return singletonList(singletonMap(CommandOperation.ERR_MSGS, "schema is not editable"));
+    }
+  }
+  public List doCmdOperations(String name,List<CommandOperation> cmds,
+                              ManagedIndexSchema schema,SolrConfig config,
+                              SolrParams params,SolrResourceLoader loader,ZkController controller) throws Exception {
+    List errs = CommandOperation.captureErrors(cmds);
+    if (!errs.isEmpty()) return errs;
+
+    if (schema instanceof ManagedIndexSchema && schema.isMutable()) {
+      return doOperations(name,cmds, schema, config, params,loader,controller);
     } else {
       return singletonList(singletonMap(CommandOperation.ERR_MSGS, "schema is not editable"));
     }
   }
 
-  private List doOperations(List<CommandOperation> operations) throws InterruptedException, IOException, KeeperException {
+  private List doOperations(String name, List<CommandOperation> operations, ManagedIndexSchema schema, SolrConfig config,
+                            SolrParams params, SolrResourceLoader loader, ZkController controller)
+      throws InterruptedException, IOException, KeeperException {
+    //@todo check for non cloud
     //The default timeout is 10 minutes when no BaseSolrResource.UPDATE_TIMEOUT_SECS is specified
-    int timeout = req.getParams().getInt(BaseSolrResource.UPDATE_TIMEOUT_SECS, 600);
+    int timeout = params.getInt(BaseSolrResource.UPDATE_TIMEOUT_SECS, 600);
 
     //If BaseSolrResource.UPDATE_TIMEOUT_SECS=0 or -1 then end time then we'll try for 10 mins ( default timeout )
     if (timeout < 1) {
       timeout = 600;
     }
     TimeOut timeOut = new TimeOut(timeout, TimeUnit.SECONDS, TimeSource.NANO_TIME);
-    SolrCore core = req.getCore();
+    String errorMsg = "Unable to persist managed schema. ";
+    List errors ;
+
+    synchronized (schema.getSchemaUpdateLock()) {
+        managedIndexSchema = getFreshManagedSchema(schema,config,loader);
+        for (CommandOperation op : operations) {
+          OpType opType = OpType.get(op.name);
+          if (opType != null) {
+            opType.perform(op, this);
+          } else {
+            op.addError("No such operation : " + op.name);
+          }
+        }
+        errors = CommandOperation.captureErrors(operations);
+      if (!errors.isEmpty()) return errors;
+        StringWriter sw = new StringWriter();
+      try {
+        managedIndexSchema.persist(sw);
+        final SolrZkClient zkClient = controller.getZkClient();
+        final String resourceLocation =  "/configs/" + name+"/"+managedIndexSchema.getResourceName();
+       zkClient.setData(resourceLocation, sw.toString().getBytes(StandardCharsets.UTF_8), managedIndexSchema.getSchemaZkVersion(), true);
+      } catch (IOException e) {
+        throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "unable to serialize schema");
+        //unlikely
+      }
+    }
+    if (errors.isEmpty() && timeOut.hasTimedOut()) {
+      log.warn(errorMsg + "Timed out.");
+      errors = singletonList(errorMsg + "Timed out.");
+    }
+    return errors;
+  }
+
+  private List doOperations(List<CommandOperation> operations, SolrCore core, SolrParams params)
+      throws InterruptedException, IOException, KeeperException {
+    //The default timeout is 10 minutes when no BaseSolrResource.UPDATE_TIMEOUT_SECS is specified
+    int timeout = params.getInt(BaseSolrResource.UPDATE_TIMEOUT_SECS, 600);
+
+    //If BaseSolrResource.UPDATE_TIMEOUT_SECS=0 or -1 then end time then we'll try for 10 mins ( default timeout )
+    if (timeout < 1) {
+      timeout = 600;
+    }
+    TimeOut timeOut = new TimeOut(timeout, TimeUnit.SECONDS, TimeSource.NANO_TIME);
     String errorMsg = "Unable to persist managed schema. ";
     List errors = Collections.emptyList();
     int latestVersion = -1;
 
-    synchronized (req.getSchema().getSchemaUpdateLock()) {
+    synchronized (core.getLatestSchema().getSchemaUpdateLock()) {
       while (!timeOut.hasTimedOut()) {
-        managedIndexSchema = getFreshManagedSchema(req.getCore());
+        managedIndexSchema = getFreshManagedSchema(core);
         for (CommandOperation op : operations) {
           OpType opType = OpType.get(op.name);
           if (opType != null) {
@@ -113,7 +209,7 @@ public class SchemaManager {
         }
         errors = CommandOperation.captureErrors(operations);
         if (!errors.isEmpty()) break;
-        SolrResourceLoader loader = req.getCore().getResourceLoader();
+        SolrResourceLoader loader = core.getResourceLoader();
         if (loader instanceof ZkSolrResourceLoader) {
           ZkSolrResourceLoader zkLoader = (ZkSolrResourceLoader) loader;
           StringWriter sw = new StringWriter();
@@ -127,8 +223,8 @@ public class SchemaManager {
           try {
             latestVersion = ZkController.persistConfigResourceToZooKeeper
                 (zkLoader, managedIndexSchema.getSchemaZkVersion(), managedIndexSchema.getResourceName(),
-                 sw.toString().getBytes(StandardCharsets.UTF_8), true);
-            req.getCore().getCoreContainer().reload(req.getCore().getName());
+                    sw.toString().getBytes(StandardCharsets.UTF_8), true);
+            core.getCoreContainer().reload(core.getName());
             break;
           } catch (ZkController.ResourceModifiedInZkException e) {
             log.info("Schema was modified by another node. Retrying..");
@@ -147,10 +243,10 @@ public class SchemaManager {
         }
       }
     }
-    if (req.getCore().getResourceLoader() instanceof ZkSolrResourceLoader) {
+    if (core.getResourceLoader() instanceof ZkSolrResourceLoader) {
       // Don't block further schema updates while waiting for a pending update to propagate to other replicas.
       // This reduces the likelihood of a (time-limited) distributed deadlock during concurrent schema updates.
-      waitForOtherReplicasToUpdate(timeOut, latestVersion);
+      waitForOtherReplicasToUpdate(core, timeOut, latestVersion);
     }
     if (errors.isEmpty() && timeOut.hasTimedOut()) {
       log.warn(errorMsg + "Timed out.");
@@ -159,8 +255,7 @@ public class SchemaManager {
     return errors;
   }
 
-  private void waitForOtherReplicasToUpdate(TimeOut timeOut, int latestVersion) {
-    SolrCore core = req.getCore();
+  private void waitForOtherReplicasToUpdate(SolrCore core, TimeOut timeOut, int latestVersion) {
     CoreDescriptor cd = core.getCoreDescriptor();
     String collection = cd.getCollectionName();
     if (collection != null) {
@@ -414,23 +509,116 @@ public class SchemaManager {
     return sb.toString();
   }
 
-  public static ManagedIndexSchema getFreshManagedSchema(SolrCore core) throws IOException,
-      KeeperException, InterruptedException {
+  public static ManagedIndexSchema getFreshManagedSchema(SolrCore core) throws IOException {
+    return getFreshManagedSchema(core.getLatestSchema(), core.getSolrConfig(), core.getResourceLoader());
+  }
 
-    SolrResourceLoader resourceLoader = core.getResourceLoader();
-    String name = core.getLatestSchema().getResourceName();
+  private static ManagedIndexSchema getFreshManagedSchema(
+      IndexSchema currentSchema, SolrConfig config, SolrResourceLoader resourceLoader) throws IOException{
+
+    String name = currentSchema.getResourceName();
     if (resourceLoader instanceof ZkSolrResourceLoader) {
       InputStream in = resourceLoader.openResource(name);
       if (in instanceof ZkSolrResourceLoader.ZkByteArrayInputStream) {
         int version = ((ZkSolrResourceLoader.ZkByteArrayInputStream) in).getStat().getVersion();
         log.info("managed schema loaded . version : {} ", version);
-        return new ManagedIndexSchema(core.getSolrConfig(), name, new InputSource(in), true, name, version,
-            core.getLatestSchema().getSchemaUpdateLock());
+        return new ManagedIndexSchema(config, name, new InputSource(in), true, name, version,
+            currentSchema.getSchemaUpdateLock());
       } else {
-        return (ManagedIndexSchema) core.getLatestSchema();
+        return (ManagedIndexSchema) currentSchema;
       }
     } else {
-      return (ManagedIndexSchema) core.getLatestSchema();
+      return (ManagedIndexSchema) currentSchema;
     }
+  }
+  public Map<String, Object> executeGET(String path, IndexSchema schema, SolrParams reqParams, SolrResourceLoader resourceLoader)
+      throws KeeperException, InterruptedException {
+    Map<String, Object> params = new HashMap<>();
+    switch (path) {
+      case "/schema":
+        params.put(IndexSchema.SCHEMA, schema.getNamedPropertyValues());
+        break;
+      case "/schema/version":
+        params.put(IndexSchema.VERSION, schema.getVersion());
+        break;
+      case "/schema/uniquekey":
+        params.put(IndexSchema.UNIQUE_KEY, schema.getUniqueKeyField().getName());
+        break;
+      case "/schema/similarity":
+        params.put(IndexSchema.SIMILARITY, schema.getSimilarityFactory().getNamedPropertyValues());
+        break;
+      case "/schema/name": {
+        final String schemaName = schema.getSchemaName();
+        if (null == schemaName) {
+          String message = "Schema has no name";
+          throw new SolrException(SolrException.ErrorCode.NOT_FOUND, message);
+        }
+        params.put(IndexSchema.NAME, schemaName);
+        break;
+      }
+      case "/schema/zkversion": {
+        int refreshIfBelowVersion = -1;
+        Object refreshParam = reqParams.get("refreshIfBelowVersion");
+        if (refreshParam != null)
+          refreshIfBelowVersion = (refreshParam instanceof Number) ? ((Number) refreshParam).intValue()
+              : Integer.parseInt(refreshParam.toString());
+        int zkVersion = -1;
+        if (schema instanceof ManagedIndexSchema) {
+          ManagedIndexSchema managed = (ManagedIndexSchema) schema;
+          zkVersion = managed.getSchemaZkVersion();
+          if (refreshIfBelowVersion != -1 && zkVersion < refreshIfBelowVersion) {
+            log.info("REFRESHING SCHEMA (refreshIfBelowVersion=" + refreshIfBelowVersion +
+                ", currentVersion=" + zkVersion + ") before returning version!");
+            if (resourceLoader instanceof ZkSolrResourceLoader) {
+              ZkSolrResourceLoader zkSolrResourceLoader = (ZkSolrResourceLoader) resourceLoader;
+              ZkIndexSchemaReader zkIndexSchemaReader = zkSolrResourceLoader.getZkIndexSchemaReader();
+              managed = zkIndexSchemaReader.refreshSchemaFromZk(refreshIfBelowVersion);
+              zkVersion = managed.getSchemaZkVersion();
+            } else {
+              throw new SolrException(SolrException.ErrorCode.BAD_REQUEST,"Doesn't implement /zkversion");
+            }
+          }
+        }
+        params.put("zkversion", zkVersion);
+        break;
+      }
+      default: {
+        List<String> parts = StrUtils.splitSmart(path, '/', true);
+        if (parts.size() > 1 && level2.containsKey(parts.get(1))) {
+          String realName = parts.get(1);
+          String fieldName = IndexSchema.nameMapping.get(realName);
+
+          String pathParam = level2.get(realName);
+          //@todo check
+//            if (parts.size() > 2) {
+//              reqParams = SolrParams.wrapDefaults(new MapSolrParams(singletonMap(pathParam, parts.get(2))), req.getParams());
+//            }
+          Map propertyValues = schema.getNamedPropertyValues(realName, reqParams);
+          Object o = propertyValues.get(fieldName);
+          if (parts.size() > 2) {
+            String name = parts.get(2);
+            if (o instanceof List) {
+              List list = (List) o;
+              for (Object obj : list) {
+                if (obj instanceof SimpleOrderedMap) {
+                  SimpleOrderedMap simpleOrderedMap = (SimpleOrderedMap) obj;
+                  if (name.equals(simpleOrderedMap.get("name"))) {
+                    params.put(fieldName.substring(0, realName.length() - 1), simpleOrderedMap);
+                    return params;
+                  }
+                }
+              }
+            }
+            throw new SolrException(SolrException.ErrorCode.NOT_FOUND, "No such path " + path);
+          } else {
+            params.put(fieldName, o);
+          }
+          return params;
+        }
+
+        throw new SolrException(SolrException.ErrorCode.NOT_FOUND, "No such path " + path);
+      }
+    }
+    return params;
   }
 }

--- a/solr/core/src/java/org/apache/solr/util/InputSourceUtil.java
+++ b/solr/core/src/java/org/apache/solr/util/InputSourceUtil.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.util;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import org.apache.solr.common.SolrException;
+import org.apache.solr.common.cloud.SolrZkClient;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.data.Stat;
+import org.xml.sax.InputSource;
+
+public class InputSourceUtil {
+  public static InputSource populate(SolrZkClient client, String path, Stat stat) {
+    try {
+      byte[] data = client.getData(path, null, stat, true);
+      InputStream schemaInputStream = new ByteArrayInputStream(data);
+      return new InputSource(schemaInputStream);
+    } catch (KeeperException.NoNodeException e) {
+      throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, "Configset path:" + path + " not found", e);
+    } catch (InterruptedException | KeeperException e) {
+      throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "Failed to access path:" + path, e);
+    }
+  }
+}


### PR DESCRIPTION
# Description
Current apis do not allow modifying a configset if it is not associated with a collection/core
For cases where a configset is created, modified and then used this is necessary

# Solution
- Make current apis directly dependent on `SolrResourceLoader` and `ManagedSchema/SolrConfig` instead of `SolrCore`
- Expose endpoints on `/api/cluster` level

# Tests
TODO

# Checklist

Please review the following and check all that apply:

- [ ] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I am authorized to contribute this code to the ASF and have removed any code I do not have a license to distribute.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have developed this patch against the `master` branch.
- [ ] I have run `ant precommit` and the appropriate test suite.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
