### PR TITLE
SOLR-13972: Warn about insecure settings on startup

### DIFF
--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -2096,18 +2096,6 @@ function start_solr() {
   SOLR_ADDL_ARGS="$2"
   SOLR_JETTY_ADDL_CONFIG="$3"
 
-  if [[ -z "${AUTHC_OPTS// }" ]]; then
-    echo "*** [WARN] *** Solr has no authentication enabled.  If you intend to expose Solr directly to users,"
-    echo " consider enabling authentication with a command such as: "
-    echo "  bin/solr auth enable -type basicAuth -credentials firstUser:firstUserPass -blockUnknown true"
-    echo " Run 'bin/solr auth --help' for more authentication options"
-  else
-    if [[ "false" == "$SOLR_SSL_ENABLED" ]]; then
-      echo "*** [WARN] *** Solr authentication is enabled, but SSL is off.  Credentials sent to Solr will be unencrypted"
-      echo " If Solr is not in a secured network, consider enabling SSL to protect request credentials and user data."
-    fi
-  fi
-
   # define default GC_TUNE
   if [ -z ${GC_TUNE+x} ]; then
       GC_TUNE=('-XX:+UseG1GC' \

--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -2096,6 +2096,18 @@ function start_solr() {
   SOLR_ADDL_ARGS="$2"
   SOLR_JETTY_ADDL_CONFIG="$3"
 
+  if [[ -z "${AUTHC_OPTS// }" ]]; then
+    echo "*** [WARN] *** Solr has no authentication enabled.  If you intend to expose Solr directly to users,"
+    echo " consider enabling authentication with a command such as: "
+    echo "  bin/solr auth enable -type basicAuth -credentials firstUser:firstUserPass -blockUnknown true"
+    echo " Run 'bin/solr auth --help' for more authentication options"
+  else
+    if [[ "false" == "$SOLR_SSL_ENABLED" ]]; then
+      echo "*** [WARN] *** Solr authentication is enabled, but SSL is off.  Credentials sent to Solr will be unencrypted"
+      echo " If Solr is not in a secured network, consider enabling SSL to protect request credentials and user data."
+    fi
+  fi
+
   # define default GC_TUNE
   if [ -z ${GC_TUNE+x} ]; then
       GC_TUNE=('-XX:+UseG1GC' \

--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -658,7 +658,7 @@ public class CoreContainer {
 
     securityConfHandler = isZooKeeperAware() ? new SecurityConfHandlerZk(this) : new SecurityConfHandlerLocal(this);
     reloadSecurityProperties();
-    warnUsersIfSecurityDisabled();
+    warnUsersOfInsecureSettings();
     this.backupRepoFactory = new BackupRepositoryFactory(cfg.getBackupRepositoryPlugins());
 
     createHandler(ZK_PATH, ZookeeperInfoHandler.class.getName(), ZookeeperInfoHandler.class);
@@ -899,17 +899,18 @@ public class CoreContainer {
     initializeAuditloggerPlugin((Map<String, Object>) securityConfig.getData().get("auditlogging"));
   }
 
-  private void warnUsersIfSecurityDisabled() {
+  private void warnUsersOfInsecureSettings() {
     if (authenticationPlugin == null || authorizationPlugin == null) {
       log.warn("Not all security plugins configured!  authentication={} authorization={}.  Solr is only as secure as " +
           "you make it. Consider configuring authentication/authorization before exposing Solr to users internal or " +
-          "external.  See https://lucene.apache.org/solr/guide/authentication-and-authorization-plugins.html for more info",
+          "external.  See https://s.apache.org/solrsecurity for more info",
           (authenticationPlugin != null) ? "enabled" : "disabled",
           (authorizationPlugin != null) ? "enabled" : "disabled");
     }
 
     if (authenticationPlugin !=null && StringUtils.isNotEmpty(System.getProperty("solr.jetty.https.port"))) {
-      log.warn("Solr authentication is enabled, but SSL is off.  Consider enabling SSL to protect user credentials and data with encryption.");
+      log.warn("Solr authentication is enabled, but SSL is off.  Consider enabling SSL to protect user credentials and " +
+          "data with encryption.");
     }
   }
 


### PR DESCRIPTION
# Description
Solr should warn users on startup if insecure settings are being used.

# Solution
Currently I've added the detection and message for this in bin/solr.  I'm not sure this is the best place for this logic - I'd like to keep logic out of bash/powershell where possible, and a smarter check would look at security.json in ZooKeeper, which is easier to do within the JVM.

But this PR is still worth reviewing if anyone has feedback on the language or appearance of the warning.

# Tests

I've done manual testing, but that's it.  If we had a `bin/solr` test framework as SOLR-11749 proposes, we could conceivably write tests for this, but that's a major task and isn't going to happen anytime soon.
