### PR TITLE
Update README.txt for analysis-extras

### DIFF
--- a/solr/contrib/analysis-extras/README.txt
+++ b/solr/contrib/analysis-extras/README.txt
@@ -6,6 +6,9 @@ analyzers for Chinese and Polish, and integration with
 OpenNLP for multilingual tokenization, part-of-speech tagging
 lemmatization, phrase chunking, and named-entity recognition.
 
+Each of the jars below relies upon including /dist/solr-analysis-extras-X.Y.jar 
+in the solrconfig.xml
+
 ICU relies upon lucene-libs/lucene-analyzers-icu-X.Y.jar
 and lib/icu4j-X.Y.jar
 


### PR DESCRIPTION
Update the analysis-extras README to include reference to including solr-analysis-extras jar.

I struggled to work out what was missing when I was using ICU for the first time, and this caught me out. There may be a better way of phrasing it.