### PR TITLE
SOLR-14213: Configuring Solr Cloud to use Shared Storage

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/CreateCollectionCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/CreateCollectionCmd.java
@@ -114,6 +114,12 @@ public class CreateCollectionCmd implements OverseerCollectionMessageHandler.Cmd
     final boolean waitForFinalState = message.getBool(WAIT_FOR_FINAL_STATE, false);
     final String alias = message.getStr(ALIAS, collectionName);
     log.info("Create collection {}", collectionName);
+    
+    if (!ocmh.overseer.getCoreContainer().isSharedStoreEnabled()) {
+      throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, 
+          "Collection " + collectionName + " cannot be created because shared storage is not enabled on this cluster."
+              + " Check solr.xml for the correct configurations");
+    }
     if (clusterState.hasCollection(collectionName)) {
       throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, "collection already exists: " + collectionName);
     }

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/CreateCollectionCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/CreateCollectionCmd.java
@@ -109,13 +109,14 @@ public class CreateCollectionCmd implements OverseerCollectionMessageHandler.Cmd
     if (ocmh.zkStateReader.aliasesManager != null) { // not a mock ZkStateReader
       ocmh.zkStateReader.aliasesManager.update();
     }
+    final boolean sharedIndex = message.getBool(SHARED_INDEX, false);
     final Aliases aliases = ocmh.zkStateReader.getAliases();
     final String collectionName = message.getStr(NAME);
     final boolean waitForFinalState = message.getBool(WAIT_FOR_FINAL_STATE, false);
     final String alias = message.getStr(ALIAS, collectionName);
     log.info("Create collection {}", collectionName);
     
-    if (!ocmh.overseer.getCoreContainer().isSharedStoreEnabled()) {
+    if (sharedIndex && !ocmh.overseer.getCoreContainer().isSharedStoreEnabled()) {
       throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, 
           "Collection " + collectionName + " cannot be created because shared storage is not enabled on this cluster."
               + " Check solr.xml for the correct configurations");

--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -742,7 +742,7 @@ public class CoreContainer {
       if (cfg.getSharedStoreConfig() != null) {
         log.info("Shared storage is enabled in Solr Cloud. Initiating SharedStoreManager.");
         sharedStoreManager = new SharedStoreManager(getZkController());
-        sharedStoreManager.load();
+        sharedStoreManager.load(this);
       }
     }
 
@@ -1089,8 +1089,7 @@ public class CoreContainer {
         }
         
         if (sharedStoreManager != null) {
-          sharedStoreManager.getBlobProcessManager().shutdown();
-          sharedStoreManager.getBlobDeleteManager().shutdown();
+          sharedStoreManager.shutdown();
         }
       }
 

--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -741,8 +741,8 @@ public class CoreContainer {
       
       if (cfg.getSharedStoreConfig() != null) {
         log.info("Shared storage is enabled in Solr Cloud. Initiating SharedStoreManager.");
-        sharedStoreManager = new SharedStoreManager(getZkController());
-        sharedStoreManager.load(this);
+        sharedStoreManager = new SharedStoreManager(this);
+        sharedStoreManager.load();
       }
     }
 

