### PR TITLE
SOLR-13101: Address flakiness of tests using async pulls and handle i…

### DIFF
--- a/solr/core/src/test/org/apache/solr/store/blob/SharedStorageSplitTest.java
+++ b/solr/core/src/test/org/apache/solr/store/blob/SharedStorageSplitTest.java
@@ -42,13 +42,7 @@ import org.apache.solr.common.cloud.DocCollection;
 import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.cloud.Slice;
 import org.apache.solr.common.cloud.ZkStateReader;
-import org.apache.solr.store.blob.client.BlobCoreMetadata;
 import org.apache.solr.store.blob.client.CoreStorageClient;
-import org.apache.solr.store.blob.process.BlobProcessUtil;
-import org.apache.solr.store.blob.process.CorePullTask;
-import org.apache.solr.store.blob.process.CorePullTask.PullCoreCallback;
-import org.apache.solr.store.blob.process.CorePullerFeeder;
-import org.apache.solr.store.blob.process.CoreSyncStatus;
 import org.apache.solr.store.shared.SolrCloudSharedStoreTestCase;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -57,7 +51,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Tests for shard splitting in conjunction with sharedf storage
+ * Tests for shard splitting in conjunction with shared storage
  */
 public class SharedStorageSplitTest extends SolrCloudSharedStoreTestCase  {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -333,30 +327,4 @@ public class SharedStorageSplitTest extends SolrCloudSharedStoreTestCase  {
     // become active (a known issue that still needs to be resolved.)
     doLiveSplitShard("livesplit1", true, 1, 8);
   }
-
-
-  private static Map<String, CountDownLatch> configureTestBlobProcessForNode(JettySolrRunner runner) {
-    Map<String, CountDownLatch> asyncPullTracker = new HashMap<>();
-
-    CorePullerFeeder cpf = new CorePullerFeeder(runner.getCoreContainer()) {  
-      @Override
-      protected CorePullTask.PullCoreCallback getCorePullTaskCallback() {
-        return new PullCoreCallback() {
-          @Override
-          public void finishedPull(CorePullTask pullTask, BlobCoreMetadata blobMetadata, CoreSyncStatus status,
-              String message) throws InterruptedException {
-            CountDownLatch latch = asyncPullTracker.get(pullTask.getPullCoreInfo().getDedupeKey());
-            if (latch != null) {
-              latch.countDown();
-            }
-          }
-        };
-      }
-    };
-
-    BlobProcessUtil testUtil = new BlobProcessUtil(runner.getCoreContainer(), cpf);
-    setupTestBlobProcessUtilForNode(testUtil, runner);
-    return asyncPullTracker;
-  }
-
 }

--- a/solr/core/src/test/org/apache/solr/store/shared/SharedCoreConcurrencyTest.java
+++ b/solr/core/src/test/org/apache/solr/store/shared/SharedCoreConcurrencyTest.java
@@ -39,12 +39,7 @@ import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.core.CoreContainer;
 import org.apache.solr.core.SolrCore;
-import org.apache.solr.store.blob.client.BlobCoreMetadata;
 import org.apache.solr.store.blob.client.CoreStorageClient;
-import org.apache.solr.store.blob.process.BlobProcessUtil;
-import org.apache.solr.store.blob.process.CorePullTask;
-import org.apache.solr.store.blob.process.CorePullerFeeder;
-import org.apache.solr.store.blob.process.CoreSyncStatus;
 import org.apache.solr.store.shared.SharedCoreConcurrencyController.SharedCoreStage;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -330,30 +325,6 @@ public class SharedCoreConcurrencyTest extends SolrCloudSharedStoreTestCase {
       prevThreadId = currentThreadId;
       prevStage = currentStage;
     }
