### PR TITLE
SOLR-14162 TestInjection can leak Timer objects

### DIFF
--- a/solr/core/src/java/org/apache/solr/util/TestInjection.java
+++ b/solr/core/src/java/org/apache/solr/util/TestInjection.java
@@ -247,8 +247,9 @@ public class TestInjection {
         if (rand.nextBoolean()) {
           throw new TestShutdownFailError("Test exception for non graceful close");
         } else {
-          
+          final Timer timer = new Timer();
           final Thread cthread = Thread.currentThread();
+
           TimerTask task = new TimerTask() {
             @Override
             public void run() {
@@ -265,11 +266,10 @@ public class TestInjection {
               }
               
               cthread.interrupt();
-              timers.remove(this);
-              cancel();
+              timers.remove(timer);
             }
           };
-          Timer timer = new Timer();
+
           timers.add(timer);
           timer.schedule(task, rand.nextInt(500));
         }


### PR DESCRIPTION
# Description

We track the outstanding Timer but try to remove TimerTask which will never be found in the collection.

# Solution

Add and remove the same Timer instances.

# Tests

The javac warning goes away.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
