### PR TITLE
LUCENE-9109: Use stack walker to implement TestSecurityManager's detection of test JVM exit

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -62,6 +62,9 @@ Improvements
   previously treated as beginning a line-ending comment (Satoshi Kato and Masaru Hasegawa via
   Michael Sokolov)
 
+* LUCENE-9109: Use StackWalker to implement TestSecurityManager's detection
+  of JVM exit (Uwe Schindler)
+
 Bug fixes
 
 * LUCENE-8663: NRTCachingDirectory.slowFileExists may open a file while 
@@ -89,6 +92,9 @@ Improvements
 * LUCENE-9102: Add maxQueryLength option to DirectSpellchecker. (Andy Webb via Bruno Roustant)
 
 * LUCENE-9091: UnifiedHighlighter HTML escaping should only escape essentials (Nándor Mátravölgyi)
+
+* LUCENE-9109: Backport some changes from master (except StackWalker) to improve
+  TestSecurityManager (Uwe Schindler)
 
 Optimizations
 ---------------------

--- a/lucene/test-framework/src/java/org/apache/lucene/util/TestSecurityManager.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/util/TestSecurityManager.java
@@ -54,12 +54,12 @@ public final class TestSecurityManager extends SecurityManager {
    */
   @Override
   public void checkExit(final int status) {
-    if (false == StackWalker.getInstance().walk(s -> s
+    if (StackWalker.getInstance().walk(s -> s
         .dropWhile(Predicate.not(TestSecurityManager::isExitStackFrame)) // skip all internal stack frames
         .dropWhile(TestSecurityManager::isExitStackFrame)                // skip all exit()/halt() stack frames
         .limit(1)                                                        // only look at one more frame (caller of exit)
         .map(StackFrame::getClassName)
-        .anyMatch(c -> c.startsWith(JUNIT4_TEST_RUNNER_PACKAGE) || 
+        .noneMatch(c -> c.startsWith(JUNIT4_TEST_RUNNER_PACKAGE) || 
             c.startsWith(ECLIPSE_TEST_RUNNER_PACKAGE) ||
             c.startsWith(IDEA_TEST_RUNNER_PACKAGE) ||
             c.startsWith(GRADLE_TEST_RUNNER_PACKAGE)))) {


### PR DESCRIPTION
This is just a small improvement in Lucene/Solr master (Java 11) to detect exit of JVM in our test framework. There are other places in Lucene that use ineffective ways to inspect the stack trace.

This one optimizes the implementation of TestSecurityManager#checkExit(status) to disallow all JVM exits outside of the official test runner by using StackWalker. In addition this needs no additional permissions, because we do not instruct StackWalker to fetch all crazy stuff like Class instances of stack elements.

The way how this works is: Walk through stack trace:

- skip all internal frames (those which come before the actual exit call)
- skip all frmes with the actual exit call
- limit to one more frame (the method calling System.exit())
- check if that remaining frame is on our whitelist

This can only be commited to master (9.0), as it requires Java 9.