### PR TITLE
SOLR-12490 Added parsing of json.queries for referring in JSON facets

### DIFF
--- a/solr/core/src/java/org/apache/solr/request/json/JsonQueryConverter.java
+++ b/solr/core/src/java/org/apache/solr/request/json/JsonQueryConverter.java
@@ -28,6 +28,10 @@ import org.apache.solr.common.SolrException;
  * @lucene.internal
  */
 class JsonQueryConverter {
+  public static final String paramsPrefix = "_tt";
+
+  public static final Object contextKey = JsonQueryConverter.class.getSimpleName();
+
   private int numParams = 0;
 
   String toLocalParams(Object jsonQueryObject, Map<String, String[]> additionalParams) {
@@ -38,7 +42,7 @@ class JsonQueryConverter {
   }
 
   private String putParam(String val, Map<String, String[]> additionalParams) {
-    String name = "_tt"+(numParams++);
+    String name = paramsPrefix+(numParams++);
     additionalParams.put(name, new String[]{val});
     return name;
   }

--- a/solr/core/src/test/org/apache/solr/search/facet/TestJsonFacets.java
+++ b/solr/core/src/test/org/apache/solr/search/facet/TestJsonFacets.java
@@ -3664,6 +3664,10 @@ public class TestJsonFacets extends SolrTestCaseHS {
         "Expected Map for 'facet', received ArrayList=[{}]",
         req("q", "*:*", "rows", "0", "json.facet", "[{}]"), SolrException.ErrorCode.BAD_REQUEST);
 
+    assertQEx("Should fail as queries is not of type map",
+        "Expected Map for 'queries', received ArrayList=[{}]",
+        req("q", "*:*", "rows", "0", "json.queries", "[{}]"), SolrException.ErrorCode.BAD_REQUEST);
+
     // range facets
     assertQEx("Should fail as 'other' is of type Map",
         "Expected list of string or comma separated string values for 'other', " +

--- a/solr/core/src/test/org/apache/solr/search/facet/TestJsonFacets.java
+++ b/solr/core/src/test/org/apache/solr/search/facet/TestJsonFacets.java
@@ -1169,14 +1169,14 @@ public class TestJsonFacets extends SolrTestCaseHS {
 
     // nested query facets on subset
     client.testJQ(params(p, "q", "id:(2 3)"
-        , "json.facet", "{ catB:{query:{q:'${cat_s}:B', facet:{nj:{query:'${where_s}:NJ'}, ny:{query:'${where_s}:NY'}} }}}"
+            , "json.facet", "{ catB:{query:{q:'${cat_s}:B', facet:{nj:{query:'${where_s}:NJ'}, ny:{query:'${where_s}:NY'}} }}}"
         )
         , "facets=={ 'count':2, 'catB':{'count':1, 'nj':{'count':1}, 'ny':{'count':0}}}"
     );
 
     // nested query facets with stats
     client.testJQ(params(p, "q", "*:*"
-        , "json.facet", "{ catB:{query:{q:'${cat_s}:B', facet:{nj:{query:{q:'${where_s}:NJ'}}, ny:{query:'${where_s}:NY'}} }}}"
+            , "json.facet", "{ catB:{query:{q:'${cat_s}:B', facet:{nj:{query:{q:'${where_s}:NJ'}}, ny:{query:'${where_s}:NY'}} }}}"
         )
         , "facets=={ 'count':6, 'catB':{'count':3, 'nj':{'count':2}, 'ny':{'count':1}}}"
     );

--- a/solr/core/src/test/org/apache/solr/search/facet/TestJsonFacets.java
+++ b/solr/core/src/test/org/apache/solr/search/facet/TestJsonFacets.java
@@ -1169,14 +1169,14 @@ public class TestJsonFacets extends SolrTestCaseHS {
 
     // nested query facets on subset
     client.testJQ(params(p, "q", "id:(2 3)"
-            , "json.facet", "{ catB:{query:{q:'${cat_s}:B', facet:{nj:{query:'${where_s}:NJ'}, ny:{query:'${where_s}:NY'}} }}}"
+        , "json.facet", "{ catB:{query:{q:'${cat_s}:B', facet:{nj:{query:'${where_s}:NJ'}, ny:{query:'${where_s}:NY'}} }}}"
         )
         , "facets=={ 'count':2, 'catB':{'count':1, 'nj':{'count':1}, 'ny':{'count':0}}}"
     );
 
     // nested query facets with stats
     client.testJQ(params(p, "q", "*:*"
-            , "json.facet", "{ catB:{query:{q:'${cat_s}:B', facet:{nj:{query:{q:'${where_s}:NJ'}}, ny:{query:'${where_s}:NY'}} }}}"
+        , "json.facet", "{ catB:{query:{q:'${cat_s}:B', facet:{nj:{query:{q:'${where_s}:NJ'}}, ny:{query:'${where_s}:NY'}} }}}"
         )
         , "facets=={ 'count':6, 'catB':{'count':3, 'nj':{'count':2}, 'ny':{'count':1}}}"
     );
@@ -2290,6 +2290,19 @@ public class TestJsonFacets extends SolrTestCaseHS {
             "}"
     );
 
+    //test filter using queries from json.queries
+    client.testJQ(params(p, "q", "*:*"
+        , "json.queries", "{catS:{'#cat_sA': '${cat_s}:A'}, ff:[{'#id_1':'-id:1'},{'#id_2':'-id:2'}]}"
+        , "json.facet", "{" +
+            ",t_filt1:{${terms} type:terms, field:${cat_s}, domain:{filter:{param:catS} } }" + // test filter via "param" type from .queries
+            ",t_filt2:{${terms} type:terms, field:${cat_s}, domain:{filter:{param:ff}} }" +  // test multi-valued query parameter from .queries
+            "}"
+        )
+        , "facets=={ count:6, " +
+            ",t_filt1:{ buckets:[ {val:A, count:2}] } " +
+            ",t_filt2:{ buckets:[ {val:B, count:2}, {val:A, count:1}] } " +
+            "}"
+    );
 
     // test acc reuse (i.e. reset() method).  This is normally used for stats that are not calculated in the first phase,
     // currently non-sorting stats.


### PR DESCRIPTION
# Description

Added DSL support for queries - to have the ability to refer from domain.filter. It supports both single and multi-value query parameters. Support forexclusion is not yet implemented.

# Solution

Intoduced json.queries field, which is translated with query DSL (see [comment](https://issues.apache.org/jira/browse/SOLR-12490?focusedCommentId=16514420&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-16514420)).

# Checklist

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
