### PR TITLE
SOLR-14106: Cleanup Jetty SslContextFactory usage

### DIFF
--- a/lucene/replicator/src/test/org/apache/lucene/replicator/ReplicatorTestCase.java
+++ b/lucene/replicator/src/test/org/apache/lucene/replicator/ReplicatorTestCase.java
@@ -61,7 +61,7 @@ public abstract class ReplicatorTestCase extends LuceneTestCase {
     // talking to that server, but for the purposes of testing that should 
     // be good enough
     final boolean useSsl = Boolean.getBoolean("tests.jettySsl");
-    final SslContextFactory sslcontext = new SslContextFactory(false);
+    final SslContextFactory.Server sslcontext = new SslContextFactory.Server();
     
     if (useSsl) {
       if (null != System.getProperty("javax.net.ssl.keyStore")) {

--- a/solr/core/src/java/org/apache/solr/client/solrj/embedded/JettySolrRunner.java
+++ b/solr/core/src/java/org/apache/solr/client/solrj/embedded/JettySolrRunner.java
@@ -278,7 +278,7 @@ public class JettySolrRunner {
       // the server as well as any client actions taken by this JVM in
       // talking to that server, but for the purposes of testing that should
       // be good enough
-      final SslContextFactory sslcontext = SSLConfig.createContextFactory(config.sslConfig);
+      final SslContextFactory.Server sslcontext = SSLConfig.createContextFactory(config.sslConfig);
 
       HttpConfiguration configuration = new HttpConfiguration();
       ServerConnector connector;

--- a/solr/core/src/test/org/apache/hadoop/http/HttpServer2.java
+++ b/solr/core/src/test/org/apache/hadoop/http/HttpServer2.java
@@ -507,7 +507,7 @@ public final class HttpServer2 implements FilterContainer {
       httpConfig.addCustomizer(new SecureRequestCustomizer());
       ServerConnector conn = createHttpChannelConnector(server, httpConfig);
 
-      SslContextFactory sslContextFactory = new SslContextFactory();
+      SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
       sslContextFactory.setNeedClientAuth(needsClientAuth);
       sslContextFactory.setKeyManagerPassword(keyPassword);
       if (keyStore != null) {

--- a/solr/server/etc/jetty-ssl.xml
+++ b/solr/server/etc/jetty-ssl.xml
@@ -6,7 +6,7 @@
 <!-- This configuration must be used in conjunction with jetty.xml -->
 <!-- and either jetty-https.xml or jetty-spdy.xml (but not both)   -->
 <!-- ============================================================= -->
-<Configure id="sslContextFactory" class="org.eclipse.jetty.util.ssl.SslContextFactory">
+<Configure id="sslContextFactory" class="org.eclipse.jetty.util.ssl.SslContextFactory$Server">
   <Call class="org.apache.solr.util.configuration.SSLConfigurationsFactory" name="current">
     <Get name="keyStorePassword" id="keyStorePassword"/>
     <Get name="trustStorePassword" id="trustStorePassword"/>

--- a/solr/server/etc/jetty.xml
+++ b/solr/server/etc/jetty.xml
@@ -132,7 +132,7 @@
         <Arg>
           <New class="org.eclipse.jetty.rewrite.handler.RedirectRegexRule">
             <Set name="regex">^/$</Set>
-            <Set name="replacement">/solr/</Set>
+            <Set name="location">/solr/</Set>
           </New>
         </Arg>
       </Call>

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/embedded/SSLConfig.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/embedded/SSLConfig.java
@@ -24,7 +24,6 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
  * @see #setUseSSL
  */
 public class SSLConfig {
-  
   private boolean useSsl;
   private boolean clientAuth;
   private String keyStore;
@@ -76,7 +75,7 @@ public class SSLConfig {
   }
 
   /**
-   * Returns an SslContextFactory that should be used by a jetty server based on the specified 
+   * Returns an SslContextFactory.Server that should be used by a jetty server based on the specified
    * SSLConfig param which may be null.
    *
    * if the SSLConfig param is non-null, then this method will return the results of 
@@ -88,8 +87,7 @@ public class SSLConfig {
    * 
    * @see #createContextFactory()
    */
-  public static SslContextFactory createContextFactory(SSLConfig sslConfig) {
-
+  public static SslContextFactory.Server createContextFactory(SSLConfig sslConfig) {
     if (sslConfig != null) {
       return sslConfig.createContextFactory();
     }
@@ -102,7 +100,7 @@ public class SSLConfig {
   }
   
   /**
-   * Returns an SslContextFactory that should be used by a jetty server based on this SSLConfig instance, 
+   * Returns an SslContextFactory.Server that should be used by a jetty server based on this SSLConfig instance,
    * or null if SSL should not be used.
    *
    * The default implementation generates a simple factory according to the keystore, truststore, 
@@ -114,14 +112,13 @@ public class SSLConfig {
    * @see #getTrustStore
    * @see #getTrustStorePassword
    */
-  public SslContextFactory createContextFactory() {
-
+  public SslContextFactory.Server createContextFactory() {
     if (! isSSLMode()) {
       return null;
     }
     // else...
     
-    SslContextFactory factory = new SslContextFactory(false);
+    SslContextFactory.Server factory = new SslContextFactory.Server();
     if (getKeyStore() != null)
       factory.setKeyStorePath(getKeyStore());
     if (getKeyStorePassword() != null)
@@ -136,12 +133,14 @@ public class SSLConfig {
         factory.setTrustStorePassword(getTrustStorePassword());
     }
     return factory;
-
   }
 
-  private static SslContextFactory configureSslFromSysProps() {
+  public SslContextFactory.Client createClientContextFactory() {
+    return new SslContextFactory.Client();
+  }
 
-    SslContextFactory sslcontext = new SslContextFactory(false);
+  private static SslContextFactory.Server configureSslFromSysProps() {
+    SslContextFactory.Server sslcontext = new SslContextFactory.Server();
 
     if (null != System.getProperty("javax.net.ssl.keyStore")) {
       sslcontext.setKeyStorePath

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -99,7 +99,6 @@ import org.slf4j.LoggerFactory;
 import static org.apache.solr.client.solrj.impl.BaseHttpSolrClient.*;
 import static org.apache.solr.common.util.Utils.getObjectByPath;
 
-// TODO: error handling, small Http2SolrClient features, security, ssl
 /**
  * Difference between this {@link Http2SolrClient} and {@link HttpSolrClient}:
  * <ul>
@@ -180,13 +179,13 @@ public class Http2SolrClient extends SolrClient {
     ThreadPoolExecutor httpClientExecutor = new ExecutorUtil.MDCAwareThreadPoolExecutor(32,
         256, 60, TimeUnit.SECONDS, queue, new SolrjNamedThreadFactory("h2sc"));
 
-    SslContextFactory sslContextFactory;
+    SslContextFactory.Client sslContextFactory;
     boolean ssl;
     if (builder.sslConfig == null) {
       sslContextFactory = getDefaultSslContextFactory();
       ssl = sslContextFactory.getTrustStore() != null || sslContextFactory.getTrustStorePath() != null;
     } else {
-      sslContextFactory = builder.sslConfig.createContextFactory();
+      sslContextFactory = builder.sslConfig.createClientContextFactory();
       ssl = true;
     }
 
@@ -868,7 +867,6 @@ public class Http2SolrClient extends SolrClient {
       this.connectionTimeout = connectionTimeOut;
       return this;
     }
-
   }
 
   public Set<String> getQueryParams() {
@@ -921,7 +919,7 @@ public class Http2SolrClient extends SolrClient {
     Http2SolrClient.defaultSSLConfig = null;
   }
 
-  private static SslContextFactory getDefaultSslContextFactory() {
+  private static SslContextFactory.Client getDefaultSslContextFactory() {
     String checkPeerNameStr = System.getProperty(HttpClientUtil.SYS_PROP_CHECK_PEER_NAME);
     boolean sslCheckPeerName = true;
     if (checkPeerNameStr == null || "false".equalsIgnoreCase(checkPeerNameStr)) {
@@ -949,5 +947,4 @@ public class Http2SolrClient extends SolrClient {
 
     return sslContextFactory;
   }
-
 }

--- a/solr/test-framework/src/java/org/apache/solr/util/SSLTestConfig.java
+++ b/solr/test-framework/src/java/org/apache/solr/util/SSLTestConfig.java
@@ -184,7 +184,7 @@ public class SSLTestConfig {
 
     return new SSLConfig(isSSLMode(), isClientAuthMode(), null, null, null, null) {
       @Override
-      public SslContextFactory createContextFactory() {
+      public SslContextFactory.Client createClientContextFactory() {
         SslContextFactory.Client factory = new SslContextFactory.Client(!checkPeerName);
         try {
           factory.setSslContext(buildClientSSLContext());
@@ -212,7 +212,7 @@ public class SSLTestConfig {
 
     return new SSLConfig(isSSLMode(), isClientAuthMode(), null, null, null, null) {
       @Override
-      public SslContextFactory createContextFactory() {
+      public SslContextFactory.Server createContextFactory() {
         SslContextFactory.Server factory = new SslContextFactory.Server();
         try {
           SSLContextBuilder builder = SSLContexts.custom();


### PR DESCRIPTION
SOLR-14106: Cleanup Jetty SslContextFactory usage

Jetty 9.4.16.v20190411 and up introduced separate
client and server SslContextFactory implementations.
This split requires the proper use of of
SslContextFactory in clients and server configs.

This fixes the following
* SSL with SOLR_SSL_NEED_CLIENT_AUTH not working since v8.2.0
* Http2SolrClient SSL not working in branch_8x