### PR TITLE
SOLR-14165 set SolrResponse's serialVersionUID explicitly

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/client/solrj/SolrResponse.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/SolrResponse.java
@@ -37,6 +37,9 @@ import java.io.Serializable;
  */
 public abstract class SolrResponse implements Serializable, MapWriter {
 
+  /** make this compatible with earlier versions */
+  private static final long serialVersionUID = -7931100103360242645L;
+
   /** Elapsed time in milliseconds for the request as seen from the client. */
   public abstract long getElapsedTime();
   


### PR DESCRIPTION
# Description

The serialVersionUID of SolrResponse changed in https://github.com/apache/lucene-solr/pull/929 making Solr nodes before/after that change mutually incompatible for some operations.

# Solution

This sets the serialVersionUID of SolrResponse explicitly to its previous value.

# Tests

I've run manual builds with/without this patch and seen that /solr/admin/collections?action=overseerstatus against stops giving the exception `java.io.InvalidClassException: org.apache.solr.client.solrj.SolrResponse; local class incompatible: stream classdesc serialVersionUID = -7931100103360242645, local class serialVersionUID = 2239939671435624715` for hybrid clusters when the patch is in place.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- (n/a) I have added tests for my changes.
- (n/a) I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
