### PR TITLE
SOLR-14138: enable request log via environ var

### DIFF
--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -262,6 +262,11 @@ else
   SOLR_JETTY_CONFIG+=("--module=http")
 fi
 
+# Requestlog options
+if [ "$SOLR_REQUESTLOG_ENABLED" == "true" ]; then
+  SOLR_JETTY_CONFIG+=("--module=requestlog")
+fi
+
 # Authentication options
 if [ -z "$SOLR_AUTH_TYPE" ] && [ -n "$SOLR_AUTHENTICATION_OPTS" ]; then
   echo "WARNING: SOLR_AUTHENTICATION_OPTS environment variable configured without associated SOLR_AUTH_TYPE variable"

--- a/solr/bin/solr.cmd
+++ b/solr/bin/solr.cmd
@@ -125,6 +125,11 @@ IF "%SOLR_SSL_ENABLED%"=="true" (
   set SOLR_SSL_OPTS=
 )
 
+REM Requestlog options
+IF "%SOLR_REQUESTLOG_ENABLED%"=="true" (
+  set "SOLR_JETTY_CONFIG=!SOLR_JETTY_CONFIG! --module=requestlog"
+)
+
 REM Authentication options
 
 IF NOT DEFINED SOLR_AUTH_TYPE (

--- a/solr/bin/solr.in.cmd
+++ b/solr/bin/solr.in.cmd
@@ -102,6 +102,9 @@ REM start rotation of logs. This is false by default as log4j2 handles this for 
 REM framework that cannot do startup rotation, you may want to enable this to let Solr rotate logs on startup.
 REM set SOLR_LOG_PRESTART_ROTATION=false
 
+REM Enables jetty request log for all requests
+REM set SOLR_REQUESTLOG_ENABLED=false
+
 REM Set the host interface to listen on. Jetty will listen on all interfaces (0.0.0.0) by default.
 REM This must be an IPv4 ("a.b.c.d") or bracketed IPv6 ("[x::y]") address, not a hostname!
 REM set SOLR_JETTY_HOST=0.0.0.0

--- a/solr/bin/solr.in.sh
+++ b/solr/bin/solr.in.sh
@@ -123,6 +123,9 @@
 # framework that cannot do startup rotation, you may want to enable this to let Solr rotate logs on startup.
 #SOLR_LOG_PRESTART_ROTATION=false
 
+# Enables jetty request log for all requests
+#SOLR_REQUESTLOG_ENABLED=false
+
 # Sets the port Solr binds to, default is 8983
 #SOLR_PORT=8983
 

--- a/solr/server/etc/jetty-requestlog.xml
+++ b/solr/server/etc/jetty-requestlog.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_0.dtd">
+
+<!-- =========================================================== -->
+<!-- Configure Request Log                                       -->
+<!-- =========================================================== -->
+
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+
+  <!-- =========================================================== -->
+  <!-- Configure Request Log                                       -->
+  <!-- =========================================================== -->
+  <Ref id="Handlers">
+    <Call name="addHandler">
+      <Arg>
+        <New id="RequestLog" class="org.eclipse.jetty.server.handler.RequestLogHandler">
+          <Set name="requestLog">
+            <New id="RequestLogImpl" class="org.eclipse.jetty.server.NCSARequestLog">
+              <Set name="filename">
+                 logs/request.yyyy_mm_dd.log
+              </Set>
+              <Set name="filenameDateFormat">yyyy_MM_dd</Set>
+              <Set name="retainDays">90</Set>
+              <Set name="append">true</Set>
+              <Set name="extended">false</Set>
+              <Set name="logCookies">false</Set>
+              <Set name="LogTimeZone">UTC</Set>
+            </New>
+          </Set>
+        </New>
+      </Arg>
+    </Call>
+  </Ref>
+</Configure>

--- a/solr/server/etc/jetty-requestlog.xml
+++ b/solr/server/etc/jetty-requestlog.xml
@@ -23,29 +23,21 @@
 <!-- =========================================================== -->
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
-
-  <!-- =========================================================== -->
-  <!-- Configure Request Log                                       -->
-  <!-- =========================================================== -->
-  <Ref id="Handlers">
-    <Call name="addHandler">
+  <Set name="RequestLog">
+    <New id="RequestLog" class="org.eclipse.jetty.server.CustomRequestLog">
+      <!-- Writer -->
       <Arg>
-        <New id="RequestLog" class="org.eclipse.jetty.server.handler.RequestLogHandler">
-          <Set name="requestLog">
-            <New id="RequestLogImpl" class="org.eclipse.jetty.server.NCSARequestLog">
-              <Set name="filename">
-                 logs/request.yyyy_mm_dd.log
-              </Set>
-              <Set name="filenameDateFormat">yyyy_MM_dd</Set>
-              <Set name="retainDays">90</Set>
-              <Set name="append">true</Set>
-              <Set name="extended">false</Set>
-              <Set name="logCookies">false</Set>
-              <Set name="LogTimeZone">UTC</Set>
-            </New>
-          </Set>
+        <New class="org.eclipse.jetty.server.AsyncRequestLogWriter">
+          <Arg><Property name="solr.log.dir" default="logs"/>/yyyy_mm_dd.request.log</Arg>
+          <Set name="filenameDateFormat">yyyy_MM_dd</Set>
+          <Set name="retainDays">90</Set>
+          <Set name="append">true</Set>
+          <Set name="timeZone">UTC</Set>
         </New>
       </Arg>
-    </Call>
-  </Ref>
+
+      <!-- Format String -->
+      <Arg><Get class="org.eclipse.jetty.server.CustomRequestLog" name="NCSA_FORMAT"/></Arg>
+    </New>
+  </Set>
 </Configure>

--- a/solr/server/etc/jetty.xml
+++ b/solr/server/etc/jetty.xml
@@ -182,33 +182,6 @@
     <Set name="handler">
       <Ref id="RewriteHandler"/>
     </Set>
-    
-    <!-- =========================================================== -->
-    <!-- Configure Request Log                                       -->
-    <!-- =========================================================== -->
-    <!--
-    <Ref id="Handlers">
-      <Call name="addHandler">
-        <Arg>
-          <New id="RequestLog" class="org.eclipse.jetty.server.handler.RequestLogHandler">
-            <Set name="requestLog">
-              <New id="RequestLogImpl" class="org.eclipse.jetty.server.NCSARequestLog">
-                <Set name="filename">
-                   logs/request.yyyy_mm_dd.log
-                </Set>
-                <Set name="filenameDateFormat">yyyy_MM_dd</Set>
-                <Set name="retainDays">90</Set>
-                <Set name="append">true</Set>
-                <Set name="extended">false</Set>
-                <Set name="logCookies">false</Set>
-                <Set name="LogTimeZone">UTC</Set>
-              </New>
-            </Set>
-          </New>
-        </Arg>
-      </Call>
-    </Ref>
-    -->
 
     <!-- =========================================================== -->
     <!-- extra options                                               -->

--- a/solr/server/etc/jetty.xml
+++ b/solr/server/etc/jetty.xml
@@ -167,9 +167,6 @@
                    </Set>
                  </New>
                </Item>
-               <Item>
-                 <New id="RequestLog" class="org.eclipse.jetty.server.handler.RequestLogHandler"/>
-               </Item>
              </Array>
            </Set>
          </New>

--- a/solr/server/modules/requestlog.mod
+++ b/solr/server/modules/requestlog.mod
@@ -1,0 +1,9 @@
+#
+# Request Log module
+#
+
+[depend]
+server
+
+[xml]
+etc/jetty-requestlog.xml


### PR DESCRIPTION
Today you have to edit XML to enable the jetty request log. This makes it work via environment variable.

It also gets this thing off the currently deprecated RequestLog class.
SOLR_LOGS_DIR is now respected by default (today it uses hardcoded `logs/`)
