### PR TITLE
SOLR-14157-backup-restore-docs-missing-parameter

### DIFF
--- a/solr/solr-ref-guide/src/collection-management.adoc
+++ b/solr/solr-ref-guide/src/collection-management.adoc
@@ -1239,6 +1239,9 @@ The BACKUP command will backup Solr indexes and configurations for a specified c
 `collection`::
 The name of the collection to be backed up. This parameter is required.
 
+`name`::
+What to name the backup that is created.  This is checked to make sure it doesn't already exist, and otherwise an error message is raised. This parameter is required.
+
 `location`::
 The location on a shared drive for the backup command to write to. Alternately it can be set as a <<cluster-node-management.adoc#clusterprop,cluster property>>.
 
@@ -1267,6 +1270,9 @@ You can use the collection <<collection-aliasing.adoc#createalias,CREATEALIAS>> 
 
 `collection`::
 The collection where the indexes will be restored into. This parameter is required.
+
+`name`::
+The name of the existing backup that you want to restore. This parameter is required.
 
 `location`::
 The location on a shared drive for the RESTORE command to read from. Alternately it can be set as a <<cluster-node-management.adoc#clusterprop,cluster property>>.


### PR DESCRIPTION
# Description

The `name` parameter is madatory on BACKUP and RESTORE commands, but isn't listed, though it is in the example URLs...

# Solution

Added the parameter.

# Tests

n/a, though manually tested the commands to confirm needed, and reviewed the Java code.

# Checklist

Please review the following and check all that apply:

- [ X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ X] I have created a Jira issue and added the issue ID to my pull request title.
- [ X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ X] I have developed this patch against the `master` branch.
- [ X] I have run `ant precommit` and the appropriate test suite.
- [ ] I have added tests for my changes.
- [ X] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
