### PR TITLE
LUCENE-9110: Switch tests to use StackWalker

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -65,6 +65,9 @@ Improvements
 * LUCENE-9109: Use StackWalker to implement TestSecurityManager's detection
   of JVM exit (Uwe Schindler)
 
+* LUCENE-9110: Refactor stack analysis in tests to use generalized LuceneTestCase
+  methods that use StackWalker (Uwe Schindler)
+
 Bug fixes
 
 * LUCENE-8663: NRTCachingDirectory.slowFileExists may open a file while 
@@ -95,6 +98,9 @@ Improvements
 
 * LUCENE-9109: Backport some changes from master (except StackWalker) to improve
   TestSecurityManager (Uwe Schindler)
+
+* LUCENE-9110: Backport refactored stack analysis in tests to use generalized
+  LuceneTestCase methods (Uwe Schindler)
 
 Optimizations
 ---------------------

--- a/lucene/core/src/test/org/apache/lucene/TestMergeSchedulerExternal.java
+++ b/lucene/core/src/test/org/apache/lucene/TestMergeSchedulerExternal.java
@@ -89,18 +89,15 @@ public class TestMergeSchedulerExternal extends LuceneTestCase {
   private static class FailOnlyOnMerge extends MockDirectoryWrapper.Failure {
     @Override
     public void eval(MockDirectoryWrapper dir)  throws IOException {
-      StackTraceElement[] trace = new Exception().getStackTrace();
-      for (int i = 0; i < trace.length; i++) {
-        if ("doMerge".equals(trace[i].getMethodName())) {
-          IOException ioe = new IOException("now failing during merge");
-          StringWriter sw = new StringWriter();
-          PrintWriter pw = new PrintWriter(sw);
-          ioe.printStackTrace(pw);
-          if (infoStream.isEnabled("IW")) {
-            infoStream.message("IW", "TEST: now throw exc:\n" + sw.toString());
-          }
-          throw ioe;
+      if (callStackContainsAnyOf("doMerge")) {
+        IOException ioe = new IOException("now failing during merge");
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        ioe.printStackTrace(pw);
+        if (infoStream.isEnabled("IW")) {
+          infoStream.message("IW", "TEST: now throw exc:\n" + sw.toString());
         }
+        throw ioe;
       }
     }
   }

--- a/lucene/core/src/test/org/apache/lucene/index/TestConcurrentMergeScheduler.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestConcurrentMergeScheduler.java
@@ -54,9 +54,7 @@ public class TestConcurrentMergeScheduler extends LuceneTestCase {
     @Override
     public void eval(MockDirectoryWrapper dir)  throws IOException {
       if (doFail && isTestThread()) {
-        boolean isDoFlush = callStackContainsAnyOf("flush");
-        boolean isClose = callStackContainsAnyOf("close");
-        if (isDoFlush && !isClose && random().nextBoolean()) {
+        if (callStackContainsAnyOf("flush") && false == callStackContainsAnyOf("close") && random().nextBoolean()) {
           hitExc = true;
           throw new IOException(Thread.currentThread().getName() + ": now failing during flush");
         }

--- a/lucene/core/src/test/org/apache/lucene/index/TestConcurrentMergeScheduler.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestConcurrentMergeScheduler.java
@@ -18,6 +18,7 @@ package org.apache.lucene.index;
 
 
 import java.io.IOException;
+import java.lang.StackWalker.StackFrame;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -56,7 +57,8 @@ public class TestConcurrentMergeScheduler extends LuceneTestCase {
       if (doFail && isTestThread()) {
         boolean isDoFlush = false;
         boolean isClose = false;
-        StackTraceElement[] trace = new Exception().getStackTrace();
+        
+        StackFrame[] trace = LuceneTestCase.getCallStack();
         for (int i = 0; i < trace.length; i++) {
           if (isDoFlush && isClose) {
             break;

--- a/lucene/core/src/test/org/apache/lucene/index/TestConcurrentMergeScheduler.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestConcurrentMergeScheduler.java
@@ -18,7 +18,6 @@ package org.apache.lucene.index;
 
 
 import java.io.IOException;
-import java.lang.StackWalker.StackFrame;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -55,21 +54,8 @@ public class TestConcurrentMergeScheduler extends LuceneTestCase {
     @Override
     public void eval(MockDirectoryWrapper dir)  throws IOException {
       if (doFail && isTestThread()) {
-        boolean isDoFlush = false;
-        boolean isClose = false;
-        
-        StackFrame[] trace = LuceneTestCase.getCallStack();
-        for (int i = 0; i < trace.length; i++) {
-          if (isDoFlush && isClose) {
-            break;
-          }
-          if ("flush".equals(trace[i].getMethodName())) {
-            isDoFlush = true;
-          }
-          if ("close".equals(trace[i].getMethodName())) {
-            isClose = true;
-          }
-        }
+        boolean isDoFlush = callStackContainsAnyOf("flush");
+        boolean isClose = callStackContainsAnyOf("close");
         if (isDoFlush && !isClose && random().nextBoolean()) {
           hitExc = true;
           throw new IOException(Thread.currentThread().getName() + ": now failing during flush");

--- a/lucene/core/src/test/org/apache/lucene/index/TestDirectoryReaderReopen.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDirectoryReaderReopen.java
@@ -659,16 +659,13 @@ public class TestDirectoryReaderReopen extends LuceneTestCase {
         }
         //System.out.println("failOn: ");
         //new Throwable().printStackTrace(System.out);
-        StackTraceElement[] trace = new Exception().getStackTrace();
-        for (int i = 0; i < trace.length; i++) {
-          if ("readLiveDocs".equals(trace[i].getMethodName())) {
-            if (VERBOSE) {
-              System.out.println("TEST: now fail; exc:");
-              new Throwable().printStackTrace(System.out);
-            }
-            failed = true;
-            throw new FakeIOException();
+        if (callStackContainsAnyOf("readLiveDocs")) {
+          if (VERBOSE) {
+            System.out.println("TEST: now fail; exc:");
+            new Throwable().printStackTrace(System.out);
           }
+          failed = true;
+          throw new FakeIOException();
         }
       }
     });

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexFileDeleter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexFileDeleter.java
@@ -414,12 +414,8 @@ public class TestIndexFileDeleter extends LuceneTestCase {
         @Override
         public void eval(MockDirectoryWrapper dir) throws IOException {
           if (doFailExc.get() && random().nextInt(4) == 1) {
-            Exception e = new Exception();
-            StackTraceElement stack[] = e.getStackTrace();
-            for (int i = 0; i < stack.length; i++) {
-              if (stack[i].getClassName().equals(IndexFileDeleter.class.getName()) && stack[i].getMethodName().equals("decRef")) {
-                throw new RuntimeException("fake fail");
-              }
+            if (callStackContains(IndexFileDeleter.class, "decRef")) {
+              throw new RuntimeException("fake fail");
             }
           }
         }
@@ -497,12 +493,8 @@ public class TestIndexFileDeleter extends LuceneTestCase {
           @Override
           public void eval(MockDirectoryWrapper dir) throws IOException {
             if (doFailExc.get() && random().nextInt(4) == 1) {
-              Exception e = new Exception();
-              StackTraceElement stack[] = e.getStackTrace();
-              for (int i = 0; i < stack.length; i++) {
-                if (stack[i].getClassName().equals(MockDirectoryWrapper.class.getName()) && stack[i].getMethodName().equals("deleteFile")) {
-                  throw new MockDirectoryWrapper.FakeIOException();
-                }
+              if (callStackContains(MockDirectoryWrapper.class, "deleteFile")) {
+                throw new MockDirectoryWrapper.FakeIOException();
               }
             }
           }

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterDelete.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterDelete.java
@@ -731,15 +731,7 @@ public class TestIndexWriterDelete extends LuceneTestCase {
           }
           new Throwable().printStackTrace(System.out);
           if (sawMaybe && !failed) {
-            boolean seen = false;
-            StackTraceElement[] trace = new Exception().getStackTrace();
-            for (int i = 0; i < trace.length; i++) {
-              if ("applyDeletesAndUpdates".equals(trace[i].getMethodName()) ||
-                  "slowFileExists".equals(trace[i].getMethodName())) {
-                seen = true;
-                break;
-              }
-            }
+            boolean seen = callStackContainsAnyOf("applyDeletesAndUpdates", "slowFileExists");
             if (!seen) {
               // Only fail once we are no longer in applyDeletes
               failed = true;
@@ -751,16 +743,12 @@ public class TestIndexWriterDelete extends LuceneTestCase {
             }
           }
           if (!failed) {
-            StackTraceElement[] trace = new Exception().getStackTrace();
-            for (int i = 0; i < trace.length; i++) {
-              if ("applyDeletesAndUpdates".equals(trace[i].getMethodName())) {
-                if (VERBOSE) {
-                  System.out.println("TEST: mock failure: saw applyDeletes");
-                  new Throwable().printStackTrace(System.out);
-                }
-                sawMaybe = true;
-                break;
+            if (callStackContainsAnyOf("applyDeletesAndUpdates")) {
+              if (VERBOSE) {
+                System.out.println("TEST: mock failure: saw applyDeletes");
+                new Throwable().printStackTrace(System.out);
               }
+              sawMaybe = true;
             }
           }
         }

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterExceptions.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterExceptions.java
@@ -567,10 +567,7 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
     @Override
     public void eval(MockDirectoryWrapper dir)  throws IOException {
       if (doFail) {
-        boolean sawFlush = callStackContainsAnyOf("flush");
-        boolean sawFinishDocument = callStackContainsAnyOf("finishDocument");
-
-        if (sawFlush && sawFinishDocument == false && count++ >= 30) {
+        if (callStackContainsAnyOf("flush") && false == callStackContainsAnyOf("finishDocument") && count++ >= 30) {
           doFail = false;
           throw new IOException("now failing during flush");
         }

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterOnDiskFull.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterOnDiskFull.java
@@ -18,8 +18,6 @@ package org.apache.lucene.index;
 
 
 import java.io.IOException;
-import java.lang.StackWalker.StackFrame;
-
 import org.apache.lucene.analysis.MockAnalyzer;
 import org.apache.lucene.codecs.LiveDocsFormat;
 import org.apache.lucene.document.Document;
@@ -479,16 +477,13 @@ public class TestIndexWriterOnDiskFull extends LuceneTestCase {
       if (!doFail) {
         return;
       }
-      StackFrame[] trace = LuceneTestCase.getCallStack();
-      for (int i = 0; i < trace.length; i++) {
-        if (SegmentMerger.class.getName().equals(trace[i].getClassName()) && "mergeTerms".equals(trace[i].getMethodName()) && !didFail1) {
-          didFail1 = true;
-          throw new IOException("fake disk full during mergeTerms");
-        }
-        if (LiveDocsFormat.class.getName().equals(trace[i].getClassName()) && "writeLiveDocs".equals(trace[i].getMethodName()) && !didFail2) {
-          didFail2 = true;
-          throw new IOException("fake disk full while writing LiveDocs");
-        }
+      if (callStackContains(SegmentMerger.class, "mergeTerms") && !didFail1) {
+        didFail1 = true;
+        throw new IOException("fake disk full during mergeTerms");
+      }
+      if (callStackContains(LiveDocsFormat.class, "writeLiveDocs") && !didFail2) {
+        didFail2 = true;
+        throw new IOException("fake disk full while writing LiveDocs");
       }
     }
   }

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterOnDiskFull.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterOnDiskFull.java
@@ -18,6 +18,7 @@ package org.apache.lucene.index;
 
 
 import java.io.IOException;
+import java.lang.StackWalker.StackFrame;
 
 import org.apache.lucene.analysis.MockAnalyzer;
 import org.apache.lucene.codecs.LiveDocsFormat;
@@ -478,7 +479,7 @@ public class TestIndexWriterOnDiskFull extends LuceneTestCase {
       if (!doFail) {
         return;
       }
-      StackTraceElement[] trace = new Exception().getStackTrace();
+      StackFrame[] trace = LuceneTestCase.getCallStack();
       for (int i = 0; i < trace.length; i++) {
         if (SegmentMerger.class.getName().equals(trace[i].getClassName()) && "mergeTerms".equals(trace[i].getMethodName()) && !didFail1) {
           didFail1 = true;

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterOnVMError.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterOnVMError.java
@@ -238,14 +238,7 @@ public class TestIndexWriterOnVMError extends LuceneTestCase {
       @Override
       public void eval(MockDirectoryWrapper dir) throws IOException {
         if (r.nextInt(3000) == 0) {
-          StackTraceElement stack[] = Thread.currentThread().getStackTrace();
-          boolean ok = false;
-          for (int i = 0; i < stack.length; i++) {
-            if (stack[i].getClassName().equals(IndexWriter.class.getName())) {
-              ok = true;
-            }
-          }
-          if (ok) {
+          if (callStackContains(IndexWriter.class)) {
             throw new OutOfMemoryError("Fake OutOfMemoryError");
           }
         }
@@ -259,14 +252,7 @@ public class TestIndexWriterOnVMError extends LuceneTestCase {
       @Override
       public void eval(MockDirectoryWrapper dir) throws IOException {
         if (r.nextInt(3000) == 0) {
-          StackTraceElement stack[] = Thread.currentThread().getStackTrace();
-          boolean ok = false;
-          for (int i = 0; i < stack.length; i++) {
-            if (stack[i].getClassName().equals(IndexWriter.class.getName())) {
-              ok = true;
-            }
-          }
-          if (ok) {
+          if (callStackContains(IndexWriter.class)) {
             throw new UnknownError("Fake UnknownError");
           }
         }
@@ -281,15 +267,10 @@ public class TestIndexWriterOnVMError extends LuceneTestCase {
     doTest(new Failure() {
       @Override
       public void eval(MockDirectoryWrapper dir) throws IOException {
-        StackTraceElement stack[] = Thread.currentThread().getStackTrace();
-        boolean ok = false;
-        for (int i = 0; i < stack.length; i++) {
-          if (stack[i].getClassName().equals(IndexFileDeleter.class.getName()) && stack[i].getMethodName().equals("checkpoint")) {
-            ok = true;
+        if (r.nextInt(4) == 0) {
+          if (callStackContains(IndexFileDeleter.class, "checkpoint")) {
+            throw new OutOfMemoryError("Fake OutOfMemoryError");
           }
-        }
-        if (ok && r.nextInt(4) == 0) {
-          throw new OutOfMemoryError("Fake OutOfMemoryError");
         }
       }
     });

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterReader.java
@@ -1067,17 +1067,14 @@ public class TestIndexWriterReader extends LuceneTestCase {
     dir.failOn(new MockDirectoryWrapper.Failure() {
       @Override
       public void eval(MockDirectoryWrapper dir) throws IOException {
-        StackTraceElement[] trace = new Exception().getStackTrace();
         if (shouldFail.get()) {
-          for (int i = 0; i < trace.length; i++) {
-            if ("getReadOnlyClone".equals(trace[i].getMethodName())) {
-              if (VERBOSE) {
-                System.out.println("TEST: now fail; exc:");
-                new Throwable().printStackTrace(System.out);
-              }
-              shouldFail.set(false);
-              throw new FakeIOException();
+          if (callStackContainsAnyOf("getReadOnlyClone")) {
+            if (VERBOSE) {
+              System.out.println("TEST: now fail; exc:");
+              new Throwable().printStackTrace(System.out);
             }
+            shouldFail.set(false);
+            throw new FakeIOException();
           }
         }
       }

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterWithThreads.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterWithThreads.java
@@ -407,9 +407,7 @@ public class TestIndexWriterWithThreads extends LuceneTestCase {
       dir.setAssertNoUnrefencedFilesOnClose(false);
 
       if (doFail) {
-        boolean sawAbortOrFlushDoc = callStackContainsAnyOf("abort", "finishDocument");
-        boolean sawCloseOrMerge = callStackContainsAnyOf("merge", "close");
-        if (sawAbortOrFlushDoc && !sawCloseOrMerge) {
+        if (callStackContainsAnyOf("abort", "finishDocument") && false == callStackContainsAnyOf("merge", "close")) {
           if (onlyOnce) {
             doFail = false;
           }

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterWithThreads.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterWithThreads.java
@@ -18,7 +18,6 @@ package org.apache.lucene.index;
 
 
 import java.io.IOException;
-import java.lang.StackWalker.StackFrame;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -408,26 +407,9 @@ public class TestIndexWriterWithThreads extends LuceneTestCase {
       dir.setAssertNoUnrefencedFilesOnClose(false);
 
       if (doFail) {
-        StackFrame[] trace = LuceneTestCase.getCallStack();
-        boolean sawAbortOrFlushDoc = false;
-        boolean sawClose = false;
-        boolean sawMerge = false;
-        for (int i = 0; i < trace.length; i++) {
-          if (sawAbortOrFlushDoc && sawMerge && sawClose) {
-            break;
-          }
-          if ("abort".equals(trace[i].getMethodName()) ||
-              "finishDocument".equals(trace[i].getMethodName())) {
-            sawAbortOrFlushDoc = true;
-          }
-          if ("merge".equals(trace[i].getMethodName())) {
-            sawMerge = true;
-          }
-          if ("close".equals(trace[i].getMethodName())) {
-            sawClose = true;
-          }
-        }
-        if (sawAbortOrFlushDoc && !sawClose && !sawMerge) {
+        boolean sawAbortOrFlushDoc = callStackContainsAnyOf("abort", "finishDocument");
+        boolean sawCloseOrMerge = callStackContainsAnyOf("merge", "close");
+        if (sawAbortOrFlushDoc && !sawCloseOrMerge) {
           if (onlyOnce) {
             doFail = false;
           }

--- a/lucene/core/src/test/org/apache/lucene/index/TestPersistentSnapshotDeletionPolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestPersistentSnapshotDeletionPolicy.java
@@ -116,11 +116,8 @@ public class TestPersistentSnapshotDeletionPolicy extends TestSnapshotDeletionPo
     dir.failOn(new MockDirectoryWrapper.Failure() {
       @Override
       public void eval(MockDirectoryWrapper dir) throws IOException {
-        StackTraceElement[] trace = Thread.currentThread().getStackTrace();
-        for (int i = 0; i < trace.length; i++) {
-          if (PersistentSnapshotDeletionPolicy.class.getName().equals(trace[i].getClassName()) && "persist".equals(trace[i].getMethodName())) {
-            throw new IOException("now fail on purpose");
-          }
+        if (callStackContains(PersistentSnapshotDeletionPolicy.class, "persist")) {
+          throw new IOException("now fail on purpose");
         }
       }
       });

--- a/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/TestUnifiedHighlighterTermVec.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/TestUnifiedHighlighterTermVec.java
@@ -133,8 +133,8 @@ public class TestUnifiedHighlighterTermVec extends LuceneTestCase {
           @Override
           public Fields getTermVectors(int docID) throws IOException {
             // if we're invoked by ParallelLeafReader then we can't do our assertion. TODO see LUCENE-6868
-            if (calledBy(ParallelLeafReader.class) == false
-                && calledBy(CheckIndex.class) == false) {
+            if (callStackContains(ParallelLeafReader.class) == false
+                && callStackContains(CheckIndex.class) == false) {
               assertFalse("Should not request TVs for doc more than once.", seenDocIDs.get(docID));
               seenDocIDs.set(docID);
             }
@@ -168,14 +168,6 @@ public class TestUnifiedHighlighterTermVec extends LuceneTestCase {
     public CacheHelper getReaderCacheHelper() {
       return null;
     }
-  }
-
-  private static boolean calledBy(Class<?> clazz) {
-    for (StackTraceElement stackTraceElement : Thread.currentThread().getStackTrace()) {
-      if (stackTraceElement.getClassName().equals(clazz.getName()))
-        return true;
-    }
-    return false;
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/lucene/test-framework/src/java/org/apache/lucene/index/BaseFieldInfoFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/index/BaseFieldInfoFormatTestCase.java
@@ -102,10 +102,8 @@ public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTes
     Failure fail = new Failure() {
       @Override
       public void eval(MockDirectoryWrapper dir) throws IOException {
-        for (StackTraceElement e : Thread.currentThread().getStackTrace()) {
-          if (doFail && "createOutput".equals(e.getMethodName())) {
-            throw new FakeIOException();
-          }
+        if (doFail && callStackContainsAnyOf("createOutput")) {
+          throw new FakeIOException();
         }
       }
     };
@@ -137,10 +135,8 @@ public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTes
     Failure fail = new Failure() {
       @Override
       public void eval(MockDirectoryWrapper dir) throws IOException {
-        for (StackTraceElement e : Thread.currentThread().getStackTrace()) {
-          if (doFail && "close".equals(e.getMethodName())) {
-            throw new FakeIOException();
-          }
+        if (doFail && callStackContainsAnyOf("close")) {
+          throw new FakeIOException();
         }
       }
     };
@@ -172,10 +168,8 @@ public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTes
     Failure fail = new Failure() {
       @Override
       public void eval(MockDirectoryWrapper dir) throws IOException {
-        for (StackTraceElement e : Thread.currentThread().getStackTrace()) {
-          if (doFail && "openInput".equals(e.getMethodName())) {
-            throw new FakeIOException();
-          }
+        if (doFail && callStackContainsAnyOf("openInput")) {
+          throw new FakeIOException();
         }
       }
     };
@@ -208,10 +202,8 @@ public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTes
     Failure fail = new Failure() {
       @Override
       public void eval(MockDirectoryWrapper dir) throws IOException {
-        for (StackTraceElement e : Thread.currentThread().getStackTrace()) {
-          if (doFail && "close".equals(e.getMethodName())) {
-            throw new FakeIOException();
-          }
+        if (doFail && callStackContainsAnyOf("close")) {
+          throw new FakeIOException();
         }
       }
     };

--- a/lucene/test-framework/src/java/org/apache/lucene/index/BaseSegmentInfoFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/index/BaseSegmentInfoFormatTestCase.java
@@ -292,10 +292,8 @@ public abstract class BaseSegmentInfoFormatTestCase extends BaseIndexFileFormatT
     Failure fail = new Failure() {
       @Override
       public void eval(MockDirectoryWrapper dir) throws IOException {
-        for (StackTraceElement e : Thread.currentThread().getStackTrace()) {
-          if (doFail && "createOutput".equals(e.getMethodName())) {
-            throw new FakeIOException();
-          }
+        if (doFail && callStackContainsAnyOf("createOutput")) {
+          throw new FakeIOException();
         }
       }
     };
@@ -325,10 +323,8 @@ public abstract class BaseSegmentInfoFormatTestCase extends BaseIndexFileFormatT
     Failure fail = new Failure() {
       @Override
       public void eval(MockDirectoryWrapper dir) throws IOException {
-        for (StackTraceElement e : Thread.currentThread().getStackTrace()) {
-          if (doFail && "close".equals(e.getMethodName())) {
-            throw new FakeIOException();
-          }
+        if (doFail && callStackContainsAnyOf("close")) {
+          throw new FakeIOException();
         }
       }
     };
@@ -358,10 +354,8 @@ public abstract class BaseSegmentInfoFormatTestCase extends BaseIndexFileFormatT
     Failure fail = new Failure() {
       @Override
       public void eval(MockDirectoryWrapper dir) throws IOException {
-        for (StackTraceElement e : Thread.currentThread().getStackTrace()) {
-          if (doFail && "openInput".equals(e.getMethodName())) {
-            throw new FakeIOException();
-          }
+        if (doFail && callStackContainsAnyOf("openInput")) {
+          throw new FakeIOException();
         }
       }
     };
@@ -392,10 +386,8 @@ public abstract class BaseSegmentInfoFormatTestCase extends BaseIndexFileFormatT
     Failure fail = new Failure() {
       @Override
       public void eval(MockDirectoryWrapper dir) throws IOException {
-        for (StackTraceElement e : Thread.currentThread().getStackTrace()) {
-          if (doFail && "close".equals(e.getMethodName())) {
-            throw new FakeIOException();
-          }
+        if (doFail && callStackContainsAnyOf("close")) {
+          throw new FakeIOException();
         }
       }
     };

--- a/lucene/test-framework/src/java/org/apache/lucene/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/util/LuceneTestCase.java
@@ -2723,7 +2723,7 @@ public abstract class LuceneTestCase extends Assert {
         .anyMatch(Set.of(methodNames)::contains));
   }
 
-  /** Inspects stack trace if the given class is called us. */
+  /** Inspects stack trace if the given class called us. */
   public static boolean callStackContains(Class<?> clazz) {
     return StackWalker.getInstance().walk(s -> s.skip(1) // exclude this utility method
         .map(StackFrame::getClassName)

--- a/lucene/test-framework/src/java/org/apache/lucene/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/util/LuceneTestCase.java
@@ -2716,7 +2716,7 @@ public abstract class LuceneTestCase extends Assert {
         .anyMatch(f -> className.equals(f.getClassName()) && methodName.equals(f.getMethodName())));
   }
 
-  /** Inspects stack trace to figure out if one of the given methodnames (no class restriction) called us. */
+  /** Inspects stack trace to figure out if one of the given method names (no class restriction) called us. */
   public static boolean callStackContainsAnyOf(String... methodNames) {
     return StackWalker.getInstance().walk(s -> s.skip(1) // exclude this utility method
         .map(StackFrame::getMethodName)
@@ -2728,14 +2728,6 @@ public abstract class LuceneTestCase extends Assert {
     return StackWalker.getInstance().walk(s -> s.skip(1) // exclude this utility method
         .map(StackFrame::getClassName)
         .anyMatch(clazz.getName()::equals));
-  }
-  
-  /** Returns the current stack trace.
-   * @deprecated Don't use this method for performance reasons, use {@code callStackContains()} variants instead. */ 
-  @Deprecated
-  public static StackFrame[] getCallStack() {
-    return StackWalker.getInstance().walk(s -> s.skip(1) // exclude this utility method
-        .toArray(StackFrame[]::new));
   }
 
   /** A runnable that can throw any checked exception. */

--- a/lucene/test-framework/src/java/org/apache/lucene/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/util/LuceneTestCase.java
@@ -21,6 +21,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
+import java.lang.StackWalker.StackFrame;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
@@ -2706,6 +2707,35 @@ public abstract class LuceneTestCase extends Assert {
         // we don't need to uninvert and compare here ... we did that in the first loop above
       }
     }
+  }
+  
+  /** Inspects stack trace to figure out if a method of a specific class called us. */
+  public static boolean callStackContains(Class<?> clazz, String methodName) {
+    final String className = clazz.getName();
+    return StackWalker.getInstance().walk(s -> s.skip(1) // exclude this utility method
+        .anyMatch(f -> className.equals(f.getClassName()) && methodName.equals(f.getMethodName())));
+  }
+
+  /** Inspects stack trace to figure out if one of the given methodnames (no class restriction) called us. */
+  public static boolean callStackContainsAnyOf(String... methodNames) {
+    return StackWalker.getInstance().walk(s -> s.skip(1) // exclude this utility method
+        .map(StackFrame::getMethodName)
+        .anyMatch(Set.of(methodNames)::contains));
+  }
+
+  /** Inspects stack trace if the given class is called us. */
+  public static boolean callStackContains(Class<?> clazz) {
+    return StackWalker.getInstance().walk(s -> s.skip(1) // exclude this utility method
+        .map(StackFrame::getClassName)
+        .anyMatch(clazz.getName()::equals));
+  }
+  
+  /** Returns the current stack trace.
+   * @deprecated Don't use this method for performance reasons, use {@code callStackContains()} variants instead. */ 
+  @Deprecated
+  public static StackFrame[] getCallStack() {
+    return StackWalker.getInstance().walk(s -> s.skip(1) // exclude this utility method
+        .toArray(StackFrame[]::new));
   }
 
   /** A runnable that can throw any checked exception. */


### PR DESCRIPTION
There are a lot of tests (especially around IndexWriter) that look into stack traces to inject failures or check that some methods were called in their call stack.

This issue will refactor all those tests by adding a few methods to LuceneTestCase that make it easy to verify if some method call/class is in stack trace. On master (Java 11) we can use StackWalker to do this checks, which has a speedup of sometimes >>2 times (depending on how deep you dive into call stack).

There are a few tests (only 3) that do more complex stack trace analysis. Those should be refactored at some point. For now I added a deprecated method to get the whole StackTrace in Java 11, which is still 2 times faster than using an Exception.

For branch 8.x i will apply the same patch, just the LuceneTestCase methods use the old "Java 8" way to inspect stack trace using the thread's stack trace (which is very expensive).

So this issue is mainly about refactoring the tests to use a common method pattern to check the existence of stack frames.

One important thing is: Using StackWalker makes sure that the stack is "correct". Stacks from Thread or Exception may miss some frames, as it does not deoptimize the code. So depending on JVMs and optimizations (e.g. Graal), call stacks may change if we still use old code for analysis. This is no longer an issue for Java 8, but may be in future.