### PR TITLE
SOLR-14109 Always log to stdout from zkcli.sh

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -133,6 +133,8 @@ Bug Fixes
 
 * SOLR-14099: Fixed @LogLevel annotation in test-framework to correctly 'unset' Loggers after test (hossman)
 
+* SOLR-14109: Always log to stdout from server/scripts/cloud-scripts/zkcli.{bat|sh} (janhoy)
+
 Other Changes
 ---------------------
 

--- a/solr/server/scripts/cloud-scripts/zkcli.bat
+++ b/solr/server/scripts/cloud-scripts/zkcli.bat
@@ -9,11 +9,7 @@ REM  Find location of this script
 set SDIR=%~dp0
 if "%SDIR:~-1%"=="\" set SDIR=%SDIR:~0,-1%
 
-if defined LOG4J_PROPS (
-  set "LOG4J_CONFIG=file:///%LOG4J_PROPS%"
-) else (
-  set "LOG4J_CONFIG=file:///%SDIR%\..\..\resources\log4j2-console.xml"
-)
+set "LOG4J_CONFIG=file:///%SDIR%\..\..\resources\log4j2-console.xml"
 
 REM Settings for ZK ACL
 REM set SOLR_ZK_CREDS_AND_ACLS=-DzkACLProvider=org.apache.solr.common.cloud.VMParamsAllAndReadonlyDigestZkACLProvider ^

--- a/solr/server/scripts/cloud-scripts/zkcli.sh
+++ b/solr/server/scripts/cloud-scripts/zkcli.sh
@@ -9,11 +9,7 @@ JVM="java"
 
 sdir="`dirname \"$0\"`"
 
-if [ -n "$LOG4J_PROPS" ]; then
-  log4j_config="file:$LOG4J_PROPS"
-else
-  log4j_config="file:$sdir/../../resources/log4j2-console.xml"
-fi
+log4j_config="file:$sdir/../../resources/log4j2-console.xml"
 
 # Settings for ZK ACL
 #SOLR_ZK_CREDS_AND_ACLS="-DzkACLProvider=org.apache.solr.common.cloud.VMParamsAllAndReadonlyDigestZkACLProvider \


### PR DESCRIPTION
There should be no reason to log anywhere else. This fixes a problem with bogous logging when running the tool from Solr's Docker image.