### PR TITLE
LUCENE-9097: Decrease the number of shape used in multi-polygon tests

### DIFF
--- a/lucene/sandbox/src/test/org/apache/lucene/document/TestLatLonMultiPolygonShapeQueries.java
+++ b/lucene/sandbox/src/test/org/apache/lucene/document/TestLatLonMultiPolygonShapeQueries.java
@@ -148,9 +148,15 @@ public class TestLatLonMultiPolygonShapeQueries extends BaseLatLonShapeTestCase 
   }
 
   @Slow
+  @Override
+  public void testRandomMedium() throws Exception {
+    doTestRandom(250);
+  }
+
+  @Slow
   @Nightly
   @Override
   public void testRandomBig() throws Exception {
-    doTestRandom(10000);
+    doTestRandom(2500);
   }
 }

--- a/lucene/sandbox/src/test/org/apache/lucene/document/TestXYMultiPolygonShapeQueries.java
+++ b/lucene/sandbox/src/test/org/apache/lucene/document/TestXYMultiPolygonShapeQueries.java
@@ -137,9 +137,15 @@ public class TestXYMultiPolygonShapeQueries extends BaseXYShapeTestCase {
   }
 
   @Slow
+  @Override
+  public void testRandomMedium() throws Exception {
+    doTestRandom(250);
+  }
+
+  @Slow
   @Nightly
   @Override
   public void testRandomBig() throws Exception {
-    doTestRandom(10000);
+    doTestRandom(2500);
   }
 }


### PR DESCRIPTION
Decrease the number so test run faster and minimise the possibility of OOM errors.