### PR TITLE
SOLR-13863: payload query function now handles string encoded payload field (delimited_payloads_string)

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/PostingsEnum.java
+++ b/lucene/core/src/java/org/apache/lucene/index/PostingsEnum.java
@@ -68,9 +68,9 @@ public abstract class PostingsEnum extends DocIdSetIterator {
   }
 
   /**
-   * Returns an empty PostingsEnum object.
+   * Returns an dummy PostingsEnum object.
    */
-  public static PostingsEnum getEmptyInstance() {
+  public static PostingsEnum getDummyInstance() {
     return new PostingsEnum() {
       @Override
       public int freq() {

--- a/lucene/core/src/java/org/apache/lucene/index/PostingsEnum.java
+++ b/lucene/core/src/java/org/apache/lucene/index/PostingsEnum.java
@@ -68,10 +68,9 @@ public abstract class PostingsEnum extends DocIdSetIterator {
   }
 
   /**
-   * Returns an dummy PostingsEnum object.
+   * Dummy PostingsEnum object.
    */
-  public static PostingsEnum getDummyInstance() {
-    return new PostingsEnum() {
+  public static PostingsEnum DUMMY_INSTANCE = new PostingsEnum() {
       @Override
       public int freq() {
         return 0;
@@ -117,7 +116,6 @@ public abstract class PostingsEnum extends DocIdSetIterator {
         return 0;
       }
     };
-  }
 
   /**
    * Returns term frequency in the current document, or 1 if the field was

--- a/lucene/core/src/java/org/apache/lucene/index/PostingsEnum.java
+++ b/lucene/core/src/java/org/apache/lucene/index/PostingsEnum.java
@@ -68,6 +68,58 @@ public abstract class PostingsEnum extends DocIdSetIterator {
   }
 
   /**
+   * Returns an empty PostingsEnum object.
+   */
+  public static PostingsEnum getEmptyInstance() {
+    return new PostingsEnum() {
+      @Override
+      public int freq() {
+        return 0;
+      }
+
+      @Override
+      public int nextPosition() throws IOException {
+        return -1;
+      }
+
+      @Override
+      public int startOffset() throws IOException {
+        return -1;
+      }
+
+      @Override
+      public int endOffset() throws IOException {
+        return -1;
+      }
+
+      @Override
+      public BytesRef getPayload() throws IOException {
+        return null;
+      }
+
+      @Override
+      public int docID() {
+        return DocIdSetIterator.NO_MORE_DOCS;
+      }
+
+      @Override
+      public int nextDoc() {
+        return DocIdSetIterator.NO_MORE_DOCS;
+      }
+
+      @Override
+      public int advance(int target) {
+        return DocIdSetIterator.NO_MORE_DOCS;
+      }
+
+      @Override
+      public long cost() {
+        return 0;
+      }
+    };
+  }
+
+  /**
    * Returns term frequency in the current document, or 1 if the field was
    * indexed with {@link IndexOptions#DOCS}. Do not call this before
    * {@link #nextDoc} is first called, nor after {@link #nextDoc} returns

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/TFValueSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/TFValueSource.java
@@ -77,7 +77,7 @@ public class TFValueSource extends TermFreqValueSource {
         }
 
         if (docs == null) {
-          docs = PostingsEnum.getDummyInstance();
+          docs = PostingsEnum.DUMMY_INSTANCE;
         }
         atDoc = -1;
       }

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/TFValueSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/TFValueSource.java
@@ -77,7 +77,7 @@ public class TFValueSource extends TermFreqValueSource {
         }
 
         if (docs == null) {
-          docs = PostingsEnum.getEmptyInstance();
+          docs = PostingsEnum.getDummyInstance();
         }
         atDoc = -1;
       }

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/TFValueSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/TFValueSource.java
@@ -25,7 +25,6 @@ import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.queries.function.FunctionValues;
 import org.apache.lucene.queries.function.docvalues.FloatDocValues;
-import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.similarities.TFIDFSimilarity;
 import org.apache.lucene.util.BytesRef;
@@ -56,7 +55,7 @@ public class TFValueSource extends TermFreqValueSource {
       throw new UnsupportedOperationException("requires a TFIDFSimilarity (such as ClassicSimilarity)");
     }
 
-    return new FloatDocValues(this) {
+      return new FloatDocValues(this) {
       PostingsEnum docs ;
       int atDoc;
       int lastDocRequested = -1;
@@ -78,52 +77,7 @@ public class TFValueSource extends TermFreqValueSource {
         }
 
         if (docs == null) {
-          docs = new PostingsEnum() {
-            @Override
-            public int freq() {
-              return 0;
-            }
-
-            @Override
-            public int nextPosition() throws IOException {
-              return -1;
-            }
-
-            @Override
-            public int startOffset() throws IOException {
-              return -1;
-            }
-
-            @Override
-            public int endOffset() throws IOException {
-              return -1;
-            }
-
-            @Override
-            public BytesRef getPayload() throws IOException {
-              return null;
-            }
-
-            @Override
-            public int docID() {
-              return DocIdSetIterator.NO_MORE_DOCS;
-            }
-
-            @Override
-            public int nextDoc() {
-              return DocIdSetIterator.NO_MORE_DOCS;
-            }
-
-            @Override
-            public int advance(int target) {
-              return DocIdSetIterator.NO_MORE_DOCS;
-            }
-
-            @Override
-            public long cost() {
-              return 0;
-            }
-          };
+          docs = PostingsEnum.getEmptyInstance();
         }
         atDoc = -1;
       }

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -80,7 +80,7 @@ Improvements
 
 * LUCENE-8984: MoreLikeThis MLT is biased for uncommon fields (Andy Hind via Anshum Gupta)
 
-* SOLR-13863: payload query function now is able to read and sort also string payload field (delimited_payloads_string)
+* SOLR-13863: payload query function now handles string encoded payload field (delimited_payloads_string)
 
 Other Changes
 ----------------------

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -80,6 +80,8 @@ Improvements
 
 * LUCENE-8984: MoreLikeThis MLT is biased for uncommon fields (Andy Hind via Anshum Gupta)
 
+* SOLR-13863: payload query function now is able to read and sort also string payload field (delimited_payloads_string)
+
 Other Changes
 ----------------------
 

--- a/solr/contrib/prometheus-exporter/src/test-files/solr/collection1/conf/managed-schema
+++ b/solr/contrib/prometheus-exporter/src/test-files/solr/collection1/conf/managed-schema
@@ -152,6 +152,10 @@
     <dynamicField name="*_dpi" type="delimited_payloads_int" indexed="true"  stored="true"/>
     <dynamicField name="*_dps" type="delimited_payloads_string" indexed="true"  stored="true"/>
 
+    <dynamicField name="*_dpff" type="delimited_payloads_float" indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_dpii" type="delimited_payloads_int" indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_dpss" type="delimited_payloads_string" indexed="true"  stored="true" multiValued="true"/>
+
     <dynamicField name="attr_*" type="text_general" indexed="true" stored="true" multiValued="true"/>
 
     <!-- Field to use to determine and enforce document uniqueness.

--- a/solr/core/src/java/org/apache/solr/search/FloatPayloadValueSource.java
+++ b/solr/core/src/java/org/apache/solr/search/FloatPayloadValueSource.java
@@ -75,7 +75,7 @@ public class FloatPayloadValueSource extends PayloadValueSource {
         if (docs == null) {
           // dummy PostingsEnum so floatVal() can work
           // when would this be called?  if field/val did not match?  this is called for every doc?  create once and cache?
-          docs = PostingsEnum.getEmptyInstance();
+          docs = PostingsEnum.getDummyInstance();
         }
         atDoc = -1;
       }

--- a/solr/core/src/java/org/apache/solr/search/FloatPayloadValueSource.java
+++ b/solr/core/src/java/org/apache/solr/search/FloatPayloadValueSource.java
@@ -32,24 +32,15 @@ import org.apache.lucene.queries.payloads.PayloadFunction;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.BytesRef;
 
-public class FloatPayloadValueSource extends ValueSource {
-  protected final String field;
-  protected final String val;
-  protected final String indexedField;
-  protected final BytesRef indexedBytes;
+public class FloatPayloadValueSource extends PayloadValueSource {
   protected final PayloadDecoder decoder;
   protected final PayloadFunction payloadFunction;
-  protected final ValueSource defaultValueSource;
 
   public FloatPayloadValueSource(String field, String val, String indexedField, BytesRef indexedBytes,
                                  PayloadDecoder decoder, PayloadFunction payloadFunction, ValueSource defaultValueSource) {
-    this.field = field;
-    this.val = val;
-    this.indexedField = indexedField;
-    this.indexedBytes = indexedBytes;
+    super(field, val, indexedField, indexedBytes, defaultValueSource);
     this.decoder = decoder;
     this.payloadFunction = payloadFunction;
-    this.defaultValueSource = defaultValueSource;
   }
 
   @Override

--- a/solr/core/src/java/org/apache/solr/search/FloatPayloadValueSource.java
+++ b/solr/core/src/java/org/apache/solr/search/FloatPayloadValueSource.java
@@ -29,7 +29,6 @@ import org.apache.lucene.queries.function.ValueSource;
 import org.apache.lucene.queries.function.docvalues.FloatDocValues;
 import org.apache.lucene.queries.payloads.PayloadDecoder;
 import org.apache.lucene.queries.payloads.PayloadFunction;
-import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.BytesRef;
 
 public class FloatPayloadValueSource extends PayloadValueSource {
@@ -76,52 +75,7 @@ public class FloatPayloadValueSource extends PayloadValueSource {
         if (docs == null) {
           // dummy PostingsEnum so floatVal() can work
           // when would this be called?  if field/val did not match?  this is called for every doc?  create once and cache?
-          docs = new PostingsEnum() {
-            @Override
-            public int freq() {
-              return 0;
-            }
-
-            @Override
-            public int nextPosition() throws IOException {
-              return -1;
-            }
-
-            @Override
-            public int startOffset() throws IOException {
-              return -1;
-            }
-
-            @Override
-            public int endOffset() throws IOException {
-              return -1;
-            }
-
-            @Override
-            public BytesRef getPayload() throws IOException {
-              return null;
-            }
-
-            @Override
-            public int docID() {
-              return DocIdSetIterator.NO_MORE_DOCS;
-            }
-
-            @Override
-            public int nextDoc() {
-              return DocIdSetIterator.NO_MORE_DOCS;
-            }
-
-            @Override
-            public int advance(int target) {
-              return DocIdSetIterator.NO_MORE_DOCS;
-            }
-
-            @Override
-            public long cost() {
-              return 0;
-            }
-          };
+          docs = PostingsEnum.getEmptyInstance();
         }
         atDoc = -1;
       }

--- a/solr/core/src/java/org/apache/solr/search/FloatPayloadValueSource.java
+++ b/solr/core/src/java/org/apache/solr/search/FloatPayloadValueSource.java
@@ -75,7 +75,7 @@ public class FloatPayloadValueSource extends PayloadValueSource {
         if (docs == null) {
           // dummy PostingsEnum so floatVal() can work
           // when would this be called?  if field/val did not match?  this is called for every doc?  create once and cache?
-          docs = PostingsEnum.getDummyInstance();
+          docs = PostingsEnum.DUMMY_INSTANCE;
         }
         atDoc = -1;
       }

--- a/solr/core/src/java/org/apache/solr/search/PayloadValueSource.java
+++ b/solr/core/src/java/org/apache/solr/search/PayloadValueSource.java
@@ -18,7 +18,6 @@
 package org.apache.solr.search;
 
 import org.apache.lucene.queries.function.ValueSource;
-import org.apache.lucene.search.SortField;
 import org.apache.lucene.util.BytesRef;
 
 public abstract class PayloadValueSource extends ValueSource {

--- a/solr/core/src/java/org/apache/solr/search/PayloadValueSource.java
+++ b/solr/core/src/java/org/apache/solr/search/PayloadValueSource.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.search;
+
+import org.apache.lucene.queries.function.ValueSource;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.util.BytesRef;
+
+public abstract class PayloadValueSource extends ValueSource {
+  protected final String field;
+  protected final String val;
+  protected final String indexedField;
+  protected final BytesRef indexedBytes;
+  protected final ValueSource defaultValueSource;
+
+  public PayloadValueSource(String field, String val, String indexedField, BytesRef indexedBytes, ValueSource defaultValueSource) {
+    this.field = field;
+    this.val = val;
+    this.indexedField = indexedField;
+    this.indexedBytes = indexedBytes;
+    this.defaultValueSource = defaultValueSource;
+  }
+
+//  public abstract SortField getSortField(boolean reverse);
+
+  // TODO: should this be formalized at the ValueSource level?  Seems to be the convention
+  public abstract String name();
+
+  @Override
+  public abstract String description();
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    PayloadValueSource that = (PayloadValueSource) o;
+
+    if (!indexedField.equals(that.indexedField)) return false;
+    if (indexedBytes != null ? !indexedBytes.equals(that.indexedBytes) : that.indexedBytes != null) return false;
+    return defaultValueSource.equals(that.defaultValueSource);
+
+  }
+
+  @Override
+  public int hashCode() {
+    int result = indexedField.hashCode();
+    result = 31 * result + (indexedBytes != null ? indexedBytes.hashCode() : 0);
+    result = 31 * result + defaultValueSource.hashCode();
+    return result;
+  }
+}

--- a/solr/core/src/java/org/apache/solr/search/StringPayloadValueSource.java
+++ b/solr/core/src/java/org/apache/solr/search/StringPayloadValueSource.java
@@ -180,7 +180,7 @@ public class StringPayloadValueSource extends PayloadValueSource {
 
   // TODO: should this be formalized at the ValueSource level?  Seems to be the convention
   public String name() {
-    return "spayload";
+    return "payload";
   }
 
   @Override
@@ -239,7 +239,9 @@ public class StringPayloadValueSource extends PayloadValueSource {
 
     @Override
     public int compareBottom(int doc) throws IOException {
-      return bottom.compareTo(docVals.strVal(doc));
+      if (this.bottom != null)
+        return bottom.compareTo(docVals.strVal(doc));
+      return -1;
     }
 
     @Override

--- a/solr/core/src/java/org/apache/solr/search/StringPayloadValueSource.java
+++ b/solr/core/src/java/org/apache/solr/search/StringPayloadValueSource.java
@@ -65,21 +65,19 @@ public class StringPayloadValueSource extends PayloadValueSource {
       public void reset() throws IOException {
         // no one should call us for deleted docs?
 
+        docs = null;
+
         if (terms != null) {
           final TermsEnum termsEnum = terms.iterator();
           if (termsEnum.seekExact(indexedBytes)) {
             docs = termsEnum.postings(null, PostingsEnum.ALL);
-          } else {
-            docs = null;
           }
-        } else {
-          docs = null;
         }
 
         if (docs == null) {
           // dummy PostingsEnum so floatVal() can work
           // when would this be called?  if field/val did not match?  this is called for every doc?  create once and cache?
-          docs = PostingsEnum.getEmptyInstance();
+          docs = PostingsEnum.getDummyInstance();
         }
         atDoc = -1;
       }

--- a/solr/core/src/java/org/apache/solr/search/StringPayloadValueSource.java
+++ b/solr/core/src/java/org/apache/solr/search/StringPayloadValueSource.java
@@ -159,7 +159,7 @@ public class StringPayloadValueSource extends PayloadValueSource {
             docs.nextPosition();
             BytesRef payload = docs.getPayload();
             if (payload != null) {
-              return bytesRefToString(payload);
+              return payload.utf8ToString();
             }
           }
           docValue = defaultValues.strVal(doc);
@@ -170,14 +170,7 @@ public class StringPayloadValueSource extends PayloadValueSource {
       }
     };
   }
-
-  private String bytesRefToString(BytesRef payload) {
-    byte[] bytes = new byte[payload.length];
-    System.arraycopy(payload.bytes, payload.offset, bytes, 0, payload.length);
-    String ret = new String(bytes);
-    return ret;
-  }
-
+  
   // TODO: should this be formalized at the ValueSource level?  Seems to be the convention
   public String name() {
     return "payload";

--- a/solr/core/src/java/org/apache/solr/search/StringPayloadValueSource.java
+++ b/solr/core/src/java/org/apache/solr/search/StringPayloadValueSource.java
@@ -77,7 +77,7 @@ public class StringPayloadValueSource extends PayloadValueSource {
         if (docs == null) {
           // dummy PostingsEnum so floatVal() can work
           // when would this be called?  if field/val did not match?  this is called for every doc?  create once and cache?
-          docs = PostingsEnum.getDummyInstance();
+          docs = PostingsEnum.DUMMY_INSTANCE;
         }
         atDoc = -1;
       }

--- a/solr/core/src/java/org/apache/solr/search/StringPayloadValueSource.java
+++ b/solr/core/src/java/org/apache/solr/search/StringPayloadValueSource.java
@@ -27,7 +27,6 @@ import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.queries.function.FunctionValues;
 import org.apache.lucene.queries.function.ValueSource;
 import org.apache.lucene.queries.function.docvalues.StrDocValues;
-import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.FieldComparator;
 import org.apache.lucene.search.FieldComparatorSource;
 import org.apache.lucene.search.IndexSearcher;
@@ -80,52 +79,7 @@ public class StringPayloadValueSource extends PayloadValueSource {
         if (docs == null) {
           // dummy PostingsEnum so floatVal() can work
           // when would this be called?  if field/val did not match?  this is called for every doc?  create once and cache?
-          docs = new PostingsEnum() {
-            @Override
-            public int freq() {
-              return 0;
-            }
-
-            @Override
-            public int nextPosition() throws IOException {
-              return -1;
-            }
-
-            @Override
-            public int startOffset() throws IOException {
-              return -1;
-            }
-
-            @Override
-            public int endOffset() throws IOException {
-              return -1;
-            }
-
-            @Override
-            public BytesRef getPayload() throws IOException {
-              return null;
-            }
-
-            @Override
-            public int docID() {
-              return DocIdSetIterator.NO_MORE_DOCS;
-            }
-
-            @Override
-            public int nextDoc() {
-              return DocIdSetIterator.NO_MORE_DOCS;
-            }
-
-            @Override
-            public int advance(int target) {
-              return DocIdSetIterator.NO_MORE_DOCS;
-            }
-
-            @Override
-            public long cost() {
-              return 0;
-            }
-          };
+          docs = PostingsEnum.getEmptyInstance();
         }
         atDoc = -1;
       }
@@ -170,7 +124,7 @@ public class StringPayloadValueSource extends PayloadValueSource {
       }
     };
   }
-  
+
   // TODO: should this be formalized at the ValueSource level?  Seems to be the convention
   public String name() {
     return "payload";

--- a/solr/core/src/java/org/apache/solr/search/StringPayloadValueSource.java
+++ b/solr/core/src/java/org/apache/solr/search/StringPayloadValueSource.java
@@ -1,0 +1,306 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.search;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.PostingsEnum;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.queries.function.FunctionValues;
+import org.apache.lucene.queries.function.ValueSource;
+import org.apache.lucene.queries.function.docvalues.StrDocValues;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.FieldComparator;
+import org.apache.lucene.search.FieldComparatorSource;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.SimpleFieldComparator;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.util.BytesRef;
+
+public class StringPayloadValueSource extends ValueSource {
+  protected final String field;
+  protected final String val;
+  protected final String indexedField;
+  protected final BytesRef indexedBytes;
+  protected final ValueSource defaultValueSource;
+
+  public StringPayloadValueSource(String field, String val, String indexedField, BytesRef indexedBytes, ValueSource defaultValueSource) {
+    this.field = field;
+    this.val = val;
+    this.indexedField = indexedField;
+    this.indexedBytes = indexedBytes;
+    this.defaultValueSource = defaultValueSource;
+  }
+
+  public SortField getSortField(boolean reverse) {
+    return new StringPayloadValueSourceSortField(reverse);
+  }
+
+  @Override
+  public FunctionValues getValues(Map context, LeafReaderContext readerContext) throws IOException {
+
+    final Terms terms = readerContext.reader().terms(indexedField);
+
+    FunctionValues defaultValues = defaultValueSource.getValues(context, readerContext);
+
+    // copied the bulk of this from TFValueSource - TODO: this is a very repeated pattern - base-class this advance logic stuff?
+    return new StrDocValues(this) {
+      PostingsEnum docs;
+      int atDoc;
+      int lastDocRequested = -1;
+      String docValue = null;
+
+      {
+        reset();
+      }
+
+      public void reset() throws IOException {
+        // no one should call us for deleted docs?
+
+        if (terms != null) {
+          final TermsEnum termsEnum = terms.iterator();
+          if (termsEnum.seekExact(indexedBytes)) {
+            docs = termsEnum.postings(null, PostingsEnum.ALL);
+          } else {
+            docs = null;
+          }
+        } else {
+          docs = null;
+        }
+
+        if (docs == null) {
+          // dummy PostingsEnum so floatVal() can work
+          // when would this be called?  if field/val did not match?  this is called for every doc?  create once and cache?
+          docs = new PostingsEnum() {
+            @Override
+            public int freq() {
+              return 0;
+            }
+
+            @Override
+            public int nextPosition() throws IOException {
+              return -1;
+            }
+
+            @Override
+            public int startOffset() throws IOException {
+              return -1;
+            }
+
+            @Override
+            public int endOffset() throws IOException {
+              return -1;
+            }
+
+            @Override
+            public BytesRef getPayload() throws IOException {
+              return null;
+            }
+
+            @Override
+            public int docID() {
+              return DocIdSetIterator.NO_MORE_DOCS;
+            }
+
+            @Override
+            public int nextDoc() {
+              return DocIdSetIterator.NO_MORE_DOCS;
+            }
+
+            @Override
+            public int advance(int target) {
+              return DocIdSetIterator.NO_MORE_DOCS;
+            }
+
+            @Override
+            public long cost() {
+              return 0;
+            }
+          };
+        }
+        atDoc = -1;
+      }
+
+      @Override
+      public String strVal(int doc) {
+        try {
+          if (doc < lastDocRequested) {
+            // out-of-order access.... reset
+            reset();
+          } else if (doc == lastDocRequested) {
+            return docValue;
+          }
+
+          lastDocRequested = doc;
+
+          if (atDoc < doc) {
+            atDoc = docs.advance(doc);
+          }
+
+          if (atDoc > doc) {
+            // term doesn't match this document... either because we hit the
+            // end, or because the next doc is after this doc.
+            docValue = defaultValues.strVal(doc);
+            return docValue;
+          }
+
+          // a match!
+          int freq = docs.freq();
+          for (int i = 0; i < freq; i++) {
+            docs.nextPosition();
+            BytesRef payload = docs.getPayload();
+            if (payload != null) {
+              return bytesRefToString(payload);
+            }
+          }
+          docValue = defaultValues.strVal(doc);
+          return docValue;
+        } catch (IOException e) {
+          throw new RuntimeException("caught exception in function " + description() + " : doc=" + doc, e);
+        }
+      }
+    };
+  }
+
+  private String bytesRefToString(BytesRef payload) {
+    byte[] bytes = new byte[payload.length];
+    System.arraycopy(payload.bytes, payload.offset, bytes, 0, payload.length);
+    String ret = new String(bytes);
+    return ret;
+  }
+
+  // TODO: should this be formalized at the ValueSource level?  Seems to be the convention
+  public String name() {
+    return "spayload";
+  }
+
+  @Override
+  public String description() {
+    return name() + '(' + field + ',' + val + ',' + defaultValueSource.toString() + ')';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    StringPayloadValueSource that = (StringPayloadValueSource) o;
+
+    if (!indexedField.equals(that.indexedField)) return false;
+    if (indexedBytes != null ? !indexedBytes.equals(that.indexedBytes) : that.indexedBytes != null) return false;
+    return defaultValueSource.equals(that.defaultValueSource);
+
+  }
+
+  @Override
+  public int hashCode() {
+    int result = indexedField.hashCode();
+    result = 31 * result + (indexedBytes != null ? indexedBytes.hashCode() : 0);
+    result = 31 * result + defaultValueSource.hashCode();
+    return result;
+  }
+
+  class StringPayloadValueSourceSortField extends SortField {
+    public StringPayloadValueSourceSortField(boolean reverse) {
+      super(description(), SortField.Type.REWRITEABLE, reverse);
+    }
+
+    @Override
+    public SortField rewrite(IndexSearcher searcher) throws IOException {
+      Map context = newContext(searcher);
+      createWeight(context, searcher);
+      return new SortField(getField(), new ValueSourceComparatorSource(context), getReverse());
+    }
+  }
+
+  class ValueSourceComparatorSource extends FieldComparatorSource {
+    private final Map context;
+
+    public ValueSourceComparatorSource(Map context) {
+      this.context = context;
+    }
+
+    @Override
+    public FieldComparator<String> newComparator(String fieldname, int numHits,
+                                                 int sortPos, boolean reversed) {
+      return new ValueSourceComparator(context, numHits);
+    }
+  }
+
+  /**
+   * Implement a {@link org.apache.lucene.search.FieldComparator} that works
+   * off of the {@link FunctionValues} for a ValueSource
+   * instead of the normal Lucene FieldComparator that works off of a FieldCache.
+   */
+  class ValueSourceComparator extends SimpleFieldComparator<String> {
+    private final String[] values;
+    private final Map fcontext;
+    private FunctionValues docVals;
+    private String bottom;
+    private String topValue;
+
+    ValueSourceComparator(Map fcontext, int numHits) {
+      this.fcontext = fcontext;
+      values = new String[numHits];
+    }
+
+    @Override
+    public int compare(int slot1, int slot2) {
+      return values[slot1].compareTo(values[slot2]);
+    }
+
+    @Override
+    public int compareBottom(int doc) throws IOException {
+      return bottom.compareTo(docVals.strVal(doc));
+    }
+
+    @Override
+    public void copy(int slot, int doc) throws IOException {
+      values[slot] = docVals.strVal(doc);
+    }
+
+    @Override
+    public void doSetNextReader(LeafReaderContext context) throws IOException {
+      docVals = getValues(fcontext, context);
+    }
+
+    @Override
+    public void setBottom(final int bottom) {
+      this.bottom = values[bottom];
+    }
+
+    @Override
+    public void setTopValue(final String value) {
+      this.topValue = value;
+    }
+
+    @Override
+    public String value(int slot) {
+      return values[slot];
+    }
+
+    @Override
+    public int compareTop(int doc) throws IOException {
+      final String docValue = docVals.strVal(doc);
+      return topValue.compareTo(docValue);
+    }
+  }
+}

--- a/solr/core/src/java/org/apache/solr/search/StringPayloadValueSource.java
+++ b/solr/core/src/java/org/apache/solr/search/StringPayloadValueSource.java
@@ -35,19 +35,10 @@ import org.apache.lucene.search.SimpleFieldComparator;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.util.BytesRef;
 
-public class StringPayloadValueSource extends ValueSource {
-  protected final String field;
-  protected final String val;
-  protected final String indexedField;
-  protected final BytesRef indexedBytes;
-  protected final ValueSource defaultValueSource;
+public class StringPayloadValueSource extends PayloadValueSource {
 
   public StringPayloadValueSource(String field, String val, String indexedField, BytesRef indexedBytes, ValueSource defaultValueSource) {
-    this.field = field;
-    this.val = val;
-    this.indexedField = indexedField;
-    this.indexedBytes = indexedBytes;
-    this.defaultValueSource = defaultValueSource;
+    super(field, val, indexedField, indexedBytes, defaultValueSource);
   }
 
   public SortField getSortField(boolean reverse) {
@@ -195,27 +186,6 @@ public class StringPayloadValueSource extends ValueSource {
   @Override
   public String description() {
     return name() + '(' + field + ',' + val + ',' + defaultValueSource.toString() + ')';
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-
-    StringPayloadValueSource that = (StringPayloadValueSource) o;
-
-    if (!indexedField.equals(that.indexedField)) return false;
-    if (indexedBytes != null ? !indexedBytes.equals(that.indexedBytes) : that.indexedBytes != null) return false;
-    return defaultValueSource.equals(that.defaultValueSource);
-
-  }
-
-  @Override
-  public int hashCode() {
-    int result = indexedField.hashCode();
-    result = 31 * result + (indexedBytes != null ? indexedBytes.hashCode() : 0);
-    result = 31 * result + defaultValueSource.hashCode();
-    return result;
   }
 
   class StringPayloadValueSourceSortField extends SortField {

--- a/solr/core/src/java/org/apache/solr/search/ValueSourceParser.java
+++ b/solr/core/src/java/org/apache/solr/search/ValueSourceParser.java
@@ -725,7 +725,8 @@ public abstract class ValueSourceParser implements NamedListInitializedPlugin {
         IndexSchema schema = fp.getReq().getCore().getLatestSchema();
         final FieldType fieldType = schema.getFieldType(tinfo.field);
 
-        if (fieldType.getTypeName().equals("delimited_payloads_string")) {
+        final String payloadEncoder = PayloadUtils.getPayloadEncoder(fieldType);
+        if (payloadEncoder.equals("identity")) {
 
           ValueSource defaultValueSource;
           if (fp.hasMoreArguments()) {

--- a/solr/core/src/java/org/apache/solr/search/ValueSourceParser.java
+++ b/solr/core/src/java/org/apache/solr/search/ValueSourceParser.java
@@ -722,6 +722,31 @@ public abstract class ValueSourceParser implements NamedListInitializedPlugin {
 
         TInfo tinfo = parseTerm(fp); // would have made this parser a new separate class and registered it, but this handy method is private :/
 
+        IndexSchema schema = fp.getReq().getCore().getLatestSchema();
+        final FieldType fieldType = schema.getFieldType(tinfo.field);
+
+        if (fieldType.getTypeName().equals("delimited_payloads_string")) {
+
+          ValueSource defaultValueSource;
+          if (fp.hasMoreArguments()) {
+            defaultValueSource = fp.parseValueSource();
+          } else {
+            defaultValueSource = new LiteralValueSource("");
+          }
+
+          if (fp.hasMoreArguments()) {
+              // functions are not supported with strings
+              throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, "Invalid payload function: " + fp.parseArg());
+          }
+
+          return new StringPayloadValueSource(
+              tinfo.field,
+              tinfo.val,
+              tinfo.indexedField,
+              tinfo.indexedBytes.get(),
+              defaultValueSource);
+        }
+
         ValueSource defaultValueSource;
         if (fp.hasMoreArguments()) {
           defaultValueSource = fp.parseValueSource();
@@ -742,7 +767,6 @@ public abstract class ValueSourceParser implements NamedListInitializedPlugin {
           throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, "Invalid payload function: " + func);
         }
 
-        IndexSchema schema = fp.getReq().getCore().getLatestSchema();
         PayloadDecoder decoder = schema.getPayloadDecoder(tinfo.field);
 
         if (decoder==null) {

--- a/solr/core/src/java/org/apache/solr/search/ValueSourceParser.java
+++ b/solr/core/src/java/org/apache/solr/search/ValueSourceParser.java
@@ -728,12 +728,7 @@ public abstract class ValueSourceParser implements NamedListInitializedPlugin {
         final String payloadEncoder = PayloadUtils.getPayloadEncoder(fieldType);
         if (payloadEncoder.equals("identity")) {
 
-          ValueSource defaultValueSource;
-          if (fp.hasMoreArguments()) {
-            defaultValueSource = fp.parseValueSource();
-          } else {
-            defaultValueSource = new LiteralValueSource("");
-          }
+          ValueSource defaultValueSource = (fp.hasMoreArguments()) ? fp.parseValueSource() : new LiteralValueSource("");
 
           if (fp.hasMoreArguments()) {
               // functions are not supported with strings
@@ -748,12 +743,7 @@ public abstract class ValueSourceParser implements NamedListInitializedPlugin {
               defaultValueSource);
         }
 
-        ValueSource defaultValueSource;
-        if (fp.hasMoreArguments()) {
-          defaultValueSource = fp.parseValueSource();
-        } else {
-          defaultValueSource = new ConstValueSource(0.0f);
-        }
+        ValueSource defaultValueSource = (fp.hasMoreArguments()) ? fp.parseValueSource() : new ConstValueSource(0.0f);
 
         PayloadFunction payloadFunction = null;
         String func = "average";

--- a/solr/core/src/test-files/solr/collection1/conf/schema11.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/schema11.xml
@@ -502,6 +502,11 @@ valued. -->
   <dynamicField name="*_dpf" type="delimited_payloads_float" indexed="true"  stored="true"/>
   <dynamicField name="*_dpi" type="delimited_payloads_int" indexed="true"  stored="true"/>
   <dynamicField name="*_dps" type="delimited_payloads_string" indexed="true"  stored="true"/>
+
+  <dynamicField name="*_dpff" type="delimited_payloads_float" indexed="true"  stored="true" multiValued="true"/>
+  <dynamicField name="*_dpii" type="delimited_payloads_int" indexed="true"  stored="true" multiValued="true"/>
+  <dynamicField name="*_dpss" type="delimited_payloads_string" indexed="true"  stored="true" multiValued="true"/>
+
   <fieldType name="delimited_payloads_float" class="solr.TextField" positionIncrementGap="100">
     <analyzer>
       <tokenizer class="solr.MockTokenizerFactory"/>

--- a/solr/core/src/test-files/solr/configsets/_default/conf/managed-schema
+++ b/solr/core/src/test-files/solr/configsets/_default/conf/managed-schema
@@ -161,6 +161,10 @@
     <dynamicField name="*_dpi" type="delimited_payloads_int" indexed="true"  stored="true"/>
     <dynamicField name="*_dps" type="delimited_payloads_string" indexed="true"  stored="true"/>
 
+    <dynamicField name="*_dpff" type="delimited_payloads_float" indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_dpii" type="delimited_payloads_int" indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_dpss" type="delimited_payloads_string" indexed="true"  stored="true" multiValued="true"/>
+
     <dynamicField name="attr_*" type="text_general" indexed="true" stored="true" multiValued="true"/>
 
     <!-- Field to use to determine and enforce document uniqueness.

--- a/solr/core/src/test/org/apache/solr/search/function/TestFunctionQuery.java
+++ b/solr/core/src/test/org/apache/solr/search/function/TestFunctionQuery.java
@@ -576,44 +576,49 @@ public class TestFunctionQuery extends SolrTestCaseJ4 {
 
     SolrInputDocument doc = new SolrInputDocument();
     doc.setField("id", "1");
-    doc.setField("vals_dpss", new String[]{"A|USD", "B|GBP", "C|EUR", "D|CHF", "D|AUD"});
+    doc.setField("vals_dpss", new String[]{"A|USD", "C|EUR", "SORT|A"});
     assertU(adoc(doc));
 
     doc = new SolrInputDocument();
     doc.setField("id", "2");
-    doc.setField("vals_dpss", new String[]{"A|usd", "B|gbp", "C|eur", "D|chf", "D|aud"});
+    doc.setField("vals_dpss", new String[]{"A|usd", "C|eur", "SORT|B"});
     assertU(adoc(doc));
 
     doc = new SolrInputDocument();
     doc.setField("id", "3");
-    doc.setField("vals_dpss", new String[]{"A|Usd", "B|Gbp", "C|Eur", "D|Chf", "D|Aud"});
+    doc.setField("vals_dpss", new String[]{"A|Usd", "C|Eur", "SORT|C"});
     assertU(adoc(doc));
 
     assertU(commit());
 
-    assertQ(req("q", "id:1", "fl", "*,score,field_a:payload(vals_dpss,A)"), "//str[@name='field_a']='USD'");
-    assertQ(req("q", "id:2", "fl", "*,score,field_a:payload(vals_dpss,C)"), "//str[@name='field_a']='eur'");
+    assertQ(req("q", "id:1", "fl", "*,score,field_test:payload(vals_dpss,A)"), "//str[@name='field_test']='USD'");
+    assertQ(req("q", "id:2", "fl", "*,score,field_test:payload(vals_dpss,C)"), "//str[@name='field_test']='eur'");
     assertQ(req("q", "*:*",
        "rows", "1",
        "sort", "payload(vals_dpss,C) asc",
-       "fl", "*,score,field_a:payload(vals_dpss,C)"), "//str[@name='field_a']='EUR'");
+       "fl", "*,score,field_test:payload(vals_dpss,C)"), "//str[@name='field_test']='EUR'");
 
     doc = new SolrInputDocument();
     doc.setField("id", "4");
-    doc.setField("vals_dpss", new String[]{"A|Usd", "B|Gbp", "D|Chf", "D|Aud"});
+    doc.setField("vals_dpss", new String[]{"A|Usd"});
     assertU(adoc(doc));
 
     assertU(commit());
 
     assertQ(req("q", "*:*",
         "rows", "1",
-        "sort", "payload(vals_dpss,C) asc",
-        "fl", "*,score,field_a:payload(vals_dpss,C)"), "//str[@name='field_a']=''");
+        "sort", "payload(vals_dpss,SORT) asc",
+        "fl", "*,score,field_test:payload(vals_dpss,SORT)"), "//str[@name='field_test']=''");
 
     assertQ(req("q", "*:*",
         "rows", "1",
-        "sort", "payload(vals_dpss,C) desc",
-        "fl", "*,score,field_a:payload(vals_dpss,C)"), "//str[@name='field_a']='Eur'");
+        "sort", "payload(vals_dpss,SORT) desc",
+        "fl", "*,score,field_test:payload(vals_dpss,SORT)"), "//str[@name='field_test']='C'");
+
+//    assertQ(req("q", "{!func}payload(vals_dpss,A):USD",
+//        "rows", "1",
+//        "fl", "*,score"), "//str[@name='id']='1'");
+
   }
 
   @Test

--- a/solr/core/src/test/org/apache/solr/search/function/TestFunctionQuery.java
+++ b/solr/core/src/test/org/apache/solr/search/function/TestFunctionQuery.java
@@ -29,6 +29,7 @@ import org.apache.lucene.search.similarities.Similarity;
 import org.apache.lucene.search.similarities.TFIDFSimilarity;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.SolrException;
+import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.params.CommonParams;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -567,6 +568,26 @@ public class TestFunctionQuery extends SolrTestCaseJ4 {
 
     // Test with debug
     assertQ(req("fl","*,score","q", "{!func}payload(vals_dpf,A)", CommonParams.DEBUG, "true"), "//float[@name='score']='1.0'");
+  }
+
+  @Test
+  public void testStringPayloadFunction() {
+    clearIndex();
+
+    SolrInputDocument doc = new SolrInputDocument();
+    doc.setField("id", "1");
+    doc.setField("vals_dpss", new String[]{"A|USD", "B|GBP", "C|EUR", "D|CHF", "D|AUD"});
+    assertU(adoc(doc));
+
+    doc = new SolrInputDocument();
+    doc.setField("id", "2");
+    doc.setField("vals_dpss", new String[]{"A|usd", "B|gbp", "C|eur", "D|chf", "D|aud"});
+    assertU(adoc(doc));
+    
+    assertU(commit());
+
+    assertQ(req("q", "id:1", "fl", "*,score,field_a:payload(vals_dpss,A)"), "//str[@name='field_a']='USD'");
+    assertQ(req("q", "id:2", "fl", "*,score,field_a:payload(vals_dpss,C)"), "//str[@name='field_a']='eur'");
   }
 
   @Test

--- a/solr/core/src/test/org/apache/solr/search/function/TestFunctionQuery.java
+++ b/solr/core/src/test/org/apache/solr/search/function/TestFunctionQuery.java
@@ -583,11 +583,37 @@ public class TestFunctionQuery extends SolrTestCaseJ4 {
     doc.setField("id", "2");
     doc.setField("vals_dpss", new String[]{"A|usd", "B|gbp", "C|eur", "D|chf", "D|aud"});
     assertU(adoc(doc));
-    
+
+    doc = new SolrInputDocument();
+    doc.setField("id", "3");
+    doc.setField("vals_dpss", new String[]{"A|Usd", "B|Gbp", "C|Eur", "D|Chf", "D|Aud"});
+    assertU(adoc(doc));
+
     assertU(commit());
 
     assertQ(req("q", "id:1", "fl", "*,score,field_a:payload(vals_dpss,A)"), "//str[@name='field_a']='USD'");
     assertQ(req("q", "id:2", "fl", "*,score,field_a:payload(vals_dpss,C)"), "//str[@name='field_a']='eur'");
+    assertQ(req("q", "*:*",
+       "rows", "1",
+       "sort", "payload(vals_dpss,C) asc",
+       "fl", "*,score,field_a:payload(vals_dpss,C)"), "//str[@name='field_a']='EUR'");
+
+    doc = new SolrInputDocument();
+    doc.setField("id", "4");
+    doc.setField("vals_dpss", new String[]{"A|Usd", "B|Gbp", "D|Chf", "D|Aud"});
+    assertU(adoc(doc));
+
+    assertU(commit());
+
+    assertQ(req("q", "*:*",
+        "rows", "1",
+        "sort", "payload(vals_dpss,C) asc",
+        "fl", "*,score,field_a:payload(vals_dpss,C)"), "//str[@name='field_a']=''");
+
+    assertQ(req("q", "*:*",
+        "rows", "1",
+        "sort", "payload(vals_dpss,C) desc",
+        "fl", "*,score,field_a:payload(vals_dpss,C)"), "//str[@name='field_a']='Eur'");
   }
 
   @Test

--- a/solr/server/solr/configsets/_default/conf/managed-schema
+++ b/solr/server/solr/configsets/_default/conf/managed-schema
@@ -161,6 +161,10 @@
     <dynamicField name="*_dpi" type="delimited_payloads_int" indexed="true"  stored="true"/>
     <dynamicField name="*_dps" type="delimited_payloads_string" indexed="true"  stored="true"/>
 
+    <dynamicField name="*_dpff" type="delimited_payloads_float" indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_dpii" type="delimited_payloads_int" indexed="true"  stored="true" multiValued="true"/>
+    <dynamicField name="*_dpss" type="delimited_payloads_string" indexed="true"  stored="true" multiValued="true"/>
+
     <dynamicField name="attr_*" type="text_general" indexed="true" stored="true" multiValued="true"/>
 
     <!-- Field to use to determine and enforce document uniqueness.

--- a/solr/solr-ref-guide/src/function-queries.adoc
+++ b/solr/solr-ref-guide/src/function-queries.adoc
@@ -299,19 +299,24 @@ See also `rord` below.
 * If there were only three values ("apple","banana","pear") for a particular field X, then `ord(X)` would be `1` for documents containing "apple", `2` for documents containing "banana", etc.
 
 === payload Function
-Returns the float value computed from the decoded payloads of the term specified.
+Returns the value computed from the decoded payloads of the term specified.
 
-The return value is computed using the `min`, `max`, or `average` of the decoded payloads. A special `first` function can be used instead of the others, to short-circuit term enumeration and return only the decoded payload of the first term.
+The field specified must have identity (string), float or integer payload encoding capability (via `DelimitedPayloadTokenFilter` or `NumericPayloadTokenFilter`). If no payload is found for the term, the default value is returned.
 
-The field specified must have float or integer payload encoding capability (via `DelimitedPayloadTokenFilter` or `NumericPayloadTokenFilter`). If no payload is found for the term, the default value is returned.
+For float or integer payload encoding, the return value is computed using the `min`, `max`, or `average` of the decoded payloads. A special `first` function can be used instead of the others, to short-circuit term enumeration and return only the decoded payload of the first term.
 
 * `payload(field_name,term)`: default value is 0.0, `average` function is used.
 * `payload(field_name,term,default_value)`: default value can be a constant, field name, or another float returning function. `average` function used.
 * `payload(field_name,term,default_value,function)`: function values can be `min`, `max`, `average`, or `first`.
 
+For identity payload encoding, the return value is matched term the decoded payloads. String payload encoding does not support function values.
+
+* `payload(field_name,term)`: default value is "", returns `value` for any document has term in the "field_name" field
+
 *Syntax Example*
 
-* `payload(payloaded_field_dpf,term,0.0,first)`
+* `payload(payloaded_field_dpf,term,0.0,first)`: float example
+* `payload(payloaded_field_dpss,term)`: multivalue string example
 
 === pow Function
 


### PR DESCRIPTION
<!--
Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

I started to use payloads because I had the classical per-store pricing problem.
But standard payload function handles only numbers and, for example, stores can also be in different countries, would be useful also have the currency and other attributes related to the store.

This pull request modify payload function query, this version is now able to read and sort payload field delimited_payloads_string.

Example document:

```
  "id":"my sample doc",
  "currencyPayload":[
    "store1|EUR",
    "store2|USD",
    "store3|GBP"
  ]
```


Querying Solr with

```
fl=payload(currencyPayload,store3)
```

would generate a response like the following:

```
  "response":{
      "docs":[{
          "id":"my sample doc", 
          "payload(currencyPayload,store3)":"GBP"
      }]
   }
```

And executing `payload(payloadCurrency,store2)` returns `EUR`, and so on.

You can use `payload` even as sorting function.

```
sort=payload(payloadField,value) asc
```

# Solution

I was looking at the original payload function is defined into the ValueSourceParser, this function uses a FloatPayloadValueSource to return the value found.

As said I fixed the current version of payload function, adding a part that handles strings. It is able to extract the string value from the payload.

Given the former example where I have a multivalue field payloadCurrency

```
payloadCurrency: [
"store1|USD",
"store2|EUR",
"store3|GBP"
]
```

executing payload(payloadCurrency,store2) returns "EUR", and so on for the remaining key/value in the field.

To implement the payload function, I've modified the ValueSourceParser where is defined the function payload and now returns a StringPayloadValueSource with the value inside (does the same thing of former FloatPayloadValueSource).

# Tests

I've created a sample solr collection where test the custom function
https://github.com/freedev/solr-payload-string-function-query 

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I am authorized to contribute this code to the ASF and have removed any code I do not have a license to distribute.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [x] I have added tests for my changes.
- [x] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
