### PR TITLE
SOLR-14219 force serialVersionUID of OverseerSolrResponse

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/OverseerSolrResponse.java
+++ b/solr/core/src/java/org/apache/solr/cloud/OverseerSolrResponse.java
@@ -26,7 +26,9 @@ import java.io.IOException;
 import java.util.Objects;
 
 public class OverseerSolrResponse extends SolrResponse {
-  
+ 
+  private static final long serialVersionUID = 4721653044098960880L;
+
   NamedList<Object> responseList = null;
 
   private long elapsedTime;


### PR DESCRIPTION
# Description

When the useUnsafeOverseerResponse=true option introduced in SOLR-14095 is used, the serialized OverseerSolrResponse has a different serialVersionUID to earlier versions, making it backwards-incompatible.

# Solution

This PR forces the serialVersionUID of OverseerSolrResponse to be the same value as before.

# Tests

Tested in a prototype environment with a mixed 8.4.1 and master-branch Solr nodes.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
