### PR TITLE
SOLR-13954: Embedded ZK in Solr now does not try to load JettyAdminServer

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -208,6 +208,8 @@ Bug Fixes
 
 * SOLR-13805: NPE when calling /solr/admin/info/health on standalone solr (Nicholas DiPiazza, shalin)
 
+* SOLR-13954: Embedded ZooKeeper in Solr now does not try to load JettyAdminServer (janhoy)
+
 Other Changes
 ---------------------
 

--- a/solr/server/solr/zoo.cfg
+++ b/solr/server/solr/zoo.cfg
@@ -29,3 +29,6 @@ syncLimit=5
 # Purge task interval in hours
 # Set to "0" to disable auto purge feature
 #autopurge.purgeInterval=1
+
+# Disable ZK AdminServer since we do not use it
+admin.enableServer=false

--- a/solr/solrj/src/test-files/solrj/solr/multicore/zoo.cfg
+++ b/solr/solrj/src/test-files/solrj/solr/multicore/zoo.cfg
@@ -15,3 +15,5 @@ syncLimit=5
 # clientPort=2181
 # NOTE: Solr sets this based on zkRun / zkHost params
 
+# Disable ZK AdminServer since we do not use it
+admin.enableServer=false


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/SOLR-13954

Fix is to disable zk adminserver, we don't use it yet.

Once we start using it (to replace 4LW) we can add needed jars.