### PR TITLE
SOLR-13987: fix admin UI to not rely on javascript eval()

### DIFF
--- a/solr/server/etc/jetty.xml
+++ b/solr/server/etc/jetty.xml
@@ -95,7 +95,19 @@
           <New class="org.eclipse.jetty.rewrite.handler.HeaderPatternRule">
             <Set name="pattern">*</Set>
             <Set name="name">Content-Security-Policy</Set>
-            <Set name="value">default-src 'none'; base-uri 'none'; form-action 'self'; frame-ancestors 'none'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval'; img-src 'self'; media-src 'self'; font-src 'self'; connect-src 'self';</Set>
+            <Set name="value">
+              default-src 'none';
+              base-uri 'none';
+              connect-src 'self';
+              form-action 'self';
+              font-src 'self';
+              frame-ancestors 'none';
+              img-src 'self';
+              media-src 'self';
+              style-src 'self' 'unsafe-inline';
+              script-src 'self';
+              worker-src 'self';
+            </Set>
           </New>
         </Arg>
       </Call>

--- a/solr/webapp/web/css/angular/angular-csp.css
+++ b/solr/webapp/web/css/angular/angular-csp.css
@@ -1,0 +1,41 @@
+/*
+The MIT License
+
+Copyright (c) 2010-2015 Google, Inc. http://angularjs.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+/**
+ * @license AngularJS v1.3.8
+ * (c) 2010-2014 Google, Inc. http://angularjs.org
+ * License: MIT
+ */
+/* Include this file in your html if you are using the CSP mode. */
+
+@charset "UTF-8";
+
+[ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak],
+.ng-cloak, .x-ng-cloak,
+.ng-hide:not(.ng-hide-animate) {
+  display: none !important;
+}
+
+ng\:form {
+  display: block;
+}

--- a/solr/webapp/web/index.html
+++ b/solr/webapp/web/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
-<html ng-app="solrAdminApp">
+<html ng-app="solrAdminApp" ng-csp>
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with
@@ -23,6 +23,7 @@ limitations under the License.
   <link rel="icon" type="image/x-icon" href="img/favicon.ico?_=${version}">
   <link rel="shortcut icon" type="image/x-icon" href="img/favicon.ico?_=${version}">
 
+  <link rel="stylesheet" type="text/css" href="css/angular/angular-csp.css?_=${version}">
   <link rel="stylesheet" type="text/css" href="css/angular/common.css?_=${version}">
   <link rel="stylesheet" type="text/css" href="css/angular/analysis.css?_=${version}">
   <link rel="stylesheet" type="text/css" href="css/angular/cloud.css?_=${version}">

--- a/solr/webapp/web/js/angular/app.js
+++ b/solr/webapp/web/js/angular/app.js
@@ -299,7 +299,7 @@ solrAdminApp.config([
             scope.$watch("data", function(newValue, oldValue) {
                 if (newValue) {
                   var treeConfig = {
-                      "plugins" : [ "themes", "json_data", "ui" ],
+                      "plugins" : [ "json_data", "ui" ],
                       "json_data" : {
                         "data" : scope.data,
                         "progressive_render" : true

--- a/solr/webapp/web/js/angular/controllers/cloud.js
+++ b/solr/webapp/web/js/angular/controllers/cloud.js
@@ -668,7 +668,7 @@ var graphSubController = function ($scope, Zookeeper) {
             }
 
             Zookeeper.clusterState(params, function (data) {
-                    eval("var state=" + data.znode.data); // @todo fix horrid means to parse JSON
+                    var state = $.parseJSON(data.znode.data);
 
                     var leaf_count = 0;
                     var graph_data = {


### PR DESCRIPTION
* Removes `'unsafe-eval'` from CSP `script-src`
* Enables Angular CSP mode
* Removes `eval()` JSON parsing in `cloud.js`
* Removes `jstree` `themes` error