### PR TITLE
LUCENE-9133: Fix for potential NPE in TermFilteredPresearcher#buildQuery

### DIFF
--- a/lucene/monitor/src/java/org/apache/lucene/monitor/TermFilteredPresearcher.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/TermFilteredPresearcher.java
@@ -105,7 +105,12 @@ public class TermFilteredPresearcher extends Presearcher {
       DocumentQueryBuilder queryBuilder = getQueryBuilder();
       for (FieldInfo field : reader.getFieldInfos()) {
 
-        TokenStream ts = new TermsEnumTokenStream(reader.terms(field.name).iterator());
+        Terms terms = reader.terms(field.name);
+        if (terms == null) {
+          continue;
+        }
+
+        TokenStream ts = new TermsEnumTokenStream(terms.iterator());
         for (CustomQueryHandler handler : queryHandlers) {
           ts = handler.wrapTermStream(field.name, ts);
         }

--- a/lucene/monitor/src/test/org/apache/lucene/monitor/TestTermPresearcher.java
+++ b/lucene/monitor/src/test/org/apache/lucene/monitor/TestTermPresearcher.java
@@ -149,4 +149,47 @@ public class TestTermPresearcher extends PresearcherTestBase {
     }
 
   }
+
+  public void testQueryBuilderHandlesEmptyField() throws IOException {
+
+    Presearcher presearcher = createPresearcher();
+
+    IndexWriterConfig iwc = new IndexWriterConfig(new KeywordAnalyzer());
+    Directory dir = new ByteBuffersDirectory();
+    IndexWriter writer = new IndexWriter(dir, iwc);
+    MonitorConfiguration config = new MonitorConfiguration(){
+      @Override
+      public IndexWriter buildIndexWriter() {
+        return writer;
+      }
+    };
+
+    try (Monitor monitor = new Monitor(ANALYZER, presearcher, config)) {
+
+      monitor.register(new MonitorQuery("1", parse("f:test")));
+
+      try (IndexReader reader = DirectoryReader.open(writer, false, false)) {
+
+        MemoryIndex mindex = new MemoryIndex();
+        mindex.addField("f", "this is a test document", WHITESPACE);
+        mindex.addField("g", "#######", ANALYZER);
+        LeafReader docsReader = (LeafReader) mindex.createSearcher().getIndexReader();
+
+        QueryIndex.QueryTermFilter termFilter = new QueryIndex.QueryTermFilter(reader);
+
+        BooleanQuery q = (BooleanQuery) presearcher.buildQuery(docsReader, termFilter);
+        BooleanQuery expected = new BooleanQuery.Builder()
+            .add(should(new BooleanQuery.Builder()
+                .add(should(new TermInSetQuery("f", new BytesRef("test")))).build()))
+            .add(should(new TermQuery(new Term("__anytokenfield", "__ANYTOKEN__"))))
+            .build();
+
+        assertEquals(expected, q);
+
+      }
+
+    }
+
+  }
+
 }

--- a/lucene/monitor/src/test/org/apache/lucene/monitor/TestTermPresearcher.java
+++ b/lucene/monitor/src/test/org/apache/lucene/monitor/TestTermPresearcher.java
@@ -131,48 +131,7 @@ public class TestTermPresearcher extends PresearcherTestBase {
 
         MemoryIndex mindex = new MemoryIndex();
         mindex.addField("f", "this is a test document", WHITESPACE);
-        LeafReader docsReader = (LeafReader) mindex.createSearcher().getIndexReader();
-
-        QueryIndex.QueryTermFilter termFilter = new QueryIndex.QueryTermFilter(reader);
-
-        BooleanQuery q = (BooleanQuery) presearcher.buildQuery(docsReader, termFilter);
-        BooleanQuery expected = new BooleanQuery.Builder()
-            .add(should(new BooleanQuery.Builder()
-                .add(should(new TermInSetQuery("f", new BytesRef("test")))).build()))
-            .add(should(new TermQuery(new Term("__anytokenfield", "__ANYTOKEN__"))))
-            .build();
-
-        assertEquals(expected, q);
-
-      }
-
-    }
-
-  }
-
-  public void testQueryBuilderHandlesEmptyField() throws IOException {
-
-    Presearcher presearcher = createPresearcher();
-
-    IndexWriterConfig iwc = new IndexWriterConfig(new KeywordAnalyzer());
-    Directory dir = new ByteBuffersDirectory();
-    IndexWriter writer = new IndexWriter(dir, iwc);
-    MonitorConfiguration config = new MonitorConfiguration(){
-      @Override
-      public IndexWriter buildIndexWriter() {
-        return writer;
-      }
-    };
-
-    try (Monitor monitor = new Monitor(ANALYZER, presearcher, config)) {
-
-      monitor.register(new MonitorQuery("1", parse("f:test")));
-
-      try (IndexReader reader = DirectoryReader.open(writer, false, false)) {
-
-        MemoryIndex mindex = new MemoryIndex();
-        mindex.addField("f", "this is a test document", WHITESPACE);
-        mindex.addField("g", "#######", ANALYZER);
+        mindex.addField("g", "#######", ANALYZER); // analyzes away to empty field
         LeafReader docsReader = (LeafReader) mindex.createSearcher().getIndexReader();
 
         QueryIndex.QueryTermFilter termFilter = new QueryIndex.QueryTermFilter(reader);


### PR DESCRIPTION
<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

TermFilteredPresearcher.buildQuery() assumes that LeafReader.terms() always returns a non-null Terms but that is not always the case.

# Solution

Check if the LeafReader  returns a null Terms for a given field.  If  so then skip that field.

# Tests

Added a new test to TestTermPresearcher that illustrates the problem. Run it without the change to buildQuery() and  you get a NPE.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [x] I have added tests for my changes.
