### PR TITLE
LUCENE-9164: Ignore ACE on tragic event if IW is closed

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -4867,6 +4867,10 @@ public class IndexWriter implements Closeable, TwoPhaseCommit, Accountable,
     assert tragedy instanceof MergePolicy.MergeAbortedException == false;
     // How can it be a tragedy when nothing happened?
     assert tragedy != null;
+    if (tragedy instanceof AlreadyClosedException && isOpen() == false) {
+      // AlreadyClosedException should not be considered a tragedy if IndexWriter is closed.
+      return;
+    }
     if (infoStream.isEnabled("IW")) {
       infoStream.message("IW", "hit tragic " + tragedy.getClass().getSimpleName() + " inside " + location);
     }


### PR DESCRIPTION
If an IndexWriter was closed, then AlreadyClosedException should not be considered a tragic event.