### PR TITLE
LUCENE-9115: NRTCachingDirectory shouldn't cache files of unknown size.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -120,7 +120,8 @@ Optimizations
 
 Bug Fixes
 ---------------------
-(No changes)
+* LUCENE-9115: NRTCachingDirectory no longer caches files of unknown size.
+  (Adrien Grand)
 
 Other
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/store/NRTCachingDirectory.java
+++ b/lucene/core/src/java/org/apache/lucene/store/NRTCachingDirectory.java
@@ -232,6 +232,8 @@ public class NRTCachingDirectory extends FilterDirectory implements Accountable 
       bytes = context.mergeInfo.estimatedMergeBytes;
     } else if (context.flushInfo != null) {
       bytes = context.flushInfo.estimatedSegmentSize;
+    } else {
+      return false;
     }
 
     return (bytes <= maxMergeSizeBytes) && (bytes + cacheSize.get()) <= maxCachedBytes;

--- a/lucene/core/src/test/org/apache/lucene/store/TestNRTCachingDirectory.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestNRTCachingDirectory.java
@@ -136,4 +136,34 @@ public class TestNRTCachingDirectory extends BaseDirectoryTestCase {
     nrtDir.close();
     fsDir.close();
   }
+
+  public void testUnknownFileSize() throws IOException {
+    Directory dir = newDirectory();
+
+    Directory nrtDir1 = new NRTCachingDirectory(dir, 1, 1) {
+      @Override
+      protected boolean doCacheWrite(String name, IOContext context) {
+        boolean cache = super.doCacheWrite(name, context);
+        assertTrue(cache);
+        return cache;
+      }
+    };
+    IOContext ioContext = new IOContext(new FlushInfo(3, 42));
+    nrtDir1.createOutput("foo", ioContext).close();
+    nrtDir1.createTempOutput("bar", "baz", ioContext).close();
+
+    Directory nrtDir2 = new NRTCachingDirectory(dir, 1, 1) {
+      @Override
+      protected boolean doCacheWrite(String name, IOContext context) {
+        boolean cache = super.doCacheWrite(name, context);
+        assertFalse(cache);
+        return cache;
+      }
+    };
+    ioContext = IOContext.DEFAULT;
+    nrtDir2.createOutput("foo", ioContext).close();
+    nrtDir2.createTempOutput("bar", "baz", ioContext).close();
+
+    dir.close();
+  }
 }


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/LUCENE-9115.