### PR TITLE
SOLR-13998: Add thread safety annotations to classes

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -219,6 +219,9 @@ Other Changes
 
 * SOLR-13992: Code refactored to have collection name, slice name in Replica, Slice (noble)
 
+* SOLR-13998: Add thread safety annotations to Solr. This only introduces the annotations and doesn't add these to
+  existing classes. (Anshum Gupta, Mark Miller)
+
 ==================  8.3.1 ==================
 
 Consult the LUCENE_CHANGES.txt file for additional, low level, changes in this release.

--- a/solr/solrj/src/java/org/apache/solr/common/annotation/SolrSingleThreaded.java
+++ b/solr/solrj/src/java/org/apache/solr/common/annotation/SolrSingleThreaded.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.common.annotation;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for classes in Solr that are not thread safe. This provides a clear indication of the thread safety of the class.
+ */
+@Documented
+@Retention(SOURCE)
+@Target(TYPE)
+public @interface SolrSingleThreaded {
+
+}

--- a/solr/solrj/src/java/org/apache/solr/common/annotation/SolrThreadSafe.java
+++ b/solr/solrj/src/java/org/apache/solr/common/annotation/SolrThreadSafe.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.common.annotation;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation is applied to a class that is thread safe. This means that the objects of this class will never be
+ * in an inconsistent state, irrespective of interleaving accesses to the object.
+ */
+@Documented
+@Retention(SOURCE)
+@Target(TYPE)
+public @interface SolrThreadSafe {
+
+}


### PR DESCRIPTION
Add thread safety annotations to classes. 

The current commit only introduces the annotations, but the actual annotations will take some time but are wip. We can then use these to add information to existing classes, as well as new classes.
