### PR TITLE
SOLR-6613: TextField.analyzeMultiTerm does not throw an exception…

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -212,7 +212,7 @@ Bug Fixes
 
 * SOLR-14122: SimUtils converts v2 to v1 request params incorrectly. (Li Cao, ab)
 
-* SOLR-6613: TextField.analyzeMultiTerm does not throw an exception when Analyzer returns no term. (Bruno Roustant)
+* SOLR-6613: TextField.analyzeMultiTerm does not throw an exception when Analyzer returns no terms. (Bruno Roustant)
 
 Other Changes
 ---------------------

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -212,6 +212,8 @@ Bug Fixes
 
 * SOLR-14122: SimUtils converts v2 to v1 request params incorrectly. (Li Cao, ab)
 
+* SOLR-6613: TextField.analyzeMultiTerm does not throw an exception when Analyzer returns no term. (Bruno Roustant)
+
 Other Changes
 ---------------------
 

--- a/solr/core/src/java/org/apache/solr/parser/SolrQueryParserBase.java
+++ b/solr/core/src/java/org/apache/solr/parser/SolrQueryParserBase.java
@@ -45,6 +45,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.RegexpQuery;
 import org.apache.lucene.search.WildcardQuery;
+import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.QueryBuilder;
 import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.Automaton;
@@ -997,8 +998,8 @@ public abstract class SolrQueryParserBase extends QueryBuilder {
 
     SchemaField sf = schema.getFieldOrNull((field));
     if (sf == null || ! (fieldType instanceof TextField)) return part;
-    String out = TextField.analyzeMultiTerm(field, part, ((TextField)fieldType).getMultiTermAnalyzer()).utf8ToString();
-    return out;
+    BytesRef out = TextField.analyzeMultiTerm(field, part, ((TextField)fieldType).getMultiTermAnalyzer());
+    return out == null ? part : out.utf8ToString();
   }
 
 

