### PR TITLE
SOLR-13101: Convert nanotime to ms

### DIFF
--- a/solr/core/src/java/org/apache/solr/store/blob/client/BlobCoreMetadata.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/client/BlobCoreMetadata.java
@@ -324,6 +324,9 @@ public class BlobCoreMetadata {
       return Objects.hash(super.hashCode(), deletedAt);
     }
 
+    /**
+     * @return time in milliseconds (converted from nanotime) that file was marked as deleted
+     */
     public long getDeletedAt() {
       return this.deletedAt;
     }

--- a/solr/core/src/java/org/apache/solr/store/blob/metadata/CorePushPull.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/metadata/CorePushPull.java
@@ -229,7 +229,6 @@ public class CorePushPull {
      */
     public void pullUpdateFromBlob(long requestQueuedTimeMs, boolean waitForSearcher, int attempt) throws Exception {
         long startTimeMs = System.nanoTime() / 1000000;
-        boolean isSuccessful = false;
 
         try {
           SolrCore solrCore = container.getCore(pushPullData.getCoreName());

--- a/solr/core/src/java/org/apache/solr/store/blob/metadata/CorePushPull.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/metadata/CorePushPull.java
@@ -114,7 +114,7 @@ public class CorePushPull {
      * @param newMetadataSuffix suffix of the new core.metadata file to be created as part of this push
      */
     public BlobCoreMetadata pushToBlobStore(String currentMetadataSuffix, String newMetadataSuffix) throws Exception {
-      long startTimeMs = BlobStoreUtils.getCurrentNanoTimeInMs();
+      long startTimeMs = BlobStoreUtils.getCurrentTimeMs();
       SolrCore solrCore = container.getCore(pushPullData.getCoreName());
       if (solrCore == null) {
         throw new Exception("Can't find core " + pushPullData.getCoreName());
@@ -135,7 +135,7 @@ public class CorePushPull {
          */
         for (BlobCoreMetadata.BlobFile d : resolvedMetadataResult.getFilesToDelete()) {
             bcmBuilder.removeFile(d);
-            BlobCoreMetadata.BlobFileToDelete bftd = new BlobCoreMetadata.BlobFileToDelete(d, BlobStoreUtils.getCurrentNanoTimeInMs());
+            BlobCoreMetadata.BlobFileToDelete bftd = new BlobCoreMetadata.BlobFileToDelete(d, BlobStoreUtils.getCurrentTimeMs());
             bcmBuilder.addFileToDelete(bftd);
         }
 
@@ -150,7 +150,7 @@ public class CorePushPull {
           String blobCoreMetadataName = BlobStoreUtils.buildBlobStoreMetadataName(currentMetadataSuffix);
           String coreMetadataPath = blobMetadata.getSharedBlobName() + "/" + blobCoreMetadataName;
           // so far checksum is not used for metadata file
-          BlobCoreMetadata.BlobFileToDelete bftd = new BlobCoreMetadata.BlobFileToDelete("", coreMetadataPath, bcmSize, BlobCoreMetadataBuilder.UNDEFINED_VALUE, BlobStoreUtils.getCurrentNanoTimeInMs());
+          BlobCoreMetadata.BlobFileToDelete bftd = new BlobCoreMetadata.BlobFileToDelete("", coreMetadataPath, bcmSize, BlobCoreMetadataBuilder.UNDEFINED_VALUE, BlobStoreUtils.getCurrentTimeMs());
           bcmBuilder.addFileToDelete(bftd);
         }
 
@@ -200,7 +200,7 @@ public class CorePushPull {
      *                     following the return from this call might see the old core content).
      */
     public void pullUpdateFromBlob(boolean waitForSearcher) throws Exception {
-         pullUpdateFromBlob(BlobStoreUtils.getCurrentNanoTimeInMs(), waitForSearcher, 0);
+         pullUpdateFromBlob(BlobStoreUtils.getCurrentTimeMs(), waitForSearcher, 0);
     }
 
     /**
@@ -227,7 +227,7 @@ public class CorePushPull {
      *                      TODO This has to be revisited before going to real prod, as environemnt issues can cause massive reindexing with this strategy
      */
     public void pullUpdateFromBlob(long requestQueuedTimeMs, boolean waitForSearcher, int attempt) throws Exception {
-        long startTimeMs = BlobStoreUtils.getCurrentNanoTimeInMs();
+        long startTimeMs = BlobStoreUtils.getCurrentTimeMs();
 
         try {
           SolrCore solrCore = container.getCore(pushPullData.getCoreName());
@@ -426,7 +426,7 @@ public class CorePushPull {
      * transfer or moving from temp dir to final destination. One option could be to just make them -1 in case of failure.
      */
     private void logBlobAction(String action, long filesAffected, long bytesTransferred, long requestQueuedTimeMs, int attempt, long startTimeMs) throws Exception {
-      long now = BlobStoreUtils.getCurrentNanoTimeInMs();
+      long now = BlobStoreUtils.getCurrentTimeMs();
       long runTime = now - startTimeMs;
       long startLatency = now - requestQueuedTimeMs;
 
@@ -499,7 +499,7 @@ public class CorePushPull {
     @VisibleForTesting
     protected boolean okForHardDelete(BlobCoreMetadata.BlobFileToDelete file) {
       // For now we only check how long ago the file was marked for delete.
-      return BlobStoreUtils.getCurrentNanoTimeInMs() - file.getDeletedAt() >= deleteManager.getDeleteDelayMs();
+      return BlobStoreUtils.getCurrentTimeMs() - file.getDeletedAt() >= deleteManager.getDeleteDelayMs();
     }
     
     @VisibleForTesting

--- a/solr/core/src/java/org/apache/solr/store/blob/metadata/CorePushPull.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/metadata/CorePushPull.java
@@ -114,7 +114,7 @@ public class CorePushPull {
      * @param newMetadataSuffix suffix of the new core.metadata file to be created as part of this push
      */
     public BlobCoreMetadata pushToBlobStore(String currentMetadataSuffix, String newMetadataSuffix) throws Exception {
-      long startTimeMs = System.nanoTime();
+      long startTimeMs = System.nanoTime() / 1000000;
       SolrCore solrCore = container.getCore(pushPullData.getCoreName());
       if (solrCore == null) {
         throw new Exception("Can't find core " + pushPullData.getCoreName());
@@ -135,7 +135,7 @@ public class CorePushPull {
          */
         for (BlobCoreMetadata.BlobFile d : resolvedMetadataResult.getFilesToDelete()) {
             bcmBuilder.removeFile(d);
-            BlobCoreMetadata.BlobFileToDelete bftd = new BlobCoreMetadata.BlobFileToDelete(d, System.currentTimeMillis());
+            BlobCoreMetadata.BlobFileToDelete bftd = new BlobCoreMetadata.BlobFileToDelete(d, System.nanoTime() / 1000000);
             bcmBuilder.addFileToDelete(bftd);
         }
 
@@ -150,7 +150,7 @@ public class CorePushPull {
           String blobCoreMetadataName = BlobStoreUtils.buildBlobStoreMetadataName(currentMetadataSuffix);
           String coreMetadataPath = blobMetadata.getSharedBlobName() + "/" + blobCoreMetadataName;
           // so far checksum is not used for metadata file
-          BlobCoreMetadata.BlobFileToDelete bftd = new BlobCoreMetadata.BlobFileToDelete("", coreMetadataPath, bcmSize, BlobCoreMetadataBuilder.UNDEFINED_VALUE, System.currentTimeMillis());
+          BlobCoreMetadata.BlobFileToDelete bftd = new BlobCoreMetadata.BlobFileToDelete("", coreMetadataPath, bcmSize, BlobCoreMetadataBuilder.UNDEFINED_VALUE, System.nanoTime() / 1000000);
           bcmBuilder.addFileToDelete(bftd);
         }
 
@@ -194,14 +194,14 @@ public class CorePushPull {
     }
 
     /**
-     * Calls {@link #pullUpdateFromBlob(long, boolean, int)}  with current epoch time and attempt no. 0.
+     * Calls {@link #pullUpdateFromBlob(long, boolean, int)}  with current relative time and attempt no. 0.
      * @param waitForSearcher <code>true</code> if this call should wait until the index searcher is created (so that any query
      *                     after the return from this method sees the new pulled content) or <code>false</code> if we request
      *                     a new index searcher to be eventually created but do not wait for it to be created (a query
      *                     following the return from this call might see the old core content).
      */
     public void pullUpdateFromBlob(boolean waitForSearcher) throws Exception {
-         pullUpdateFromBlob(System.nanoTime(), waitForSearcher, 0);
+         pullUpdateFromBlob(System.nanoTime() / 1000000, waitForSearcher, 0);
     }
 
     /**
@@ -213,7 +213,7 @@ public class CorePushPull {
      * <li>Local core did not exist (was created empty before calling this method) and is fetched from Blob</li>
      * </ol>
      * 
-     * @param requestQueuedTimeMs epoch time in milliseconds when the pull request was queued(meaningful in case of async pushing)
+     * @param requestQueuedTimeMs relative time in milliseconds when the pull request was queued(meaningful in case of async pushing)
      *                            only used for logging purposes
      * @param waitForSearcher <code>true</code> if this call should wait until the index searcher is created (so that any query
      *                     after the return from this method sees the new pulled content) or <code>false</code> if we request
@@ -228,7 +228,9 @@ public class CorePushPull {
      *                      TODO This has to be revisited before going to real prod, as environemnt issues can cause massive reindexing with this strategy
      */
     public void pullUpdateFromBlob(long requestQueuedTimeMs, boolean waitForSearcher, int attempt) throws Exception {
-        long startTimeMs = System.nanoTime();
+        long startTimeMs = System.nanoTime() / 1000000;
+        boolean isSuccessful = false;
+
         try {
           SolrCore solrCore = container.getCore(pushPullData.getCoreName());
           if (solrCore == null) {
@@ -426,7 +428,7 @@ public class CorePushPull {
      * transfer or moving from temp dir to final destination. One option could be to just make them -1 in case of failure.
      */
     private void logBlobAction(String action, long filesAffected, long bytesTransferred, long requestQueuedTimeMs, int attempt, long startTimeMs) throws Exception {
-      long now = System.nanoTime();
+      long now = System.nanoTime() / 1000000;
       long runTime = now - startTimeMs;
       long startLatency = now - requestQueuedTimeMs;
 
@@ -499,7 +501,7 @@ public class CorePushPull {
     @VisibleForTesting
     protected boolean okForHardDelete(BlobCoreMetadata.BlobFileToDelete file) {
       // For now we only check how long ago the file was marked for delete.
-      return System.nanoTime() - file.getDeletedAt() >= deleteManager.getDeleteDelayMs();
+      return (System.nanoTime() / 1000000) - file.getDeletedAt() >= deleteManager.getDeleteDelayMs();
     }
     
     @VisibleForTesting

--- a/solr/core/src/java/org/apache/solr/store/blob/process/BlobDeleterTask.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/process/BlobDeleterTask.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.solr.store.blob.client.CoreStorageClient;
+import org.apache.solr.store.blob.util.BlobStoreUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,12 +58,12 @@ class BlobDeleterTask implements Runnable {
     this.blobNames = blobNames;
     this.attempt = new AtomicInteger(0);
     this.executor = executor;
-    this.queuedTimeMs = System.nanoTime() / 1000000;
+    this.queuedTimeMs = BlobStoreUtils.getCurrentNanoTimeInMs();
   }
 
   @Override
   public void run() {
-    final long startTimeMs = System.nanoTime() / 1000000;
+    final long startTimeMs = BlobStoreUtils.getCurrentNanoTimeInMs();
     boolean isSuccess = true;
       
     try {
@@ -97,7 +98,7 @@ class BlobDeleterTask implements Runnable {
           executor.execute(this);
         }
       } finally {
-        long now = System.nanoTime() / 1000000;
+        long now = BlobStoreUtils.getCurrentNanoTimeInMs();
         long runTimeMs = now - startTimeMs;
         long startLatency = now - this.queuedTimeMs;
         String message = String.format(Locale.ROOT,

--- a/solr/core/src/java/org/apache/solr/store/blob/process/BlobDeleterTask.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/process/BlobDeleterTask.java
@@ -57,12 +57,12 @@ class BlobDeleterTask implements Runnable {
     this.blobNames = blobNames;
     this.attempt = new AtomicInteger(0);
     this.executor = executor;
-    this.queuedTimeMs = System.nanoTime();
+    this.queuedTimeMs = System.nanoTime() / 1000000;
   }
 
   @Override
   public void run() {
-    final long startTimeMs = System.nanoTime();
+    final long startTimeMs = System.nanoTime() / 1000000;
     boolean isSuccess = true;
       
     try {
@@ -97,14 +97,14 @@ class BlobDeleterTask implements Runnable {
           executor.execute(this);
         }
       } finally {
-        long now = System.nanoTime();
-        long runTime = now - startTimeMs;
+        long now = System.nanoTime() / 1000000;
+        long runTimeMs = now - startTimeMs;
         long startLatency = now - this.queuedTimeMs;
         String message = String.format(Locale.ROOT,
                "sharedBlobName=%s action=DELETE storageProvider=%s bucketRegion=%s bucketName=%s "
                       + "runTime=%s startLatency=%s attempt=%s filesAffected=%s isSuccess=%s",
                       sharedBlobName, client.getStorageProvider().name(), client.getBucketRegion(),
-                      client.getBucketName(), runTime, startLatency, attempt.get(), this.blobNames.size(), isSuccess);
+                      client.getBucketName(), runTimeMs, startLatency, attempt.get(), this.blobNames.size(), isSuccess);
         log.info(message);
       }
   }

--- a/solr/core/src/java/org/apache/solr/store/blob/process/BlobDeleterTask.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/process/BlobDeleterTask.java
@@ -58,12 +58,12 @@ class BlobDeleterTask implements Runnable {
     this.blobNames = blobNames;
     this.attempt = new AtomicInteger(0);
     this.executor = executor;
-    this.queuedTimeMs = BlobStoreUtils.getCurrentNanoTimeInMs();
+    this.queuedTimeMs = BlobStoreUtils.getCurrentTimeMs();
   }
 
   @Override
   public void run() {
-    final long startTimeMs = BlobStoreUtils.getCurrentNanoTimeInMs();
+    final long startTimeMs = BlobStoreUtils.getCurrentTimeMs();
     boolean isSuccess = true;
       
     try {
@@ -98,7 +98,7 @@ class BlobDeleterTask implements Runnable {
           executor.execute(this);
         }
       } finally {
-        long now = BlobStoreUtils.getCurrentNanoTimeInMs();
+        long now = BlobStoreUtils.getCurrentTimeMs();
         long runTimeMs = now - startTimeMs;
         long startLatency = now - this.queuedTimeMs;
         String message = String.format(Locale.ROOT,

--- a/solr/core/src/java/org/apache/solr/store/blob/process/CorePullTask.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/process/CorePullTask.java
@@ -79,7 +79,7 @@ public class CorePullTask implements DeduplicatingList.Deduplicatable<String> {
   private final PullCoreCallback callback;
 
   CorePullTask(CoreContainer coreContainer, PullCoreInfo pullCoreInfo, PullCoreCallback callback, Set<String> coresCreatedNotPulledYet) {
-    this(coreContainer, pullCoreInfo, System.nanoTime() / 1000000, 0, 0L, callback, coresCreatedNotPulledYet);
+    this(coreContainer, pullCoreInfo, BlobStoreUtils.getCurrentNanoTimeInMs(), 0, 0L, callback, coresCreatedNotPulledYet);
   }
 
   @VisibleForTesting
@@ -207,7 +207,7 @@ public class CorePullTask implements DeduplicatingList.Deduplicatable<String> {
     final long lastAttemptTimestampCopy = getLastAttemptTimestamp();
 
     if (attemptsCopy != 0) {
-      long now = System.nanoTime() / 1000000;
+      long now = BlobStoreUtils.getCurrentNanoTimeInMs();
       if (now - lastAttemptTimestampCopy < MIN_RETRY_DELAY_MS) {
         Thread.sleep(MIN_RETRY_DELAY_MS - now + lastAttemptTimestampCopy);
       }

--- a/solr/core/src/java/org/apache/solr/store/blob/process/CorePullTask.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/process/CorePullTask.java
@@ -79,7 +79,7 @@ public class CorePullTask implements DeduplicatingList.Deduplicatable<String> {
   private final PullCoreCallback callback;
 
   CorePullTask(CoreContainer coreContainer, PullCoreInfo pullCoreInfo, PullCoreCallback callback, Set<String> coresCreatedNotPulledYet) {
-    this(coreContainer, pullCoreInfo, System.nanoTime(), 0, 0L, callback, coresCreatedNotPulledYet);
+    this(coreContainer, pullCoreInfo, System.nanoTime() / 1000000, 0, 0L, callback, coresCreatedNotPulledYet);
   }
 
   @VisibleForTesting
@@ -207,7 +207,7 @@ public class CorePullTask implements DeduplicatingList.Deduplicatable<String> {
     final long lastAttemptTimestampCopy = getLastAttemptTimestamp();
 
     if (attemptsCopy != 0) {
-      long now = System.nanoTime();
+      long now = System.nanoTime() / 1000000;
       if (now - lastAttemptTimestampCopy < MIN_RETRY_DELAY_MS) {
         Thread.sleep(MIN_RETRY_DELAY_MS - now + lastAttemptTimestampCopy);
       }

--- a/solr/core/src/java/org/apache/solr/store/blob/process/CorePullTask.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/process/CorePullTask.java
@@ -79,7 +79,7 @@ public class CorePullTask implements DeduplicatingList.Deduplicatable<String> {
   private final PullCoreCallback callback;
 
   CorePullTask(CoreContainer coreContainer, PullCoreInfo pullCoreInfo, PullCoreCallback callback, Set<String> coresCreatedNotPulledYet) {
-    this(coreContainer, pullCoreInfo, BlobStoreUtils.getCurrentNanoTimeInMs(), 0, 0L, callback, coresCreatedNotPulledYet);
+    this(coreContainer, pullCoreInfo, BlobStoreUtils.getCurrentTimeMs(), 0, 0L, callback, coresCreatedNotPulledYet);
   }
 
   @VisibleForTesting
@@ -207,7 +207,7 @@ public class CorePullTask implements DeduplicatingList.Deduplicatable<String> {
     final long lastAttemptTimestampCopy = getLastAttemptTimestamp();
 
     if (attemptsCopy != 0) {
-      long now = BlobStoreUtils.getCurrentNanoTimeInMs();
+      long now = BlobStoreUtils.getCurrentTimeMs();
       if (now - lastAttemptTimestampCopy < MIN_RETRY_DELAY_MS) {
         Thread.sleep(MIN_RETRY_DELAY_MS - now + lastAttemptTimestampCopy);
       }

--- a/solr/core/src/java/org/apache/solr/store/blob/process/CorePullerFeeder.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/process/CorePullerFeeder.java
@@ -117,7 +117,7 @@ public class CorePullerFeeder extends CoreSyncFeeder {
       syncsEnqueuedSinceLastLog++;
 
       // Log if it's time (we did at least one pull otherwise we would be still blocked in the calls above)
-      final long now = BlobStoreUtils.getCurrentNanoTimeInMs();
+      final long now = BlobStoreUtils.getCurrentTimeMs();
       final long msSinceLastLog = now - lastLoggedTimestamp;
       if (msSinceLastLog > minMsBetweenLogs) {
         log.info("Since last pull log " + msSinceLastLog + " ms ago, added "
@@ -213,7 +213,7 @@ public class CorePullerFeeder extends CoreSyncFeeder {
         PullCoreInfo pullCoreInfo = pullTask.getPullCoreInfo();
         if (status.isTransientError() && pullTask.getAttempts() < MAX_ATTEMPTS) {
           pullTask.setAttempts(pullTask.getAttempts() + 1);
-          pullTask.setLastAttemptTimestamp(BlobStoreUtils.getCurrentNanoTimeInMs());
+          pullTask.setLastAttemptTimestamp(BlobStoreUtils.getCurrentTimeMs());
           pullTaskQueue.addDeduplicated(pullTask, true);
           log.info(String.format(Locale.ROOT, "Pulling core %s failed with transient error. Retrying. Last status=%s attempts=%s . %s",
               pullCoreInfo.getSharedStoreName(), status, pullTask.getAttempts(), message == null ? "" : message));

--- a/solr/core/src/java/org/apache/solr/store/blob/process/CorePullerFeeder.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/process/CorePullerFeeder.java
@@ -116,7 +116,7 @@ public class CorePullerFeeder extends CoreSyncFeeder {
       syncsEnqueuedSinceLastLog++;
 
       // Log if it's time (we did at least one pull otherwise we would be still blocked in the calls above)
-      final long now = System.nanoTime();
+      final long now = System.nanoTime() / 1000000;
       final long msSinceLastLog = now - lastLoggedTimestamp;
       if (msSinceLastLog > minMsBetweenLogs) {
         log.info("Since last pull log " + msSinceLastLog + " ms ago, added "
@@ -212,7 +212,7 @@ public class CorePullerFeeder extends CoreSyncFeeder {
         PullCoreInfo pullCoreInfo = pullTask.getPullCoreInfo();
         if (status.isTransientError() && pullTask.getAttempts() < MAX_ATTEMPTS) {
           pullTask.setAttempts(pullTask.getAttempts() + 1);
-          pullTask.setLastAttemptTimestamp(System.nanoTime());
+          pullTask.setLastAttemptTimestamp(System.nanoTime() / 1000000);
           pullTaskQueue.addDeduplicated(pullTask, true);
           log.info(String.format(Locale.ROOT, "Pulling core %s failed with transient error. Retrying. Last status=%s attempts=%s . %s",
               pullCoreInfo.getSharedStoreName(), status, pullTask.getAttempts(), message == null ? "" : message));

--- a/solr/core/src/java/org/apache/solr/store/blob/process/CorePullerFeeder.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/process/CorePullerFeeder.java
@@ -25,6 +25,7 @@ import org.apache.solr.core.CoreContainer;
 import org.apache.solr.store.blob.client.BlobCoreMetadata;
 import org.apache.solr.store.blob.metadata.BlobCoreSyncer;
 import org.apache.solr.store.blob.metadata.PushPullData;
+import org.apache.solr.store.blob.util.BlobStoreUtils;
 import org.apache.solr.store.blob.util.DeduplicatingList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -116,7 +117,7 @@ public class CorePullerFeeder extends CoreSyncFeeder {
       syncsEnqueuedSinceLastLog++;
 
       // Log if it's time (we did at least one pull otherwise we would be still blocked in the calls above)
-      final long now = System.nanoTime() / 1000000;
+      final long now = BlobStoreUtils.getCurrentNanoTimeInMs();
       final long msSinceLastLog = now - lastLoggedTimestamp;
       if (msSinceLastLog > minMsBetweenLogs) {
         log.info("Since last pull log " + msSinceLastLog + " ms ago, added "
@@ -212,7 +213,7 @@ public class CorePullerFeeder extends CoreSyncFeeder {
         PullCoreInfo pullCoreInfo = pullTask.getPullCoreInfo();
         if (status.isTransientError() && pullTask.getAttempts() < MAX_ATTEMPTS) {
           pullTask.setAttempts(pullTask.getAttempts() + 1);
-          pullTask.setLastAttemptTimestamp(System.nanoTime() / 1000000);
+          pullTask.setLastAttemptTimestamp(BlobStoreUtils.getCurrentNanoTimeInMs());
           pullTaskQueue.addDeduplicated(pullTask, true);
           log.info(String.format(Locale.ROOT, "Pulling core %s failed with transient error. Retrying. Last status=%s attempts=%s . %s",
               pullCoreInfo.getSharedStoreName(), status, pullTask.getAttempts(), message == null ? "" : message));

--- a/solr/core/src/java/org/apache/solr/store/blob/process/CorePusher.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/process/CorePusher.java
@@ -90,10 +90,10 @@ public class CorePusher {
       // so there is no question of starvation.
       // One option could be to snapshot a queue of pusher threads, we are working on behalf of,
       // before we capture the commit point to push. Once finished pushing, we can dismiss all those threads together.
-      long startTimeMs = System.nanoTime();
+      long startTimeNs = System.nanoTime();
       corePushLock.lock();
       try {
-        long lockAcquisitionTime = System.nanoTime() - startTimeMs;
+        long lockAcquisitionTime = (System.nanoTime() - startTimeNs) / 1000000;
         SolrCore core = coreContainer.getCore(coreName);
         if (core == null) {
           throw new SolrException(ErrorCode.SERVER_ERROR, "Can't find core " + coreName);

--- a/solr/core/src/java/org/apache/solr/store/blob/process/CorePusher.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/process/CorePusher.java
@@ -90,10 +90,10 @@ public class CorePusher {
       // so there is no question of starvation.
       // One option could be to snapshot a queue of pusher threads, we are working on behalf of,
       // before we capture the commit point to push. Once finished pushing, we can dismiss all those threads together.
-      long startTimeMs = BlobStoreUtils.getCurrentNanoTimeInMs();
+      long startTimeMs = BlobStoreUtils.getCurrentTimeMs();
       corePushLock.lock();
       try {
-        long lockAcquisitionTime = BlobStoreUtils.getCurrentNanoTimeInMs() - startTimeMs;
+        long lockAcquisitionTime = BlobStoreUtils.getCurrentTimeMs() - startTimeMs;
         SolrCore core = coreContainer.getCore(coreName);
         if (core == null) {
           throw new SolrException(ErrorCode.SERVER_ERROR, "Can't find core " + coreName);

--- a/solr/core/src/java/org/apache/solr/store/blob/process/CorePusher.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/process/CorePusher.java
@@ -90,10 +90,10 @@ public class CorePusher {
       // so there is no question of starvation.
       // One option could be to snapshot a queue of pusher threads, we are working on behalf of,
       // before we capture the commit point to push. Once finished pushing, we can dismiss all those threads together.
-      long startTimeNs = System.nanoTime();
+      long startTimeMs = BlobStoreUtils.getCurrentNanoTimeInMs();
       corePushLock.lock();
       try {
-        long lockAcquisitionTime = (System.nanoTime() - startTimeNs) / 1000000;
+        long lockAcquisitionTime = BlobStoreUtils.getCurrentNanoTimeInMs() - startTimeMs;
         SolrCore core = coreContainer.getCore(coreName);
         if (core == null) {
           throw new SolrException(ErrorCode.SERVER_ERROR, "Can't find core " + coreName);

--- a/solr/core/src/java/org/apache/solr/store/blob/util/BlobStoreUtils.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/util/BlobStoreUtils.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.solr.cloud.CloudDescriptor;
 import org.apache.solr.cloud.ZkController;
@@ -73,6 +74,16 @@ public class BlobStoreUtils {
    */
   public static String generateMetadataSuffix() {
     return UUID.randomUUID().toString();
+  }
+
+  /**
+   * Returns current nano time in millisecond resolution for use in measuring elapsed time.
+   * 
+   * Note: Do not combine this value with currentTimeMillis - currentTimeMillis will return ms relative to epoch
+   * while this method returns ms relative to some arbitrary time
+   */
+  public static long getCurrentNanoTimeInMs() {
+    return TimeUnit.MILLISECONDS.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
   }
 
   /***

--- a/solr/core/src/java/org/apache/solr/store/blob/util/BlobStoreUtils.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/util/BlobStoreUtils.java
@@ -77,12 +77,11 @@ public class BlobStoreUtils {
   }
 
   /**
-   * Returns current nano time in millisecond resolution for use in measuring elapsed time.
-   * 
-   * Note: Do not combine this value with currentTimeMillis - currentTimeMillis will return ms relative to epoch
+   * Returns current time in milliseconds for use in measuring elapsed time.
+   * Cannot be combined with currentTimeMillis - currentTimeMillis will return ms relative to epoch
    * while this method returns ms relative to some arbitrary time
    */
-  public static long getCurrentNanoTimeInMs() {
+  public static long getCurrentTimeMs() {
     return TimeUnit.MILLISECONDS.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
   }
 

--- a/solr/core/src/test/org/apache/solr/store/blob/client/CoreStorageClientTest.java
+++ b/solr/core/src/test/org/apache/solr/store/blob/client/CoreStorageClientTest.java
@@ -110,7 +110,7 @@ public class CoreStorageClientTest extends SolrTestCaseJ4 {
     File pulled = File.createTempFile("myPulledFile", ".txt");
     try {
       // Write binary data
-      byte bytesWritten[] = {0, -1, 5, 10, 32, 127, -15, 20, 0, -100, 40, 0, 0, 0, (byte) BlobStoreUtils.getCurrentNanoTimeInMs()};
+      byte bytesWritten[] = {0, -1, 5, 10, 32, 127, -15, 20, 0, -100, 40, 0, 0, 0, (byte) BlobStoreUtils.getCurrentTimeMs()};
 
       FileUtils.writeByteArrayToFile(local, bytesWritten);
 

--- a/solr/core/src/test/org/apache/solr/store/blob/client/CoreStorageClientTest.java
+++ b/solr/core/src/test/org/apache/solr/store/blob/client/CoreStorageClientTest.java
@@ -109,7 +109,7 @@ public class CoreStorageClientTest extends SolrTestCaseJ4 {
     File pulled = File.createTempFile("myPulledFile", ".txt");
     try {
       // Write binary data
-      byte bytesWritten[] = {0, -1, 5, 10, 32, 127, -15, 20, 0, -100, 40, 0, 0, 0, (byte) System.nanoTime()};
+      byte bytesWritten[] = {0, -1, 5, 10, 32, 127, -15, 20, 0, -100, 40, 0, 0, 0, (byte) (System.nanoTime() / 1000000)};
 
       FileUtils.writeByteArrayToFile(local, bytesWritten);
 

--- a/solr/core/src/test/org/apache/solr/store/blob/client/CoreStorageClientTest.java
+++ b/solr/core/src/test/org/apache/solr/store/blob/client/CoreStorageClientTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.lucene.util.IOUtils;
 import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.store.blob.util.BlobStoreUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -109,7 +110,7 @@ public class CoreStorageClientTest extends SolrTestCaseJ4 {
     File pulled = File.createTempFile("myPulledFile", ".txt");
     try {
       // Write binary data
-      byte bytesWritten[] = {0, -1, 5, 10, 32, 127, -15, 20, 0, -100, 40, 0, 0, 0, (byte) (System.nanoTime() / 1000000)};
+      byte bytesWritten[] = {0, -1, 5, 10, 32, 127, -15, 20, 0, -100, 40, 0, 0, 0, (byte) BlobStoreUtils.getCurrentNanoTimeInMs()};
 
       FileUtils.writeByteArrayToFile(local, bytesWritten);
 


### PR DESCRIPTION
# Description

Continue logging ms, but use System.nanoTime instead of System.currentTimeMillis for more precise measurement of elapsed time. Specifically updating references from this previous PR: https://github.com/apache/lucene-solr/pull/1117/

# Solution

Divide nanoseconds by 1000000 to get milliseconds. Converting nanoTime to milliseconds is more precise than using currentTimeMillis because it does not use the system clock time which could face disruptions

# Tests

Ran ant test and manually examined loglines
