### PR TITLE
SOLR-14044: Support collection and shard deletion in shared storage

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/Overseer.java
+++ b/solr/core/src/java/org/apache/solr/cloud/Overseer.java
@@ -70,6 +70,9 @@ import org.apache.solr.core.CoreContainer;
 import org.apache.solr.handler.admin.CollectionsHandler;
 import org.apache.solr.handler.component.HttpShardHandler;
 import org.apache.solr.logging.MDCLoggingContext;
+import org.apache.solr.store.blob.process.BlobDeleteManager;
+import org.apache.solr.store.blob.process.BlobDeleteProcessor;
+import org.apache.solr.store.shared.SharedStoreManager;
 import org.apache.solr.store.shared.metadata.SharedShardMetadataController;
 import org.apache.solr.update.UpdateShardHandler;
 import org.apache.zookeeper.CreateMode;
@@ -78,6 +81,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.Timer;
+import com.google.common.annotations.VisibleForTesting;
 
 /**
  * Cluster leader. Responsible for processing state updates, node assignments, creating/deleting
@@ -792,6 +796,7 @@ public class Overseer implements SolrCloseable {
         triggerThread.join();
       } catch (InterruptedException e)  {}
     }
+
     updaterThread = null;
     ccThread = null;
     triggerThread = null;
@@ -989,5 +994,4 @@ public class Overseer implements SolrCloseable {
     }
     getStateUpdateQueue().offer(data);
   }
-
 }

--- a/solr/core/src/java/org/apache/solr/cloud/Overseer.java
+++ b/solr/core/src/java/org/apache/solr/cloud/Overseer.java
@@ -70,9 +70,6 @@ import org.apache.solr.core.CoreContainer;
 import org.apache.solr.handler.admin.CollectionsHandler;
 import org.apache.solr.handler.component.HttpShardHandler;
 import org.apache.solr.logging.MDCLoggingContext;
-import org.apache.solr.store.blob.process.BlobDeleteManager;
-import org.apache.solr.store.blob.process.BlobDeleteProcessor;
-import org.apache.solr.store.shared.SharedStoreManager;
 import org.apache.solr.store.shared.metadata.SharedShardMetadataController;
 import org.apache.solr.update.UpdateShardHandler;
 import org.apache.zookeeper.CreateMode;
@@ -81,7 +78,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.Timer;
-import com.google.common.annotations.VisibleForTesting;
 
 /**
  * Cluster leader. Responsible for processing state updates, node assignments, creating/deleting
@@ -796,7 +792,6 @@ public class Overseer implements SolrCloseable {
         triggerThread.join();
       } catch (InterruptedException e)  {}
     }
-
     updaterThread = null;
     ccThread = null;
     triggerThread = null;
@@ -994,4 +989,5 @@ public class Overseer implements SolrCloseable {
     }
     getStateUpdateQueue().offer(data);
   }
+
 }

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/DeleteCollectionCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/DeleteCollectionCmd.java
@@ -18,6 +18,13 @@
 
 package org.apache.solr.cloud.api.collections;
 
+import static org.apache.solr.common.params.CollectionAdminParams.COLOCATED_WITH;
+import static org.apache.solr.common.params.CollectionAdminParams.FOLLOW_ALIASES;
+import static org.apache.solr.common.params.CollectionAdminParams.WITH_COLLECTION;
+import static org.apache.solr.common.params.CollectionParams.CollectionAction.DELETE;
+import static org.apache.solr.common.params.CommonAdminParams.ASYNC;
+import static org.apache.solr.common.params.CommonParams.NAME;
+
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -25,7 +32,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 import org.apache.solr.cloud.Overseer;
@@ -47,16 +56,13 @@ import org.apache.solr.core.SolrInfoBean;
 import org.apache.solr.core.snapshots.SolrSnapshotManager;
 import org.apache.solr.handler.admin.MetricsHistoryHandler;
 import org.apache.solr.metrics.SolrMetricManager;
+import org.apache.solr.store.blob.process.BlobDeleteManager;
+import org.apache.solr.store.blob.process.BlobDeleteProcessor;
+import org.apache.solr.store.blob.process.BlobDeleterTask.BlobDeleterTaskResult;
+import org.apache.solr.store.shared.SharedStoreManager;
 import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.apache.solr.common.params.CollectionAdminParams.COLOCATED_WITH;
-import static org.apache.solr.common.params.CollectionAdminParams.FOLLOW_ALIASES;
-import static org.apache.solr.common.params.CollectionAdminParams.WITH_COLLECTION;
-import static org.apache.solr.common.params.CollectionParams.CollectionAction.DELETE;
-import static org.apache.solr.common.params.CommonAdminParams.ASYNC;
-import static org.apache.solr.common.params.CommonParams.NAME;
 
 public class DeleteCollectionCmd implements OverseerCollectionMessageHandler.Cmd {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -140,6 +146,34 @@ public class DeleteCollectionCmd implements OverseerCollectionMessageHandler.Cmd
           // because when a new collection with same name is created, new replicas may reuse the old dataDir
           removeCounterNode = false;
           break;
+        }
+      }
+      
+      // Delete the collection files from shared store. We want to delete all of the files before we delete
+      // the collection state from ZooKeeper.
+      DocCollection docCollection = zkStateReader.getClusterState().getCollectionOrNull(collection);
+      if (docCollection != null && docCollection.getSharedIndex()) {
+        SharedStoreManager sharedStoreManager = ocmh.overseer.getCoreContainer().getSharedStoreManager();
+        BlobDeleteManager deleteManager = sharedStoreManager.getBlobDeleteManager();
+        BlobDeleteProcessor deleteProcessor = deleteManager.getOverseerDeleteProcessor();
+        // deletes all files belonging to this collection
+        CompletableFuture<BlobDeleterTaskResult> deleteFuture = 
+            deleteProcessor.deleteCollection(collection, false);
+        
+        try {
+          // TODO: Find a reasonable timeout value
+          BlobDeleterTaskResult result = deleteFuture.get(60, TimeUnit.SECONDS);
+          if (!result.isSuccess()) {
+            log.warn("Deleting all files belonging to shared collection " + collection + 
+                " was not successful! Files belonging to this collection may be orphaned.");
+          }
+        } catch (TimeoutException tex) {
+          // We can orphan files here if we don't delete everything in time but what matters for potentially
+          // reusing the collection name is that the zookeeper state of the collection gets deleted which 
+          // will happen in the finally block
+          throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "Could not complete deleting collection" + 
+              collection + " from shared store in a reasonable amount of time, files belonging to this collection"
+                  + " may be orphaned.", tex);
         }
       }
 

--- a/solr/core/src/java/org/apache/solr/store/blob/client/CoreStorageClient.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/client/CoreStorageClient.java
@@ -136,6 +136,11 @@ public interface CoreStorageClient {
   public void shutdown();
   
   /**
+   * Lists all file names with the given prefix
+   */
+  public List<String> listCoreBlobFiles(String prefix) throws BlobException;
+  
+  /**
    * Lists the blob file names of all of files listed under a given core name's blob store
    * hierarchy that are older than the given timestamp value in milliseconds. Important to 
    * note that that the wall clock of your caller will vary with that of the blob store service

--- a/solr/core/src/java/org/apache/solr/store/blob/client/LocalStorageClient.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/client/LocalStorageClient.java
@@ -237,6 +237,20 @@ public class LocalStorageClient implements CoreStorageClient {
   public void shutdown() {
       
   }
+  
+  @Override
+  public List<String> listCoreBlobFiles(String prefix) throws BlobException {
+    try {
+      Path path = Paths.get(getBlobAbsolutePath(prefix));
+      List<String> blobFiles =
+        Files.walk(path).map(Path::toFile)
+        .map(file -> BlobClientUtils.concatenatePaths(prefix, file.getName()))
+        .collect(Collectors.toList());
+      return blobFiles;
+    } catch (Exception ex) {
+      throw new BlobException(ex);
+    }
+  }
     
   @Override
   public List<String> listCoreBlobFilesOlderThan(String blobName, long timestamp) throws BlobException {

--- a/solr/core/src/java/org/apache/solr/store/blob/client/LocalStorageClient.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/client/LocalStorageClient.java
@@ -251,7 +251,6 @@ public class LocalStorageClient implements CoreStorageClient {
         Files.walk(path).map(Path::toFile)
           .filter(file -> (!file.isDirectory()))
           .map(file -> {
-            log.info("DEBUG " + file.getAbsolutePath().substring(rootBlobDir.length()));
             // extracts just the file system blob file name without the root dir
             return file.getAbsolutePath().substring(rootBlobDir.length());
           })

--- a/solr/core/src/java/org/apache/solr/store/blob/client/S3StorageClient.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/client/S3StorageClient.java
@@ -270,6 +270,28 @@ public class S3StorageClient implements CoreStorageClient {
   public void shutdown() {
     s3Client.shutdown();
   }
+  
+  @Override
+  public List<String> listCoreBlobFiles(String prefix) throws BlobException {
+    ListObjectsRequest listRequest = new ListObjectsRequest();
+    listRequest.setBucketName(blobBucketName);
+    listRequest.setPrefix(prefix);
+    
+    List<String> blobFiles = new LinkedList<>();
+    try {
+      ObjectListing objectListing = s3Client.listObjects(listRequest);
+      iterateObjectListingAndConsume(objectListing, object -> {
+        blobFiles.add(object.getKey());
+      });
+      return blobFiles;
+    } catch (AmazonServiceException ase) {
+      throw handleAmazonServiceException(ase);
+    } catch (AmazonClientException ace) {
+      throw new BlobClientException(ace);
+    } catch (Exception ex) {
+      throw new BlobException(ex);
+    }
+  }
 
   @Override
   public List<String> listCoreBlobFilesOlderThan(String blobName, long timestamp) throws BlobException {

--- a/solr/core/src/java/org/apache/solr/store/blob/metadata/CorePushPull.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/metadata/CorePushPull.java
@@ -139,7 +139,7 @@ public class CorePushPull {
          */
         for (BlobCoreMetadata.BlobFile d : resolvedMetadataResult.getFilesToDelete()) {
             bcmBuilder.removeFile(d);
-            BlobCoreMetadata.BlobFileToDelete bftd = new BlobCoreMetadata.BlobFileToDelete(d, System.currentTimeMillis());
+            BlobCoreMetadata.BlobFileToDelete bftd = new BlobCoreMetadata.BlobFileToDelete(d, System.nanoTime() / 1000000);
             bcmBuilder.addFileToDelete(bftd);
         }
 
@@ -154,7 +154,7 @@ public class CorePushPull {
           String blobCoreMetadataName = BlobStoreUtils.buildBlobStoreMetadataName(currentMetadataSuffix);
           String coreMetadataPath = blobMetadata.getSharedBlobName() + "/" + blobCoreMetadataName;
           // so far checksum is not used for metadata file
-          BlobCoreMetadata.BlobFileToDelete bftd = new BlobCoreMetadata.BlobFileToDelete("", coreMetadataPath, bcmSize, BlobCoreMetadataBuilder.UNDEFINED_VALUE, System.currentTimeMillis());
+          BlobCoreMetadata.BlobFileToDelete bftd = new BlobCoreMetadata.BlobFileToDelete("", coreMetadataPath, bcmSize, BlobCoreMetadataBuilder.UNDEFINED_VALUE, System.nanoTime() / 1000000);
           bcmBuilder.addFileToDelete(bftd);
         }
 
