### PR TITLE
MINOR: Fix Incorrect Constant Name in Codec Docs

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene84/package-info.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene84/package-info.java
@@ -154,7 +154,7 @@
  * {@link org.apache.lucene.codecs.lucene84.Lucene84PostingsFormat Term Frequency data}. 
  * For each term in the dictionary, the numbers of all the
  * documents that contain that term, and the frequency of the term in that
- * document, unless frequencies are omitted (IndexOptions.DOCS_ONLY)
+ * document, unless frequencies are omitted ({@link org.apache.lucene.index.IndexOptions#DOCS IndexOptions.DOCS})
  * </li>
  * <li>
  * {@link org.apache.lucene.codecs.lucene84.Lucene84PostingsFormat Term Proximity data}. 


### PR DESCRIPTION
The name was wrong here. Also, added a link to make this doc more
fun to navigate in HTML form and make sure it doesn't go bad again.