--- a/solr/core/src/java/org/apache/solr/schema/TextField.java
+++ b/solr/core/src/java/org/apache/solr/schema/TextField.java
@@ -173,8 +173,10 @@ public class TextField extends FieldType {
 
       TermToBytesRefAttribute termAtt = source.getAttribute(TermToBytesRefAttribute.class);
 
-      if (!source.incrementToken())
-        throw  new SolrException(SolrException.ErrorCode.BAD_REQUEST,"analyzer returned no terms for multiTerm term: " + part);
+      if (!source.incrementToken()) {
+        // Accept no token because it may have been filtered out by a StopFilter for example.
+        return null;
+      }
       BytesRef bytes = BytesRef.deepCopyOf(termAtt.getBytesRef());
       if (source.incrementToken())
         throw  new SolrException(SolrException.ErrorCode.BAD_REQUEST,"analyzer returned too many terms for multiTerm term: " + part);

--- a/solr/core/src/java/org/apache/solr/schema/TextField.java
+++ b/solr/core/src/java/org/apache/solr/schema/TextField.java
@@ -165,6 +165,16 @@ public class TextField extends FieldType {
     return new SolrRangeQuery(field.getName(), lower, upper, minInclusive, maxInclusive);
   }
 
+  /**
+   * Analyzes a text part using the provided {@link Analyzer} for a multi-term query.
+   * <p>
+   * Expects a single token to be used as multi-term term. This single token might also be filtered out
+   * so zero token is supported and null is returned in this case.
+   *
+   * @return The multi-term term bytes; or null if there is no multi-term terms.
+   * @throws SolrException If the {@link Analyzer} tokenizes more than one token;
+   * or if an underlying {@link IOException} occurs.
+   */
   public static BytesRef analyzeMultiTerm(String field, String part, Analyzer analyzerIn) {
     if (part == null || analyzerIn == null) return null;
 
@@ -174,7 +184,7 @@ public class TextField extends FieldType {
       TermToBytesRefAttribute termAtt = source.getAttribute(TermToBytesRefAttribute.class);
 
       if (!source.incrementToken()) {
-        // Accept no token because it may have been filtered out by a StopFilter for example.
+        // Accept no tokens because it may have been filtered out by a StopFilter for example.
         return null;
       }
       BytesRef bytes = BytesRef.deepCopyOf(termAtt.getBytesRef());

--- a/solr/core/src/test/org/apache/solr/schema/TestTextField.java
+++ b/solr/core/src/test/org/apache/solr/schema/TestTextField.java
@@ -32,7 +32,7 @@ public class TestTextField extends SolrTestCaseJ4 {
 
   @Test
   public void testAnalyzeMultiTerm() {
-    // No term provided by the StopFilter (stop word) for the multi-term part.
+    // No terms provided by the StopFilter (stop word) for the multi-term part.
     // This is supported. Check TextField.analyzeMultiTerm returns null (and does not throw an exception).
     BytesRef termBytes = TextField.analyzeMultiTerm("field", "the", new StopAnalyzer(EnglishAnalyzer.ENGLISH_STOP_WORDS_SET));
     assertNull(termBytes);
@@ -44,11 +44,7 @@ public class TestTextField extends SolrTestCaseJ4 {
 
     // Two terms provided by the WhitespaceTokenizer for the multi-term part.
     // This is not allowed. Expect an exception.
-    try {
-      termBytes = TextField.analyzeMultiTerm("field", "term1 term2", new WhitespaceAnalyzer());
-      fail("Expected exception was not thrown, returned term \"" + termBytes.utf8ToString() + "\"");
-    } catch (SolrException e) {
-      assertEquals("Unexpected exception", SolrException.ErrorCode.BAD_REQUEST.code, e.code());
-    }
+    SolrException exception = expectThrows(SolrException.class, () -> TextField.analyzeMultiTerm("field", "term1 term2", new WhitespaceAnalyzer()));
+    assertEquals("Unexpected error code", SolrException.ErrorCode.BAD_REQUEST.code, exception.code());
   }
 }

--- a/solr/core/src/test/org/apache/solr/schema/TestTextField.java
+++ b/solr/core/src/test/org/apache/solr/schema/TestTextField.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.schema;
+
+import org.apache.lucene.analysis.core.StopAnalyzer;
+import org.apache.lucene.analysis.core.WhitespaceAnalyzer;
+import org.apache.lucene.analysis.en.EnglishAnalyzer;
+import org.apache.lucene.util.BytesRef;
+import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.common.SolrException;
+import org.junit.Test;
+
+/**
+ * Tests directly {@link org.apache.solr.schema.TextField} methods.
+ */
+public class TestTextField extends SolrTestCaseJ4 {
+
+  @Test
+  public void testAnalyzeMultiTerm() {
+    // No term provided by the StopFilter (stop word) for the multi-term part.
+    // This is supported. Check TextField.analyzeMultiTerm returns null (and does not throw an exception).
+    BytesRef termBytes = TextField.analyzeMultiTerm("field", "the", new StopAnalyzer(EnglishAnalyzer.ENGLISH_STOP_WORDS_SET));
+    assertNull(termBytes);
+
+    // One term provided by the WhitespaceTokenizer for the multi-term part.
+    // This is the regular case. Check TextField.analyzeMultiTerm returns it (and does not throw an exception).
+    termBytes = TextField.analyzeMultiTerm("field", "Sol", new WhitespaceAnalyzer());
+    assertEquals("Sol", termBytes.utf8ToString());
+
+    // Two terms provided by the WhitespaceTokenizer for the multi-term part.
+    // This is not allowed. Expect an exception.
+    try {
+      termBytes = TextField.analyzeMultiTerm("field", "term1 term2", new WhitespaceAnalyzer());
+      fail("Expected exception was not thrown, returned term \"" + termBytes.utf8ToString() + "\"");
+    } catch (SolrException e) {
+      assertEquals("Unexpected exception", SolrException.ErrorCode.BAD_REQUEST.code, e.code());
+    }
+  }
+}


### PR DESCRIPTION
when Analyzer returns no term.