### PR TITLE
SOLR-14205 Do not fail when given timeout to connectionImpl.isValid()…

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/sql/ConnectionImpl.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/sql/ConnectionImpl.java
@@ -317,7 +317,11 @@ class ConnectionImpl implements Connection {
     // check that the connection isn't closed and able to connect within the timeout
     try {
       if(!isClosed()) {
-        this.client.connect(timeout, TimeUnit.SECONDS);
+        if (timeout == 0) {
+          this.client.connect();
+        } else {
+          this.client.connect(timeout, TimeUnit.SECONDS);
+        }
         return true;
       }
     } catch (InterruptedException|TimeoutException ignore) {

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/io/sql/JdbcTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/io/sql/JdbcTest.java
@@ -496,6 +496,8 @@ public class JdbcTest extends SolrCloudTestCase {
   private void testJDBCMethods(String collection, String connectionString, Properties properties, String sql) throws Exception {
     try (Connection con = DriverManager.getConnection(connectionString, properties)) {
       assertTrue(con.isValid(DEFAULT_CONNECTION_TIMEOUT));
+      assertTrue("connection should be valid when checked with timeout = 0 -> con.isValid(0)", con.isValid(0));
+
 
       assertEquals(zkHost, con.getCatalog());
       con.setCatalog(zkHost);


### PR DESCRIPTION
… = 0

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description
When timeout = 0  handle it as if there is no timeout

# Solution
Call the solr-client without specifying a timeout

# Tests
add conn.isValid(0) == true to the JdbcTest case


# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
