### PR TITLE
LUCENE-9098 Report bad term for fuzzy query, SOLR-13190 Surface Fuzzy term errors in Solr

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/FuzzyTermsEnum.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FuzzyTermsEnum.java
@@ -37,6 +37,7 @@ import org.apache.lucene.util.UnicodeUtil;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.CompiledAutomaton;
 import org.apache.lucene.util.automaton.LevenshteinAutomata;
+import org.apache.lucene.util.automaton.TooComplexToDeterminizeException;
 
 /** Subclass of TermsEnum for enumerating all terms that are similar
  * to the specified filter term.
@@ -131,7 +132,11 @@ public final class FuzzyTermsEnum extends BaseTermsEnum {
       prevAutomata = new CompiledAutomaton[maxEdits+1];
       Automaton[] automata = buildAutomata(termText, prefixLength, transpositions, maxEdits);
       for (int i = 0; i <= maxEdits; i++) {
-        prevAutomata[i] = new CompiledAutomaton(automata[i], true, false);
+        try {
+          prevAutomata[i] = new CompiledAutomaton(automata[i], true, false);
+        } catch (TooComplexToDeterminizeException e) {
+          throw new FuzzyTermsException(term.text(), e);
+        }
       }
       // first segment computes the automata, and we share with subsequent segments via this Attribute:
       dfaAtt.setAutomata(prevAutomata);
@@ -405,6 +410,17 @@ public final class FuzzyTermsEnum extends BaseTermsEnum {
     @Override
     public void reflectWith(AttributeReflector reflector) {
       reflector.reflect(LevenshteinAutomataAttribute.class, "automata", automata);
+    }
+  }
+
+  /**
+   * Thrown to indicate that there was an issue creating a fuzzy query for a given term.
+   * Typically occurs with terms longer than 220 UTF-8 characters,
+   * but also possible with shorter terms consisting of UTF-32 code points.
+   */
+  public static class FuzzyTermsException extends RuntimeException {
+    private FuzzyTermsException(String term, Throwable cause) {
+      super("Term too complex: " + term, cause);
     }
   }
 }

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -37,6 +37,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.ReaderUtil;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.FieldComparator;
+import org.apache.lucene.search.FuzzyTermsEnum;
 import org.apache.lucene.search.LeafFieldComparator;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
@@ -1484,7 +1485,11 @@ public class QueryComponent extends SearchComponent
 
     SolrIndexSearcher searcher = req.getSearcher();
 
-    searcher.search(result, cmd);
+    try {
+      searcher.search(result, cmd);
+    } catch (FuzzyTermsEnum.FuzzyTermsException e) {
+      throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, e);
+    }
     rb.setResult(result);
 
     ResultContext ctx = new BasicResultContext(rb);

--- a/solr/core/src/test/org/apache/solr/search/FuzzySearchTest.java
+++ b/solr/core/src/test/org/apache/solr/search/FuzzySearchTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.search;
+
+import java.io.IOException;
+
+import org.apache.lucene.util.LuceneTestCase;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.impl.BaseHttpSolrClient;
+import org.apache.solr.client.solrj.impl.CloudSolrClient;
+import org.apache.solr.client.solrj.request.CollectionAdminRequest;
+import org.apache.solr.cloud.SolrCloudTestCase;
+import org.apache.solr.common.SolrInputDocument;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+@LuceneTestCase.Slow
+public class FuzzySearchTest extends SolrCloudTestCase {
+  private final static String COLLECTION = "c1";
+  private CloudSolrClient client;
+
+  @BeforeClass
+  public static void setupCluster() throws Exception {
+    configureCluster(1).addConfig(COLLECTION, configset("cloud-minimal")).configure();
+  }
+
+  @Before
+  public void setupCollection() throws Exception {
+    client = cluster.getSolrClient();
+    client.setDefaultCollection(COLLECTION);
+
+    CollectionAdminRequest.createCollection(COLLECTION, 1, 1).process(client);
+    cluster.waitForActiveCollection(COLLECTION, 1, 1);
+  }
+
+  @Test
+  public void testTooComplex() throws IOException, SolrServerException {
+    SolrInputDocument doc = new SolrInputDocument();
+
+    doc.setField("id", "1");
+    doc.setField("text", "foo");
+    client.add(doc);
+    client.commit(); // Must have index files written, but the contents don't matter
+
+    SolrQuery query = new SolrQuery("text:headquarters\\(在日米海軍横須賀基地司令部庁舎\\/旧横須賀鎮守府会議所・横須賀海軍艦船部\\)~");
+
+    BaseHttpSolrClient.RemoteSolrException e = expectThrows(BaseHttpSolrClient.RemoteSolrException.class, () -> client.query(query));
+    assertTrue("Should be client error, not server error", e.code() >= 400 && e.code() < 500);
+  }
+}


### PR DESCRIPTION
# Description

When a fuzzy query encounters a term that is too complex, the exception
should report the term instead of a cryptic message about too many
states. This supersedes #554

# Solution

Catch the exception and regrow it with term information present.

# Tests

Added tests which generate long terms and feed them to fuzzy query.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
