### PR TITLE
LUCENE-9096: Implementation of CompressingTermVectorsWriter.flushOffsets can be simpler

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/compressing/CompressingTermVectorsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/compressing/CompressingTermVectorsWriter.java
@@ -564,17 +564,9 @@ public final class CompressingTermVectorsWriter extends TermVectorsWriter {
           final int fieldNumOff = Arrays.binarySearch(fieldNums, fd.fieldNum);
           int pos = 0;
           for (int i = 0; i < fd.numTerms; ++i) {
-            int previousPos = 0;
-            int previousOff = 0;
-            for (int j = 0; j < fd.freqs[i]; ++j) {
-              final int position = positionsBuf[fd.posStart + pos];
-              final int startOffset = startOffsetsBuf[fd.offStart + pos];
-              sumPos[fieldNumOff] += position - previousPos;
-              sumOffsets[fieldNumOff] += startOffset - previousOff;
-              previousPos = position;
-              previousOff = startOffset;
-              ++pos;
-            }
+            sumPos[fieldNumOff] += positionsBuf[fd.posStart + fd.freqs[i]-1 + pos];
+            sumOffsets[fieldNumOff] += startOffsetsBuf[fd.offStart + fd.freqs[i]-1 + pos];
+            pos += fd.freqs[i];
           }
           assert pos == fd.totalPositions;
         }


### PR DESCRIPTION
**Description**
In CompressingTermVectorsWriter.flushOffsets, the calculation of sumPos and sumOffsets is a little redundant

**Solution**
Simplify the process.

**Tests**
I have no idea how to test it, I‘m really appreciate anyone giving me ideas. I have compared before&after, the result is same.

**Checklist**
Please review the following and check all that apply:
- [x] reviewed the guidelines for How to Contribute and my code conforms to the standards described there to the best of my ability.
- [x]  I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers access to contribute to my PR branch. (optional but recommended)
- [x]  I have developed this patch against the master branch.
- [x]  I have run ant precommit and the appropriate test suite.
- [ ]  I have added tests for my changes.
- [ ]  I have added documentation for the Ref Guide (for Solr changes only).