### PR TITLE
SOLR-13101: Log accurate file counts for Push and Pull in CorePushPull

### DIFF
--- a/solr/core/src/java/org/apache/solr/store/blob/metadata/CorePushPull.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/metadata/CorePushPull.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.invoke.MethodHandles;
-import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -39,6 +38,7 @@ import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.solr.common.SolrException;
+import org.apache.solr.common.util.Pair;
 import org.apache.solr.core.CoreContainer;
 import org.apache.solr.core.DirectoryFactory;
 import org.apache.solr.core.SolrCore;
@@ -119,6 +119,10 @@ public class CorePushPull {
       if (solrCore == null) {
         throw new Exception("Can't find core " + pushPullData.getCoreName());
       }
+      
+      long actualFilesAffected = 0;
+      long bytesTransferred = 0;
+      boolean isSuccessful = false;
 
       try {
         // Creating the new BlobCoreMetadata as a modified clone of the existing one
@@ -159,6 +163,7 @@ public class CorePushPull {
         // point for the (potentially long) time it takes to push all files to the Blob store.
         Directory coreIndexDir = solrCore.getDirectoryFactory().get(solrCore.getIndexDir(), DirectoryFactory.DirContext.DEFAULT, solrCore.getSolrConfig().indexConfig.lockType);
         solrCore.getDeletionPolicy().saveCommitPoint(solrServerMetadata.getGeneration());
+        
         try {
           // Directory's javadoc says: "Java's i/o APIs not used directly, but rather all i/o is through this API"
           // But this is untrue/totally false/misleading. IndexFetcher has File all over.
@@ -168,6 +173,9 @@ public class CorePushPull {
 
             String blobPath = pushFileToBlobStore(coreStorageClient, coreIndexDir, cfd.getFileName(), cfd.getFileSize());
             bcmBuilder.addFile(new BlobCoreMetadata.BlobFile(cfd.getFileName(), blobPath, cfd.getFileSize(), cfd.getChecksum()));
+            
+            actualFilesAffected++;
+            bytesTransferred += cfd.getFileSize();
           }
         } finally {
           solrCore.getDeletionPolicy().releaseCommitPoint(solrServerMetadata.getGeneration());
@@ -181,15 +189,13 @@ public class CorePushPull {
 
         String blobCoreMetadataName = BlobStoreUtils.buildBlobStoreMetadataName(newMetadataSuffix);
         coreStorageClient.pushCoreMetadata(blobMetadata.getSharedBlobName(), blobCoreMetadataName, newBcm);
+        isSuccessful = true;
         return newBcm;
       } finally {
         solrCore.close();
 
-        long filesAffected = resolvedMetadataResult.getFilesToPush().size();
-        long bytesTransferred = resolvedMetadataResult.getFilesToPush().stream().mapToLong(cfd -> cfd.getFileSize()).sum();
-        
-        // todo correctness stuff
-        logBlobAction("PUSH", filesAffected, bytesTransferred, startTimeMs, 0, startTimeMs);
+        long expectedFilesAffected = resolvedMetadataResult.getFilesToPush().size();
+        logBlobAction("PUSH", expectedFilesAffected, actualFilesAffected, bytesTransferred, isSuccessful, startTimeMs, 0, startTimeMs);
       }
     }
 
@@ -225,10 +231,16 @@ public class CorePushPull {
      * @throws Exception    In the context of the PoC and first runs, we ignore errors such as Blob Server not available
      *                      or network issues. We therefore consider all exceptions thrown by this method as a sign that
      *                      it is durably not possible to pull the core from the Blob Store.
-     *                      TODO This has to be revisited before going to real prod, as environemnt issues can cause massive reindexing with this strategy
+     *                      TODO This has to be revisited before going to real prod, as environment issues can cause massive reindexing with this strategy
      */
     public void pullUpdateFromBlob(long requestQueuedTimeMs, boolean waitForSearcher, int attempt) throws Exception {
         long startTimeMs = System.nanoTime();
+        
+        long expectedFilesAffected = 0;
+        long actualFilesAffected = 0;
+        long bytesTransferred = 0;
+        boolean isSuccessful = false;
+
         try {
           SolrCore solrCore = container.getCore(pushPullData.getCoreName());
           if (solrCore == null) {
@@ -266,7 +278,11 @@ public class CorePushPull {
               } else {
                 filesToDownload = resolvedMetadataResult.getFilesToPull();
               }
-              downloadFilesFromBlob(tempIndexDir, filesToDownload);
+
+              Pair<Long, Long> fileTransferData = downloadFilesFromBlob(tempIndexDir, filesToDownload);
+              expectedFilesAffected = filesToDownload.size();
+              actualFilesAffected = fileTransferData.first();
+              bytesTransferred = fileTransferData.second();
 
               Directory indexDir = solrCore.getDirectoryFactory().get(indexDirPath, DirectoryFactory.DirContext.DEFAULT, solrCore.getSolrConfig().indexConfig.lockType);
               try {
@@ -356,14 +372,12 @@ public class CorePushPull {
               // CorruptCoreHandler.notifyBlobPullFailure(container, coreName, blobMetadata);
               throw se;
             }
+            isSuccessful = true;
           } finally {
             solrCore.close();
           }
         } finally {
-          long filesAffected = resolvedMetadataResult.getFilesToPull().size();
-          long bytesTransferred = resolvedMetadataResult.getFilesToPull().stream().mapToLong(bf -> bf.getFileSize()).sum();
-          
-          logBlobAction("PULL", filesAffected, bytesTransferred, requestQueuedTimeMs, attempt, startTimeMs);
+          logBlobAction("PULL", expectedFilesAffected, actualFilesAffected, bytesTransferred, isSuccessful, requestQueuedTimeMs, attempt, startTimeMs);
         }
     }
 
@@ -419,23 +433,20 @@ public class CorePushPull {
 
     /**
      * Logs soblb line for push or pull action 
-     * TODO: This is for callers of this method.
-     * fileAffected and bytesTransferred represent correct values only in case of success
-     * In case of failure(partial processing) we are not accurate.
-     * Do we want to change that? If yes, then in case of pull is downloading of files locally to temp folder is considered
-     * transfer or moving from temp dir to final destination. One option could be to just make them -1 in case of failure.
      */
-    private void logBlobAction(String action, long filesAffected, long bytesTransferred, long requestQueuedTimeMs, int attempt, long startTimeMs) throws Exception {
+    private void logBlobAction(String action, long expectedFilesAffected, long actualFilesAffected, long bytesTransferred, boolean isSuccessful,
+        long requestQueuedTimeMs, int attempt, long startTimeMs) throws Exception {
       long now = System.nanoTime();
       long runTime = now - startTimeMs;
       long startLatency = now - requestQueuedTimeMs;
 
       String message = String.format(Locale.ROOT,
             "PushPullData=[%s] action=%s storageProvider=%s bucketRegion=%s bucketName=%s "
-              + "runTime=%s startLatency=%s bytesTransferred=%s attempt=%s filesAffected=%s localGeneration=%s blobGeneration=%s ",
+              + "runTime=%s startLatency=%s bytesTransferred=%s attempt=%s expectedFilesAffected=%s actualFilesAffected=%s isSuccessful=%s "
+              + "localGeneration=%s blobGeneration=%s ",
           pushPullData.toString(), action, coreStorageClient.getStorageProvider().name(), coreStorageClient.getBucketRegion(),
-          coreStorageClient.getBucketName(), runTime, startLatency, bytesTransferred, attempt, filesAffected,
-          solrServerMetadata.getGeneration(), blobMetadata.getGeneration());
+          coreStorageClient.getBucketName(), runTime, startLatency, bytesTransferred, attempt, expectedFilesAffected, actualFilesAffected,
+          isSuccessful, solrServerMetadata.getGeneration(), blobMetadata.getGeneration());
       log.info(message);
     }
 
@@ -443,21 +454,30 @@ public class CorePushPull {
      * Downloads files from the Blob store 
      * @param destDir (temporary) directory into which files should be downloaded.
      * @param filesToDownload blob files to be downloaded
+     * @return number of files downloaded and number of bytes transferred successfully
      */
     @VisibleForTesting
-    protected void downloadFilesFromBlob(Directory destDir, Collection<? extends BlobFile> filesToDownload) throws Exception {
+    protected Pair<Long, Long> downloadFilesFromBlob(Directory destDir, Collection<? extends BlobFile> filesToDownload) throws Exception {
       // Synchronously download all Blob blobs (remember we're running on an async thread, so no need to be async twice unless
       // we eventually want to parallelize downloads of multiple blobs, but for the PoC we don't :)
+      long filesDownloaded = 0;
+      long bytesTransferred = 0;
       for (BlobFile bf: filesToDownload) {
         log.info("About to create " + bf.getSolrFileName() + " for core " + pushPullData.getCoreName() +
             " from index on blob " + pushPullData.getSharedStoreName());
-        IndexOutput io = destDir.createOutput(bf.getSolrFileName(), DirectoryFactory.IOCONTEXT_NO_CACHE);
 
-        try (OutputStream outStream = new IndexOutputStream(io);
-          InputStream bis = coreStorageClient.pullStream(bf.getBlobName())) {
-          IOUtils.copy(bis, outStream);
-        }
+          try (IndexOutput io = destDir.createOutput(bf.getSolrFileName(), DirectoryFactory.IOCONTEXT_NO_CACHE);
+              OutputStream outStream = new IndexOutputStream(io);
+            InputStream bis = coreStorageClient.pullStream(bf.getBlobName())) {
+            IOUtils.copy(bis, outStream);
+            
+            filesDownloaded++;
+            bytesTransferred += bf.getFileSize();
+          } catch (Exception e) {
+            return new Pair<>(filesDownloaded, bytesTransferred);
+          }
       }
+      return new Pair<>(filesDownloaded, bytesTransferred);
     }
 
     /**


### PR DESCRIPTION
# Description

Number of files and bytes pushed/pulled are logged when pushing to or pulling from blobstore, but values are only accurate when operation is successful. Log expected and actual file count, actual byte count, and add back boolean for whether operation was successful.

# Solution

Count number of files/bytes actually transferred

# Tests

Ran ant test, and working on adding additional unit tests.

Logline for successful push:
`PushPullData=[collectionName=gettingstarted shardName=shard1 sharedStoreName=gettingstarted_shard1 coreName=gettingstarted_shard1_replica_s1] action=PUSH storageProvider=LOCAL_FILE_SYSTEM bucketRegion=N/A bucketName=N/A runTime=44325264 startLatency=44325264 bytesTransferred=2076 attempt=0 expectedFilesAffected=10 actualFilesAffected=10 isSuccessful=true localGeneration=2 blobGeneration=-1 `

Logline for successful pull:
`PushPullData=[collectionName=pulltest2 shardName=shard2 sharedStoreName=pulltest2_shard2 coreName=pulltest2_shard2_replica_s6] action=PULL storageProvider=LOCAL_FILE_SYSTEM bucketRegion=N/A bucketName=N/A runTime=70088178 startLatency=70090032 bytesTransferred=9828 attempt=0 expectedFilesAffected=46 actualFilesAffected=46 isSuccessful=true localGeneration=1 blobGeneration=6`

Logline for exception thrown partway through push:
`PushPullData=[collectionName=gettingstarted shardName=shard1 sharedStoreName=gettingstarted_shard1 coreName=gettingstarted_shard1_replica_s1] action=PUSH storageProvider=LOCAL_FILE_SYSTEM bucketRegion=N/A bucketName=N/A runTime=6363713 startLatency=6363713 bytesTransferred=1132 attempt=0 expectedFilesAffected=10 actualFilesAffected=6 isSuccessful=false localGeneration=2 blobGeneration=-1`

Logline for exception thrown partway through pull:
`PushPullData=[collectionName=pulltest2 shardName=shard1 sharedStoreName=pulltest2_shard1 coreName=pulltest2_shard1_replica_s1] action=PULL storageProvider=LOCAL_FILE_SYSTEM bucketRegion=N/A bucketName=N/A runTime=9548098 startLatency=9548350 bytesTransferred=1404 attempt=0 expectedFilesAffected=19 actualFilesAffected=6 isSuccessful=false localGeneration=1 blobGeneration=3`