-  }
-
-  private Map<String, CountDownLatch> configureTestBlobProcessForNode(JettySolrRunner runner) {
-    Map<String, CountDownLatch> asyncPullTracker = new HashMap<>();
-
-    CorePullerFeeder cpf = new CorePullerFeeder(runner.getCoreContainer()) {
-      @Override
-      protected CorePullTask.PullCoreCallback getCorePullTaskCallback() {
-        return new CorePullTask.PullCoreCallback() {
-          @Override
-          public void finishedPull(CorePullTask pullTask, BlobCoreMetadata blobMetadata, CoreSyncStatus status,
-                                   String message) throws InterruptedException {
-            CountDownLatch latch = asyncPullTracker.get(pullTask.getPullCoreInfo().getCoreName());
-            if(latch != null) {
-              latch.countDown();
-            }
-          }
-        };
-      }
-    };
-
-    BlobProcessUtil testUtil = new BlobProcessUtil(runner.getCoreContainer(), cpf);
-    setupTestBlobProcessUtilForNode(testUtil, runner);
-    return asyncPullTracker;
   }
 
   private void configureTestSharedConcurrencyControllerForNode(JettySolrRunner runner, List<String> progress) {

--- a/solr/core/src/test/org/apache/solr/store/shared/SharedStoreMissingCoreTest.java
+++ b/solr/core/src/test/org/apache/solr/store/shared/SharedStoreMissingCoreTest.java
@@ -235,26 +235,4 @@ public class SharedStoreMissingCoreTest extends SolrCloudSharedStoreTestCase {
     Collections.sort(actualDocs);
     assertEquals("wrong docs", expectedDocs.toString(), actualDocs.toString());
   }
-
-  private Map<String, CountDownLatch> configureTestBlobProcessForNode(JettySolrRunner runner) {
-    Map<String, CountDownLatch> asyncPullTracker = new HashMap<>();
-
-    CorePullerFeeder cpf = new CorePullerFeeder(runner.getCoreContainer()) {
-      @Override
-      protected CorePullTask.PullCoreCallback getCorePullTaskCallback() {
-        return new PullCoreCallback() {
-          @Override
-          public void finishedPull(CorePullTask pullTask, BlobCoreMetadata blobMetadata, CoreSyncStatus status,
-                                   String message) throws InterruptedException {
-            CountDownLatch latch = asyncPullTracker.get(pullTask.getPullCoreInfo().getCoreName());
-            latch.countDown();
-          }
-        };
-      }
-    };
-
-    BlobProcessUtil testUtil = new BlobProcessUtil(runner.getCoreContainer(), cpf);
-    setupTestBlobProcessUtilForNode(testUtil, runner);
-    return asyncPullTracker;
-  }
 }

--- a/solr/core/src/test/org/apache/solr/store/shared/SimpleSharedStoreEndToEndPullTest.java
+++ b/solr/core/src/test/org/apache/solr/store/shared/SimpleSharedStoreEndToEndPullTest.java
@@ -33,13 +33,7 @@ import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.core.CoreContainer;
 import org.apache.solr.core.SolrCore;
-import org.apache.solr.store.blob.client.BlobCoreMetadata;
 import org.apache.solr.store.blob.client.CoreStorageClient;
-import org.apache.solr.store.blob.process.BlobProcessUtil;
-import org.apache.solr.store.blob.process.CorePullTask;
-import org.apache.solr.store.blob.process.CorePullTask.PullCoreCallback;
-import org.apache.solr.store.blob.process.CorePullerFeeder;
-import org.apache.solr.store.blob.process.CoreSyncStatus;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -166,29 +160,4 @@ public class SimpleSharedStoreEndToEndPullTest extends SolrCloudSharedStoreTestC
       core.close();
     }
   }
-  
-  private Map<String, CountDownLatch> configureTestBlobProcessForNode(JettySolrRunner runner) {
-    Map<String, CountDownLatch> asyncPullTracker = new HashMap<>();
-
-    CorePullerFeeder cpf = new CorePullerFeeder(runner.getCoreContainer()) {
-      @Override
-      protected CorePullTask.PullCoreCallback getCorePullTaskCallback() {
-        return new PullCoreCallback() {
-          @Override
-          public void finishedPull(CorePullTask pullTask, BlobCoreMetadata blobMetadata, CoreSyncStatus status,
-                                   String message) throws InterruptedException {
-            CountDownLatch latch = asyncPullTracker.get(pullTask.getPullCoreInfo().getCoreName());
-            if (latch != null) {
-              latch.countDown();
-            }
-          }
-        };
-      }
-    };
-
-    BlobProcessUtil testUtil = new BlobProcessUtil(runner.getCoreContainer(), cpf);
-    setupTestBlobProcessUtilForNode(testUtil, runner);
-    return asyncPullTracker;
-  }
-  
 }

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/ZkStateReader.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/ZkStateReader.java
@@ -973,7 +973,7 @@ public class ZkStateReader implements SolrCloseable {
         }
         return false;
       });
-    } catch (TimeoutException | InterruptedException e) {
+    } catch (TimeoutException e) {
       throw new SolrException(ErrorCode.SERVICE_UNAVAILABLE, "No registered leader was found after waiting for "
           + timeout + "ms " + ", collection: " + collection + " slice: " + shard + " saw state=" + clusterState.getCollectionOrNull(collection)
           + " with live_nodes=" + clusterState.getLiveNodes());


### PR DESCRIPTION
…nterrupt properly

Summary
- Addressing test flakiness from two issues:
  - Tests that rely on async pulls have test scaffolding that allows a custom pulling mechanisms to be injected into mini cluster nodes and countdown CDLs on pull completions. We shouldn't instantiate a new callback object on each call to getCorePullTaskCallback.
  - Interrupt exception was being swallowed and causing leaking threads 

Changes
- Refactored and moved the async test logic into SolrCloudSharedStoreTestCase. Only initiate the callback instance once and not per call
- Don't catch InterruptedException in ZkStateReader. I opened a JIRA/PR in master for this https://github.com/apache/lucene-solr/pull/1023 but it hasn't been merged yet so including it here. We'll get it on next upgrade ideally.
