### PR TITLE
SOLR-14135: Utils.toJavabin returns a byte[] instead of InputStream

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/OverseerSolrResponse.java
+++ b/solr/core/src/java/org/apache/solr/cloud/OverseerSolrResponse.java
@@ -69,7 +69,7 @@ public class OverseerSolrResponse extends SolrResponse {
       return SolrResponse.serializable(responseObject);
     }
     try {
-      return Utils.toJavabin(responseObject.getResponse()).readAllBytes();
+      return Utils.toJavabin(responseObject.getResponse());
     } catch (IOException|RuntimeException e) {
       throw new SolrException(ErrorCode.SERVER_ERROR, "Exception serializing response to Javabin", e);
     }

--- a/solr/solrj/src/java/org/apache/solr/common/util/Utils.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/Utils.java
@@ -35,7 +35,6 @@ import org.apache.solr.common.cloud.ZkOperation;
 import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.common.params.CommonParams;
 import org.apache.zookeeper.KeeperException;
-import org.apache.zookeeper.server.ByteBufferInputStream;
 import org.noggit.CharArr;
 import org.noggit.JSONParser;
 import org.noggit.JSONWriter;
@@ -168,11 +167,14 @@ public class Utils {
     return v;
   }
 
-  public static InputStream toJavabin(Object o) throws IOException {
+  public static byte[] toJavabin(Object o) throws IOException {
     try (final JavaBinCodec jbc = new JavaBinCodec()) {
-      BinaryRequestWriter.BAOS baos = new BinaryRequestWriter.BAOS();
-      jbc.marshal(o, baos);
-      return new ByteBufferInputStream(ByteBuffer.wrap(baos.getbuf(), 0, baos.size()));
+      try (BinaryRequestWriter.BAOS baos = new BinaryRequestWriter.BAOS()) {
+        jbc.marshal(o, baos);
+        byte[] result = new byte[baos.size()];
+        System.arraycopy(baos.getbuf(), 0, result, 0, baos.size());
+        return result;
+      }
     }
   }
   

--- a/solr/solrj/src/test/org/apache/solr/common/util/UtilsTest.java
+++ b/solr/solrj/src/test/org/apache/solr/common/util/UtilsTest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.common.util;
+
+import org.apache.solr.SolrTestCase;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class UtilsTest extends SolrTestCase {
+
+  @Test
+  public void testJavabinHelpers() throws IOException {
+    NamedList<Object> nl = new NamedList<>();
+    nl.add("foo", new NamedList<>());
+    byte[] bytes = Utils.toJavabin(nl);
+    Object serialized = Utils.fromJavabin(bytes);
+    assertEquals(nl, serialized);
+  }
+
+}


### PR DESCRIPTION
I'm not too convinced about this PR honestly, I started thinking in doing this mostly because in the 8x branch we can't use InputStream's `readAllBytes();` method, but this may actually hurt future consumers of this method, if they don't need to read all bytes at once. I'll leave this PR for now, worst case I'll keep the tests.