### PR TITLE
LUCENE-9067: Polygon2D#contains is now thread safe

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -143,6 +143,8 @@ Other
 
 * LUCENE-9046: Fix wrong example in Javadoc of TermInSetQuery (Namgyu Kim)
 
+* LUCENE-9067: PolygonD#contains() is now thread safe. (Ignacio Vera)
+
 Build
 
 * Upgrade forbiddenapis to version 2.7; upgrade Groovy to 2.4.17.  (Uwe Schindler)

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -145,7 +145,7 @@ Other
 
 * LUCENE-8983: Add sandbox PhraseWildcardQuery to control multi-terms expansions in a phrase. (Bruno Roustant)
 
-* LUCENE-9067: PolygonD#contains() is now thread safe. (Ignacio Vera)
+* LUCENE-9067: Polygon2D#contains() is now thread safe. (Ignacio Vera)
 
 Build
 

--- a/lucene/core/src/java/org/apache/lucene/geo/EdgeTree.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/EdgeTree.java
@@ -76,7 +76,7 @@ public class EdgeTree {
 
   /**
    * Returns true if the point crosses this edge subtree an odd number of times. It
-   * throws a {@link @ContainBoundaryException} if the point is on an edge.
+   * throws a {@link ContainsBoundaryException} if the point is on an edge.
    * <p>
    * See <a href="https://www.ecse.rpi.edu/~wrf/Research/Short_Notes/pnpoly.html">
    * https://www.ecse.rpi.edu/~wrf/Research/Short_Notes/pnpoly.html</a> for more information.

--- a/lucene/core/src/java/org/apache/lucene/geo/EdgeTree.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/EdgeTree.java
@@ -317,7 +317,7 @@ public class EdgeTree {
   private static class ContainsBoundaryException extends RuntimeException {
 
     /** Sole constructor. */
-  public ContainsBoundaryException() {
+    ContainsBoundaryException() {
       super();
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/geo/EdgeTree.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/EdgeTree.java
@@ -17,7 +17,6 @@
 package org.apache.lucene.geo;
 
 import java.util.Arrays;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.lucene.geo.GeoUtils.lineCrossesLine;
 import static org.apache.lucene.geo.GeoUtils.lineCrossesLineWithBoundary;
@@ -38,7 +37,7 @@ import static org.apache.lucene.geo.GeoUtils.orient;
  *
  * @lucene.internal
  */
-public  class EdgeTree {
+public class EdgeTree {
     // lat-lon pair (in original order) of the two vertices
     final double y1, y2;
     final double x1, x2;
@@ -50,6 +49,8 @@ public  class EdgeTree {
     EdgeTree left;
     /** right child edge, or null */
     EdgeTree right;
+    /** helper exception to signal a point is on an edge when checking for contains */
+    final private static ContainsBoundaryException containsBoundaryException = new ContainsBoundaryException();
 
   EdgeTree(double x1, double y1, double x2, double y2, double low, double max) {
       this.y1 = y1;
@@ -61,7 +62,21 @@ public  class EdgeTree {
     }
 
   /**
-   * Returns true if the point crosses this edge subtree an odd number of times
+   * Returns true if the point is on an edge or crosses the edge subtree an odd number
+   * of times.
+   */
+  protected boolean contains(double x, double y) {
+    try {
+      return containsPnPoly(x, y);
+    } catch (ContainsBoundaryException ex) {
+      // point is on an edge
+      return true;
+    }
+  }
+
+  /**
+   * Returns true if the point crosses this edge subtree an odd number of times. It
+   * throws a {@link @ContainBoundaryException} if the point is on an edge.
    * <p>
    * See <a href="https://www.ecse.rpi.edu/~wrf/Research/Short_Notes/pnpoly.html">
    * https://www.ecse.rpi.edu/~wrf/Research/Short_Notes/pnpoly.html</a> for more information.
@@ -90,30 +105,28 @@ public  class EdgeTree {
   // THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
   // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
   // IN THE SOFTWARE.
-  protected boolean contains(double x, double y, AtomicBoolean isOnEdge) {
+  private boolean containsPnPoly(double x, double y) {
     boolean res = false;
-    if (isOnEdge.get() == false && y <= this.max) {
+    if (y <= this.max) {
       if (y == this.y1 && y == this.y2 ||
           (y <= this.y1 && y >= this.y2) != (y >= this.y1 && y <= this.y2)) {
         if ((x == this.x1 && x == this.x2) ||
             ((x <= this.x1 && x >= this.x2) != (x >= this.x1 && x <= this.x2) &&
                 GeoUtils.orient(this.x1, this.y1, this.x2, this.y2, x, y) == 0)) {
-          // if its on the boundary return true
-          isOnEdge.set(true);
-          return true;
+          throw containsBoundaryException;
         } else if (this.y1 > y != this.y2 > y) {
           res = x < (this.x2 - this.x1) * (y - this.y1) / (this.y2 - this.y1) + this.x1;
         }
       }
       if (this.left != null) {
-        res ^= left.contains(x, y, isOnEdge);
+        res ^= left.containsPnPoly(x, y);
       }
 
       if (this.right != null && y >= this.low) {
-        res ^= right.contains(x, y, isOnEdge);
+        res ^= right.containsPnPoly(x, y);
       }
     }
-    return isOnEdge.get() || res;
+    return res;
   }
 
   /** returns true if the provided x, y point lies on the line */
@@ -299,5 +312,13 @@ public  class EdgeTree {
       newNode.max = Math.max(newNode.max, newNode.right.max);
     }
     return newNode;
+  }
+
+  private static class ContainsBoundaryException extends RuntimeException {
+
+    /** Sole constructor. */
+  public ContainsBoundaryException() {
+      super();
+    }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/geo/EdgeTree.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/EdgeTree.java
@@ -17,7 +17,6 @@
 package org.apache.lucene.geo;
 
 import java.util.Arrays;
-import java.util.zip.ZipEntry;
 
 import static org.apache.lucene.geo.GeoUtils.lineCrossesLine;
 import static org.apache.lucene.geo.GeoUtils.lineCrossesLineWithBoundary;
@@ -51,9 +50,9 @@ public class EdgeTree {
     /** right child edge, or null */
     EdgeTree right;
     /** helper bytes to signal a point is on an edge when checking, it is within the edge tree or disjoint */
-    final private byte FALSE =0;
-    final private byte TRUE =1;
-    final private byte ON_EDGE =2;
+    final private byte FALSE = 0;
+    final private byte TRUE = 1;
+    final private byte ON_EDGE = 2;
 
   EdgeTree(double x1, double y1, double x2, double y2, double low, double max) {
       this.y1 = y1;

--- a/lucene/core/src/java/org/apache/lucene/geo/EdgeTree.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/EdgeTree.java
@@ -116,14 +116,14 @@ public class EdgeTree {
       }
       if (this.left != null) {
         res ^= left.containsPnPoly(x, y);
-        if (((res >> 1) & 1) == 1) {
+        if ((res & 0x02) == 0x02) {
           return ON_EDGE;
         }
       }
 
       if (this.right != null && y >= this.low) {
         res ^= right.containsPnPoly(x, y);
-        if (((res >> 1) & 1) == 1) {
+        if ((res & 0x02) == 0x02) {
           return ON_EDGE;
         }
       }

--- a/lucene/core/src/java/org/apache/lucene/geo/EdgeTree.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/EdgeTree.java
@@ -49,10 +49,10 @@ public class EdgeTree {
     EdgeTree left;
     /** right child edge, or null */
     EdgeTree right;
-    /** helper bytes to signal a point is on an edge when checking, it is within the edge tree or disjoint */
-    final private byte FALSE = 0;
-    final private byte TRUE = 1;
-    final private byte ON_EDGE = 2;
+    /** helper bytes to signal if a point is on an edge, it is within the edge tree or disjoint */
+    final private byte FALSE = 0x00;
+    final private byte TRUE = 0x01;
+    final private byte ON_EDGE = 0x02;
 
   EdgeTree(double x1, double y1, double x2, double y2, double low, double max) {
       this.y1 = y1;

--- a/lucene/core/src/java/org/apache/lucene/geo/EdgeTree.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/EdgeTree.java
@@ -50,9 +50,9 @@ public class EdgeTree {
     /** right child edge, or null */
     EdgeTree right;
     /** helper bytes to signal if a point is on an edge, it is within the edge tree or disjoint */
-    final private byte FALSE = 0x00;
-    final private byte TRUE = 0x01;
-    final private byte ON_EDGE = 0x02;
+    final private static byte FALSE = 0x00;
+    final private static byte TRUE = 0x01;
+    final private static byte ON_EDGE = 0x02;
 
   EdgeTree(double x1, double y1, double x2, double y2, double low, double max) {
       this.y1 = y1;
@@ -130,6 +130,7 @@ public class EdgeTree {
         }
       }
     }
+    assert res >= FALSE && res <= ON_EDGE;
     return res;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/geo/EdgeTree.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/EdgeTree.java
@@ -72,7 +72,9 @@ public class EdgeTree {
   }
 
   /**
-   * Returns true if the point crosses this edge subtree an odd number of times.
+   * Returns byte 0x00 if the point crosses this edge subtree an even number of times.
+   * Returns byte 0x01 if the point crosses this edge subtree an odd number of times.
+   * Returns byte 0x02 if the point is on one of the edges.
    * <p>
    * See <a href="https://www.ecse.rpi.edu/~wrf/Research/Short_Notes/pnpoly.html">
    * https://www.ecse.rpi.edu/~wrf/Research/Short_Notes/pnpoly.html</a> for more information.

--- a/lucene/core/src/java/org/apache/lucene/geo/Polygon2D.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/Polygon2D.java
@@ -16,8 +16,6 @@
  */
 package org.apache.lucene.geo;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.apache.lucene.index.PointValues.Relation;
 
 /**
@@ -41,8 +39,6 @@ public class Polygon2D implements Component2D {
   final protected Component2D holes;
   /** Edges of the polygon represented as a 2-d interval tree.*/
   final EdgeTree tree;
-  /** helper boolean for points on boundary */
-  final private AtomicBoolean containsBoundary = new AtomicBoolean(false);
 
   protected Polygon2D(final double minX, final double maxX, final double minY, final double maxY, double[] x, double[] y, Component2D holes) {
     this.minY = minY;
@@ -92,8 +88,7 @@ public class Polygon2D implements Component2D {
   }
 
   private boolean internalContains(double x, double y) {
-    containsBoundary.set(false);
-    if (tree.contains(x, y, containsBoundary)) {
+    if (tree.contains(x, y)) {
       if (holes != null && holes.contains(x, y)) {
         return false;
       }


### PR DESCRIPTION
This PR adds an early termination exception for the case a point lies on the boundary of an edge tree.