### PR TITLE
LUCENE-8962: Add ability to selectively merge on commit

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/FilterMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FilterMergePolicy.java
@@ -58,8 +58,8 @@ public class FilterMergePolicy extends MergePolicy {
   }
 
   @Override
-  public MergeSpecification findCommitMerges(SegmentInfos segmentInfos, MergeContext mergeContext) throws IOException {
-    return in.findCommitMerges(segmentInfos, mergeContext);
+  public MergeSpecification findFullFlushMerges(MergeTrigger mergeTrigger, SegmentInfos segmentInfos, MergeContext mergeContext) throws IOException {
+    return in.findFullFlushMerges(mergeTrigger, segmentInfos, mergeContext);
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/index/FilterMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FilterMergePolicy.java
@@ -58,6 +58,11 @@ public class FilterMergePolicy extends MergePolicy {
   }
 
   @Override
+  public MergeSpecification findCommitMerges(SegmentInfos segmentInfos, MergeContext mergeContext) throws IOException {
+    return in.findCommitMerges(segmentInfos, mergeContext);
+  }
+
+  @Override
   public boolean useCompoundFile(SegmentInfos infos, SegmentCommitInfo mergedInfo, MergeContext mergeContext)
       throws IOException {
     return in.useCompoundFile(infos, mergedInfo, mergeContext);

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3266,7 +3266,7 @@ public class IndexWriter implements Closeable, TwoPhaseCommit, Accountable,
               if (anyChanges) {
                 // Find any merges that can execute on commit (per MergePolicy).
                 MergePolicy.MergeSpecification mergeSpec =
-                    config.getMergePolicy().findCommitMerges(segmentInfos, this);
+                    config.getMergePolicy().findFullFlushMerges(MergeTrigger.COMMIT, segmentInfos, this);
                 if (mergeSpec != null && mergeSpec.merges.size() > 0) {
                   int mergeCount = mergeSpec.merges.size();
                   commitMerges = new ArrayList<>(mergeCount);
@@ -3323,7 +3323,7 @@ public class IndexWriter implements Closeable, TwoPhaseCommit, Accountable,
         // block until  the merges that we registered complete. As they complete, they will update toCommit to
         // replace merged segments with the result of each merge.
         config.getIndexWriterEvents().beginMergeOnCommit();
-        mergeScheduler.merge(this, MergeTrigger.FULL_FLUSH, true);
+        mergeScheduler.merge(this, MergeTrigger.COMMIT, true);
         long mergeWaitStart = System.nanoTime();
         int abandonedCount = 0;
         long waitTimeMillis = (long) (config.getMaxCommitMergeWaitSeconds() * 1000.0);

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3331,7 +3331,7 @@ public class IndexWriter implements Closeable, TwoPhaseCommit, Accountable,
           if (mergeAwaitLatch.await(waitTimeMillis, TimeUnit.MILLISECONDS) == false) {
             synchronized (this) {
               // Need to do this in a synchronized block, to make sure none of our commit merges are currently
-              // executing mergeFinished (since mergeFinished itself is called from with the IndexWriter lock).
+              // executing mergeFinished (since mergeFinished itself is called from within the IndexWriter lock).
               // After we clear the value from mergeAwaitLatchRef, the merges we schedule will still execute as
               // usual, but when they finish, they won't attempt to update toCommit or modify segment reference
               // counts.

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3276,7 +3276,7 @@ public class IndexWriter implements Closeable, TwoPhaseCommit, Accountable,
                         updateSegmentInfosOnMergeFinish(oneMerge, toCommit, mergeAwaitLatchRef);
                     if (registerMerge(trackedMerge) == false) {
                       throw new IllegalStateException("MergePolicy " + config.getMergePolicy().getClass() +
-                          " returned merging segments from findCommitMerges");
+                          " returned merging segments from findFullFlushMerges");
                     }
                     commitMerges.add(trackedMerge);
                   }

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriterConfig.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriterConfig.java
@@ -490,6 +490,7 @@ public final class IndexWriterConfig extends LiveIndexWriterConfig {
   /**
    * Expert: sets the amount of time to wait for merges returned by MergePolicy.findCommitMerges(...).
    * If this time is reached, we proceed with the commit based on segments merged up to that point.
+   * The merges are not cancelled, and may still run to completion independent of the commit.
    */
   public IndexWriterConfig setMaxCommitMergeWaitSeconds(double maxCommitMergeWaitSeconds) {
     this.maxCommitMergeWaitSeconds = maxCommitMergeWaitSeconds;

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriterConfig.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriterConfig.java
@@ -488,9 +488,8 @@ public final class IndexWriterConfig extends LiveIndexWriterConfig {
   }
 
   /**
-   * Expert: sets the amount of time to wait for merges returned by by MergePolicy.findCommitMerges(...).
-   * If this time is reached, those merges will be aborted and we will wait again. If this time limit is reached again,
-   * we will abort the commit.
+   * Expert: sets the amount of time to wait for merges returned by MergePolicy.findCommitMerges(...).
+   * If this time is reached, we proceed with the commit based on segments merged up to that point.
    */
   public IndexWriterConfig setMaxCommitMergeWaitSeconds(double maxCommitMergeWaitSeconds) {
     this.maxCommitMergeWaitSeconds = maxCommitMergeWaitSeconds;

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriterConfig.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriterConfig.java
@@ -113,7 +113,7 @@ public final class IndexWriterConfig extends LiveIndexWriterConfig {
   /** Default value for whether calls to {@link IndexWriter#close()} include a commit. */
   public final static boolean DEFAULT_COMMIT_ON_CLOSE = true;
 
-  /** Default value for time to wait for merges on commit (when using a {@link MergePolicy} that implements findCommitMerges). */
+  /** Default value for time to wait for merges on commit (when using a {@link MergePolicy} that implements findFullFlushMerges). */
   public static final double DEFAULT_MAX_COMMIT_MERGE_WAIT_SECONDS = 30.0;
   
   // indicates whether this config instance is already attached to a writer.
@@ -488,7 +488,7 @@ public final class IndexWriterConfig extends LiveIndexWriterConfig {
   }
 
   /**
-   * Expert: sets the amount of time to wait for merges returned by MergePolicy.findCommitMerges(...).
+   * Expert: sets the amount of time to wait for merges returned by MergePolicy.findFullFlushMerges(...).
    * If this time is reached, we proceed with the commit based on segments merged up to that point.
    * The merges are not cancelled, and may still run to completion independent of the commit.
    */

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriterConfig.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriterConfig.java
@@ -112,6 +112,9 @@ public final class IndexWriterConfig extends LiveIndexWriterConfig {
   
   /** Default value for whether calls to {@link IndexWriter#close()} include a commit. */
   public final static boolean DEFAULT_COMMIT_ON_CLOSE = true;
+
+  /** Default value for time to wait for merges on commit (when using a {@link MergePolicy} that implements findCommitMerges). */
+  public static final double DEFAULT_MAX_COMMIT_MERGE_WAIT_SECONDS = 30.0;
   
   // indicates whether this config instance is already attached to a writer.
   // not final so that it can be cloned properly.
@@ -481,6 +484,24 @@ public final class IndexWriterConfig extends LiveIndexWriterConfig {
    */
   public IndexWriterConfig setCommitOnClose(boolean commitOnClose) {
     this.commitOnClose = commitOnClose;
+    return this;
+  }
+
+  /**
+   * Expert: sets the amount of time to wait for merges returned by by MergePolicy.findCommitMerges(...).
+   * If this time is reached, those merges will be aborted and we will wait again. If this time limit is reached again,
+   * we will abort the commit.
+   */
+  public IndexWriterConfig setMaxCommitMergeWaitSeconds(double maxCommitMergeWaitSeconds) {
+    this.maxCommitMergeWaitSeconds = maxCommitMergeWaitSeconds;
+    return this;
+  }
+
+  /**
+   * Set the callback that gets invoked when IndexWriter performs various actions.
+   */
+  public IndexWriterConfig setIndexWriterEvents(IndexWriterEvents indexWriterEvents) {
+    this.indexWriterEvents = indexWriterEvents;
     return this;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriterEvents.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriterEvents.java
@@ -41,7 +41,7 @@ public interface IndexWriterEvents {
 
   /**
    * Signals the start of waiting for a merge on commit, returned from
-   * {@link MergePolicy#findCommitMerges(SegmentInfos, MergePolicy.MergeContext)}.
+   * {@link MergePolicy#findFullFlushMerges(MergeTrigger, SegmentInfos, MergePolicy.MergeContext)}.
    */
   void beginMergeOnCommit();
 

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriterEvents.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriterEvents.java
@@ -19,12 +19,14 @@
 
 package org.apache.lucene.index;
 
+/**
+ * Callback interface to signal various actions taken by IndexWriter.
+ */
 public interface IndexWriterEvents {
   /**
    * A default implementation that ignores all events.
    */
-  final class NullEvents implements IndexWriterEvents {
-    private NullEvents() { }
+  IndexWriterEvents NULL_EVENTS = new IndexWriterEvents() {
     @Override
     public void beginMergeOnCommit() { }
 
@@ -33,8 +35,7 @@ public interface IndexWriterEvents {
 
     @Override
     public void abandonedMergesOnCommit(int abandonedCount) { }
-  }
-  IndexWriterEvents NULL_EVENTS = new NullEvents();
+  };
 
   /**
    * Signals the start of waiting for a merge on commit, returned from

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriterEvents.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriterEvents.java
@@ -21,6 +21,8 @@ package org.apache.lucene.index;
 
 /**
  * Callback interface to signal various actions taken by IndexWriter.
+ *
+ * @lucene.experimental
  */
 public interface IndexWriterEvents {
   /**

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriterEvents.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriterEvents.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+package org.apache.lucene.index;
+
+public interface IndexWriterEvents {
+  /**
+   * A default implementation that ignores all events.
+   */
+  final class NullEvents implements IndexWriterEvents {
+    private NullEvents() { }
+    @Override
+    public void beginMergeOnCommit() { }
+
+    @Override
+    public void finishMergeOnCommit() { }
+
+    @Override
+    public void abandonedMergesOnCommit(int abandonedCount) { }
+  }
+  IndexWriterEvents NULL_EVENTS = new NullEvents();
+
+  /**
+   * Signals the start of waiting for a merge on commit, returned from
+   * {@link MergePolicy#findCommitMerges(SegmentInfos, MergePolicy.MergeContext)}.
+   */
+  void beginMergeOnCommit();
+
+  /**
+   * Signals the end of waiting for merges on commit. This may be either because the merges completed, or because we timed out according
+   * to the limit set in {@link IndexWriterConfig#setMaxCommitMergeWaitSeconds(double)}.
+   */
+  void finishMergeOnCommit();
+
+  /**
+   * Called to signal that we abandoned some merges on commit upon reaching the timeout specified in
+   * {@link IndexWriterConfig#setMaxCommitMergeWaitSeconds(double)}.
+   */
+  void abandonedMergesOnCommit(int abandonedCount);
+}

--- a/lucene/core/src/java/org/apache/lucene/index/LiveIndexWriterConfig.java
+++ b/lucene/core/src/java/org/apache/lucene/index/LiveIndexWriterConfig.java
@@ -117,7 +117,7 @@ public class LiveIndexWriterConfig {
   /** the attributes for the NRT readers */
   protected Map<String, String> readerAttributes = Collections.emptyMap();
 
-  /** Amount of time to wait for merges returned by MergePolicy.findCommitMerges(...) */
+  /** Amount of time to wait for merges returned by MergePolicy.findFullFlushMerges(...) */
   protected volatile double maxCommitMergeWaitSeconds;
 
   /** Callback interface called on index writer actions. */
@@ -489,7 +489,7 @@ public class LiveIndexWriterConfig {
   }
 
   /**
-   * Expert: return the amount of time to wait for merges returned by by MergePolicy.findCommitMerges(...).
+   * Expert: return the amount of time to wait for merges returned by by MergePolicy.findFullFlushMerges(...).
    * If this time is reached, we proceed with the commit based on segments merged up to that point.
    * The merges are not cancelled, and may still run to completion independent of the commit.
    */

--- a/lucene/core/src/java/org/apache/lucene/index/LiveIndexWriterConfig.java
+++ b/lucene/core/src/java/org/apache/lucene/index/LiveIndexWriterConfig.java
@@ -117,6 +117,12 @@ public class LiveIndexWriterConfig {
   /** the attributes for the NRT readers */
   protected Map<String, String> readerAttributes = Collections.emptyMap();
 
+  /** Amount of time to wait for merges returned by MergePolicy.findCommitMerges(...) */
+  protected volatile double maxCommitMergeWaitSeconds;
+
+  /** Callback interface called on index writer actions. */
+  protected IndexWriterEvents indexWriterEvents;
+
 
   // used by IndexWriterConfig
   LiveIndexWriterConfig(Analyzer analyzer) {
@@ -141,6 +147,8 @@ public class LiveIndexWriterConfig {
     readerPooling = IndexWriterConfig.DEFAULT_READER_POOLING;
     indexerThreadPool = new DocumentsWriterPerThreadPool();
     perThreadHardLimitMB = IndexWriterConfig.DEFAULT_RAM_PER_THREAD_HARD_LIMIT_MB;
+    maxCommitMergeWaitSeconds = IndexWriterConfig.DEFAULT_MAX_COMMIT_MERGE_WAIT_SECONDS;
+    indexWriterEvents = IndexWriterEvents.NULL_EVENTS;
   }
   
   /** Returns the default analyzer to use for indexing documents. */
@@ -480,6 +488,22 @@ public class LiveIndexWriterConfig {
     return softDeletesField;
   }
 
+  /**
+   * Expert: return the amount of time to wait for merges returned by by MergePolicy.findCommitMerges(...).
+   * If this time is reached, those merges will be aborted and we will wait again. If this time limit is reached again,
+   * we will abort the commit.
+   */
+  public double getMaxCommitMergeWaitSeconds() {
+    return maxCommitMergeWaitSeconds;
+  }
+
+  /**
+   * Returns a callback used to signal actions taken by the {@link IndexWriter}.
+   */
+  public IndexWriterEvents getIndexWriterEvents() {
+    return indexWriterEvents;
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
@@ -505,6 +529,8 @@ public class LiveIndexWriterConfig {
     sb.append("checkPendingFlushOnUpdate=").append(isCheckPendingFlushOnUpdate()).append("\n");
     sb.append("softDeletesField=").append(getSoftDeletesField()).append("\n");
     sb.append("readerAttributes=").append(getReaderAttributes()).append("\n");
+    sb.append("maxCommitMergeWaitSeconds=").append(getMaxCommitMergeWaitSeconds()).append("\n");
+    sb.append("indexWriterEvents=").append(getIndexWriterEvents().getClass().getName()).append("\n");
     return sb.toString();
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/LiveIndexWriterConfig.java
+++ b/lucene/core/src/java/org/apache/lucene/index/LiveIndexWriterConfig.java
@@ -490,8 +490,8 @@ public class LiveIndexWriterConfig {
 
   /**
    * Expert: return the amount of time to wait for merges returned by by MergePolicy.findCommitMerges(...).
-   * If this time is reached, those merges will be aborted and we will wait again. If this time limit is reached again,
-   * we will abort the commit.
+   * If this time is reached, we proceed with the commit based on segments merged up to that point.
+   * The merges are not cancelled, and may still run to completion independent of the commit.
    */
   public double getMaxCommitMergeWaitSeconds() {
     return maxCommitMergeWaitSeconds;

--- a/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
@@ -527,6 +527,19 @@ public abstract class MergePolicy {
       SegmentInfos segmentInfos, MergeContext mergeContext) throws IOException;
 
   /**
+   * Identifies merges that we want to execute (synchronously) on commit. By default, do not synchronously merge on commit.
+   *
+   * Implementers of this method should use isMergingSegment to exclude any already-merging segments from the returned
+   * {@link MergeSpecification}. If a segment already registered in a merge is returned, then the commit will fail.
+   *
+   * @param segmentInfos the total set of segments in the index (while preparing the commit)
+   * @param mergeContext the IndexWriter to find the merges on
+   */
+  public MergeSpecification findCommitMerges(SegmentInfos segmentInfos, MergeContext mergeContext) throws IOException {
+    return null;
+  }
+
+  /**
    * Returns true if a new segment (regardless of its origin) should use the
    * compound file format. The default implementation returns <code>true</code>
    * iff the size of the given mergedInfo is less or equal to

--- a/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
@@ -529,8 +529,8 @@ public abstract class MergePolicy {
   /**
    * Identifies merges that we want to execute (synchronously) on commit. By default, do not synchronously merge on commit.
    *
-   * Implementers of this method should use isMergingSegment to exclude any already-merging segments from the returned
-   * {@link MergeSpecification}. If a segment already registered in a merge is returned, then the commit will fail.
+   * If a returned {@link OneMerge} includes a segment already included in a registered merge, then the commit will fail.
+   * Use {@link MergeContext#getMergingSegments()} to determine which segments are currently registered to merge.
    *
    * @param segmentInfos the total set of segments in the index (while preparing the commit)
    * @param mergeContext the IndexWriter to find the merges on

--- a/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
@@ -510,7 +510,7 @@ public abstract class MergePolicy {
  *          an original segment present in the
  *          to-be-merged index; else, it was a segment
  *          produced by a cascaded merge.
-   * @param mergeContext the IndexWriter to find the merges on
+   * @param mergeContext the MergeContext to find the merges on
    */
   public abstract MergeSpecification findForcedMerges(
       SegmentInfos segmentInfos, int maxSegmentCount, Map<SegmentCommitInfo,Boolean> segmentsToMerge, MergeContext mergeContext)
@@ -521,7 +521,7 @@ public abstract class MergePolicy {
    * deletes from the index.
    *  @param segmentInfos
    *          the total set of segments in the index
-   * @param mergeContext the IndexWriter to find the merges on
+   * @param mergeContext the MergeContext to find the merges on
    */
   public abstract MergeSpecification findForcedDeletesMerges(
       SegmentInfos segmentInfos, MergeContext mergeContext) throws IOException;
@@ -529,11 +529,19 @@ public abstract class MergePolicy {
   /**
    * Identifies merges that we want to execute (synchronously) on commit. By default, do not synchronously merge on commit.
    *
-   * If a returned {@link OneMerge} includes a segment already included in a registered merge, then the commit will fail.
+   * Any merges returned here will make {@link IndexWriter#commit()} or {@link IndexWriter#prepareCommit()} block until
+   * the merges complete or until {@link IndexWriterConfig#getMaxCommitMergeWaitSeconds()} have elapsed. This may be
+   * used to merge small segments that have just been flushed as part of the commit, reducing the number of segments in
+   * the commit. If a merge does not complete in the allotted time, it will continue to execute, but will not be reflected
+   * in the commit.
+   *
+   * If a {@link OneMerge} in the returned {@link MergeSpecification} includes a segment already included in a registered
+   * merge, then {@link IndexWriter#commit()} or {@link IndexWriter#prepareCommit()} will throw a {@link IllegalStateException}.
    * Use {@link MergeContext#getMergingSegments()} to determine which segments are currently registered to merge.
    *
    * @param segmentInfos the total set of segments in the index (while preparing the commit)
-   * @param mergeContext the IndexWriter to find the merges on
+   * @param mergeContext the MergeContext to find the merges on, which should be used to determine which segments are
+   *                     already in a registered merge (see {@link MergeContext#getMergingSegments()}).
    */
   public MergeSpecification findCommitMerges(SegmentInfos segmentInfos, MergeContext mergeContext) throws IOException {
     return null;

--- a/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
@@ -539,11 +539,12 @@ public abstract class MergePolicy {
    * merge, then {@link IndexWriter#commit()} or {@link IndexWriter#prepareCommit()} will throw a {@link IllegalStateException}.
    * Use {@link MergeContext#getMergingSegments()} to determine which segments are currently registered to merge.
    *
+   * @param mergeTrigger the event that triggered the merge (COMMIT or FULL_FLUSH).
    * @param segmentInfos the total set of segments in the index (while preparing the commit)
    * @param mergeContext the MergeContext to find the merges on, which should be used to determine which segments are
-   *                     already in a registered merge (see {@link MergeContext#getMergingSegments()}).
+ *                     already in a registered merge (see {@link MergeContext#getMergingSegments()}).
    */
-  public MergeSpecification findCommitMerges(SegmentInfos segmentInfos, MergeContext mergeContext) throws IOException {
+  public MergeSpecification findFullFlushMerges(MergeTrigger mergeTrigger, SegmentInfos segmentInfos, MergeContext mergeContext) throws IOException {
     return null;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/MergeTrigger.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergeTrigger.java
@@ -47,5 +47,10 @@ public enum MergeTrigger {
   /**
    * Merge was triggered by a closing IndexWriter.
    */
-  CLOSING
+  CLOSING,
+
+  /**
+   * Merge was triggered on commit.
+   */
+  COMMIT,
 }

--- a/lucene/core/src/java/org/apache/lucene/index/NoMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/NoMergePolicy.java
@@ -46,7 +46,7 @@ public final class NoMergePolicy extends MergePolicy {
   public MergeSpecification findForcedDeletesMerges(SegmentInfos segmentInfos, MergeContext mergeContext) { return null; }
 
   @Override
-  public MergeSpecification findCommitMerges(SegmentInfos segmentInfos, MergeContext mergeContext) { return null; }
+  public MergeSpecification findFullFlushMerges(MergeTrigger mergeTrigger, SegmentInfos segmentInfos, MergeContext mergeContext) { return null; }
 
   @Override
   public boolean useCompoundFile(SegmentInfos segments, SegmentCommitInfo newSegment, MergeContext mergeContext) {

--- a/lucene/core/src/java/org/apache/lucene/index/NoMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/NoMergePolicy.java
@@ -46,6 +46,9 @@ public final class NoMergePolicy extends MergePolicy {
   public MergeSpecification findForcedDeletesMerges(SegmentInfos segmentInfos, MergeContext mergeContext) { return null; }
 
   @Override
+  public MergeSpecification findCommitMerges(SegmentInfos segmentInfos, MergeContext mergeContext) { return null; }
+
+  @Override
   public boolean useCompoundFile(SegmentInfos segments, SegmentCommitInfo newSegment, MergeContext mergeContext) {
     return newSegment.info.getUseCompoundFile();
   }

--- a/lucene/core/src/java/org/apache/lucene/index/OneMergeWrappingMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/OneMergeWrappingMergePolicy.java
@@ -60,8 +60,8 @@ public class OneMergeWrappingMergePolicy extends FilterMergePolicy {
   }
 
   @Override
-  public MergeSpecification findCommitMerges(SegmentInfos segmentInfos, MergeContext mergeContext) throws IOException {
-    return wrapSpec(in.findCommitMerges(segmentInfos, mergeContext));
+  public MergeSpecification findFullFlushMerges(MergeTrigger mergeTrigger, SegmentInfos segmentInfos, MergeContext mergeContext) throws IOException {
+    return wrapSpec(in.findFullFlushMerges(mergeTrigger, segmentInfos, mergeContext));
   }
 
   private MergeSpecification wrapSpec(MergeSpecification spec) {

--- a/lucene/core/src/java/org/apache/lucene/index/OneMergeWrappingMergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/OneMergeWrappingMergePolicy.java
@@ -59,6 +59,11 @@ public class OneMergeWrappingMergePolicy extends FilterMergePolicy {
     return wrapSpec(in.findForcedDeletesMerges(segmentInfos, mergeContext));
   }
 
+  @Override
+  public MergeSpecification findCommitMerges(SegmentInfos segmentInfos, MergeContext mergeContext) throws IOException {
+    return wrapSpec(in.findCommitMerges(segmentInfos, mergeContext));
+  }
+
   private MergeSpecification wrapSpec(MergeSpecification spec) {
     MergeSpecification wrapped = spec == null ? null : new MergeSpecification();
     if (wrapped != null) {

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMergePolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMergePolicy.java
@@ -301,9 +301,9 @@ public class TestIndexWriterMergePolicy extends LuceneTestCase {
 
     MergePolicy mergeOnCommitPolicy = new LogDocMergePolicy() {
       @Override
-      public MergeSpecification findCommitMerges(SegmentInfos segmentInfos, MergeContext mergeContext) throws IOException {
+      public MergeSpecification findFullFlushMerges(MergeTrigger mergeTrigger, SegmentInfos segmentInfos, MergeContext mergeContext) {
         // Optimize down to a single segment on commit
-        if (segmentInfos.size() > 1) {
+        if (mergeTrigger == MergeTrigger.COMMIT && segmentInfos.size() > 1) {
           List<SegmentCommitInfo> nonMergingSegments = new ArrayList<>();
           for (SegmentCommitInfo sci : segmentInfos) {
             if (mergeContext.getMergingSegments().contains(sci) == false) {

--- a/lucene/test-framework/src/java/org/apache/lucene/index/MockRandomMergePolicy.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/index/MockRandomMergePolicy.java
@@ -129,7 +129,7 @@ public class MockRandomMergePolicy extends MergePolicy {
   }
 
   @Override
-  public MergeSpecification findCommitMerges(SegmentInfos segmentInfos, MergeContext mergeContext) throws IOException {
+  public MergeSpecification findFullFlushMerges(MergeTrigger mergeTrigger, SegmentInfos segmentInfos, MergeContext mergeContext) throws IOException {
     MergeSpecification mergeSpecification = findMerges(null, segmentInfos, mergeContext);
     if (mergeSpecification == null) {
       return null;

--- a/lucene/test-framework/src/java/org/apache/lucene/index/MockRandomMergePolicy.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/index/MockRandomMergePolicy.java
@@ -129,6 +129,38 @@ public class MockRandomMergePolicy extends MergePolicy {
   }
 
   @Override
+  public MergeSpecification findCommitMerges(SegmentInfos segmentInfos, MergeContext mergeContext) throws IOException {
+    MergeSpecification mergeSpecification = findMerges(null, segmentInfos, mergeContext);
+    if (mergeSpecification == null) {
+      return null;
+    }
+    // Do not return any merges involving already-merging segments.
+    MergeSpecification filteredMergeSpecification = new MergeSpecification();
+    for (OneMerge oneMerge : mergeSpecification.merges) {
+      boolean filtered = false;
+      List<SegmentCommitInfo> nonMergingSegments = new ArrayList<>();
+      for (SegmentCommitInfo sci : oneMerge.segments) {
+        if (mergeContext.getMergingSegments().contains(sci) == false) {
+          nonMergingSegments.add(sci);
+        } else {
+          filtered = true;
+        }
+      }
+      if (filtered == true) {
+        if (nonMergingSegments.size() > 0) {
+          filteredMergeSpecification.add(new OneMerge(nonMergingSegments));
+        }
+      } else {
+        filteredMergeSpecification.add(oneMerge);
+      }
+    }
+    if (filteredMergeSpecification.merges.size() > 0) {
+      return filteredMergeSpecification;
+    }
+    return null;
+  }
+
+  @Override
   public boolean useCompoundFile(SegmentInfos infos, SegmentCommitInfo mergedInfo, MergeContext mergeContext) throws IOException {
     // 80% of the time we create CFS:
     return random.nextInt(5) != 1;

--- a/lucene/test-framework/src/java/org/apache/lucene/util/LuceneTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/util/LuceneTestCase.java
@@ -1004,6 +1004,7 @@ public abstract class LuceneTestCase extends Assert {
     if (rarely(r)) {
       c.setCheckPendingFlushUpdate(false);
     }
+    c.setMaxCommitMergeWaitSeconds(atLeast(r, 1));
     return c;
   }
 


### PR DESCRIPTION
<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->

# Description

If we have many index writer threads, they will flush their DWPT buffers
on commit, resulting in many small segments, which can be merged before
the commit returns.

# Solution

This adds a new "findCommitMerges" method to MergePolicy, which can specify merges to be executed as part of preparing a commit. By default, we return null for backward compatibility (i.e. don't merge on commit).

In IndexWriter, we call findCommitMerges from prepareCommitInternal, after we have cloned the SegmentInfos. If we found commit merges, we wrap each OneMerge so that on completion, they update the cloned SegmentInfos and reference counts of segment files. Outside the flush lock, we wait (up to max time specified in IndexWriterConfig) for the commit merges to complete before calling startCommit. 

Also, added an IndexWriterEvents callback (configurable through IndexWriterConfig) so that consuming code can be notified of merge on commit events (to emit metrics on time spent waiting for the merges to complete, for example).

# Tests

1. Added findCommitMerges implementation to MockRandomMergePolicy.
2. Added explicit test case for merge-on-commit behavior in TestIndexWriterMergePolicy.

# Checklist

Please review the following and check all that apply:

- [✓] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [✓] I have created a Jira issue and added the issue ID to my pull request title.
- [✓] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [✓] I have developed this patch against the `master` branch.
- [✓] I have run `ant precommit` and the appropriate test suite.
- [✓] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
