### PR TITLE
LUCENE-9051: random access for IndexedDISI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ build
 dist
 lib
 test-lib
-/*~
+*~
 /velocity.log
 /build.properties
 /.idea
@@ -29,4 +29,9 @@ pom.xml
 __pycache__
 /dev-tools/scripts/scripts.iml
 .DS_Store
-
+/.gradle/
+/_lucene-solr.iml
+/buildSrc/
+/dev-tools/dev-tools.iml
+/user.gradle
+/user.properties


### PR DESCRIPTION
# Description
Enables random access over DocValues via its existing advanceExact method. With this change, callers may provide docids in any order rather than having to enforce that they never decrease over subsequent calls to the iterator API.
