### PR TITLE
LUCENE-9102: add maxQueryLength option to DirectSpellChecker

### DIFF
--- a/lucene/suggest/src/java/org/apache/lucene/search/spell/DirectSpellChecker.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/spell/DirectSpellChecker.java
@@ -75,6 +75,8 @@ public class DirectSpellChecker {
   private float thresholdFrequency = 0f;
   /** minimum length of a query word to return suggestions */
   private int minQueryLength = 4;
+  /** maximum length of a query word to return suggestions */
+  private int maxQueryLength = 0;
   /** value in [0..1] (or absolute number &gt;= 1) representing the maximum
    *  number of documents (of the total) a query term can appear in to
    *  be corrected. */
@@ -198,6 +200,19 @@ public class DirectSpellChecker {
     this.minQueryLength = minQueryLength;
   }
 
+  /** Get the maximum length of a query term to return suggestions */
+  public int getMaxQueryLength() {
+    return maxQueryLength;
+  }
+
+  /** 
+   * Set the maximum length of a query term (default: 0, i.e. no maximum)
+   * to return suggestions. 
+   */
+  public void setMaxQueryLength(int maxQueryLength) {
+    this.maxQueryLength = maxQueryLength;
+  }
+
   /**
    * Get the maximum threshold of documents a query term can appear in order
    * to provide suggestions.
@@ -317,7 +332,11 @@ public class DirectSpellChecker {
       SuggestMode suggestMode, float accuracy) throws IOException {
     final CharsRefBuilder spare = new CharsRefBuilder();
     String text = term.text();
-    if (minQueryLength > 0 && text.codePointCount(0, text.length()) < minQueryLength)
+
+    int textLength = text.codePointCount(0, text.length());
+    if (minQueryLength > 0 && textLength < minQueryLength)
+      return new SuggestWord[0];
+    if (maxQueryLength > 0 && textLength > maxQueryLength)
       return new SuggestWord[0];
     
     if (lowerCaseTerms) {

--- a/lucene/suggest/src/java/org/apache/lucene/search/spell/DirectSpellChecker.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/spell/DirectSpellChecker.java
@@ -197,6 +197,8 @@ public class DirectSpellChecker {
    * metric.
    */
   public void setMinQueryLength(int minQueryLength) {
+    if (minQueryLength > this.maxQueryLength)
+      throw new IllegalArgumentException("minQueryLength must not be greater than maxQueryLength");
     this.minQueryLength = minQueryLength;
   }
 
@@ -211,6 +213,8 @@ public class DirectSpellChecker {
    * Long queries can be expensive to process and/or trigger exceptions.
    */
   public void setMaxQueryLength(int maxQueryLength) {
+    if (maxQueryLength < this.minQueryLength)
+      throw new IllegalArgumentException("maxQueryLength must not be smaller than minQueryLength");
     this.maxQueryLength = maxQueryLength;
   }
 

--- a/lucene/suggest/src/java/org/apache/lucene/search/spell/DirectSpellChecker.java
+++ b/lucene/suggest/src/java/org/apache/lucene/search/spell/DirectSpellChecker.java
@@ -76,7 +76,7 @@ public class DirectSpellChecker {
   /** minimum length of a query word to return suggestions */
   private int minQueryLength = 4;
   /** maximum length of a query word to return suggestions */
-  private int maxQueryLength = 0;
+  private int maxQueryLength = Integer.MAX_VALUE;
   /** value in [0..1] (or absolute number &gt;= 1) representing the maximum
    *  number of documents (of the total) a query term can appear in to
    *  be corrected. */
@@ -206,8 +206,9 @@ public class DirectSpellChecker {
   }
 
   /** 
-   * Set the maximum length of a query term (default: 0, i.e. no maximum)
-   * to return suggestions. 
+   * Set the maximum length of a query term to return suggestions. 
+   * <p>
+   * Long queries can be expensive to process and/or trigger exceptions.
    */
   public void setMaxQueryLength(int maxQueryLength) {
     this.maxQueryLength = maxQueryLength;
@@ -334,9 +335,7 @@ public class DirectSpellChecker {
     String text = term.text();
 
     int textLength = text.codePointCount(0, text.length());
-    if (minQueryLength > 0 && textLength < minQueryLength)
-      return new SuggestWord[0];
-    if (maxQueryLength > 0 && textLength > maxQueryLength)
+    if (textLength < minQueryLength || textLength > maxQueryLength)
       return new SuggestWord[0];
     
     if (lowerCaseTerms) {

--- a/lucene/suggest/src/test/org/apache/lucene/search/spell/TestDirectSpellChecker.java
+++ b/lucene/suggest/src/test/org/apache/lucene/search/spell/TestDirectSpellChecker.java
@@ -147,12 +147,14 @@ public class TestDirectSpellChecker extends LuceneTestCase {
         "fobar"), 1, ir, SuggestMode.SUGGEST_MORE_POPULAR);
     assertEquals(0, similar.length);
     
+    // confirm that a term shorter than minQueryLength is not spellchecked
     spellChecker = new DirectSpellChecker(); // reset defaults
     spellChecker.setMinQueryLength(5);
     similar = spellChecker.suggestSimilar(new Term("text", "foba"), 1, ir,
         SuggestMode.SUGGEST_MORE_POPULAR);
     assertEquals(0, similar.length);
 
+    // confirm that a term longer than maxQueryLength is not spellchecked
     spellChecker = new DirectSpellChecker(); // reset defaults
     spellChecker.setMaxQueryLength(5);
     similar = spellChecker.suggestSimilar(new Term("text", "foobrr"), 1, ir,

--- a/lucene/suggest/src/test/org/apache/lucene/search/spell/TestDirectSpellChecker.java
+++ b/lucene/suggest/src/test/org/apache/lucene/search/spell/TestDirectSpellChecker.java
@@ -152,6 +152,12 @@ public class TestDirectSpellChecker extends LuceneTestCase {
     similar = spellChecker.suggestSimilar(new Term("text", "foba"), 1, ir,
         SuggestMode.SUGGEST_MORE_POPULAR);
     assertEquals(0, similar.length);
+
+    spellChecker = new DirectSpellChecker(); // reset defaults
+    spellChecker.setMaxQueryLength(5);
+    similar = spellChecker.suggestSimilar(new Term("text", "foobrr"), 1, ir,
+        SuggestMode.SUGGEST_MORE_POPULAR);
+    assertEquals(0, similar.length);
     
     spellChecker = new DirectSpellChecker(); // reset defaults
     spellChecker.setMaxEdits(1);


### PR DESCRIPTION
# Description

Attempting to spellcheck some long query terms can trigger org.apache.lucene.util.automaton.TooComplexToDeterminizeException.

(See also https://github.com/apache/lucene-solr/pull/1107 for a corresponding Solr change.)

# Solution

This change adds a maxQueryLength option to DirectSpellchecker so that Lucene can be configured to not attempt to spellcheck terms over a specified length.

# Tests

A new test checks that terms longer than maxQueryLength are not spellchecked.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [x] I have added tests for my changes.