--- a/solr/core/src/java/org/apache/solr/core/NodeConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/NodeConfig.java
@@ -78,6 +78,8 @@ public class NodeConfig {
   private final PluginInfo transientCacheConfig;
 
   private final PluginInfo tracerConfig;
+  
+  private final SharedStoreConfig sharedStoreConfig;
 
   private NodeConfig(String nodeName, Path coreRootDirectory, Path solrDataHome, Integer booleanQueryMaxClauseCount,
                      Path configSetBaseDirectory, String sharedLibDirectory,
@@ -87,7 +89,8 @@ public class NodeConfig {
                      LogWatcherConfig logWatcherConfig, CloudConfig cloudConfig, Integer coreLoadThreads, int replayUpdatesThreads,
                      int transientCacheSize, boolean useSchemaCache, String managementPath, SolrResourceLoader loader,
                      Properties solrProperties, PluginInfo[] backupRepositoryPlugins,
-                     MetricsConfig metricsConfig, PluginInfo transientCacheConfig, PluginInfo tracerConfig) {
+                     MetricsConfig metricsConfig, PluginInfo transientCacheConfig, PluginInfo tracerConfig,
+                     SharedStoreConfig sharedStoreConfig) {
     this.nodeName = nodeName;
     this.coreRootDirectory = coreRootDirectory;
     this.solrDataHome = solrDataHome;
@@ -114,6 +117,7 @@ public class NodeConfig {
     this.metricsConfig = metricsConfig;
     this.transientCacheConfig = transientCacheConfig;
     this.tracerConfig = tracerConfig;
+    this.sharedStoreConfig = sharedStoreConfig;
 
     if (this.cloudConfig != null && this.getCoreLoadThreadCount(false) < 2) {
       throw new SolrException(SolrException.ErrorCode.SERVER_ERROR,
@@ -232,6 +236,10 @@ public class NodeConfig {
   public PluginInfo getTracerConfiguratorPluginInfo() {
     return tracerConfig;
   }
+  
+  public SharedStoreConfig getSharedStoreConfig() {
+    return sharedStoreConfig;
+  }
 
   public static class NodeConfigBuilder {
 
@@ -261,6 +269,7 @@ public class NodeConfig {
     private MetricsConfig metricsConfig;
     private PluginInfo transientCacheConfig;
     private PluginInfo tracerConfig;
+    private SharedStoreConfig sharedStoreConfig;
 
     private final SolrResourceLoader loader;
     private final String nodeName;
@@ -422,13 +431,18 @@ public class NodeConfig {
       this.tracerConfig = tracerConfig;
       return this;
     }
+    
+    public NodeConfigBuilder setSharedStoreConfig(SharedStoreConfig sharedStoreConfig) {
+      this.sharedStoreConfig = sharedStoreConfig;
+      return this;
+    }
 
     public NodeConfig build() {
       return new NodeConfig(nodeName, coreRootDirectory, solrDataHome, booleanQueryMaxClauseCount,
                             configSetBaseDirectory, sharedLibDirectory, shardHandlerFactoryConfig,
                             updateShardHandlerConfig, coreAdminHandlerClass, collectionsAdminHandlerClass, healthCheckHandlerClass, infoHandlerClass, configSetsHandlerClass,
                             logWatcherConfig, cloudConfig, coreLoadThreads, replayUpdatesThreads, transientCacheSize, useSchemaCache, managementPath, loader, solrProperties,
-                            backupRepositoryPlugins, metricsConfig, transientCacheConfig, tracerConfig);
+                            backupRepositoryPlugins, metricsConfig, transientCacheConfig, tracerConfig, sharedStoreConfig);
     }
   }
 }

--- a/solr/core/src/java/org/apache/solr/core/SharedStoreConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SharedStoreConfig.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.core;
+
+import org.apache.solr.common.util.NamedList;
+import org.apache.solr.core.SolrXmlConfig;
+
+/**
+ * Configuration class representing the configuration of Solr Cloud using shared storage
+ * to persist index files. The configuration properties come from solr.xml and are loaded
+ * via {@link SolrXmlConfig} at Solr startup. The presence of sharedStore section in the solr.xml
+ * file of a Solr Cloud mode cluster indicates the user's intention to enable shared storage 
+ * capabilities in the cluster and starts the necessary components required to create/support
+ * shared-type Solr collections.
+ * 
+ * TODO: This class is bare bones until we convert the many hard coded configuration values
+ * into configurable fields that can be specified under this section. The current responsibility
+ * of this class is to ensure shared storage is enabled on the cluster and initiate the necessary
+ * processes associated with it.
+ */
+public class SharedStoreConfig {
+  
+  public static SharedStoreConfig loadSharedStoreConfig(NamedList<Object> nl) {
+    if (nl == null) {
+      // shared store is not configured
+      return null;
+    }
+    return new SharedStoreConfig();
+  }
+}

--- a/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
@@ -16,10 +16,8 @@
  */
 package org.apache.solr.core;
 
-import javax.management.MBeanServer;
-import javax.xml.xpath.XPath;
-import javax.xml.xpath.XPathConstants;
-import javax.xml.xpath.XPathExpressionException;
+import static org.apache.solr.common.params.CommonParams.NAME;
+
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.lang.invoke.MethodHandles;
@@ -34,7 +32,11 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
-import com.google.common.base.Strings;
+import javax.management.MBeanServer;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.solr.client.solrj.impl.HttpClientUtil;
 import org.apache.solr.common.SolrException;
@@ -51,7 +53,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 
-import static org.apache.solr.common.params.CommonParams.NAME;
+import com.google.common.base.Strings;
 
 
 /**
@@ -95,6 +97,12 @@ public class SolrXmlConfig {
       }
       updateConfig = deprecatedUpdateConfig;
     }
+    
+    SharedStoreConfig sharedStoreConfig = null;
+    if (config.getNodeList("solr/sharedStore", false).getLength() > 0) {
+      sharedStoreConfig = SharedStoreConfig.loadSharedStoreConfig(
+          readNodeListAsNamedList(config, "solr/sharedStore/*[@name]", "<sharedStore>"));
+    }
 
     NodeConfig.NodeConfigBuilder configBuilder = new NodeConfig.NodeConfigBuilder(nodeName, config.getResourceLoader());
     configBuilder.setUpdateShardHandlerConfig(updateConfig);
@@ -107,6 +115,7 @@ public class SolrXmlConfig {
       configBuilder.setCloudConfig(cloudConfig);
     configBuilder.setBackupRepositoryPlugins(getBackupRepositoryPluginInfos(config));
     configBuilder.setMetricsConfig(getMetricsConfig(config));
+    configBuilder.setSharedStoreConfig(sharedStoreConfig);
     return fillSolrSection(configBuilder, entries);
   }
 

--- a/solr/core/src/java/org/apache/solr/store/blob/metadata/ServerSideMetadata.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/metadata/ServerSideMetadata.java
@@ -45,7 +45,6 @@ import org.apache.solr.core.IndexDeletionPolicyWrapper;
 import org.apache.solr.core.SolrCore;
 import org.apache.solr.store.blob.client.BlobCoreMetadata;
 import org.apache.solr.store.blob.client.BlobException;
-import org.apache.solr.store.shared.SharedStoreManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -98,7 +97,7 @@ public class ServerSideMetadata {
   private final long generation;
   private final SolrCore core;
   private final String coreName;
-  private final CoreContainer coreContainer;
+  private final CoreContainer container;
 
   /**
    * Given a core name, builds the local metadata
@@ -110,7 +109,7 @@ public class ServerSideMetadata {
    */
   public ServerSideMetadata(String coreName, CoreContainer coreContainer, boolean reserveCommit) throws Exception {
     this.coreName = coreName;
-    this.coreContainer = coreContainer;
+    this.container = coreContainer;
     this.core = coreContainer.getCore(coreName);
 
     if (core == null) {
@@ -194,7 +193,7 @@ public class ServerSideMetadata {
   }
 
   public CoreContainer getCoreContainer() {
-    return coreContainer;
+    return container;
   }
 
   public long getGeneration() {

--- a/solr/core/src/java/org/apache/solr/store/blob/metadata/ServerSideMetadata.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/metadata/ServerSideMetadata.java
@@ -45,6 +45,7 @@ import org.apache.solr.core.IndexDeletionPolicyWrapper;
 import org.apache.solr.core.SolrCore;
 import org.apache.solr.store.blob.client.BlobCoreMetadata;
 import org.apache.solr.store.blob.client.BlobException;
+import org.apache.solr.store.shared.SharedStoreManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -97,7 +98,7 @@ public class ServerSideMetadata {
   private final long generation;
   private final SolrCore core;
   private final String coreName;
-  private final CoreContainer container;
+  private final CoreContainer coreContainer;
 
   /**
    * Given a core name, builds the local metadata
@@ -107,10 +108,10 @@ public class ServerSideMetadata {
    *
    * @throws Exception if core corresponding to <code>coreName</code> can't be found.
    */
-  public ServerSideMetadata(String coreName, CoreContainer container, boolean reserveCommit) throws Exception {
+  public ServerSideMetadata(String coreName, CoreContainer coreContainer, boolean reserveCommit) throws Exception {
     this.coreName = coreName;
-    this.container = container;
-    this.core = container.getCore(coreName);
+    this.coreContainer = coreContainer;
+    this.core = coreContainer.getCore(coreName);
 
     if (core == null) {
       throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "Can't find core " + coreName);
@@ -193,7 +194,7 @@ public class ServerSideMetadata {
   }
 
   public CoreContainer getCoreContainer() {
-    return this.container;
+    return coreContainer;
   }
 
   public long getGeneration() {

--- a/solr/core/src/java/org/apache/solr/store/blob/process/BlobProcessUtil.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/process/BlobProcessUtil.java
@@ -18,9 +18,12 @@ package org.apache.solr.store.blob.process;
 
 import java.lang.invoke.MethodHandles;
 
+import org.apache.solr.common.SolrException;
 import org.apache.solr.core.CoreContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
 
 /**
  * Utils related to blob background process e.g. init/shutdown of blob's background processes
@@ -33,18 +36,19 @@ public class BlobProcessUtil {
   /*
    * Start the Blob store async core pull machinery
    */
-  public BlobProcessUtil(CoreContainer coreContainer) {
-    this(coreContainer, new CorePullerFeeder(coreContainer));
+  public void load(CoreContainer coreContainer) {
+    load(new CorePullerFeeder(coreContainer));
   }
   
-  /*
-   * Start the Blob store async core pull machinery
-   */
-  public BlobProcessUtil(CoreContainer coreContainer, CorePullerFeeder cpf) {    
+  @VisibleForTesting
+  public void load(CorePullerFeeder cpf) {
     runningFeeder = initializeCorePullerFeeder(cpf);
   }
   
   public CorePullerFeeder getCorePullerFeeder() {
+    if (runningFeeder == null) {
+      throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "BlobProcessUtil has not been initialized yet!");
+    }
     return runningFeeder;
   }
   

--- a/solr/core/src/java/org/apache/solr/store/blob/process/BlobProcessUtil.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/process/BlobProcessUtil.java
@@ -19,7 +19,7 @@ package org.apache.solr.store.blob.process;
 import java.lang.invoke.MethodHandles;
 
 import org.apache.solr.common.SolrException;
-import org.apache.solr.core.CoreContainer;
+import org.apache.solr.store.shared.SharedStoreManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,8 +36,8 @@ public class BlobProcessUtil {
   /*
    * Start the Blob store async core pull machinery
    */
-  public void load(CoreContainer coreContainer) {
-    load(new CorePullerFeeder(coreContainer));
+  public void load(SharedStoreManager storeManager) {
+    load(new CorePullerFeeder(storeManager));
   }
   
   @VisibleForTesting

--- a/solr/core/src/java/org/apache/solr/store/blob/process/CorePullerFeeder.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/process/CorePullerFeeder.java
@@ -94,14 +94,6 @@ public class CorePullerFeeder extends CoreSyncFeeder {
 
   @Override
   void feedTheMonsters() throws InterruptedException {
-    while (cores.getSharedStoreManager() == null) {
-      // todo: Fix cyclic initialization sequence
-      // if thread starts early it will be killed since the initialization of sharedStoreManager has triggered the
-      // creation of this thread and following line will throw NPE.
-      if (Thread.interrupted()) {
-        throw new InterruptedException();
-      }
-    }
     CorePullTracker tracker = cores.getSharedStoreManager().getCorePullTracker();
     final long minMsBetweenLogs = 15000;
     long lastLoggedTimestamp = 0L;

--- a/solr/core/src/java/org/apache/solr/store/blob/process/CoreSyncFeeder.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/process/CoreSyncFeeder.java
@@ -25,7 +25,7 @@ import java.util.Set;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 //import com.force.commons.util.concurrent.NamedThreadFactory; difference?
 import org.apache.lucene.util.NamedThreadFactory;
-import org.apache.solr.core.CoreContainer;
+import org.apache.solr.store.shared.SharedStoreManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +37,7 @@ public abstract class CoreSyncFeeder implements Runnable, Closeable {
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  protected final CoreContainer cores;
+  protected final SharedStoreManager storeManager;
 
   /**
    * Maximum number of elements in the queue, NOT counting re-inserts after failures. Total queue size might therefore
@@ -64,9 +64,9 @@ public abstract class CoreSyncFeeder implements Runnable, Closeable {
   private volatile Thread executionThread;
   private volatile boolean closed = false;
 
-  protected CoreSyncFeeder(CoreContainer cores, int numSyncThreads) {
+  protected CoreSyncFeeder(SharedStoreManager storeManager, int numSyncThreads) {
     this.numSyncThreads = numSyncThreads;
-    this.cores = cores;
+    this.storeManager = storeManager;
   }
 
   @Override
@@ -115,7 +115,7 @@ public abstract class CoreSyncFeeder implements Runnable, Closeable {
   }
 
   boolean shouldContinueRunning() {
-    return !this.cores.isShutDown();
+    return !this.storeManager.getCoreContainer().isShutDown();
   }
 
   @Override

--- a/solr/core/src/java/org/apache/solr/store/shared/SharedCoreConcurrencyController.java
+++ b/solr/core/src/java/org/apache/solr/store/shared/SharedCoreConcurrencyController.java
@@ -132,15 +132,15 @@ public class SharedCoreConcurrencyController {
    */
   public static int MAX_ATTEMPTS_INDEXING_PULL_WRITE_LOCK = 10;
 
-  private final CoreContainer cores;
+  private final SharedShardMetadataController metadataController;
   /**
    * This cache maintains the shared store version the each core is at or ahead of(core has to sometimes be ahead of
    * shared store given indexing first happens locally before being propagated to shared store).
    */
   private final ConcurrentHashMap<String, SharedCoreVersionMetadata> coresVersionMetadata;
 
-  public SharedCoreConcurrencyController(CoreContainer cores) {
-    this.cores = cores;
+  public SharedCoreConcurrencyController(SharedShardMetadataController metadataController) {
+    this.metadataController = metadataController;
     coresVersionMetadata = buildMetadataCache();
   }
 
@@ -301,7 +301,6 @@ public class SharedCoreConcurrencyController {
 
   @VisibleForTesting
   protected void ensureShardVersionMetadataNodeExists(String collectionName, String shardName) {
-    SharedShardMetadataController metadataController = cores.getSharedStoreManager().getSharedShardMetadataController();
     try {
       // creates the metadata node if it doesn't exist
       metadataController.ensureMetadataNodeExists(collectionName, shardName);

--- a/solr/core/src/java/org/apache/solr/store/shared/SharedStoreManager.java
+++ b/solr/core/src/java/org/apache/solr/store/shared/SharedStoreManager.java
@@ -104,9 +104,10 @@ public class SharedStoreManager {
     blobProcessUtil = processUtil;
   }
   
+  @VisibleForTesting
   public void initBlobDeleteManager(BlobDeleteManager blobDeleteManager) {
     if (this.blobDeleteManager != null) {
-      blobDeleteManager.shutdown();
+      this.blobDeleteManager.shutdown();
     }
     this.blobDeleteManager = blobDeleteManager;
   }

--- a/solr/core/src/java/org/apache/solr/store/shared/SharedStoreManager.java
+++ b/solr/core/src/java/org/apache/solr/store/shared/SharedStoreManager.java
@@ -43,71 +43,38 @@ public class SharedStoreManager {
 
   public SharedStoreManager(ZkController controller) {
     zkController = controller;
-    // initialize BlobProcessUtil with the SharedStoreManager for background processes to be ready
-    blobProcessUtil = new BlobProcessUtil(zkController.getCoreContainer());
-    blobCoreSyncer = new BlobCoreSyncer();
-    sharedCoreConcurrencyController = new SharedCoreConcurrencyController(zkController.getCoreContainer());
-  }
-  
-  @VisibleForTesting
-  public void initBlobStorageProvider(BlobStorageProvider blobStorageProvider) {
-    this.blobStorageProvider = blobStorageProvider;
-  }
-  
-  @VisibleForTesting
-  public void initBlobProcessUtil(BlobProcessUtil processUtil) {
-    if (blobProcessUtil != null) {
-      blobProcessUtil.shutdown();
-    }
-    blobProcessUtil = processUtil;
-  }
-  
-  /*
-   * Initiates a SharedShardMetadataController if it doesn't exist and returns one 
-   */
-  public SharedShardMetadataController getSharedShardMetadataController() {
-    if (sharedShardMetadataController != null) {
-      return sharedShardMetadataController;
-    }
+    blobStorageProvider = new BlobStorageProvider();
+    blobDeleteManager = new BlobDeleteManager(getBlobStorageProvider().getClient());
+    corePullTracker = new CorePullTracker();
     sharedShardMetadataController = new SharedShardMetadataController(zkController.getSolrCloudManager());
+    sharedCoreConcurrencyController = new SharedCoreConcurrencyController(sharedShardMetadataController);
+  }
+  
+  /**
+   * Start blob processes that depend on an initiated SharedStoreManager
+   */
+  public void load() {
+    blobCoreSyncer = new BlobCoreSyncer();
+    blobProcessUtil = new BlobProcessUtil(zkController.getCoreContainer());
+  }
+
+  public SharedShardMetadataController getSharedShardMetadataController() {
     return sharedShardMetadataController;
   }
   
-  /*
-   * Initiates a BlobStorageProvider if it doesn't exist and returns one 
-   */
   public BlobStorageProvider getBlobStorageProvider() {
-    if (blobStorageProvider != null) {
-      return blobStorageProvider;
-    }
-    blobStorageProvider = new BlobStorageProvider();
     return blobStorageProvider;
   }
   
-  /*
-   * Initiates a BlobDeleteManager if it doesn't exist and returns one 
-   */
   public BlobDeleteManager getBlobDeleteManager() {
-    if (blobDeleteManager != null) {
-      return blobDeleteManager;
-    }
-    blobDeleteManager = new BlobDeleteManager(getBlobStorageProvider().getClient());
     return blobDeleteManager;
   }
   
   public BlobProcessUtil getBlobProcessManager() {
-    if (blobProcessUtil != null) {
-      return blobProcessUtil;
-    }
-    blobProcessUtil = new BlobProcessUtil(zkController.getCoreContainer());
     return blobProcessUtil;
   }
   
   public CorePullTracker getCorePullTracker() {
-    if (corePullTracker != null) {
-      return corePullTracker ;
-    }
-    corePullTracker = new CorePullTracker();
     return corePullTracker ;
   }
   
@@ -122,6 +89,19 @@ public class SharedStoreManager {
   @VisibleForTesting
   public void initConcurrencyController(SharedCoreConcurrencyController concurrencyController) {
     this.sharedCoreConcurrencyController = concurrencyController;
+  }
+  
+  @VisibleForTesting
+  public void initBlobStorageProvider(BlobStorageProvider blobStorageProvider) {
+    this.blobStorageProvider = blobStorageProvider;
+  }
+  
+  @VisibleForTesting
+  public void initBlobProcessUtil(BlobProcessUtil processUtil) {
+    if (blobProcessUtil != null) {
+      blobProcessUtil.shutdown();
+    }
+    blobProcessUtil = processUtil;
   }
 
 }

--- a/solr/core/src/java/org/apache/solr/store/shared/SharedStoreManager.java
+++ b/solr/core/src/java/org/apache/solr/store/shared/SharedStoreManager.java
@@ -34,7 +34,7 @@ import com.google.common.annotations.VisibleForTesting;
  */
 public class SharedStoreManager {
   
-  private ZkController zkController;
+  private CoreContainer coreContainer;
   private SharedShardMetadataController sharedShardMetadataController;
   private BlobStorageProvider blobStorageProvider;
   private BlobDeleteManager blobDeleteManager;
@@ -43,8 +43,10 @@ public class SharedStoreManager {
   private BlobCoreSyncer blobCoreSyncer;
   private SharedCoreConcurrencyController sharedCoreConcurrencyController;
 
-  public SharedStoreManager(ZkController controller) {
-    zkController = controller;
+  public SharedStoreManager(CoreContainer coreContainer) {
+    this.coreContainer = coreContainer;
+    ZkController zkController = coreContainer.getZkController();
+    
     blobStorageProvider = new BlobStorageProvider();
     blobDeleteManager = new BlobDeleteManager(getBlobStorageProvider().getClient());
     corePullTracker = new CorePullTracker();
@@ -57,8 +59,8 @@ public class SharedStoreManager {
   /**
    * Start blob processes that depend on an initiated {@link SharedStoreManager} in {@link CoreContainer}
    */
-  public void load(CoreContainer coreContainer) {
-    blobProcessUtil.load(coreContainer);
+  public void load() {
+    blobProcessUtil.load(this);
   }
 
   public SharedShardMetadataController getSharedShardMetadataController() {
@@ -87,6 +89,10 @@ public class SharedStoreManager {
 
   public SharedCoreConcurrencyController getSharedCoreConcurrencyController() {
     return sharedCoreConcurrencyController;
+  }
+  
+  public CoreContainer getCoreContainer() {
+    return coreContainer;
   }
   
   public void shutdown() {

--- a/solr/core/src/test-files/solr/solr-sharedstore.xml
+++ b/solr/core/src/test-files/solr/solr-sharedstore.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<!--
+ All (relative) paths are relative to the installation path
+-->
+<solr> 
+  <str name="shareSchema">${shareSchema:false}</str> 
+  <str name="configSetBaseDir">${configSetBaseDir:configsets}</str> 
+  <str name="coreRootDirectory">${coreRootDirectory:.}</str> 
+  <str name="collectionsHandler">${collectionsHandler:solr.CollectionsHandler}</str> 
+	
+	<shardHandlerFactory name="shardHandlerFactory" class="HttpShardHandlerFactory"> 
+    <str name="urlScheme">${urlScheme:}</str> 
+    <int name="socketTimeout">${socketTimeout:90000}</int> 
+    <int name="connTimeout">${connTimeout:15000}</int> 
+    <str name="shardsWhitelist">${SOLR_TESTS_SHARDS_WHITELIST:}</str> 
+  </shardHandlerFactory> 
+	
+	<solrcloud> 
+		<str name="host">127.0.0.1</str> 
+		<int name="hostPort">${hostPort:8983}</int> 
+		<str name="hostContext">${hostContext:solr}</str> 
+		<int name="zkClientTimeout">${solr.zkclienttimeout:30000}</int> 
+		<bool name="genericCoreNodeNames">${genericCoreNodeNames:true}</bool> 
+		<int name="leaderVoteWait">${leaderVoteWait:10000}</int> 
+		<int name="distribUpdateConnTimeout">${distribUpdateConnTimeout:45000}</int> 
+		<int name="distribUpdateSoTimeout">${distribUpdateSoTimeout:340000}</int> 
+		<str name="zkCredentialsProvider">${zkCredentialsProvider:org.apache.solr.common.cloud.DefaultZkCredentialsProvider}</str>  
+		<str name="zkACLProvider">${zkACLProvider:org.apache.solr.common.cloud.DefaultZkACLProvider}</str>  
+	</solrcloud> 
+	
+	<sharedStore>
+	 <!-- The presence of this config section enables shared storage capabilities for the entire cluster if it
+	 is in Solr Cloud mode -->
+	</sharedStore>
+	
+	<metrics> 
+		<reporter name="default" class="org.apache.solr.metrics.reporters.SolrJmxReporter"> 
+		  <str name="rootName">solr_${hostPort:8983}</str> 
+		</reporter> 
+	</metrics> 
+</solr>

--- a/solr/core/src/test/org/apache/solr/cloud/api/collections/SharedStorageShardMetadataTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/api/collections/SharedStorageShardMetadataTest.java
@@ -16,17 +16,14 @@
  */
 package org.apache.solr.cloud.api.collections;
 
-import java.nio.file.Path;
 import java.util.Map;
 
-import org.apache.solr.client.solrj.embedded.JettySolrRunner;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.common.cloud.DocCollection;
 import org.apache.solr.common.cloud.Replica.Type;
 import org.apache.solr.common.cloud.Slice;
 import org.apache.solr.common.cloud.ZkStateReader;
-import org.apache.solr.store.blob.client.CoreStorageClient;
 import org.apache.solr.store.shared.SolrCloudSharedStoreTestCase;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -41,19 +38,8 @@ public class SharedStorageShardMetadataTest extends SolrCloudSharedStoreTestCase
   
   @BeforeClass
   public static void setupCluster() throws Exception {    
-    configureCluster(3)
-      .addConfig("conf", configset("cloud-minimal"))
-      .configure();
-    
-    // we don't use this in testing
-    Path sharedStoreRootPath = createTempDir("tempDir");
-    CoreStorageClient storageClient = setupLocalBlobStoreClient(sharedStoreRootPath, DEFAULT_BLOB_DIR_NAME);
-    // configure same client for each runner, this isn't a concurrency test so this is fine
-    for (JettySolrRunner runner : cluster.getJettySolrRunners()) {
-      setupTestSharedClientForNode(getBlobStorageProviderTestInstance(storageClient), runner);
-    }
+    setupCluster(3);
   }
-  
   
   @AfterClass
   public static void teardownTest() throws Exception {

--- a/solr/core/src/test/org/apache/solr/cloud/api/collections/SimpleSharedStorageCollectionTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/api/collections/SimpleSharedStorageCollectionTest.java
@@ -69,7 +69,7 @@ public class SimpleSharedStorageCollectionTest extends SolrCloudSharedStoreTestC
    */
   @Test
   public void testCreateCollectionSharedDisabled() throws Exception {
-    setupClusterSharedDisable(3);
+    setupClusterSharedDisable(1);
     String collectionName = "BlobBasedCollectionName1";
     CloudSolrClient cloudClient = cluster.getSolrClient();
     

--- a/solr/core/src/test/org/apache/solr/cloud/api/collections/SimpleSharedStorageCollectionTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/api/collections/SimpleSharedStorageCollectionTest.java
@@ -16,47 +16,34 @@
  */
 package org.apache.solr.cloud.api.collections;
 
-import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.solr.client.solrj.embedded.JettySolrRunner;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.UpdateRequest;
+import org.apache.solr.common.SolrException;
 import org.apache.solr.common.cloud.DocCollection;
 import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.cloud.Replica.Type;
 import org.apache.solr.common.cloud.ZkStateReader;
-import org.apache.solr.store.blob.client.CoreStorageClient;
 import org.apache.solr.store.shared.SharedCoreConcurrencyController;
 import org.apache.solr.store.shared.SharedCoreConcurrencyController.SharedCoreVersionMetadata;
 import org.apache.solr.store.shared.SolrCloudSharedStoreTestCase;
 import org.junit.After;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
  * Tests related to shared storage based collections, i.e. collections having only replicas of type {@link Type#SHARED}.
  */
 public class SimpleSharedStorageCollectionTest extends SolrCloudSharedStoreTestCase {
-
-  private static Path sharedStoreRootPath;
-  
-  @BeforeClass
-  public static void setupClass() throws Exception {
-    sharedStoreRootPath = createTempDir("tempDir");    
-  }
   
   @After
   public void teardownTest() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
     }
-    // clean up the shared store after each test. The temp dir should clean up itself after the
-    // test class finishes
-    FileUtils.cleanDirectory(sharedStoreRootPath.toFile());
   }
   
   /**
@@ -66,7 +53,6 @@ public class SimpleSharedStorageCollectionTest extends SolrCloudSharedStoreTestC
   @Test
   public void testCreateCollection() throws Exception {
     setupCluster(3);
-    setupSolrNodes();
     String collectionName = "BlobBasedCollectionName1";
     CloudSolrClient cloudClient = cluster.getSolrClient();
     
@@ -76,6 +62,28 @@ public class SimpleSharedStorageCollectionTest extends SolrCloudSharedStoreTestC
     waitForState("Timed-out wait for collection to be created", collectionName, clusterShape(1, 1));
     assertTrue(cloudClient.getZkStateReader().getZkClient().exists(ZkStateReader.COLLECTIONS_ZKNODE + "/" + collectionName, false));
   }
+  
+  /**
+   * Test that verifies that a collection creation command for a "shared" type collection fails
+   * if the cluster was not enabled with shared storage
+   */
+  @Test
+  public void testCreateCollectionSharedDisabled() throws Exception {
+    setupClusterSharedDisable(3);
+    String collectionName = "BlobBasedCollectionName1";
+    CloudSolrClient cloudClient = cluster.getSolrClient();
+    
+    CollectionAdminRequest.Create create = CollectionAdminRequest.createCollection(collectionName, 1, 0).setSharedIndex(true).setSharedReplicas(1);
+    try {
+      create.process(cloudClient);
+      fail("Request should have failed");
+    } catch (SolrException ex) {
+      assertEquals(SolrException.ErrorCode.BAD_REQUEST.code, ex.code());
+      assertTrue(ex.getMessage().contains("shared storage is not enabled"));
+    } catch (Exception ex) {
+      fail("Unexpected exception thrown " + ex.getMessage());
+    }
+  }
 
   /**
    * Test that verifies that adding a NRT replica to a shared collection fails but adding a SHARED replica
@@ -84,7 +92,6 @@ public class SimpleSharedStorageCollectionTest extends SolrCloudSharedStoreTestC
   @Test
   public void testAddReplica() throws Exception {
     setupCluster(3);
-    setupSolrNodes();
     String collectionName = "BlobBasedCollectionName2";
     CloudSolrClient cloudClient = cluster.getSolrClient();
     
@@ -123,7 +130,6 @@ public class SimpleSharedStorageCollectionTest extends SolrCloudSharedStoreTestC
     String shardNames = "shard1";
     
     // setup testing components
-    setupSolrNodes();
     AtomicInteger evictionCount = new AtomicInteger(0);
     SharedCoreConcurrencyController concurrencyController = 
         configureTestSharedConcurrencyControllerForNode(cluster.getJettySolrRunner(0), evictionCount);
@@ -161,18 +167,12 @@ public class SimpleSharedStorageCollectionTest extends SolrCloudSharedStoreTestC
     assertEquals(null, scvm.getMetadataSuffix());
     assertEquals(null, scvm.getBlobCoreMetadata());
   }
-  
-  private void setupSolrNodes() throws Exception {
-    for (JettySolrRunner process : cluster.getJettySolrRunners()) {
-      CoreStorageClient storageClient = setupLocalBlobStoreClient(sharedStoreRootPath, DEFAULT_BLOB_DIR_NAME);
-      setupTestSharedClientForNode(getBlobStorageProviderTestInstance(storageClient), process);
-    }
-  }
 
   private SharedCoreConcurrencyController configureTestSharedConcurrencyControllerForNode(JettySolrRunner runner,
       AtomicInteger evictionCount) {
     SharedCoreConcurrencyController concurrencyController = 
-        new SharedCoreConcurrencyController(runner.getCoreContainer()) {
+        new SharedCoreConcurrencyController(runner.getCoreContainer().getSharedStoreManager()
+            .getSharedShardMetadataController()) {
       
       @Override
       public boolean removeCoreVersionMetadataIfPresent(String coreName) {

--- a/solr/core/src/test/org/apache/solr/store/blob/SharedStorageSplitTest.java
+++ b/solr/core/src/test/org/apache/solr/store/blob/SharedStorageSplitTest.java
@@ -17,7 +17,6 @@
 package org.apache.solr.store.blob;
 
 import java.lang.invoke.MethodHandles;
-import java.nio.file.Path;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -43,7 +42,6 @@ import org.apache.solr.common.cloud.DocCollection;
 import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.cloud.Slice;
 import org.apache.solr.common.cloud.ZkStateReader;
-import org.apache.solr.store.blob.client.CoreStorageClient;
 import org.apache.solr.store.shared.SolrCloudSharedStoreTestCase;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -60,21 +58,13 @@ public class SharedStorageSplitTest extends SolrCloudSharedStoreTestCase  {
   static Map<String, Map<String, CountDownLatch>> solrProcessesTaskTracker = new HashMap<>();
   
   @BeforeClass
-  public static void setupCluster() throws Exception {    
-    configureCluster(2)
-      .addConfig("conf", configset("cloud-minimal"))
-      .configure();
+  public static void setupCluster() throws Exception {
+    setupCluster(2);
     
-    // we don't use this in testing
-    Path sharedStoreRootPath = createTempDir("tempDir");
-    CoreStorageClient storageClient = setupLocalBlobStoreClient(sharedStoreRootPath, DEFAULT_BLOB_DIR_NAME);
-    // configure same client for each runner, this isn't a concurrency test so this is fine
     for (JettySolrRunner runner : cluster.getJettySolrRunners()) {
-      setupTestSharedClientForNode(getBlobStorageProviderTestInstance(storageClient), runner);
       solrProcessesTaskTracker.put(runner.getNodeName(), configureTestBlobProcessForNode(runner));
     }
   }
-  
   
   @AfterClass
   public static void teardownTest() throws Exception {

--- a/solr/core/src/test/org/apache/solr/store/shared/SimpleSharedStoreEndToEndPullTest.java
+++ b/solr/core/src/test/org/apache/solr/store/shared/SimpleSharedStoreEndToEndPullTest.java
@@ -16,13 +16,11 @@
  */
 package org.apache.solr.store.shared;
 
-import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.embedded.JettySolrRunner;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
@@ -33,9 +31,7 @@ import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.core.CoreContainer;
 import org.apache.solr.core.SolrCore;
-import org.apache.solr.store.blob.client.CoreStorageClient;
 import org.junit.After;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -43,21 +39,11 @@ import org.junit.Test;
  */
 public class SimpleSharedStoreEndToEndPullTest extends SolrCloudSharedStoreTestCase {
   
-  private static Path sharedStoreRootPath;
-  
-  @BeforeClass
-  public static void setupClass() throws Exception {
-    sharedStoreRootPath = createTempDir("tempDir");    
-  }
-  
   @After
   public void teardownTest() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
     }
-    // clean up the shared store after each test. The temp dir should clean up itself after the
-    // test class finishes
-    FileUtils.cleanDirectory(sharedStoreRootPath.toFile());
   }
   
   /**
@@ -73,13 +59,9 @@ public class SimpleSharedStoreEndToEndPullTest extends SolrCloudSharedStoreTestC
     Map<String, Map<String, CountDownLatch>> solrProcessesTaskTracker = new HashMap<>();
     
     JettySolrRunner solrProcess1 = cluster.getJettySolrRunner(0);
-    CoreStorageClient storageClient1 = setupLocalBlobStoreClient(sharedStoreRootPath, DEFAULT_BLOB_DIR_NAME);
-    setupTestSharedClientForNode(getBlobStorageProviderTestInstance(storageClient1), solrProcess1);
     Map<String, CountDownLatch> asyncPullLatches1 = configureTestBlobProcessForNode(solrProcess1);
     
     JettySolrRunner solrProcess2 = cluster.getJettySolrRunner(1);
-    CoreStorageClient storageClient2 = setupLocalBlobStoreClient(sharedStoreRootPath, DEFAULT_BLOB_DIR_NAME);
-    setupTestSharedClientForNode(getBlobStorageProviderTestInstance(storageClient2), solrProcess2);
     Map<String, CountDownLatch> asyncPullLatches2 = configureTestBlobProcessForNode(solrProcess2);
     
     solrProcessesTaskTracker.put(solrProcess1.getNodeName(), asyncPullLatches1);

--- a/solr/core/src/test/org/apache/solr/store/shared/SolrCloudSharedStoreTestCase.java
+++ b/solr/core/src/test/org/apache/solr/store/shared/SolrCloudSharedStoreTestCase.java
@@ -188,7 +188,8 @@ public class SolrCloudSharedStoreTestCase extends SolrCloudTestCase {
       }
     };
 
-    BlobProcessUtil testUtil = new BlobProcessUtil(runner.getCoreContainer(), cpf);
+    BlobProcessUtil testUtil = new BlobProcessUtil();
+    testUtil.load(cpf);
     setupTestBlobProcessUtilForNode(testUtil, runner);
     return asyncPullTracker;
   }

--- a/solr/core/src/test/org/apache/solr/store/shared/SolrCloudSharedStoreTestCase.java
+++ b/solr/core/src/test/org/apache/solr/store/shared/SolrCloudSharedStoreTestCase.java
@@ -181,7 +181,7 @@ public class SolrCloudSharedStoreTestCase extends SolrCloudTestCase {
       }
     };
     
-    CorePullerFeeder cpf = new CorePullerFeeder(runner.getCoreContainer()) {  
+    CorePullerFeeder cpf = new CorePullerFeeder(runner.getCoreContainer().getSharedStoreManager()) {  
       @Override
       protected CorePullTask.PullCoreCallback getCorePullTaskCallback() {
         return callback;

--- a/solr/core/src/test/org/apache/solr/store/shared/metadata/SharedShardMetadataControllerTest.java
+++ b/solr/core/src/test/org/apache/solr/store/shared/metadata/SharedShardMetadataControllerTest.java
@@ -22,9 +22,9 @@ import java.util.NoSuchElementException;
 import org.apache.solr.client.solrj.cloud.SolrCloudManager;
 import org.apache.solr.client.solrj.cloud.autoscaling.BadVersionException;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
-import org.apache.solr.cloud.SolrCloudTestCase;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.util.Utils;
+import org.apache.solr.store.shared.SolrCloudSharedStoreTestCase;
 import org.apache.solr.store.shared.metadata.SharedShardMetadataController.SharedShardVersionMetadata;
 import org.apache.zookeeper.data.Stat;
 import org.junit.After;
@@ -34,7 +34,7 @@ import org.junit.Test;
 /**
  * Tests for {@link SharedShardMetadataController}
  */
-public class SharedShardMetadataControllerTest extends SolrCloudTestCase {
+public class SharedShardMetadataControllerTest extends SolrCloudSharedStoreTestCase {
 
   static final String TEST_COLLECTION_NAME = "testCollectionName1";
   static final String TEST_SHARD_NAME = "testShardName";
@@ -47,9 +47,7 @@ public class SharedShardMetadataControllerTest extends SolrCloudTestCase {
   @BeforeClass
   public static void setupCluster() throws Exception {
     assumeWorkingMockito();
-    configureCluster(1)
-      .addConfig("conf", configset("cloud-minimal"))
-      .configure();
+    setupCluster(1);
     
     cloudManager = cluster.getJettySolrRunner(0).getCoreContainer().
         getZkController().getSolrCloudManager();

--- a/solr/core/src/test/org/apache/solr/update/processor/DistributedZkUpdateProcessorTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/DistributedZkUpdateProcessorTest.java
@@ -20,11 +20,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-import java.io.File;
-import java.nio.file.Path;
-
-import org.apache.commons.io.FileUtils;
-import org.apache.solr.client.solrj.embedded.JettySolrRunner;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.UpdateRequest;
@@ -41,7 +36,6 @@ import org.apache.solr.core.SolrCore;
 import org.apache.solr.request.LocalSolrQueryRequest;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.response.SolrQueryResponse;
-import org.apache.solr.store.blob.client.CoreStorageClient;
 import org.apache.solr.store.blob.process.CoreUpdateTracker;
 import org.apache.solr.store.shared.SolrCloudSharedStoreTestCase;
 import org.apache.solr.update.AddUpdateCommand;
@@ -55,16 +49,9 @@ import org.mockito.Mockito;
  * Test for the {@link DistributedZkUpdateProcessor}.
  */
 public class DistributedZkUpdateProcessorTest extends SolrCloudSharedStoreTestCase {    
-
-  private static Path sharedStoreRootPath;
-  private static CoreStorageClient storageClient;
   
   @BeforeClass
   public static void setupTestClass() throws Exception {
-    assumeWorkingMockito();
-    sharedStoreRootPath = createTempDir("tempDir");
-    storageClient = setupLocalBlobStoreClient(sharedStoreRootPath, DEFAULT_BLOB_DIR_NAME);
-    
     assumeWorkingMockito();
   }
   
@@ -72,8 +59,6 @@ public class DistributedZkUpdateProcessorTest extends SolrCloudSharedStoreTestCa
   public void teardownTest() throws Exception {
     cluster.deleteAllCollections();
     shutdownCluster();
-    File blobPath = sharedStoreRootPath.toFile();
-    FileUtils.cleanDirectory(blobPath);
   }
   
   /**
@@ -84,7 +69,6 @@ public class DistributedZkUpdateProcessorTest extends SolrCloudSharedStoreTestCa
   @Test
   public void testNonLeaderSharedReplicaFailsOnForwardedCommit() throws Exception {
     setupCluster(1);
-    setupTestSharedClientForNode(getBlobStorageProviderTestInstance(storageClient), cluster.getJettySolrRunner(0));
 
     String collectionName = "sharedCollection";
     CloudSolrClient cloudClient = cluster.getSolrClient();
@@ -175,7 +159,6 @@ public class DistributedZkUpdateProcessorTest extends SolrCloudSharedStoreTestCa
    */
   private void testReplicaUpdatesZk(Replica.Type replicaType, boolean isUpdateAnIsolatedCommit, boolean isWriteToSharedStoreExpected) throws Exception {
     setupCluster(1);
-    setupTestSharedClientForNode(getBlobStorageProviderTestInstance(storageClient), cluster.getJettySolrRunner(0));
 
     // Set collection name and create client
     String collectionName = "testCollection";
@@ -257,11 +240,6 @@ public class DistributedZkUpdateProcessorTest extends SolrCloudSharedStoreTestCa
   @Test
   public void testSharedReplicaSimpleUpdateOnLeaderSuccess() throws Exception {
     setupCluster(3);
-    
-    // configure same client for each runner, this isn't a concurrency test so this is fine
-    for (JettySolrRunner runner : cluster.getJettySolrRunners()) {
-      setupTestSharedClientForNode(getBlobStorageProviderTestInstance(storageClient), runner);
-    }
     
     String collectionName = "sharedCollection";
     CloudSolrClient cloudClient = cluster.getSolrClient();


### PR DESCRIPTION
This is an initial PR that allows Solr Cloud to be configured to use shared storage or not. Prior to this, shared storage is "on" by default with components be lazily initialized as needed e.g. when a collection of type shared is created. This of course is difficult to do correctly. 

The solution proposed by this PR is check for the presence of a <sharedStorage> section in solr.xml that indicates the user's intention to use shared storage and initiate the components on startup. This also sets the stage for future work we need to do to move some hard coded values into configurable parameters that would be specified in sharedStorage. See the JIRA for further discussion. 

Changes:
- solr.xml supports a bare-bone <sharedStorage></sharedStorage> section that should be added to enable shared storage on the cluster
- If core discovery discovers a shared collection but the cluster is not shared storage enabled, this is considered a fatal error (user error) and solr will not start in stable state
- Collections of type shared can only be created if the cluster is shared storage enabled (all shared functionality is already gated behind the presence of shared replicas within shared collections)
- Added a test in SimpleSharedStorageCollectionTest to ensure proper feature gating
- Refactored our test setup for anything using SolrCloudSharedStoreTestCase to automatically start a mini solr cluster with a solr.xml (added solr-sharedstorage.xml) containing the sharedStorage section. Also made a change moving the local FS client setup into this parent class  so that any extending test classes don't need to worry about setting the shared directory up unless they want to mock the client themselves