@@ -509,7 +509,7 @@ public class CorePushPull {
     @VisibleForTesting
     protected boolean okForHardDelete(BlobCoreMetadata.BlobFileToDelete file) {
       // For now we only check how long ago the file was marked for delete.
-      return System.nanoTime() - file.getDeletedAt() >= deleteManager.getDeleteDelayMs();
+      return (System.nanoTime() / 1000000) - file.getDeletedAt() >= deleteManager.getDeleteDelayMs();
     }
     
     /**

--- a/solr/core/src/java/org/apache/solr/store/blob/metadata/CorePushPull.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/metadata/CorePushPull.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.invoke.MethodHandles;
-import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -31,7 +30,6 @@ import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.io.IOUtils;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.store.Directory;
@@ -50,10 +48,13 @@ import org.apache.solr.store.blob.client.ToFromJson;
 import org.apache.solr.store.blob.metadata.ServerSideMetadata.CoreFileData;
 import org.apache.solr.store.blob.metadata.SharedStoreResolutionUtil.SharedMetadataResolutionResult;
 import org.apache.solr.store.blob.process.BlobDeleteManager;
+import org.apache.solr.store.blob.process.BlobDeleteProcessor;
 import org.apache.solr.store.blob.util.BlobStoreUtils;
 import org.apache.solr.store.shared.metadata.SharedShardMetadataController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
 
 /**
  * Class pushing updates from the local core to the Blob Store and pulling updates from Blob store to local core.
@@ -502,6 +503,9 @@ public class CorePushPull {
       return System.nanoTime() - file.getDeletedAt() >= deleteManager.getDeleteDelayMs();
     }
     
+    /**
+     * @return true if the files were enqueued for deletion successfully
+     */
     @VisibleForTesting
     protected boolean enqueueForDelete(String coreName, Set<BlobCoreMetadata.BlobFileToDelete> blobFiles) {
       if (blobFiles == null || blobFiles.isEmpty()) {
@@ -510,7 +514,14 @@ public class CorePushPull {
       Set<String> blobNames = blobFiles.stream()
                                 .map(blobFile -> blobFile.getBlobName())
                                 .collect(Collectors.toCollection(HashSet::new));
-      return deleteManager.enqueueForDelete(coreName, blobNames);
+      
+      BlobDeleteProcessor deleteProcessor = deleteManager.getDeleteProcessor();
+      try {
+        deleteProcessor.deleteFiles(coreName, blobNames, true);
+        return true;
+      } catch (Exception ex) {
+        return false;
+      }
     }
 
     /**

--- a/solr/core/src/java/org/apache/solr/store/blob/process/BlobDeleteManager.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/process/BlobDeleteManager.java
@@ -168,9 +168,9 @@ public class BlobDeleteManager {
     isShutdown.set(true);
     log.info("BlobDeleteManager is shutting down");
     
-    deleteProcessor.shutdown();
+    deleteProcessor.close();
     log.info("BlobDeleteProcessor " + deleteProcessor.getName() + " has shutdown");
-    overseerDeleteProcessor.shutdown();
+    overseerDeleteProcessor.close();
     log.info("BlobDeleteProcessor " + overseerDeleteProcessor.getName() + " has shutdown");
   }
 

--- a/solr/core/src/java/org/apache/solr/store/blob/process/BlobDeleteManager.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/process/BlobDeleteManager.java
@@ -71,9 +71,6 @@ public class BlobDeleteManager {
   /**
    * Limit to the number of blob files to delete accepted on the delete queue (and lost in case of server crash). When
    * the queue reaches that size, no more deletes are accepted (will be retried later for a core, next time it is pushed).
-   * (note that tests in searchserver.blobstore.metadata.CorePushTest trigger a merge that enqueues more than 100 files to
-   * be deleted. If that constant is reduced to 100 for example, some enqueues in the test will fail and there will be
-   * files left to be deleted where we've expected none. So don't reduce it too much :)
    */
   private static final int DEFAULT_ALMOST_MAX_DELETER_QUEUE_SIZE = 200;
   
@@ -113,7 +110,7 @@ public class BlobDeleteManager {
 
   /**
    * Creates a new BlobDeleteManager with the provided {@link CoreStorageClient} and instantiates
-   * it with a default deletedelayMs, queue size, and thread pool size. A default {@link BlobDeleteProcessor}
+   * it with a default deleteDelayMs, queue size, and thread pool size. A default {@link BlobDeleteProcessor}
    * is also created.
    */
   public BlobDeleteManager(CoreStorageClient client) {

--- a/solr/core/src/java/org/apache/solr/store/blob/process/BlobDeleteProcessor.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/process/BlobDeleteProcessor.java
@@ -57,7 +57,7 @@ public class BlobDeleteProcessor {
    * re-enqueue at the tail of the queue ({@link BlobDeleteManager} creates a list), so there might be additional
    * processing delay if the queue is not empty and is processed before the enqueued retry is processed).
    */
-  private final int defaultMaxDeleteAttempts;
+  private final int maxDeleteAttempts;
   private final long fixedRetryDelay;
   private final CoreStorageClient client;
   private final BlockingQueue<Runnable> deleteQueue;
@@ -75,7 +75,7 @@ public class BlobDeleteProcessor {
       int defaultMaxDeleteAttempts, long fixedRetryDelay) {
     this.name = name;
     this.almostMaxQueueSize = almostMaxQueueSize;
-    this.defaultMaxDeleteAttempts = defaultMaxDeleteAttempts;
+    this.maxDeleteAttempts = defaultMaxDeleteAttempts;
     this.fixedRetryDelay = fixedRetryDelay;
     NamedThreadFactory threadFactory = new NamedThreadFactory(name);
 
@@ -96,7 +96,7 @@ public class BlobDeleteProcessor {
    */
   public CompletableFuture<BlobDeleterTaskResult> deleteFiles(String collectionName, Set<String> blobNames, boolean allowRetry) {
     BlobDeleterTask task = new BlobFileDeletionTask(client, collectionName, blobNames, 
-        allowRetry, defaultMaxDeleteAttempts);
+        allowRetry, maxDeleteAttempts);
     return enqueue(task, false);
   }
   
@@ -108,7 +108,7 @@ public class BlobDeleteProcessor {
    */
   public CompletableFuture<BlobDeleterTaskResult> deleteCollection(String collectionName, boolean allowRetry) {
     BlobDeleterTask task = new BlobPrefixedFileDeletionTask(client, collectionName, collectionName, 
-        allowRetry, defaultMaxDeleteAttempts);
+        allowRetry, maxDeleteAttempts);
     return enqueue(task, false);
   }
   
@@ -122,7 +122,7 @@ public class BlobDeleteProcessor {
    */
   public CompletableFuture<BlobDeleterTaskResult> deleteShard(String collectionName, String sharedShardName, boolean allowRetry) {
     BlobDeleterTask task = new BlobPrefixedFileDeletionTask(client, collectionName, 
-        sharedShardName + BlobClientUtils.BLOB_FILE_PATH_DELIMITER, allowRetry, defaultMaxDeleteAttempts);
+        sharedShardName + BlobClientUtils.BLOB_FILE_PATH_DELIMITER, allowRetry, maxDeleteAttempts);
     return enqueue(task, false);
   }
   

--- a/solr/core/src/java/org/apache/solr/store/blob/process/BlobDeleteProcessor.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/process/BlobDeleteProcessor.java
@@ -16,6 +16,7 @@
  */
 package org.apache.solr.store.blob.process;
 
+import java.io.Closeable;
 import java.lang.invoke.MethodHandles;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
@@ -45,7 +46,7 @@ import com.google.common.annotations.VisibleForTesting;
  * 
  * Instances of {@link BlobDeleteProcessor} are managed by the {@link BlobDeleteManager}.
  */
-public class BlobDeleteProcessor {
+public class BlobDeleteProcessor implements Closeable {
   
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   
@@ -164,7 +165,8 @@ public class BlobDeleteProcessor {
     });
   }
   
-  public void shutdown() {
+  @Override
+  public void close() {
     deleteExecutor.shutdown();
   }  
   

--- a/solr/core/src/java/org/apache/solr/store/blob/process/BlobDeleteProcessor.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/process/BlobDeleteProcessor.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.store.blob.process;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.lucene.util.NamedThreadFactory;
+import org.apache.solr.common.SolrException;
+import org.apache.solr.common.cloud.ZkStateReader;
+import org.apache.solr.common.util.ExecutorUtil.MDCAwareThreadPoolExecutor;
+import org.apache.solr.store.blob.client.CoreStorageClient;
+import org.apache.solr.store.blob.process.BlobDeleterTask.BlobDeleterTaskResult;
+import org.apache.solr.store.blob.process.BlobDeleterTask.BlobFileDeletionTask;
+import org.apache.solr.store.blob.process.BlobDeleterTask.BlobPrefixedFileDeletionTask;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+
+/**
+ * A generic deletion processor used for deleting object files from shared
+ * storage. Each processor manages its own task bounded thread pool for processing
+ * {@link BlobDeleterTask} asynchronously. Processors support retrying tasks if 
+ * necessary but retry decisions are left to the individual task implementations.  
+ * 
+ * Instances of {@link BlobDeleteProcessor} are managed by the {@link BlobDeleteManager}.
+ */
+public class BlobDeleteProcessor {
+  
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  
+  private final String name;
+  private final int almostMaxQueueSize;
+  /**
+   * Note we sleep() after each failed attempt, so multiply this value by {@link #fixedRetryDelay} to find
+   * out how long we'll retry (at least) if Blob access fails for some reason ("at least" because we
+   * re-enqueue at the tail of the queue ({@link BlobDeleteManager} creates a list), so there might be additional
+   * processing delay if the queue is not empty and is processed before the enqueued retry is processed).
+   */
+  private final int defaultMaxDeleteAttempts;
+  private final long fixedRetryDelay;
+  private final CoreStorageClient client;
+  private final BlockingQueue<Runnable> deleteQueue;
+  private final MDCAwareThreadPoolExecutor deleteExecutor;
+  
+  /**
+   * @param name identifying the processor
+   * @param client the storage client to use in this processor
+   * @param almostMaxQueueSize the target max queue size
+   * @param numDeleterThreads the number of threads to configure in the underlying thread pool
+   * @param defaultMaxDeleteAttempts maximum number of attempts to retry any task enqueued in this processor
+   * @param fixedRetryDelay fixed time delay in ms between retry attempts
+   */
+  public BlobDeleteProcessor(String name, CoreStorageClient client, int almostMaxQueueSize, int numDeleterThreads,
+      int defaultMaxDeleteAttempts, long fixedRetryDelay) {
+    this.name = name;
+    this.almostMaxQueueSize = almostMaxQueueSize;
+    this.defaultMaxDeleteAttempts = defaultMaxDeleteAttempts;
+    this.fixedRetryDelay = fixedRetryDelay;
+    NamedThreadFactory threadFactory = new NamedThreadFactory(name);
+
+    // Note this queue MUST NOT BE BOUNDED, or we risk deadlocks given that BlobDeleterTask's 
+    // re-enqueue themselves upon failure
+    deleteQueue = new LinkedBlockingDeque<>();
+    
+    deleteExecutor = new MDCAwareThreadPoolExecutor(numDeleterThreads, numDeleterThreads, 0L, TimeUnit.SECONDS, deleteQueue, threadFactory);
+    this.client = client;
+  }
+  
+  /**
+   * Enqueues the given set of files for deletion from shared store as an async task. 
+   * 
+   * @param collectionName the name of the collection the files belong to
+   * @param blobNames list of file paths to delete from shared store
+   * @param allowRetry flag indicating if the task should be retried if it fails
+   */
+  public CompletableFuture<BlobDeleterTaskResult> deleteFiles(String collectionName, Set<String> blobNames, boolean allowRetry) {
+    BlobDeleterTask task = new BlobFileDeletionTask(client, collectionName, blobNames, 
+        allowRetry, defaultMaxDeleteAttempts);
+    return enqueue(task, false);
+  }
+  
+  /**
+   * Enqueues a task to delete all files belonging to the given collection from shared store as an async task.
+   * 
+   * @param collectionName the name of the collection to be deleted from shared store
+   * @param allowRetry flag indicating if the task should be retried if it fails
+   */
+  public CompletableFuture<BlobDeleterTaskResult> deleteCollection(String collectionName, boolean allowRetry) {
+    BlobDeleterTask task = new BlobPrefixedFileDeletionTask(client, collectionName, collectionName, 
+        allowRetry, defaultMaxDeleteAttempts);
+    return enqueue(task, false);
+  }
+  
+  /**
+   * Enqueues a task to delete all files belonging to the given collection and {@link ZkStateReader#SHARED_SHARD_NAME} 
+   * from shared store as an async task.
+   * 
+   * @param collectionName the name of the collection the files belong to
+   * @param sharedShardName the identifier for the shardId located on the shared store  
+   * @param allowRetry flag indicating if the task should be retried if it fails
+   */
+  public CompletableFuture<BlobDeleterTaskResult> deleteShard(String collectionName, String sharedShardName, boolean allowRetry) {
+    BlobDeleterTask task = new BlobPrefixedFileDeletionTask(client, collectionName, sharedShardName, 
+        allowRetry, defaultMaxDeleteAttempts);
+    return enqueue(task, false);
+  }
+  
+  /**
+   * Enqueues a task to be processed by a thread in the {@link BlobDeleteProcessor#deleteExecutor} thread
+   * pool. The callback is handled by the same execution thread and will re-enqueue a task that has failed
+   * and should be retried. Tasks that are enqueued via the retry mechanism are not bound by the same size
+   * constraints as newly minted tasks are.
+   * 
+   * @returns CompletableFuture to allow calling threads the capability to block on the 
+   * computation results as needed, retrieved suppressed exceptions in retry, etc
+   */
+  @VisibleForTesting
+  protected CompletableFuture<BlobDeleterTaskResult> enqueue(BlobDeleterTask task, boolean isRetry) {
+    if (!isRetry && deleteQueue.size() > almostMaxQueueSize) {
+      throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, 
+          "Unable to enqueue deletion task: " + task.toString());
+    }
+
+    return CompletableFuture.supplyAsync(() -> {
+      return task.call();
+    }, deleteExecutor)
+    .thenCompose(result -> {
+      // the callback will execute on the same thread as the executing task
+      if (!result.isSuccess() && result.shouldRetry()) {
+        try {
+          // Some delay before retry... (could move this delay to before trying to delete a file that previously
+          // failed to be deleted, that way if the queue is busy and it took time to retry, we don't add an additional
+          // delay on top of that. On the other hand, an exception here could be an issue with the Blob store
+          // itself and nothing specific to the file at hand, so slowing all delete attempts for all files might
+          // make sense.
+          Thread.sleep(fixedRetryDelay);
+          return enqueue(result.getTask(), result.shouldRetry());
+        } catch (Exception ex) {
+          log.error("Could not re-enqueue failed deleter task that should have been enqueued!", ex);
+        }
+      }
+      return CompletableFuture.completedFuture(result);
+    });
+  }
+  
+  public void shutdown() {
+    deleteExecutor.shutdown();
+  }  
+  
+  public String getName() {
+    return name;
+  }
+}

--- a/solr/core/src/java/org/apache/solr/store/blob/process/BlobDeleteProcessor.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/process/BlobDeleteProcessor.java
@@ -27,6 +27,7 @@ import org.apache.lucene.util.NamedThreadFactory;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.common.util.ExecutorUtil.MDCAwareThreadPoolExecutor;
+import org.apache.solr.store.blob.client.BlobClientUtils;
 import org.apache.solr.store.blob.client.CoreStorageClient;
 import org.apache.solr.store.blob.process.BlobDeleterTask.BlobDeleterTaskResult;
 import org.apache.solr.store.blob.process.BlobDeleterTask.BlobFileDeletionTask;
@@ -120,8 +121,8 @@ public class BlobDeleteProcessor {
    * @param allowRetry flag indicating if the task should be retried if it fails
    */
   public CompletableFuture<BlobDeleterTaskResult> deleteShard(String collectionName, String sharedShardName, boolean allowRetry) {
-    BlobDeleterTask task = new BlobPrefixedFileDeletionTask(client, collectionName, sharedShardName, 
-        allowRetry, defaultMaxDeleteAttempts);
+    BlobDeleterTask task = new BlobPrefixedFileDeletionTask(client, collectionName, 
+        sharedShardName + BlobClientUtils.BLOB_FILE_PATH_DELIMITER, allowRetry, defaultMaxDeleteAttempts);
     return enqueue(task, false);
   }
   

--- a/solr/core/src/java/org/apache/solr/store/blob/process/BlobDeleterTask.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/process/BlobDeleterTask.java
@@ -52,7 +52,7 @@ public abstract class BlobDeleterTask implements Callable<BlobDeleterTaskResult>
     this.client = client;
     this.collectionName = collectionName;
     this.attempt = new AtomicInteger(0);
-    this.queuedTimeMs = System.nanoTime();
+    this.queuedTimeMs = System.nanoTime() / 1000000;
     this.allowRetry = allowRetry;
     this.maxAttempts = maxAttempts;
   }
@@ -71,7 +71,7 @@ public abstract class BlobDeleterTask implements Callable<BlobDeleterTaskResult>
   @Override
   public BlobDeleterTaskResult call() {
     List<String> filesDeleted = new LinkedList<>();
-    final long startTimeMs = System.nanoTime();
+    final long startTimeMs = System.nanoTime() / 1000000;
     boolean isSuccess = true;
     boolean shouldRetry = false;
     try {
@@ -97,7 +97,7 @@ public abstract class BlobDeleterTask implements Callable<BlobDeleterTaskResult>
         }
       }
     } finally {
-      long now = System.nanoTime();
+      long now = System.nanoTime() / 1000000;
       long runTime = now - startTimeMs;
       long startLatency = now - this.queuedTimeMs;
       log(getActionName(), collectionName, runTime, startLatency, isSuccess, getAdditionalLogMessage());

--- a/solr/core/src/java/org/apache/solr/store/blob/process/BlobDeleterTask.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/process/BlobDeleterTask.java
@@ -165,7 +165,7 @@ public abstract class BlobDeleterTask implements Callable<BlobDeleterTaskResult>
     }
     
     /**
-     * @return the files that are being deleted. Note if the task wasn't successful there is no gaurantee
+     * @return the files that are being deleted. Note if the task wasn't successful there is no guarantee
      * all of these files were in fact deleted from shared storage
      */
     public Collection<String> getFilesDeleted() {

--- a/solr/core/src/java/org/apache/solr/store/blob/process/BlobDeleterTask.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/process/BlobDeleterTask.java
@@ -18,94 +18,244 @@
 package org.apache.solr.store.blob.process;
 
 import java.lang.invoke.MethodHandles;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Locale;
 import java.util.Set;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.solr.store.blob.client.CoreStorageClient;
+import org.apache.solr.store.blob.process.BlobDeleterTask.BlobDeleterTaskResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Task in charge of deleting Blobs (files) from blob store.
+ * Generic deletion task for files located on shared storage
  */
-class BlobDeleterTask implements Runnable {
+public abstract class BlobDeleterTask implements Callable<BlobDeleterTaskResult> {
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-
-  /**
-   * Note we sleep() after each failed attempt, so multiply this value by {@link #SLEEP_MS_FAILED_ATTEMPT} to find
-   * out how long we'll retry (at least) if Blob access fails for some reason ("at least" because we
-   * re-enqueue at the tail of the queue ({@link BlobDeleteManager} creates a list), so there might be additional
-   * processing delay if the queue is not empty and is processed before the enqueued retry is processed).
-   */
-  private static int MAX_DELETE_ATTEMPTS = 50;
-  private static long SLEEP_MS_FAILED_ATTEMPT = TimeUnit.SECONDS.toMillis(10);
-
+  
   private final CoreStorageClient client;
-  private final String sharedBlobName;
-  private final Set<String> blobNames;
+  private final String collectionName;
   private final AtomicInteger attempt;
-  private final ThreadPoolExecutor executor;
+  
   private final long queuedTimeMs;
+  private final int maxAttempts;
+  private final boolean allowRetry;
+  private Throwable err;
 
-  BlobDeleterTask(CoreStorageClient client, String sharedBlobName, Set<String> blobNames, ThreadPoolExecutor executor) {
-    this.client = client; 
-    this.sharedBlobName = sharedBlobName;
-    this.blobNames = blobNames;
+  public BlobDeleterTask(CoreStorageClient client, String collectionName, boolean allowRetry,
+      int maxAttempts) {
+    this.client = client;
+    this.collectionName = collectionName;
     this.attempt = new AtomicInteger(0);
-    this.executor = executor;
     this.queuedTimeMs = System.nanoTime();
+    this.allowRetry = allowRetry;
+    this.maxAttempts = maxAttempts;
   }
-
+  
+  /**
+   * Performs a deletion action and request against the shared storage for the given collection
+   * and returns the list of file paths deleted
+   */
+  public abstract Collection<String> doDelete() throws Exception;
+  
+  /**
+   * Return a String representing the action performed by the BlobDeleterTask for logging purposes
+   */
+  public abstract String getActionName();
+  
   @Override
-  public void run() {
+  public BlobDeleterTaskResult call() {
+    List<String> filesDeleted = new LinkedList<>();
     final long startTimeMs = System.nanoTime();
     boolean isSuccess = true;
-      
+    boolean shouldRetry = false;
     try {
-      client.deleteBlobs(blobNames);
-      // Blob might not have been deleted if at some point we've enqueued files to delete while doing a core push,
-      // but the push ended up failing and the core.metadata file was not updated. We ended up with the blobs enqueued for
-      // delete and eventually removed by a BlobDeleterTask and the files to delete still present in core.metadata
-      // so enqueued again.
-      // Note it is ok to delete these files even if the core.metadata update fails. The delete is not linked
-      // to the push activity, it is related to blobs marked for delete that can be safely removed after some delay has passed.
-      } catch (Exception e) {
-        isSuccess = false;
-        int attempts = attempt.incrementAndGet();
-
-        log.warn("Blob file delete task failed."
-                +" attempt=" + attempts +  " sharedBlobName=" + this.sharedBlobName + " numOfBlobs=" + this.blobNames.size(), e);
-
-        if (attempts < MAX_DELETE_ATTEMPTS) {
-          // We failed, but we'll try again. Enqueue the task for a new delete attempt. attempt already increased.
-          // Note this execute call accepts the
-          try {
-            // Some delay before retry... (could move this delay to before trying to delete a file that previously
-            // failed to be deleted, that way if the queue is busy and it took time to retry, we don't add an additional
-            // delay on top of that. On the other hand, an exception here could be an issue with the Blob store
-            // itself and nothing specific to the file at hand, so slowing all delete attempts for all files might
-            // make sense. Splunk will eventually tell us... or not.
-            Thread.sleep(SLEEP_MS_FAILED_ATTEMPT);
-          } catch (InterruptedException ie) {
-            Thread.currentThread().interrupt();
-          }
-          // This can throw an exception if the pool is shutting down.
-          executor.execute(this);
-        }
-      } finally {
-        long now = System.nanoTime();
-        long runTime = now - startTimeMs;
-        long startLatency = now - this.queuedTimeMs;
-        String message = String.format(Locale.ROOT,
-               "sharedBlobName=%s action=DELETE storageProvider=%s bucketRegion=%s bucketName=%s "
-                      + "runTime=%s startLatency=%s attempt=%s filesAffected=%s isSuccess=%s",
-                      sharedBlobName, client.getStorageProvider().name(), client.getBucketRegion(),
-                      client.getBucketName(), runTime, startLatency, attempt.get(), this.blobNames.size(), isSuccess);
-        log.info(message);
+      filesDeleted.addAll(doDelete());
+      attempt.incrementAndGet();
+      return new BlobDeleterTaskResult(this, filesDeleted, isSuccess, shouldRetry, err);
+    } catch (Exception ex) {
+      if (err == null) {
+        err = ex;
+      } else {
+        err.addSuppressed(ex);
       }
+      int attempts = attempt.incrementAndGet();
+      isSuccess = false;
+      log.warn("BlobDeleterTask failed on attempt=" + attempts  + " collection=" + collectionName
+          + " task=" + toString(), ex);
+      if (allowRetry) {
+        if (attempts < maxAttempts) {
+          shouldRetry = true;
+        } else {
+          log.warn("Reached " + maxAttempts + " attempt limit for deletion task " + toString() + 
+              ". This task won't be retried.");
+        }
+      }
+    } finally {
+      long now = System.nanoTime();
+      long runTime = now - startTimeMs;
+      long startLatency = now - this.queuedTimeMs;
+      log(getActionName(), collectionName, runTime, startLatency, isSuccess, getAdditionalLogMessage());
+    }
+    return new BlobDeleterTaskResult(this, filesDeleted, isSuccess, shouldRetry, err);
+  }
+  
+  /**
+   * Override-able by deletion tasks to provide additional action specific logging
+   */
+  public String getAdditionalLogMessage() {
+    return "";
+  }
+  
+  @Override
+  public String toString() {
+    return "collectionName=" + collectionName + " allowRetry=" + allowRetry + 
+        " queuedTimeMs=" + queuedTimeMs + " attemptsTried=" + attempt.get();
+  }
+  
+  public int getAttempts() {
+    return attempt.get();
+  }
+
+  public void log(String action, String collectionName, long runTime, long startLatency, boolean isSuccess, 
+      String additionalMessage) {
+    String message = String.format(Locale.ROOT, 
+        "action=%s storageProvider=%s bucketRegion=%s bucketName=%s, runTime=%s "
+        + "startLatency=%s attempt=%s isSuccess=%s %s",
+        action, client.getStorageProvider().name(), client.getBucketRegion(), client.getBucketName(),
+        runTime, startLatency, attempt.get(), isSuccess, additionalMessage);
+    log.info(message);
+  }
+  
+  /**
+   * Represents the result of a deletion task
+   */
+  public static class BlobDeleterTaskResult {
+    private final BlobDeleterTask task;
+    private final Collection<String> filesDeleted;
+    private final boolean isSuccess;
+    private final boolean shouldRetry;
+    private final Throwable err;
+    
+    public BlobDeleterTaskResult(BlobDeleterTask task, Collection<String> filesDeleted, 
+        boolean isSuccess, boolean shouldRetry, Throwable errs) {
+      this.task = task;
+      this.filesDeleted = filesDeleted;
+      this.isSuccess = isSuccess;
+      this.shouldRetry = shouldRetry;
+      this.err = errs;
+    }
+    
+    public boolean isSuccess() {
+      return isSuccess;
+    }
+    
+    public boolean shouldRetry() {
+      return shouldRetry;
+    }
+    
+    public BlobDeleterTask getTask() {
+      return task;
+    }
+    
+    /**
+     * @return the files that are being deleted. Note if the task wasn't successful there is no gaurantee
+     * all of these files were in fact deleted from shared storage
+     */
+    public Collection<String> getFilesDeleted() {
+      return filesDeleted;
+    }
+    
+    public Throwable getError() {
+      return err;
+    }
+  }
+  
+  /**
+   * A BlobDeleterTask that deletes a given set of blob files from shared store
+   */
+  public static class BlobFileDeletionTask extends BlobDeleterTask {
+    private final CoreStorageClient client;
+    private final Set<String> blobNames;
+    
+    /**
+     * Constructor for BlobDeleterTask that deletes a given set of blob files from shared store
+     */
+    public BlobFileDeletionTask(CoreStorageClient client, String collectionName, Set<String> blobNames, boolean allowRetry,
+        int maxRetryAttempt) {
+      super(client, collectionName, allowRetry, maxRetryAttempt);
+      this.blobNames = blobNames;
+      this.client = client;
+    }
+
+    @Override
+    public Collection<String> doDelete() throws Exception {
+      client.deleteBlobs(blobNames);
+      return blobNames;
+    }
+
+    @Override
+    public String getActionName() {
+      return "DELETE";
+    }
+    
+    @Override 
+    public String getAdditionalLogMessage() {
+      return "filesAffected=" + blobNames.size();
+    }
+    
+    @Override
+    public String toString() {
+      return "BlobFileDeletionTask action=" + getActionName() + " totalFilesSpecified=" + blobNames.size() + 
+          " " + super.toString();
+    }
+  }
+  
+  /**
+   * A BlobDeleterTask that deletes all files from shared storage with the given string prefix 
+   */
+  public static class BlobPrefixedFileDeletionTask extends BlobDeleterTask {
+    private final CoreStorageClient client;
+    private final String prefix;
+    
+    private int affectedFiles = 0;
+    
+    /**
+     * Constructor for BlobDeleterTask that deletes all files from shared storage with the given string prefix 
+     */
+    public BlobPrefixedFileDeletionTask(CoreStorageClient client, String collectionName, String prefix, boolean allowRetry,
+        int maxRetryAttempt) {
+      super(client, collectionName, allowRetry, maxRetryAttempt);
+      this.prefix = prefix;
+      this.client = client;
+    }
+
+    @Override
+    public List<String> doDelete() throws Exception {
+      List<String> allFiles = client.listCoreBlobFiles(prefix);
+      affectedFiles = allFiles.size();
+      client.deleteBlobs(allFiles);
+      return allFiles;
+    }
+
+    @Override
+    public String getActionName() {
+      return "DELETE_FILES_PREFIXED";
+    }
+    
+    @Override 
+    public String getAdditionalLogMessage() {
+      return "filesAffected=" + affectedFiles;
+    }
+    
+    @Override
+    public String toString() {
+      return "BlobCollectionDeletionTask action=" + getActionName() + " " + super.toString();
+    }
   }
 }

--- a/solr/core/src/java/org/apache/solr/store/shared/SharedStoreManager.java
+++ b/solr/core/src/java/org/apache/solr/store/shared/SharedStoreManager.java
@@ -84,9 +84,6 @@ public class SharedStoreManager {
     return blobStorageProvider;
   }
   
-  /*
-   * Initiates a BlobDeleteManager if it doesn't exist and returns one 
-   */
   public BlobDeleteManager getBlobDeleteManager() {
     if (blobDeleteManager != null) {
       return blobDeleteManager;
@@ -122,6 +119,14 @@ public class SharedStoreManager {
   @VisibleForTesting
   public void initConcurrencyController(SharedCoreConcurrencyController concurrencyController) {
     this.sharedCoreConcurrencyController = concurrencyController;
+  }
+  
+  @VisibleForTesting
+  public void initBlobDeleteManager(BlobDeleteManager blobDeleteManager) {
+    if (this.blobDeleteManager != null) {
+      blobDeleteManager.shutdown();
+    }
+    this.blobDeleteManager = blobDeleteManager;
   }
 
 }

--- a/solr/core/src/test/org/apache/solr/store/blob/client/CoreStorageClientTest.java
+++ b/solr/core/src/test/org/apache/solr/store/blob/client/CoreStorageClientTest.java
@@ -24,6 +24,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Collection;
+import java.util.LinkedList;
 import java.util.List;
 
 import org.apache.commons.io.FileUtils;
@@ -86,6 +87,22 @@ public class CoreStorageClientTest extends SolrTestCaseJ4 {
     // core name length + uuid4 length + 1 for delimiter + 4 for the "xxx." prepended
     int expectedBlobKeyLength = TEST_CORE_NAME_1.length() + uuid4length + 1 + 4;
     Assert.assertEquals(blobPath.length(), expectedBlobKeyLength);
+  }
+  
+  @Test
+  public void testListBlobFiles() throws Exception {
+    List<String> expectedPaths = new LinkedList<>();
+    expectedPaths.add(
+        blobClient.pushStream(TEST_CORE_NAME_1, new ByteArrayInputStream(EMPTY_BYTES_ARR), EMPTY_BYTES_ARR.length, "xxx"));
+    expectedPaths.add(
+        blobClient.pushStream(TEST_CORE_NAME_1, new ByteArrayInputStream(EMPTY_BYTES_ARR), EMPTY_BYTES_ARR.length, "yyy"));
+    expectedPaths.add(
+        blobClient.pushStream(TEST_CORE_NAME_2, new ByteArrayInputStream(EMPTY_BYTES_ARR), EMPTY_BYTES_ARR.length, "zzzz"));
+    expectedPaths.add(
+        blobClient.pushStream(TEST_CORE_NAME_2, new ByteArrayInputStream(EMPTY_BYTES_ARR), EMPTY_BYTES_ARR.length, "1234"));
+    // the common prefix is s_test_core_name for these blob files
+    List<String> blobFiles = blobClient.listCoreBlobFiles("s_test_core_name");
+    Assert.assertTrue(blobFiles.containsAll(expectedPaths));
   }
     
   @Test

--- a/solr/core/src/test/org/apache/solr/store/blob/client/CoreStorageClientTest.java
+++ b/solr/core/src/test/org/apache/solr/store/blob/client/CoreStorageClientTest.java
@@ -102,7 +102,7 @@ public class CoreStorageClientTest extends SolrTestCaseJ4 {
         blobClient.pushStream(TEST_CORE_NAME_2, new ByteArrayInputStream(EMPTY_BYTES_ARR), EMPTY_BYTES_ARR.length, "1234"));
     // the common prefix is s_test_core_name for these blob files
     List<String> blobFiles = blobClient.listCoreBlobFiles("s_test_core_name");
-    Assert.assertTrue(blobFiles.containsAll(expectedPaths));
+    Assert.assertTrue(blobFiles.toString(), blobFiles.containsAll(expectedPaths));
   }
     
   @Test

--- a/solr/core/src/test/org/apache/solr/store/blob/client/CoreStorageClientTest.java
+++ b/solr/core/src/test/org/apache/solr/store/blob/client/CoreStorageClientTest.java
@@ -101,8 +101,10 @@ public class CoreStorageClientTest extends SolrTestCaseJ4 {
         blobClient.pushStream(TEST_CORE_NAME_2, new ByteArrayInputStream(EMPTY_BYTES_ARR), EMPTY_BYTES_ARR.length, "zzzz"));
     expectedPaths.add(
         blobClient.pushStream(TEST_CORE_NAME_2, new ByteArrayInputStream(EMPTY_BYTES_ARR), EMPTY_BYTES_ARR.length, "1234"));
+    blobClient.pushStream("s_test_core_nomatch", new ByteArrayInputStream(EMPTY_BYTES_ARR), EMPTY_BYTES_ARR.length, "1234");
     // the common prefix is s_test_core_name for these blob files
     List<String> blobFiles = blobClient.listCoreBlobFiles("s_test_core_name");
+    Assert.assertEquals(expectedPaths.size(), blobFiles.size());
     Assert.assertTrue(blobFiles.toString(), blobFiles.containsAll(expectedPaths));
   }
     

--- a/solr/core/src/test/org/apache/solr/store/blob/process/BlobDeleteProcessorTest.java
+++ b/solr/core/src/test/org/apache/solr/store/blob/process/BlobDeleteProcessorTest.java
@@ -87,24 +87,23 @@ public class BlobDeleteProcessorTest extends SolrTestCaseJ4 {
     int retryDelay = 500; 
     String name = "testName";
     
-    BlobDeleteProcessor processor = buildBlobDeleteProcessorForTest(enqueuedTasks, blobClient,
-        maxQueueSize, numThreads, defaultMaxAttempts, retryDelay);
-    Set<String> names = new HashSet<>();
-    names.add("test1");
-    names.add("test2");
-    // uses the specified defaultMaxAttempts at the processor (not task) level 
-    CompletableFuture<BlobDeleterTaskResult> cf = processor.deleteFiles(name, names, true);
-    // wait for this task and all its potential retries to finish
-    BlobDeleterTaskResult res = cf.get(5000, TimeUnit.MILLISECONDS);
-    assertEquals(1, enqueuedTasks.size());
-    
-    assertEquals(1, enqueuedTasks.size());
-    assertNotNull(res);
-    assertEquals(1, res.getTask().getAttempts());
-    assertEquals(true, res.isSuccess());
-    assertEquals(false, res.shouldRetry());
-    
-    processor.shutdown();
+    try (BlobDeleteProcessor processor = buildBlobDeleteProcessorForTest(enqueuedTasks, blobClient,
+        maxQueueSize, numThreads, defaultMaxAttempts, retryDelay)) {
+      Set<String> names = new HashSet<>();
+      names.add("test1");
+      names.add("test2");
+      // uses the specified defaultMaxAttempts at the processor (not task) level 
+      CompletableFuture<BlobDeleterTaskResult> cf = processor.deleteFiles(name, names, true);
+      // wait for this task and all its potential retries to finish
+      BlobDeleterTaskResult res = cf.get(5000, TimeUnit.MILLISECONDS);
+      assertEquals(1, enqueuedTasks.size());
+      
+      assertEquals(1, enqueuedTasks.size());
+      assertNotNull(res);
+      assertEquals(1, res.getTask().getAttempts());
+      assertEquals(true, res.isSuccess());
+      assertEquals(false, res.shouldRetry());
+    }
   }
   
   /**
@@ -120,21 +119,20 @@ public class BlobDeleteProcessorTest extends SolrTestCaseJ4 {
     int retryDelay = 500; 
     String name = "testName";
     
-    BlobDeleteProcessor processor = buildBlobDeleteProcessorForTest(enqueuedTasks, blobClient,
-        maxQueueSize, numThreads, defaultMaxAttempts, retryDelay);
-    // uses the specified defaultMaxAttempts at the processor (not task) level 
-    CompletableFuture<BlobDeleterTaskResult> cf = processor.deleteCollection(name, true);
-    // wait for this task and all its potential retries to finish
-    BlobDeleterTaskResult res = cf.get(5000, TimeUnit.MILLISECONDS);
-    assertEquals(1, enqueuedTasks.size());
-    
-    assertEquals(1, enqueuedTasks.size());
-    assertNotNull(res);
-    assertEquals(1, res.getTask().getAttempts());
-    assertEquals(true, res.isSuccess());
-    assertEquals(false, res.shouldRetry());
-    
-    processor.shutdown();
+    try (BlobDeleteProcessor processor = buildBlobDeleteProcessorForTest(enqueuedTasks, blobClient,
+        maxQueueSize, numThreads, defaultMaxAttempts, retryDelay)) {
+      // uses the specified defaultMaxAttempts at the processor (not task) level 
+      CompletableFuture<BlobDeleterTaskResult> cf = processor.deleteCollection(name, true);
+      // wait for this task and all its potential retries to finish
+      BlobDeleterTaskResult res = cf.get(5000, TimeUnit.MILLISECONDS);
+      assertEquals(1, enqueuedTasks.size());
+      
+      assertEquals(1, enqueuedTasks.size());
+      assertNotNull(res);
+      assertEquals(1, res.getTask().getAttempts());
+      assertEquals(true, res.isSuccess());
+      assertEquals(false, res.shouldRetry());
+    }
   }
   
   /**
@@ -150,21 +148,20 @@ public class BlobDeleteProcessorTest extends SolrTestCaseJ4 {
     int retryDelay = 500; 
     String name = "testName";
     
-    BlobDeleteProcessor processor = buildBlobDeleteProcessorForTest(enqueuedTasks, blobClient,
-        maxQueueSize, numThreads, defaultMaxAttempts, retryDelay);
-    // uses the specified defaultMaxAttempts at the processor (not task) level 
-    CompletableFuture<BlobDeleterTaskResult> cf = processor.deleteShard(name, name, true);
-    // wait for this task and all its potential retries to finish
-    BlobDeleterTaskResult res = cf.get(5000, TimeUnit.MILLISECONDS);
-    assertEquals(1, enqueuedTasks.size());
-    
-    assertEquals(1, enqueuedTasks.size());
-    assertNotNull(res);
-    assertEquals(1, res.getTask().getAttempts());
-    assertEquals(true, res.isSuccess());
-    assertEquals(false, res.shouldRetry());
-    
-    processor.shutdown();
+    try (BlobDeleteProcessor processor = buildBlobDeleteProcessorForTest(enqueuedTasks, blobClient,
+        maxQueueSize, numThreads, defaultMaxAttempts, retryDelay)) {
+      // uses the specified defaultMaxAttempts at the processor (not task) level 
+      CompletableFuture<BlobDeleterTaskResult> cf = processor.deleteShard(name, name, true);
+      // wait for this task and all its potential retries to finish
+      BlobDeleterTaskResult res = cf.get(5000, TimeUnit.MILLISECONDS);
+      assertEquals(1, enqueuedTasks.size());
+      
+      assertEquals(1, enqueuedTasks.size());
+      assertNotNull(res);
+      assertEquals(1, res.getTask().getAttempts());
+      assertEquals(true, res.isSuccess());
+      assertEquals(false, res.shouldRetry());
+    }
   }
   
   /**
@@ -182,27 +179,25 @@ public class BlobDeleteProcessorTest extends SolrTestCaseJ4 {
     String name = "testName";
     boolean isRetry = false;
     
-    BlobDeleteProcessor processor = buildBlobDeleteProcessorForTest(enqueuedTasks, blobClient,
-        maxQueueSize, numThreads, defaultMaxAttempts, retryDelay);
-    
-    // enqueue a task that fails and is not retryable
-    CompletableFuture<BlobDeleterTaskResult> cf = 
-        processor.enqueue(buildFailingTaskForTest(blobClient, name, totalAttempts, false), isRetry);
-    // wait for this task and all its potential retries to finish
-    BlobDeleterTaskResult res = cf.get(5000, TimeUnit.MILLISECONDS);
-    
-    // the first fails
-    assertEquals(1, enqueuedTasks.size());
-    assertNotNull(res);
-    assertEquals(1, res.getTask().getAttempts());
-    assertEquals(false, res.isSuccess());
-    assertEquals(false, res.shouldRetry());
-
-    // initial error + 0 retry errors suppressed
-    assertNotNull(res.getError());
-    assertEquals(0, res.getError().getSuppressed().length);
-    
-    processor.shutdown();
+    try (BlobDeleteProcessor processor = buildBlobDeleteProcessorForTest(enqueuedTasks, blobClient,
+        maxQueueSize, numThreads, defaultMaxAttempts, retryDelay)) {
+      // enqueue a task that fails and is not retryable
+      CompletableFuture<BlobDeleterTaskResult> cf = 
+          processor.enqueue(buildFailingTaskForTest(blobClient, name, totalAttempts, false), isRetry);
+      // wait for this task and all its potential retries to finish
+      BlobDeleterTaskResult res = cf.get(5000, TimeUnit.MILLISECONDS);
+      
+      // the first fails
+      assertEquals(1, enqueuedTasks.size());
+      assertNotNull(res);
+      assertEquals(1, res.getTask().getAttempts());
+      assertEquals(false, res.isSuccess());
+      assertEquals(false, res.shouldRetry());
+  
+      // initial error + 0 retry errors suppressed
+      assertNotNull(res.getError());
+      assertEquals(0, res.getError().getSuppressed().length);
+    }
   }
   
   /**
@@ -221,28 +216,26 @@ public class BlobDeleteProcessorTest extends SolrTestCaseJ4 {
     String name = "testName";
     boolean isRetry = false;
     
-    BlobDeleteProcessor processor = buildBlobDeleteProcessorForTest(enqueuedTasks, blobClient,
-        maxQueueSize, numThreads, defaultMaxAttempts, retryDelay);
-  
-    // enqueue a task that fails totalFails number of times before succeeding
-    CompletableFuture<BlobDeleterTaskResult> cf = 
-        processor.enqueue(buildScheduledFailingTaskForTest(blobClient, name, totalAttempts, true, totalFails), isRetry);
-    
-    // wait for this task and all its potential retries to finish
-    BlobDeleterTaskResult res = cf.get(5000, TimeUnit.MILLISECONDS);
-    
-    // the first 3 fail and last one succeeds
-    assertEquals(4, enqueuedTasks.size());
-    
-    assertNotNull(res);
-    assertEquals(4, res.getTask().getAttempts());
-    assertEquals(true, res.isSuccess());
-    
-    // initial error + 2 retry errors suppressed
-    assertNotNull(res.getError());
-    assertEquals(2, res.getError().getSuppressed().length);
-  
-    processor.shutdown();
+    try (BlobDeleteProcessor processor = buildBlobDeleteProcessorForTest(enqueuedTasks, blobClient,
+        maxQueueSize, numThreads, defaultMaxAttempts, retryDelay)) {
+      // enqueue a task that fails totalFails number of times before succeeding
+      CompletableFuture<BlobDeleterTaskResult> cf = 
+          processor.enqueue(buildScheduledFailingTaskForTest(blobClient, name, totalAttempts, true, totalFails), isRetry);
+      
+      // wait for this task and all its potential retries to finish
+      BlobDeleterTaskResult res = cf.get(5000, TimeUnit.MILLISECONDS);
+      
+      // the first 3 fail and last one succeeds
+      assertEquals(4, enqueuedTasks.size());
+      
+      assertNotNull(res);
+      assertEquals(4, res.getTask().getAttempts());
+      assertEquals(true, res.isSuccess());
+      
+      // initial error + 2 retry errors suppressed
+      assertNotNull(res.getError());
+      assertEquals(2, res.getError().getSuppressed().length);
+    }
   }
   
   /**
@@ -259,28 +252,27 @@ public class BlobDeleteProcessorTest extends SolrTestCaseJ4 {
     String name = "testName";
     boolean isRetry = false;
     
-    BlobDeleteProcessor processor = buildBlobDeleteProcessorForTest(enqueuedTasks, blobClient,
-        maxQueueSize, numThreads, defaultMaxAttempts, retryDelay);
-    // enqueue a task that fails every time it runs but is configured to retry
-    CompletableFuture<BlobDeleterTaskResult> cf = 
-        processor.enqueue(buildFailingTaskForTest(blobClient, name, totalAttempts, true), isRetry);
-    
-    // wait for this task and all its potential retries to finish 
-    BlobDeleterTaskResult res = cf.get(5000, TimeUnit.MILLISECONDS);
-    // 1 initial enqueue + 4 retries
-    assertEquals(5, enqueuedTasks.size());
-    
-    assertNotNull(res);
-    assertEquals(5, res.getTask().getAttempts());
-    assertEquals(false, res.isSuccess());
-    // circuit breaker should be false after all attempts are exceeded
-    assertEquals(false, res.shouldRetry());
-    
-    // initial error + 4 retry errors suppressed
-    assertNotNull(res.getError());
-    assertEquals(4, res.getError().getSuppressed().length);
-    
-    processor.shutdown();
+    try (BlobDeleteProcessor processor = buildBlobDeleteProcessorForTest(enqueuedTasks, blobClient,
+        maxQueueSize, numThreads, defaultMaxAttempts, retryDelay)) {
+      // enqueue a task that fails every time it runs but is configured to retry
+      CompletableFuture<BlobDeleterTaskResult> cf = 
+          processor.enqueue(buildFailingTaskForTest(blobClient, name, totalAttempts, true), isRetry);
+      
+      // wait for this task and all its potential retries to finish 
+      BlobDeleterTaskResult res = cf.get(5000, TimeUnit.MILLISECONDS);
+      // 1 initial enqueue + 4 retries
+      assertEquals(5, enqueuedTasks.size());
+      
+      assertNotNull(res);
+      assertEquals(5, res.getTask().getAttempts());
+      assertEquals(false, res.isSuccess());
+      // circuit breaker should be false after all attempts are exceeded
+      assertEquals(false, res.shouldRetry());
+      
+      // initial error + 4 retry errors suppressed
+      assertNotNull(res.getError());
+      assertEquals(4, res.getError().getSuppressed().length);
+    }
   }
   
   /**
@@ -297,41 +289,41 @@ public class BlobDeleteProcessorTest extends SolrTestCaseJ4 {
     String name = "testName";
     boolean allowRetry = false;
     
-    BlobDeleteProcessor processor = buildBlobDeleteProcessorForTest(enqueuedTasks, blobClient,
-        maxQueueSize, numThreads, defaultMaxAttempts, retryDelay);
-    // numThreads is 1 and we'll enqueue a blocking task that ensures our pool
-    // will be occupied while we add new tasks subsequently to test enqueue rejection
-    CountDownLatch tasklatch = new CountDownLatch(1);
-    processor.enqueue(buildBlockingTaskForTest(tasklatch), allowRetry);
-
-    // Fill the internal work queue beyond the maxQueueSize, the internal queue size is not 
-    // approximate so we'll just add beyond the max
-    for (int i = 0; i < maxQueueSize*2; i++) {
+    try (BlobDeleteProcessor processor = buildBlobDeleteProcessorForTest(enqueuedTasks, blobClient,
+        maxQueueSize, numThreads, defaultMaxAttempts, retryDelay)) {
+      // numThreads is 1 and we'll enqueue a blocking task that ensures our pool
+      // will be occupied while we add new tasks subsequently to test enqueue rejection
+      CountDownLatch tasklatch = new CountDownLatch(1);
+      processor.enqueue(buildBlockingTaskForTest(tasklatch), allowRetry);
+  
+      // Fill the internal work queue beyond the maxQueueSize, the internal queue size is not 
+      // approximate so we'll just add beyond the max
+      for (int i = 0; i < maxQueueSize*2; i++) {
+        try {
+          processor.deleteCollection(name, allowRetry);
+        } catch (Exception ex) {
+          // ignore
+        }
+      }
+      
+      // verify adding a new task is rejected
       try {
         processor.deleteCollection(name, allowRetry);
+        fail("Task should have been rejected");
       } catch (Exception ex) {
-        // ignore
+        assertTrue(ex.getMessage().contains("Unable to enqueue deletion"));
       }
+      CompletableFuture<BlobDeleterTaskResult> cf = null;
+      try {
+        // verify adding a task that is marked as a retry is not rejected 
+         cf = processor.enqueue(buildFailingTaskForTest(blobClient, name, 5, true), /* isRetry */ true);
+      } catch (Exception ex) {
+        fail("Task should not have been rejected");
+      }
+      
+      // clean up and unblock the task
+      tasklatch.countDown();
     }
-    
-    // verify adding a new task is rejected
-    try {
-      processor.deleteCollection(name, allowRetry);
-      fail("Task should have been rejected");
-    } catch (Exception ex) {
-      assertTrue(ex.getMessage().contains("Unable to enqueue deletion"));
-    }
-    CompletableFuture<BlobDeleterTaskResult> cf = null;
-    try {
-      // verify adding a task that is marked as a retry is not rejected 
-       cf = processor.enqueue(buildFailingTaskForTest(blobClient, name, 5, true), /* isRetry */ true);
-    } catch (Exception ex) {
-      fail("Task should not have been rejected");
-    }
-    
-    // clean up and unblock the task
-    tasklatch.countDown();
-    processor.shutdown();
   }
   
   /**
@@ -346,37 +338,36 @@ public class BlobDeleteProcessorTest extends SolrTestCaseJ4 {
     int retryDelay = 100;
     int numberOfTasks = 200;
     
-    BlobDeleteProcessor processor = buildBlobDeleteProcessorForTest(enqueuedTasks, blobClient,
-        maxQueueSize, numThreads, defaultMaxAttempts, retryDelay);
-    List<BlobDeleterTask> tasks = generateRandomTasks(defaultMaxAttempts, numberOfTasks);
-    List<CompletableFuture<BlobDeleterTaskResult>> taskResultsFutures = new LinkedList<>();
-    List<BlobDeleterTaskResult> results = new LinkedList<>();
-    for (BlobDeleterTask t : tasks) {
-      taskResultsFutures.add(processor.enqueue(t, false));
-    }
-    
-    taskResultsFutures.forEach(cf -> {
-      try {
-        results.add(cf.get(20000, TimeUnit.MILLISECONDS));
-      } catch (Exception ex) {
-        fail("We timed out on some task!");
+    try (BlobDeleteProcessor processor = buildBlobDeleteProcessorForTest(enqueuedTasks, blobClient,
+        maxQueueSize, numThreads, defaultMaxAttempts, retryDelay)) {
+      List<BlobDeleterTask> tasks = generateRandomTasks(defaultMaxAttempts, numberOfTasks);
+      List<CompletableFuture<BlobDeleterTaskResult>> taskResultsFutures = new LinkedList<>();
+      List<BlobDeleterTaskResult> results = new LinkedList<>();
+      for (BlobDeleterTask t : tasks) {
+        taskResultsFutures.add(processor.enqueue(t, false));
       }
-    });
-    
-    // we shouldn't enqueue more than (numberOfTasks * defaultMaxAttempts) tasks to the pool 
-    assertTrue(enqueuedTasks.size() < (numberOfTasks * defaultMaxAttempts));
-    assertEquals(numberOfTasks, results.size());
-    int totalAttempts = 0;
-    for (BlobDeleterTaskResult res : results) {
-      assertNotNull(res);
-      assertNotNull(res.getTask());
-      assertEquals("scheduledFailingTask", res.getTask().getActionName());
-      totalAttempts += res.getTask().getAttempts();
-    }
-    // total task attempts should be consistent with our test scaffolding
-    assertTrue(totalAttempts < (numberOfTasks * defaultMaxAttempts));
       
-    processor.shutdown();
+      taskResultsFutures.forEach(cf -> {
+        try {
+          results.add(cf.get(20000, TimeUnit.MILLISECONDS));
+        } catch (Exception ex) {
+          fail("We timed out on some task!");
+        }
+      });
+      
+      // we shouldn't enqueue more than (numberOfTasks * defaultMaxAttempts) tasks to the pool 
+      assertTrue(enqueuedTasks.size() < (numberOfTasks * defaultMaxAttempts));
+      assertEquals(numberOfTasks, results.size());
+      int totalAttempts = 0;
+      for (BlobDeleterTaskResult res : results) {
+        assertNotNull(res);
+        assertNotNull(res.getTask());
+        assertEquals("scheduledFailingTask", res.getTask().getActionName());
+        totalAttempts += res.getTask().getAttempts();
+      }
+      // total task attempts should be consistent with our test scaffolding
+      assertTrue(totalAttempts < (numberOfTasks * defaultMaxAttempts));
+    }
   }
   
   private List<BlobDeleterTask> generateRandomTasks(int defaultMaxAttempts, int taskCount) {

--- a/solr/core/src/test/org/apache/solr/store/blob/process/BlobDeleteProcessorTest.java
+++ b/solr/core/src/test/org/apache/solr/store/blob/process/BlobDeleteProcessorTest.java
@@ -1,0 +1,472 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.store.blob.process;
+
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.store.blob.client.BlobException;
+import org.apache.solr.store.blob.client.CoreStorageClient;
+import org.apache.solr.store.blob.client.LocalStorageClient;
+import org.apache.solr.store.blob.process.BlobDeleterTask.BlobDeleterTaskResult;
+import org.apache.solr.store.blob.process.BlobDeleterTask.BlobFileDeletionTask;
+import org.apache.solr.store.blob.process.BlobDeleterTask.BlobPrefixedFileDeletionTask;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link BlobDeleteProcessor}
+ */
+public class BlobDeleteProcessorTest extends SolrTestCaseJ4 {
+  
+  private static String DEFAULT_PROCESSOR_NAME = "DeleterForTest";
+  private static Path sharedStoreRootPath;
+  private static CoreStorageClient blobClient;
+  
+  private static List<BlobDeleterTask> enqueuedTasks;
+
+  @BeforeClass
+  public static void setupTestClass() throws Exception {
+    sharedStoreRootPath = createTempDir("tempDir");
+    System.setProperty(LocalStorageClient.BLOB_STORE_LOCAL_FS_ROOT_DIR_PROPERTY, sharedStoreRootPath.resolve("LocalBlobStore/").toString());
+    blobClient = new LocalStorageClient() {
+       
+      // no ops for BlobFileDeletionTask and BlobPrefixedFileDeletionTask to execute successfully
+      @Override
+      public void deleteBlobs(Collection<String> paths) throws BlobException {
+        return;
+      }
+
+      // no ops for BlobFileDeletionTask and BlobPrefixedFileDeletionTask to execute successfully
+      @Override
+      public List<String> listCoreBlobFiles(String prefix) throws BlobException {
+        return new LinkedList<>();
+      }
+    };
+  }
+  
+  @Before
+  public void setup() {
+    enqueuedTasks = new LinkedList<BlobDeleterTask>();
+  }
+  
+  /**
+   * Verify we enqueue a {@link BlobFileDeletionTask} with the correct parameters.
+   * Note we're not testing the functionality of the deletion task here only that the processor successfully
+   * handles the task. End to end blob deletion tests can be found {@link SharedStoreDeletionProcessTest} 
+   */
+  @Test
+  public void testDeleteFilesEnqueueTask() throws Exception {
+    int maxQueueSize = 3;
+    int numThreads = 1;
+    int defaultMaxAttempts = 5;
+    int retryDelay = 500; 
+    String name = "testName";
+    
+    BlobDeleteProcessor processor = buildBlobDeleteProcessorForTest(enqueuedTasks, blobClient,
+        maxQueueSize, numThreads, defaultMaxAttempts, retryDelay);
+    Set<String> names = new HashSet<>();
+    names.add("test1");
+    names.add("test2");
+    // uses the specified defaultMaxAttempts at the processor (not task) level 
+    CompletableFuture<BlobDeleterTaskResult> cf = processor.deleteFiles(name, names, true);
+    // wait for this task and all its potential retries to finish
+    BlobDeleterTaskResult res = cf.get(5000, TimeUnit.MILLISECONDS);
+    assertEquals(1, enqueuedTasks.size());
+    
+    assertEquals(1, enqueuedTasks.size());
+    assertNotNull(res);
+    assertEquals(1, res.getTask().getAttempts());
+    assertEquals(true, res.isSuccess());
+    assertEquals(false, res.shouldRetry());
+    
+    processor.shutdown();
+  }
+  
+  /**
+   * Verify we enqueue a {@link BlobPrefixedFileDeletionTask} with the correct parameters.
+   * Note we're not testing the functionality of the deletion task here only that the processor successfully
+   * handles the task. End to end blob deletion tests can be found {@link SharedStoreDeletionProcessTest} 
+   */
+  @Test
+  public void testDeleteShardEnqueueTask() throws Exception {
+    int maxQueueSize = 3;
+    int numThreads = 1;
+    int defaultMaxAttempts = 5;
+    int retryDelay = 500; 
+    String name = "testName";
+    
+    BlobDeleteProcessor processor = buildBlobDeleteProcessorForTest(enqueuedTasks, blobClient,
+        maxQueueSize, numThreads, defaultMaxAttempts, retryDelay);
+    // uses the specified defaultMaxAttempts at the processor (not task) level 
+    CompletableFuture<BlobDeleterTaskResult> cf = processor.deleteCollection(name, true);
+    // wait for this task and all its potential retries to finish
+    BlobDeleterTaskResult res = cf.get(5000, TimeUnit.MILLISECONDS);
+    assertEquals(1, enqueuedTasks.size());
+    
+    assertEquals(1, enqueuedTasks.size());
+    assertNotNull(res);
+    assertEquals(1, res.getTask().getAttempts());
+    assertEquals(true, res.isSuccess());
+    assertEquals(false, res.shouldRetry());
+    
+    processor.shutdown();
+  }
+  
+  /**
+   * Verify we enqueue a {@link BlobPrefixedFileDeletionTask} with the correct parameters.
+   * Note we're not testing the functionality of the deletion task here only that the processor successfully
+   * handles the task. End to end blob deletion tests can be found {@link SharedStoreDeletionProcessTest} 
+   */
+  @Test
+  public void testDeleteCollectionEnqueueTask() throws Exception {
+    int maxQueueSize = 3;
+    int numThreads = 1;
+    int defaultMaxAttempts = 5;
+    int retryDelay = 500; 
+    String name = "testName";
+    
+    BlobDeleteProcessor processor = buildBlobDeleteProcessorForTest(enqueuedTasks, blobClient,
+        maxQueueSize, numThreads, defaultMaxAttempts, retryDelay);
+    // uses the specified defaultMaxAttempts at the processor (not task) level 
+    CompletableFuture<BlobDeleterTaskResult> cf = processor.deleteShard(name, name, true);
+    // wait for this task and all its potential retries to finish
+    BlobDeleterTaskResult res = cf.get(5000, TimeUnit.MILLISECONDS);
+    assertEquals(1, enqueuedTasks.size());
+    
+    assertEquals(1, enqueuedTasks.size());
+    assertNotNull(res);
+    assertEquals(1, res.getTask().getAttempts());
+    assertEquals(true, res.isSuccess());
+    assertEquals(false, res.shouldRetry());
+    
+    processor.shutdown();
+  }
+  
+  /**
+   * Verify that we don't retry tasks that are not configured to be retried
+   * and end up failing
+   */
+  @Test
+  public void testNonRetryableTask() throws Exception {
+    int maxQueueSize = 3;
+    int numThreads = 1;
+    int defaultMaxAttempts = 1; // ignored when we build the test task
+    int retryDelay = 500;
+    int totalAttempts = 5; // total number of attempts the task should be tried 
+
+    String name = "testName";
+    boolean isRetry = false;
+    
+    BlobDeleteProcessor processor = buildBlobDeleteProcessorForTest(enqueuedTasks, blobClient,
+        maxQueueSize, numThreads, defaultMaxAttempts, retryDelay);
+    
+    // enqueue a task that fails and is not retryable
+    CompletableFuture<BlobDeleterTaskResult> cf = 
+        processor.enqueue(buildFailingTaskForTest(blobClient, name, totalAttempts, false), isRetry);
+    // wait for this task and all its potential retries to finish
+    BlobDeleterTaskResult res = cf.get(5000, TimeUnit.MILLISECONDS);
+    
+    // the first fails
+    assertEquals(1, enqueuedTasks.size());
+    assertNotNull(res);
+    assertEquals(1, res.getTask().getAttempts());
+    assertEquals(false, res.isSuccess());
+    assertEquals(false, res.shouldRetry());
+
+    // initial error + 0 retry errors suppressed
+    assertNotNull(res.getError());
+    assertEquals(0, res.getError().getSuppressed().length);
+    
+    processor.shutdown();
+  }
+  
+  /**
+   * Verify that the retry logic kicks in for tasks configured to retry
+   * and subsequent retry succeeds
+   */
+  @Test
+  public void testRetryableTaskSucceeds() throws Exception {
+    int maxQueueSize = 3;
+    int numThreads = 1;
+    int defaultMaxAttempts = 1; // ignored when we build the test task
+    int retryDelay = 500;
+    int totalAttempts = 5; // total number of attempts the task should be tried 
+    int totalFails = 3; // total number of times the task should fail
+    
+    String name = "testName";
+    boolean isRetry = false;
+    
+    BlobDeleteProcessor processor = buildBlobDeleteProcessorForTest(enqueuedTasks, blobClient,
+        maxQueueSize, numThreads, defaultMaxAttempts, retryDelay);
+    // enqueue a task that fails totalFails number of times before succeeding
+    CompletableFuture<BlobDeleterTaskResult> cf = 
+        processor.enqueue(buildScheduledFailingTaskForTest(blobClient, name, totalAttempts, true, totalFails), isRetry);
+    
+    // wait for this task and all its potential retries to finish
+    BlobDeleterTaskResult res = cf.get(5000, TimeUnit.MILLISECONDS);
+    
+    // the first 3 fail and last one succeeds
+    assertEquals(4, enqueuedTasks.size());
+    
+    assertNotNull(res);
+    assertEquals(4, res.getTask().getAttempts());
+    assertEquals(true, res.isSuccess());
+    
+    // initial error + 2 retry errors suppressed
+    assertNotNull(res.getError());
+    assertEquals(2, res.getError().getSuppressed().length);
+    
+    processor.shutdown();
+  }
+  
+  /**
+   * Verify that after all task attempts are exhausted we bail out
+   */
+  @Test
+  public void testRetryableTaskFails() throws Exception {
+    int maxQueueSize = 3;
+    int numThreads = 1;
+    int defaultMaxAttempts = 1; // ignored when we build the test task
+    int retryDelay = 500;
+    int totalAttempts = 5; // total number of attempts the task should be tried
+    
+    String name = "testName";
+    boolean isRetry = false;
+    
+    BlobDeleteProcessor processor = buildBlobDeleteProcessorForTest(enqueuedTasks, blobClient,
+        maxQueueSize, numThreads, defaultMaxAttempts, retryDelay);
+    // enqueue a task that fails every time it runs but is configured to retry
+    CompletableFuture<BlobDeleterTaskResult> cf = 
+        processor.enqueue(buildFailingTaskForTest(blobClient, name, totalAttempts, true), isRetry);
+    
+    // wait for this task and all its potential retries to finish 
+    BlobDeleterTaskResult res = cf.get(5000, TimeUnit.MILLISECONDS);
+    // 1 initial enqueue + 4 retries
+    assertEquals(5, enqueuedTasks.size());
+    
+    assertNotNull(res);
+    assertEquals(5, res.getTask().getAttempts());
+    assertEquals(false, res.isSuccess());
+    // circuit breaker should be false after all attempts are exceeded
+    assertEquals(false, res.shouldRetry());
+    
+    // initial error + 4 retry errors suppressed
+    assertNotNull(res.getError());
+    assertEquals(4, res.getError().getSuppressed().length);
+    
+    processor.shutdown();
+  }
+  
+  /**
+   * Verify that we cannot add more deletion tasks to the processor if the work queue
+   * is at its target max but that we can re-add tasks that are retries to the queue
+   */
+  @Test
+  public void testWorkQueueFull() throws Exception {
+    int maxQueueSize = 3;
+    int numThreads = 1;
+    int defaultMaxAttempts = 1;
+    int retryDelay = 1000;
+    
+    String name = "testName";
+    boolean allowRetry = false;
+    
+    BlobDeleteProcessor processor = buildBlobDeleteProcessorForTest(enqueuedTasks, blobClient,
+        maxQueueSize, numThreads, defaultMaxAttempts, retryDelay);
+    // numThreads is 1 and we'll enqueue a blocking task that ensures our pool
+    // will be occupied while we add new tasks subsequently to test enqueue rejection
+    CountDownLatch tasklatch = new CountDownLatch(1);
+    processor.enqueue(buildBlockingTaskForTest(tasklatch), allowRetry);
+
+    // Fill the internal work queue beyond the maxQueueSize, the internal queue size is not 
+    // approximate so we'll just add beyond the max
+    for (int i = 0; i < maxQueueSize*2; i++) {
+      try {
+        processor.deleteCollection(name, allowRetry);
+      } catch (Exception ex) {
+        // ignore
+      }
+    }
+    
+    // verify adding a new task is rejected
+    try {
+      processor.deleteCollection(name, allowRetry);
+      fail("Task should have been rejected");
+    } catch (Exception ex) {
+      assertTrue(ex.getMessage().contains("Unable to enqueue deletion"));
+    }
+    CompletableFuture<BlobDeleterTaskResult> cf = null;
+    try {
+      // verify adding a task that is marked as a retry is not rejected 
+       cf = processor.enqueue(buildFailingTaskForTest(blobClient, name, 5, true), /* isRetry */ true);
+    } catch (Exception ex) {
+      fail("Task should not have been rejected");
+    }
+    
+    // clean up and unblock the task
+    tasklatch.countDown();
+    processor.shutdown();
+  }
+  
+  /**
+   * Verify that with a continuous stream of delete tasks being enqueued, all eventually complete
+   * successfully in the face of failing tasks and retries without locking up our pool anywhere
+   */
+  @Test
+  public void testSimpleConcurrentDeletionEnqueues() throws Exception {
+    int maxQueueSize = 200;
+    int numThreads = 5;
+    int defaultMaxAttempts = 5;
+    int retryDelay = 100;
+    int numberOfTasks = 200;
+    
+    BlobDeleteProcessor processor = buildBlobDeleteProcessorForTest(enqueuedTasks, blobClient,
+        maxQueueSize, numThreads, defaultMaxAttempts, retryDelay);
+    List<BlobDeleterTask> tasks = generateRandomTasks(defaultMaxAttempts, numberOfTasks);
+    List<CompletableFuture<BlobDeleterTaskResult>> taskResultsFutures = new LinkedList<>();
+    List<BlobDeleterTaskResult> results = new LinkedList<>();
+    for (BlobDeleterTask t : tasks) {
+      taskResultsFutures.add(processor.enqueue(t, false));
+    }
+    
+    taskResultsFutures.forEach(cf -> {
+      try {
+        results.add(cf.get(20000, TimeUnit.MILLISECONDS));
+      } catch (Exception ex) {
+        fail("We timed out on some task!");
+      }
+    });
+    
+    // we shouldn't enqueue more than (numberOfTasks * defaultMaxAttempts) tasks to the pool 
+    assertTrue(enqueuedTasks.size() < (numberOfTasks * defaultMaxAttempts));
+    assertEquals(numberOfTasks, results.size());
+    int totalAttempts = 0;
+    for (BlobDeleterTaskResult res : results) {
+      assertNotNull(res);
+      assertNotNull(res.getTask());
+      assertEquals("scheduledFailingTask", res.getTask().getActionName());
+      totalAttempts += res.getTask().getAttempts();
+    }
+    // total task attempts should be consistent with our test scaffolding
+    assertTrue(totalAttempts < (numberOfTasks * defaultMaxAttempts));
+      
+    processor.shutdown();
+  }
+  
+  private List<BlobDeleterTask> generateRandomTasks(int defaultMaxAttempts, int taskCount) {
+    List<BlobDeleterTask> tasks = new LinkedList<>();
+    for (int i = 0; i < taskCount; i++) {
+      BlobDeleterTask task = null;
+      int totalAttempts = random().nextInt(defaultMaxAttempts);
+      int totalFails = random().nextInt(defaultMaxAttempts + 1);
+      task = buildScheduledFailingTaskForTest(blobClient, "test"+i, totalAttempts, true, totalFails);
+      tasks.add(task);
+    }
+    return tasks;
+  }
+  
+  /**
+   * Returns a test-only task for just holding onto a resource for test purposes
+   */
+  private BlobDeleterTask buildBlockingTaskForTest(CountDownLatch latch) {
+    return new BlobDeleterTask(null, null, false, 0) {
+      @Override
+      public Collection<String> doDelete() throws Exception {
+        // block until something forces this latch to count down
+        latch.await();
+        return null;
+      }
+      
+      @Override
+      public String getActionName() { return "blockingTask"; }
+    };
+  }
+  
+  /**
+   * Returns a test-only task that always fails on action execution by throwing an
+   * exception
+   */
+  private BlobDeleterTask buildFailingTaskForTest(CoreStorageClient client, 
+      String collectionName, int maxRetries, boolean allowRetries) {
+    return new BlobDeleterTask(client, collectionName, allowRetries, maxRetries) {
+      @Override
+      public Collection<String> doDelete() throws Exception {
+        throw new Exception("");
+      }
+      
+      @Override
+      public String getActionName() { return "failingTask"; }
+    };
+  }
+  
+  /**
+   * Returns a test-only task that fails a specified number of times before succeeding
+   */
+  private BlobDeleterTask buildScheduledFailingTaskForTest(CoreStorageClient client, 
+      String collectionName, int maxRetries, boolean allowRetries, int failTotal) {
+    return new BlobDeleterTask(client, collectionName, allowRetries, maxRetries) {
+      private AtomicInteger failCount = new AtomicInteger(0);
+      
+      @Override
+      public Collection<String> doDelete() throws Exception {
+        while (failCount.get() < failTotal) {
+          failCount.incrementAndGet();
+          throw new Exception("");
+        }
+        return null;
+      }
+      
+      @Override
+      public String getActionName() { return "scheduledFailingTask"; }
+    };
+  }
+  
+  // enables capturing all enqueues to the executor pool, including retries
+  private BlobDeleteProcessor buildBlobDeleteProcessorForTest(List<BlobDeleterTask> enqueuedTasks, 
+      CoreStorageClient client, int almostMaxQueueSize, int numDeleterThreads, int defaultMaxDeleteAttempts, 
+      long fixedRetryDelay) {
+    return new BlobDeleteProcessorForTest(DEFAULT_PROCESSOR_NAME, client, almostMaxQueueSize, numDeleterThreads,
+        defaultMaxDeleteAttempts, fixedRetryDelay, enqueuedTasks);
+  }
+  
+  class BlobDeleteProcessorForTest extends BlobDeleteProcessor {
+    List<BlobDeleterTask> enqueuedTasks;
+    
+    public BlobDeleteProcessorForTest(String name, CoreStorageClient client, int almostMaxQueueSize,
+        int numDeleterThreads, int defaultMaxDeleteAttempts, long fixedRetryDelay, List<BlobDeleterTask> enqueuedTasks) {
+      super(name, client, almostMaxQueueSize, numDeleterThreads, defaultMaxDeleteAttempts, fixedRetryDelay);
+      this.enqueuedTasks = enqueuedTasks;
+    }
+    
+    @Override
+    protected CompletableFuture<BlobDeleterTaskResult> enqueue(BlobDeleterTask task, boolean isRetry) {
+      enqueuedTasks.add(task);
+      return super.enqueue(task, isRetry);
+    }
+  }
+}

--- a/solr/core/src/test/org/apache/solr/store/blob/process/BlobDeleteProcessorTest.java
+++ b/solr/core/src/test/org/apache/solr/store/blob/process/BlobDeleteProcessorTest.java
@@ -223,6 +223,7 @@ public class BlobDeleteProcessorTest extends SolrTestCaseJ4 {
     
     BlobDeleteProcessor processor = buildBlobDeleteProcessorForTest(enqueuedTasks, blobClient,
         maxQueueSize, numThreads, defaultMaxAttempts, retryDelay);
+  
     // enqueue a task that fails totalFails number of times before succeeding
     CompletableFuture<BlobDeleterTaskResult> cf = 
         processor.enqueue(buildScheduledFailingTaskForTest(blobClient, name, totalAttempts, true, totalFails), isRetry);
@@ -240,7 +241,7 @@ public class BlobDeleteProcessorTest extends SolrTestCaseJ4 {
     // initial error + 2 retry errors suppressed
     assertNotNull(res.getError());
     assertEquals(2, res.getError().getSuppressed().length);
-    
+  
     processor.shutdown();
   }
   
@@ -399,7 +400,7 @@ public class BlobDeleteProcessorTest extends SolrTestCaseJ4 {
       public Collection<String> doDelete() throws Exception {
         // block until something forces this latch to count down
         latch.await();
-        return null;
+        return new LinkedList<>();
       }
       
       @Override
@@ -438,7 +439,7 @@ public class BlobDeleteProcessorTest extends SolrTestCaseJ4 {
           failCount.incrementAndGet();
           throw new Exception("");
         }
-        return null;
+        return new LinkedList<>();
       }
       
       @Override

--- a/solr/core/src/test/org/apache/solr/store/blob/process/SharedStoreDeletionProcessTest.java
+++ b/solr/core/src/test/org/apache/solr/store/blob/process/SharedStoreDeletionProcessTest.java
@@ -1,0 +1,329 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.store.blob.process;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.embedded.JettySolrRunner;
+import org.apache.solr.client.solrj.impl.CloudSolrClient;
+import org.apache.solr.client.solrj.request.CollectionAdminRequest;
+import org.apache.solr.client.solrj.request.UpdateRequest;
+import org.apache.solr.cloud.MiniSolrCloudCluster;
+import org.apache.solr.cloud.api.collections.Assign;
+import org.apache.solr.common.cloud.DocCollection;
+import org.apache.solr.store.blob.client.CoreStorageClient;
+import org.apache.solr.store.blob.metadata.DeleteBlobStrategyTest;
+import org.apache.solr.store.blob.process.BlobDeleterTask.BlobDeleterTaskResult;
+import org.apache.solr.store.shared.SolrCloudSharedStoreTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests around the deletion of files from shared storage via background deletion
+ * processes as triggered by normal indexing and collection api calls
+ */
+public class SharedStoreDeletionProcessTest extends SolrCloudSharedStoreTestCase {
+  
+  private static String DEFAULT_PROCESSOR_NAME = "DeleterForTest";
+  private static Path sharedStoreRootPath;
+  
+  private List<CompletableFuture<BlobDeleterTaskResult>> taskFutures;
+  private List<CompletableFuture<BlobDeleterTaskResult>> overseerTaskFutures;
+  
+  @BeforeClass
+  public static void setupClass() throws Exception {
+    sharedStoreRootPath = createTempDir("tempDir");    
+  }
+  
+  @Before
+  public void setupTest() {
+    taskFutures = new LinkedList<>();
+    overseerTaskFutures = new LinkedList<>();
+  }
+
+  @After
+  public void teardownTest() throws Exception {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+    // clean up the shared store after each test. The temp dir should clean up itself after the
+    // test class finishes
+    FileUtils.cleanDirectory(sharedStoreRootPath.toFile());
+  }
+ 
+  /**
+   * Test that verifies that files marked for deletion during the indexing process get
+   * enqueued for deletion and deleted. This test case differs from {@link DeleteBlobStrategyTest}
+   * because it tests the end-to-end indexing flow with a {@link MiniSolrCloudCluster}
+   */
+  @Test
+  public void testIndexingTriggersDeletes() throws Exception {
+    setupCluster(1);
+    setupSolrNodes();
+    JettySolrRunner node = cluster.getJettySolrRunner(0);
+    int numThreads = 5;
+    int targetMaxAttempts = 5;
+    // files don't need to age before marked for deletion, deleted as indexed in this test
+    int delay = 0;
+    initiateDeleteManagerForTest(node, targetMaxAttempts, numThreads, delay,
+        taskFutures, overseerTaskFutures);
+    
+    // set up the collection
+    String collectionName = "SharedCollection";
+    int maxShardsPerNode = 1;
+    int numReplicas = 1;
+    String shardNames = "shard1";
+    setupSharedCollectionWithShardNames(collectionName, maxShardsPerNode, numReplicas, shardNames);
+    
+    // index and track deletions, commits are implicit in shared storage so we expect pushes to occur 
+    // per batch and new segment index files to be deleted per batch with the exception of the very first
+    sendIndexingBatch(collectionName, /*numDocs */ 1, /* docIdStart */ 0);
+    assertEquals(0, taskFutures.size());
+    
+    // next indexing batch should cause files to be added for deletion
+    sendIndexingBatch(collectionName, /*numDocs */ 1, /* docIdStart */ 1);
+    assertEquals(1, taskFutures.size());
+    
+    CompletableFuture<BlobDeleterTaskResult> cf = taskFutures.get(0);
+    BlobDeleterTaskResult result = cf.get(5000, TimeUnit.MILLISECONDS);
+    
+    // verify the files were deleted
+    CoreStorageClient storageClient = node.getCoreContainer().getSharedStoreManager().getBlobStorageProvider().getClient();
+    assertTrue(result.isSuccess());
+    assertFilesDeleted(storageClient, result);
+  }
+  
+  /**
+   * Test that verifies that collection deletion command deletes all files for the given collection on the
+   * happy path
+   */
+  @Test
+  public void testDeleteCollectionCommand() throws Exception {
+    setupCluster(1);
+    setupSolrNodes();
+    CloudSolrClient cloudClient = cluster.getSolrClient();
+    JettySolrRunner node = cluster.getJettySolrRunner(0);
+    int numThreads = 5;
+    int targetMaxAttempts = 5;
+    // files don't need to age before marked for deletion, deleted as indexed in this test
+    int delay = 0;
+    initiateDeleteManagerForTest(node, targetMaxAttempts, numThreads, delay,
+        taskFutures, overseerTaskFutures);
+    
+    // set up the collection
+    String collectionName = "SharedCollection";
+    int maxShardsPerNode = 10;
+    int numReplicas = 1;
+    String shardNames = "shard1,shard2";
+    setupSharedCollectionWithShardNames(collectionName, maxShardsPerNode, numReplicas, shardNames);
+    
+    // index a bunch of docs
+    for (int i = 0; i < 10; i++) {
+      int numDocs = 100;
+      sendIndexingBatch(collectionName, numDocs, i*numDocs);
+    }
+    assertTrue(taskFutures.size() > 0);
+    assertEquals(0, overseerTaskFutures.size());
+    
+    // do collection deletion
+    CollectionAdminRequest.Delete delete = CollectionAdminRequest.deleteCollection(collectionName);
+    delete.process(cloudClient).getResponse();
+    assertEquals(1, overseerTaskFutures.size());
+    
+    // wait for the deletion command to complete
+    CompletableFuture<BlobDeleterTaskResult> cf = taskFutures.get(0);
+    BlobDeleterTaskResult result = cf.get(5000, TimeUnit.MILLISECONDS);
+    
+    // the collection should no longer exist on zookeeper
+    cloudClient.getZkStateReader().forceUpdateCollection(collectionName);
+    assertNull(cloudClient.getZkStateReader().getClusterState().getCollectionOrNull(collectionName));
+    
+    // verify the files in the deletion tasks were all deleted
+    CoreStorageClient storageClient = node.getCoreContainer().getSharedStoreManager().getBlobStorageProvider().getClient();
+    assertTrue(result.isSuccess());
+    assertFilesDeleted(storageClient, result);
+    
+    // verify no files belonging to this collection exists on shared storage
+    List<String> names = storageClient.listCoreBlobFiles(collectionName);
+    assertTrue(names.isEmpty());
+  }
+  
+  /**
+   * Test that verifies that shard deletion command deletes all files for the given shard on the
+   * happy path
+   */
+  @Test
+  public void testDeleteShardCommand() throws Exception {
+    setupCluster(1);
+    setupSolrNodes();
+    CloudSolrClient cloudClient = cluster.getSolrClient();
+    JettySolrRunner node = cluster.getJettySolrRunner(0);
+    int numThreads = 5;
+    int targetMaxAttempts = 5;
+    // files don't need to age before marked for deletion, deleted as indexed in this test
+    int delay = 0;
+    initiateDeleteManagerForTest(node, targetMaxAttempts, numThreads, delay,
+        taskFutures, overseerTaskFutures);
+    
+    // set up the collection
+    String collectionName = "SharedCollection";
+    int maxShardsPerNode = 10;
+    int numReplicas = 1;
+    String shardNames = "shard1";
+    setupSharedCollectionWithShardNames(collectionName, maxShardsPerNode, numReplicas, shardNames);
+    
+    // index a bunch of docs
+    for (int i = 0; i < 10; i++) {
+      int numDocs = 100;
+      sendIndexingBatch(collectionName, numDocs, i*numDocs);
+    }
+    assertTrue(taskFutures.size() > 0);
+    assertEquals(0, overseerTaskFutures.size());
+    
+    // split the shard so the parents are set inactive and can be deleted 
+    CollectionAdminRequest.SplitShard splitShard = CollectionAdminRequest.splitShard(collectionName)
+        .setShardName("shard1");
+    splitShard.process(cloudClient);
+    waitForState("Timed out waiting for sub shards to be active.",
+        collectionName, activeClusterShape(2, 3));
+    
+    // do shard deletion on the parent
+    CollectionAdminRequest.DeleteShard delete = CollectionAdminRequest.deleteShard(collectionName, "shard1");
+    delete.process(cloudClient).getResponse();
+    assertEquals(1, overseerTaskFutures.size());
+    
+    // wait for the deletion command to complete
+    CompletableFuture<BlobDeleterTaskResult> cf = taskFutures.get(0);
+    BlobDeleterTaskResult result = cf.get(5000, TimeUnit.MILLISECONDS);
+    
+    // the collection shard should no longer exist on zookeeper
+    cloudClient.getZkStateReader().forceUpdateCollection(collectionName);
+    DocCollection coll = cloudClient.getZkStateReader().getClusterState().getCollectionOrNull(collectionName); 
+    assertNotNull(coll);
+    assertNull(coll.getSlice("shard1"));
+    
+    // verify the files in the deletion tasks were all deleted
+    CoreStorageClient storageClient = node.getCoreContainer().getSharedStoreManager().getBlobStorageProvider().getClient();
+    assertTrue(result.isSuccess());
+    assertFilesDeleted(storageClient, result);
+    
+    // verify no files belonging to shard1 in the collection exists on shared storage
+    List<String> names = storageClient.listCoreBlobFiles(Assign.buildSharedShardName(collectionName, "shard1/"));
+    assertTrue(names.isEmpty());
+    
+    // verify files belonging to shard1_0 and shard1_1 exist still
+    names = storageClient.listCoreBlobFiles(Assign.buildSharedShardName(collectionName, "shard1_0"));
+    assertFalse(names.isEmpty());
+    names = storageClient.listCoreBlobFiles(Assign.buildSharedShardName(collectionName, "shard1_1"));
+    assertFalse(names.isEmpty());
+  }
+  
+  private void assertFilesDeleted(CoreStorageClient storageClient, BlobDeleterTaskResult result) throws IOException {
+    Collection<String> filesDeleted = result.getFilesDeleted();
+    for (String filename : filesDeleted) {
+      InputStream s = null;
+      try  {
+        s = storageClient.pullStream(filename);
+        fail(filename + " should have been deleted from shared store");
+      } catch (Exception ex) {
+        if (!(ex.getCause() instanceof FileNotFoundException)) {
+          fail("Unexpected exception thrown = " + ex.getMessage());
+        }
+      } finally {
+        if (s != null) {
+          s.close();
+        }
+      }
+    }
+  }
+  
+  private void sendIndexingBatch(String collectionName, int numberOfDocs, int docIdStart) throws SolrServerException, IOException {
+    UpdateRequest updateReq = new UpdateRequest();
+    for (int k = docIdStart; k < docIdStart + numberOfDocs; k++) {
+      updateReq.add("id", Integer.toString(k));
+    }
+    updateReq.process(cluster.getSolrClient(), collectionName);
+  }
+  
+  private BlobDeleteManager initiateDeleteManagerForTest(JettySolrRunner solrRunner, 
+      int almostMaxQueueSize, int numDeleterThreads, int deleteDelayMs, List<CompletableFuture<BlobDeleterTaskResult>> taskFutures,
+      List<CompletableFuture<BlobDeleterTaskResult>> overseerTaskFutures) {
+    CoreStorageClient client = solrRunner.getCoreContainer().getSharedStoreManager().getBlobStorageProvider().getClient();
+    int maxQueueSize = 200;
+    int numThreads = 5;
+    int defaultMaxAttempts = 5;
+    int retryDelay = 500; 
+    
+    // setup processors with the same defaults but enhanced to capture future results
+    BlobDeleteProcessor processor = buildBlobDeleteProcessorForTest(taskFutures, client,
+        maxQueueSize, numThreads, defaultMaxAttempts, retryDelay);
+    BlobDeleteProcessor overseerProcessor = buildBlobDeleteProcessorForTest(overseerTaskFutures, client,
+        maxQueueSize, numThreads, defaultMaxAttempts, retryDelay);
+    
+    BlobDeleteManager deleteManager = new BlobDeleteManager(client, deleteDelayMs, processor, overseerProcessor);
+    setupBlobDeleteManagerForNode(deleteManager, solrRunner);
+    return deleteManager;
+  }
+  
+  private void setupSolrNodes() throws Exception {
+    for (JettySolrRunner process : cluster.getJettySolrRunners()) {
+      CoreStorageClient storageClient = setupLocalBlobStoreClient(sharedStoreRootPath, DEFAULT_BLOB_DIR_NAME);
+      setupTestSharedClientForNode(getBlobStorageProviderTestInstance(storageClient), process);
+    }
+  }
+  
+  // enables capturing all enqueues to the executor pool, including retries
+  private BlobDeleteProcessor buildBlobDeleteProcessorForTest(List<CompletableFuture<BlobDeleterTaskResult>> taskFutures, 
+      CoreStorageClient client, int almostMaxQueueSize, int numDeleterThreads, int defaultMaxDeleteAttempts, 
+      long fixedRetryDelay) {
+    return new BlobDeleteProcessorForTest(DEFAULT_PROCESSOR_NAME, client, almostMaxQueueSize, numDeleterThreads,
+        defaultMaxDeleteAttempts, fixedRetryDelay, taskFutures);
+  }
+  
+  /**
+   * Test class extending BlobDeleteProcessor to allow capturing task futures
+   */
+  class BlobDeleteProcessorForTest extends BlobDeleteProcessor {
+    List<CompletableFuture<BlobDeleterTaskResult>> futures;
+    
+    public BlobDeleteProcessorForTest(String name, CoreStorageClient client, int almostMaxQueueSize,
+        int numDeleterThreads, int defaultMaxDeleteAttempts, long fixedRetryDelay, 
+        List<CompletableFuture<BlobDeleterTaskResult>> taskFutures) {
+      super(name, client, almostMaxQueueSize, numDeleterThreads, defaultMaxDeleteAttempts, fixedRetryDelay);
+      this.futures = taskFutures;
+    }
+    
+    @Override
+    protected CompletableFuture<BlobDeleterTaskResult> enqueue(BlobDeleterTask task, boolean isRetry) {
+      CompletableFuture<BlobDeleterTaskResult> futureRes = super.enqueue(task, isRetry);
+      futures.add(futureRes);
+      return futureRes;
+    }
+  }
+}

--- a/solr/core/src/test/org/apache/solr/store/shared/SolrCloudSharedStoreTestCase.java
+++ b/solr/core/src/test/org/apache/solr/store/shared/SolrCloudSharedStoreTestCase.java
@@ -28,11 +28,12 @@ import org.apache.solr.cloud.SolrCloudTestCase;
 import org.apache.solr.store.blob.client.BlobCoreMetadata;
 import org.apache.solr.store.blob.client.CoreStorageClient;
 import org.apache.solr.store.blob.client.LocalStorageClient;
+import org.apache.solr.store.blob.process.BlobDeleteManager;
 import org.apache.solr.store.blob.process.BlobProcessUtil;
 import org.apache.solr.store.blob.process.CorePullTask;
+import org.apache.solr.store.blob.process.CorePullTask.PullCoreCallback;
 import org.apache.solr.store.blob.process.CorePullerFeeder;
 import org.apache.solr.store.blob.process.CoreSyncStatus;
-import org.apache.solr.store.blob.process.CorePullTask.PullCoreCallback;
 import org.apache.solr.store.blob.provider.BlobStorageProvider;
 
 /**
@@ -99,6 +100,14 @@ public class SolrCloudSharedStoreTestCase extends SolrCloudTestCase {
   protected static void setupTestSharedConcurrencyControllerForNode(SharedCoreConcurrencyController concurrencyController, JettySolrRunner solrRunner) {
     SharedStoreManager manager = solrRunner.getCoreContainer().getSharedStoreManager();
     manager.initConcurrencyController(concurrencyController);
+  }
+  
+  /**
+   * Configures the Solr process with the given {@link BlobDeleteManager}
+   */
+  protected static void setupBlobDeleteManagerForNode(BlobDeleteManager deleteManager, JettySolrRunner solrRunner) {
+    SharedStoreManager manager = solrRunner.getCoreContainer().getSharedStoreManager();
+    manager.initBlobDeleteManager(deleteManager);
   }
 
   /**


### PR DESCRIPTION
This PR addS support for shard and collection deletion in shared storage (SOLR-14044) and also includes a major refactor of the existing BlobDeleteManager and deletion code.

The BlobDeleteManager uses refactors the existing async processing machinery and BlobDeleteManager manages two deletion pools now - the existing one for handling normal indexing flow deletion (as we push) and a pool used specifically by the Overseer for handling collection and shard deletion. 

Currently working on a another test that I should add soon but the rest is review-able. 