### PR TITLE
LUCENE-9113: Speed up merging doc values' terms dictionaries.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -115,7 +115,8 @@ Improvements
 
 Optimizations
 ---------------------
-(No changes)
+
+* LUCENE-9113: Faster merging of SORTED/SORTED_SET doc values. (Adrien Grand)
 
 Bug Fixes
 ---------------------


### PR DESCRIPTION
This makes the merged view call `TermsEnum#next` on its subs rather than `#lookupOrd`.