### PR TITLE
SOLR-13101: Don't invoke push to shared store for isolated commits.

### DIFF
--- a/solr/core/src/java/org/apache/solr/store/blob/process/CorePullerThread.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/process/CorePullerThread.java
@@ -96,7 +96,16 @@ public class CorePullerThread implements Runnable {
             corePullLock.writeLock().unlock();
           }
         } else {
-          log.info(String.format("Could not acquire pull write lock, going back to task queue, pullCoreInfo=%s", task.getPullCoreInfo().toString()));
+          /**
+           * TODO: We need to add this back to task queue with some delay otherwise, on a non-leader node, a core being
+           *       queried back to back will keep hitting this very frequently.
+           *       {@link CorePullTask#pullCoreFromBlob(boolean)} too on re-attempts, sleeps the thread, instead of adding back 
+           *       to task queue with delay. Both of these places would need re-enqueue-with-delay functionality. 
+           *       {@link CorePullTask#getLastAttemptTimestamp()} also talks about that need.
+           *
+           *       Commenting out the log line for now to at least avoid the flooding in the logs.
+           */
+          // log.info(String.format("Could not acquire pull write lock, going back to task queue, pullCoreInfo=%s", task.getPullCoreInfo().toString()));
           workQueue.addDeduplicated(task, true);
         }
       } catch (InterruptedException ie) {

--- a/solr/core/src/test/org/apache/solr/store/shared/SimpleSharedStoreEndToEndPushTest.java
+++ b/solr/core/src/test/org/apache/solr/store/shared/SimpleSharedStoreEndToEndPushTest.java
@@ -40,7 +40,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * A simple end-to-end push test for collections using a shared store 
+ * A simple end-to-end push tests for collections using a shared store 
  */
 public class SimpleSharedStoreEndToEndPushTest extends SolrCloudSharedStoreTestCase {
   
@@ -62,11 +62,24 @@ public class SimpleSharedStoreEndToEndPushTest extends SolrCloudSharedStoreTestC
   }
   
   /**
-   * Verify that doing sending a single update with commit=true pushes to the shared store on a 
-   * shared-based collection
+   * Verify that doing a single update to shared collection with commit=true pushes to the shared store. 
    */
   @Test
-  public void testUpdatePushesToBlobSuccess() throws Exception {
+  public void testUpdatePushesToBlobWithCommit() throws Exception {
+    testUpdatePushesToBlob(true);
+  }
+
+  /**
+   * Verify that doing a single update to shared collection even without commit pushes to the shared store. 
+   * This will work because Solr will implicitly add commit=true for a shared collection
+   */
+  @Test
+  public void testUpdatePushesToBlobWithoutCommit() throws Exception {
+    testUpdatePushesToBlob(false);
+  }
+
+  public void testUpdatePushesToBlob(boolean withCommit) throws Exception {
+
     setupCluster(1);
     CloudSolrClient cloudClient = cluster.getSolrClient();
     
@@ -85,7 +98,11 @@ public class SimpleSharedStoreEndToEndPushTest extends SolrCloudSharedStoreTestC
     // send an update to the cluster
     UpdateRequest updateReq = new UpdateRequest();
     updateReq.add("id", "1");
-    updateReq.commit(cloudClient, collectionName);
+    if (withCommit) {
+      updateReq.commit(cloudClient, collectionName);
+    } else {
+      updateReq.process(cloudClient, collectionName);
+    }
     
     // verify we can find the document
     QueryRequest queryReq = new QueryRequest(new SolrQuery("*:*"));

--- a/solr/core/src/test/org/apache/solr/update/processor/DistributedZkUpdateProcessorTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/DistributedZkUpdateProcessorTest.java
@@ -29,11 +29,13 @@ import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.UpdateRequest;
 import org.apache.solr.common.SolrException;
+import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.cloud.DocCollection;
 import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.cloud.Slice;
 import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.common.util.SimpleOrderedMap;
 import org.apache.solr.core.CoreContainer;
 import org.apache.solr.core.SolrCore;
 import org.apache.solr.request.LocalSolrQueryRequest;
@@ -42,6 +44,7 @@ import org.apache.solr.response.SolrQueryResponse;
 import org.apache.solr.store.blob.client.CoreStorageClient;
 import org.apache.solr.store.blob.process.CoreUpdateTracker;
 import org.apache.solr.store.shared.SolrCloudSharedStoreTestCase;
+import org.apache.solr.update.AddUpdateCommand;
 import org.apache.solr.update.CommitUpdateCommand;
 import org.junit.After;
 import org.junit.BeforeClass;
@@ -82,148 +85,172 @@ public class DistributedZkUpdateProcessorTest extends SolrCloudSharedStoreTestCa
   public void testNonLeaderSharedReplicaFailsOnForwardedCommit() throws Exception {
     setupCluster(1);
     setupTestSharedClientForNode(getBlobStorageProviderTestInstance(storageClient), cluster.getJettySolrRunner(0));
-    
+
     String collectionName = "sharedCollection";
     CloudSolrClient cloudClient = cluster.getSolrClient();
-    
+
     setupSharedCollectionWithShardNames(collectionName, 2, 2, "shard1");
-    
+
     // get the replica that's not the leader for the shard
     DocCollection collection = cloudClient.getZkStateReader().getClusterState().getCollection(collectionName);
     Slice slice = collection.getSlice("shard1");
     Replica leaderReplica = collection.getLeader("shard1");
     Replica follower = null;
     for (Replica repl : slice.getReplicas()) {
-      if (repl.getName() != leaderReplica.getName()) {
+      if (!repl.getName().equals(leaderReplica.getName())) {
         follower = repl;
         break;
       }
     }
-    
+
     if (follower == null) {
       fail("This test has been misconfigured");
     }
-    
+
+    DistributedZkUpdateProcessor processor = null;
     SolrCore core = getCoreContainer(follower.getNodeName()).getCore(follower.getCoreName());
-    // Setup request such that the COMMIT_END_POINT is set to replicas. This indicates that
-    // a leader has forwarded an update to its replicas which isn't possible but a safety 
-    // check exists nonetheless. 
-    ModifiableSolrParams params = new ModifiableSolrParams();
-    params.set(DistributedZkUpdateProcessor.COMMIT_END_POINT, "replicas");
-    SolrQueryRequest req = new LocalSolrQueryRequest(core, params);
-    
-    // have the follower process the command as if it was forwarded it
-    SolrQueryResponse rsp = new SolrQueryResponse();
-    CoreUpdateTracker tracker = Mockito.mock(CoreUpdateTracker.class);
-    DistributedZkUpdateProcessor processor = new DistributedZkUpdateProcessor(req, rsp, null, tracker);
-    CommitUpdateCommand cmd = new CommitUpdateCommand(req, false);
-    
     try {
+      // Setup request such that the COMMIT_END_POINT is set to replicas. This indicates that
+      // a leader has forwarded an update to its replicas which isn't possible but a safety 
+      // check exists nonetheless. 
+      ModifiableSolrParams params = new ModifiableSolrParams();
+      params.set(DistributedZkUpdateProcessor.COMMIT_END_POINT, "replicas");
+      SolrQueryRequest req = new LocalSolrQueryRequest(core, params);
+
+      // have the follower process the command as if it was forwarded it
+      SolrQueryResponse rsp = new SolrQueryResponse();
+      CoreUpdateTracker tracker = Mockito.mock(CoreUpdateTracker.class);
+      processor = new DistributedZkUpdateProcessor(req, rsp, null, tracker);
+      CommitUpdateCommand cmd = new CommitUpdateCommand(req, false);
+
       processor.processCommit(cmd);
       fail("Exception should have been thrown on processCommit");
     } catch (SolrException ex) {
       assertTrue(ex.getMessage().contains("Unexpected indexing forwarding"));
     } finally {
-      processor.finish();
-      processor.close();
+      if (processor != null) {
+        processor.finish();
+        processor.close();
+      }
       core.close();
     }
   }
   
   /**
-   * Create shared collection, create SHARED replica, index data, and confirm that
-   * CoreUpdateTracker is accessed on commit.
+   * Create shared collection, create SHARED replica, index data, and confirm that commit writes to shared store.
    */
   @Test
-  public void testSharedReplicaUpdatesZk() throws Exception {
-    setupCluster(1);
-    setupTestSharedClientForNode(getBlobStorageProviderTestInstance(storageClient), cluster.getJettySolrRunner(0));
-    
-    // Set collection name and create client
-    String collectionName = "BlobBasedCollectionName1";
-    CloudSolrClient cloudClient = cluster.getSolrClient();
-
-    // Create collection
-    setupSharedCollectionWithShardNames(collectionName, 1, 1, "shard1");
-
-    // Verify that collection was created
-    waitForState("Timed-out wait for collection to be created", collectionName, clusterShape(1, 1));
-    assertTrue(cloudClient.getZkStateReader().getZkClient().exists(ZkStateReader.COLLECTIONS_ZKNODE + "/" + collectionName, false));
-    DocCollection collection = cloudClient.getZkStateReader().getClusterState().getCollection(collectionName);
-    
-    // Get core from collection
-    Replica newReplica = collection.getReplicas().get(0);
-    SolrCore core = getCoreContainer(newReplica.getNodeName()).getCore(newReplica.getCoreName());
-    
-    // Verify that replica type corresponds with sharedIndex value
-    Replica.Type replicaType = core.getCoreDescriptor().getCloudDescriptor().getReplicaType();
-    assertEquals(replicaType, Replica.Type.SHARED);
-        
-    // Mock out DistributedZkUpdateProcessor
-    SolrQueryResponse rsp = new SolrQueryResponse();
-    SolrQueryRequest req = new LocalSolrQueryRequest(core, new ModifiableSolrParams());
-    CoreUpdateTracker tracker = Mockito.mock(CoreUpdateTracker.class);
-    DistributedZkUpdateProcessor processor = new DistributedZkUpdateProcessor(req, rsp, null, tracker);
-    
-    // Make a commit and close processor and core
-    processor.processCommit(new CommitUpdateCommand(req, false));
-    processor.finish();
-    processor.close();
-    core.close();
-    
-    // Verify that core tracker was updated
-    verify(tracker).persistShardIndexToSharedStore(any(), any(), any(), any());
+  public void testSharedReplicaUpdate() throws Exception {
+    boolean isUpdateAnIsolatedCommit = false;
+    // if update has something to add or delete(i.e. not an isolated commit)
+    // we expect a write to shared store
+    boolean isWriteToSharedStoreExpected = true;
+    testReplicaUpdatesZk(Replica.Type.SHARED, isUpdateAnIsolatedCommit, isWriteToSharedStoreExpected);
   }
-  
+
   /**
-   * Create collection, create NRT replica, index data, and confirm that CoreUpdateTracker
-   * is NOT accessed on commit.
+   * Create shared collection, create SHARED replica, and confirm that isolated commit does not write to shared store.
    */
   @Test
-  public void testNRTReplicaUpdatesZk() throws Exception {
+  public void testSharedReplicaIsolatedCommit() throws Exception {
+    boolean isUpdateAnIsolatedCommit = true;
+    // if update has nothing to add or delete(i.e. just an isolated commit)
+    // we expect no write to shared store
+    boolean isWriteToSharedStoreExpected = false;
+    testReplicaUpdatesZk(Replica.Type.SHARED, isUpdateAnIsolatedCommit, isWriteToSharedStoreExpected);
+  }
+
+  /**
+   * Creates a collection with desired ({@code replicaType}), makes a desired {@code isUpdateAnIsolatedCommit} update
+   * to the collection and ensure that write to shared store happened as expected {@code isWriteToSharedStoreExpected}.
+   * 
+   * @param replicaType only SHARED and NRT are supported
+   * @param isUpdateAnIsolatedCommit if true add one document and then commit, otherwise, just an isolated commit
+   *                                 Few ways isolated commit can manifest in actual usage:
+   *                                 1. Client does indexing for while before issuing a separate commit.
+   *                                 2. SolrJ client issuing a separate follow up commit command to affected shards than
+   *                                    actual indexing request even when SolrJ client's caller issued a single update
+   *                                    command with commit=true.
+   * @param isWriteToSharedStoreExpected whether write to shared store is expected or not
+   */
+  private void testReplicaUpdatesZk(Replica.Type replicaType, boolean isUpdateAnIsolatedCommit, boolean isWriteToSharedStoreExpected) throws Exception {
     setupCluster(1);
     setupTestSharedClientForNode(getBlobStorageProviderTestInstance(storageClient), cluster.getJettySolrRunner(0));
-    
+
     // Set collection name and create client
-    String collectionName = "CollectionName2";
+    String collectionName = "testCollection";
     CloudSolrClient cloudClient = cluster.getSolrClient();
-    
+
     // Create collection
-    CollectionAdminRequest.Create create = CollectionAdminRequest
-        .createCollectionWithImplicitRouter(collectionName, "conf", "shard2", 0)
+    if (replicaType == Replica.Type.SHARED) {
+      setupSharedCollectionWithShardNames(collectionName, 1, 1, "shard1");
+    } else if (replicaType == Replica.Type.NRT) {
+      CollectionAdminRequest.Create create = CollectionAdminRequest
+          .createCollectionWithImplicitRouter(collectionName, "conf", "shard2", 0)
           .setSharedIndex(false)
           .setNrtReplicas(1);
-    create.process(cloudClient);
+      create.process(cloudClient);
+    } else {
+      throw new IllegalArgumentException(replicaType.name() + " replica type is not supported.");
+    }
 
     // Verify that collection was created
     waitForState("Timed-out wait for collection to be created", collectionName, clusterShape(1, 1));
     assertTrue(cloudClient.getZkStateReader().getZkClient().exists(ZkStateReader.COLLECTIONS_ZKNODE + "/" + collectionName, false));
     DocCollection collection = cloudClient.getZkStateReader().getClusterState().getCollection(collectionName);
 
+    DistributedZkUpdateProcessor processor = null;
+    CoreUpdateTracker tracker = Mockito.mock(CoreUpdateTracker.class);
     // Get core from collection
     Replica newReplica = collection.getReplicas().get(0);
     SolrCore core = getCoreContainer(newReplica.getNodeName()).getCore(newReplica.getCoreName());
-    
-    // Verify that replica type corresponds with sharedIndex value
-    Replica.Type replicaType = core.getCoreDescriptor().getCloudDescriptor().getReplicaType();
-    assertEquals(replicaType, Replica.Type.NRT);
-        
-    // Mock out DistributedZkUpdateProcessor
-    SolrQueryResponse rsp = new SolrQueryResponse();
-    SolrQueryRequest req = new LocalSolrQueryRequest(core, new ModifiableSolrParams());
-    CoreUpdateTracker tracker = Mockito.mock(CoreUpdateTracker.class);
-    DistributedZkUpdateProcessor processor = new DistributedZkUpdateProcessor(req, rsp, null, tracker);
-    
-    // Make a commit and close processor and core
-    processor.processCommit(new CommitUpdateCommand(req, false));
-    processor.finish();
-    processor.close();
-    core.close();
-    
-    // Verify that core tracker was not updated
-    verify(tracker, never()).persistShardIndexToSharedStore(any(), any(), any(), any()); 
+    try {
+      // Verify that replica type is as expected
+      assertEquals("wrong replica type", core.getCoreDescriptor().getCloudDescriptor().getReplicaType(), replicaType);
+
+      // Mock out DistributedZkUpdateProcessor
+      SolrQueryResponse rsp = new SolrQueryResponse();
+      rsp.addResponseHeader(new SimpleOrderedMap<>());
+      SolrQueryRequest req = new LocalSolrQueryRequest(core, new ModifiableSolrParams());
+      processor = new DistributedZkUpdateProcessor(req, rsp, null, tracker);
+      if (!isUpdateAnIsolatedCommit) {
+        // index a doc
+        AddUpdateCommand cmd = new AddUpdateCommand(req);
+        cmd.solrDoc = new SolrInputDocument();
+        cmd.solrDoc.addField("id", "1");
+        processor.processAdd(cmd);
+      }
+
+      // Make a commit
+      processor.processCommit(new CommitUpdateCommand(req, false));
+    } finally {
+      if (processor != null) {
+        processor.finish();
+        processor.close();
+      }
+      core.close();
+    }
+
+    if (isWriteToSharedStoreExpected) {
+      // Verify that core tracker was updated
+      verify(tracker).persistShardIndexToSharedStore(any(), any(), any(), any());
+    } else {
+      // Verify that core tracker was not updated
+      verify(tracker, never()).persistShardIndexToSharedStore(any(), any(), any(), any());
+    }
   }
-  
+
+  /**
+   * Create collection, create NRT replica, index data, and confirm that commit does not write to shared store.
+   */
+  @Test
+  public void testNRTReplicaUpdate() throws Exception {
+    boolean isIsolatedCommit = false;
+    // update to non-SHARED replica should not write to shared store
+    boolean isWriteToSharedStoreExpected = false;
+    testReplicaUpdatesZk(Replica.Type.NRT, isIsolatedCommit, isWriteToSharedStoreExpected);
+  }
+
   /**
    * Test update only happens on leader replica for a 1 shard shared collection
    */
@@ -272,8 +299,12 @@ public class DistributedZkUpdateProcessorTest extends SolrCloudSharedStoreTestCa
       // the commit should have only happened on the leader and it should have more index files than the default 
       assertTrue(leaderReplicaCore.getDeletionPolicy().getLatestCommit().getFileNames().size() > 1);
     } finally {
-      leaderReplicaCore.close();
-      followerReplicaCore.close();
+      if (leaderReplica != null) {
+        leaderReplicaCore.close();
+      }
+      if (followerReplica != null) {
+        followerReplicaCore.close();
+      }
     }
   }
 }


### PR DESCRIPTION
-Don't invoke push to shared store for isolated commits.
-Disable the noisy "going back to task queue" log line.