### PR TITLE
SOLR-14072: Deprecate Blob API and runtimeLib

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -183,8 +183,8 @@ Upgrade Notes
 
 * SOLR-14065: VelocityResponseWriter has been deprecated and may be removed in a future version.
 
-* SOLR-14072: The "Blob Store" API and "runtimeLib" plugin mechanism that uses it is now considered deprecated.  The
-  replacement to it is the "Package Manager" system, which includes a "File Store".  These are experimental currently
+* SOLR-14072: The "Blob Store" API and "runtimeLib" plugin mechanism that uses it is now considered deprecated. The
+  replacement to it is the "Package Management" system, which includes a "File Store". These are experimental currently
   but will grow/stabalize/mature.
 
 New Features

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -183,6 +183,10 @@ Upgrade Notes
 
 * SOLR-14065: VelocityResponseWriter has been deprecated and may be removed in a future version.
 
+* SOLR-14072: The "Blob Store" API and "runtimeLib" plugin mechanism that uses it is now considered deprecated.  The
+  replacement to it is the "Package Manager" system, which includes a "File Store".  These are experimental currently
+  but will grow/stabalize/mature.
+
 New Features
 ---------------------
 * SOLR-13821: A Package store to store and load package artifacts (noble, Ishan Chattopadhyaya)

--- a/solr/solr-ref-guide/src/adding-custom-plugins-in-solrcloud-mode.adoc
+++ b/solr/solr-ref-guide/src/adding-custom-plugins-in-solrcloud-mode.adoc
@@ -18,6 +18,12 @@
 
 In SolrCloud mode, custom plugins need to be shared across all nodes of the cluster.
 
+.Deprecated
+[IMPORTANT]
+====
+The functionality here is a subset of the <<package-manager.adoc#package-manager,Package Management>> system.  It will no longer be supported in Solr 9.
+====
+
 When running Solr in SolrCloud mode and you want to use custom code (such as custom analyzers, tokenizers, query parsers, and other plugins), it can be cumbersome to add jars to the classpath on all nodes in your cluster. Using the <<blob-store-api.adoc#blob-store-api,Blob Store API>> and special commands with the <<config-api.adoc#config-api,Config API>>, you can upload jars to a special system-level collection and dynamically load plugins from them at runtime without needing to restart any nodes.
 
 .This Feature is Disabled By Default


### PR DESCRIPTION
Bare minimum.