### PR TITLE
LUCENE-9197: fix wrong implementation on Point2D#withinTriangle

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/geo/Point2D.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/Point2D.java
@@ -70,6 +70,9 @@ public class Point2D implements Component2D {
   @Override
   public PointValues.Relation relateTriangle(double minX, double maxX, double minY, double maxY,
                                              double ax, double ay, double bx, double by, double cx, double cy) {
+    if (ax == bx && bx == cx && ay == by && by == cy) {
+      return contains(ax, ay) ? PointValues.Relation.CELL_INSIDE_QUERY : PointValues.Relation.CELL_OUTSIDE_QUERY;
+    }
     if (Component2D.pointInTriangle(minX, maxX, minY, maxY, x, y, ax, ay, bx, by, cx, cy)) {
       return PointValues.Relation.CELL_INSIDE_QUERY;
     }

--- a/lucene/core/src/java/org/apache/lucene/geo/Point2D.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/Point2D.java
@@ -19,8 +19,6 @@ package org.apache.lucene.geo;
 
 import org.apache.lucene.index.PointValues;
 
-import static org.apache.lucene.geo.GeoUtils.orient;
-
 /**
  * 2D point implementation containing geo spatial logic.
  *
@@ -72,31 +70,7 @@ public class Point2D implements Component2D {
   @Override
   public PointValues.Relation relateTriangle(double minX, double maxX, double minY, double maxY,
                                              double ax, double ay, double bx, double by, double cx, double cy) {
-    if (Component2D.containsPoint(x, y, minX, maxX, minY, maxY) == false) {
-      return PointValues.Relation.CELL_OUTSIDE_QUERY;
-    }
-    if (ax == bx && bx == cx && ay == by && by == cy) {
-      return  PointValues.Relation.CELL_INSIDE_QUERY;
-    } else if (ax == cx && ay == cy) {
-      // indexed "triangle" is a line:
-      if (orient(ax, ay, bx, by, x, y) == 0) {
-        return PointValues.Relation.CELL_INSIDE_QUERY;
-      }
-      return PointValues.Relation.CELL_OUTSIDE_QUERY;
-    } else if (ax == bx && ay == by) {
-      // indexed "triangle" is a line:
-      if (orient(bx, by, cx, cy, x, y) == 0) {
-        return PointValues.Relation.CELL_INSIDE_QUERY;
-      }
-      return PointValues.Relation.CELL_OUTSIDE_QUERY;
-    } else if (bx == cx && by == cy) {
-      // indexed "triangle" is a line:
-      if (orient(cx, cy, ax, ay, x, y) == 0) {
-        return PointValues.Relation.CELL_INSIDE_QUERY;
-      }
-      return PointValues.Relation.CELL_OUTSIDE_QUERY;
-    } else if (Component2D.pointInTriangle(minX, maxX, minY, maxY, x, y, ax, ay, bx, by, cx, cy) == true) {
-      // indexed "triangle" is a triangle:
+    if (Component2D.pointInTriangle(minX, maxX, minY, maxY, x, y, ax, ay, bx, by, cx, cy)) {
       return PointValues.Relation.CELL_INSIDE_QUERY;
     }
     return PointValues.Relation.CELL_OUTSIDE_QUERY;
@@ -105,10 +79,8 @@ public class Point2D implements Component2D {
   @Override
   public WithinRelation withinTriangle(double minX, double maxX, double minY, double maxY,
                                        double aX, double aY, boolean ab, double bX, double bY, boolean bc, double cX, double cY, boolean ca) {
-    if (aX == bX && aY == bY && aX == cX && aY == cY) {
-      if (contains(aX, aY)) {
-        return WithinRelation.CANDIDATE;
-      }
+    if (Component2D.pointInTriangle(minX, maxX, minY, maxY, x, y, aX, aY, bX, bY, cX, cY)) {
+      return WithinRelation.CANDIDATE;
     }
     return WithinRelation.DISJOINT;
   }

--- a/lucene/core/src/test/org/apache/lucene/geo/TestPoint2D.java
+++ b/lucene/core/src/test/org/apache/lucene/geo/TestPoint2D.java
@@ -31,29 +31,36 @@ public class TestPoint2D extends LuceneTestCase {
     double cx = 5;
     double cy = 4;
     assertEquals(Relation.CELL_OUTSIDE_QUERY, point2D.relateTriangle(ax, ay, bx, by , cx, cy));
+    assertEquals(Component2D.WithinRelation.DISJOINT,
+        point2D.withinTriangle(ax, ay, random().nextBoolean(), bx, by, random().nextBoolean(), cx, cy, random().nextBoolean()));
   }
 
   public void testTriangleIntersects() {
     Component2D point2D = Point2D.create(new double[] {0, 0});
     double ax = 0.0;
     double ay = 0.0;
-    double bx = 1;
-    double by = 0;
-    double cx = 0;
-    double cy = 1;
+    double bx = 0.0;
+    double by = 0.0;
+    double cx = 0.0;
+    double cy = 0.0;
     assertEquals(Relation.CELL_INSIDE_QUERY, point2D.relateTriangle(ax, ay, bx, by , cx, cy));
+    assertEquals(Component2D.WithinRelation.CANDIDATE,
+        point2D.withinTriangle(ax, ay, random().nextBoolean(), bx, by, random().nextBoolean(), cx, cy, random().nextBoolean()));
   }
 
   public void testTriangleContains() {
     Component2D point2D = Point2D.create(new double[] {0, 0});
-    double ax = 0.0;
-    double ay = 0.0;
-    double bx = 0;
-    double by = 0;
+    double ax = -1.0;
+    double ay = -1.0;
+    double bx = 1;
+    double by = -1;
     double cx = 0;
-    double cy = 0;
+    double cy = 2;
     assertEquals(Relation.CELL_INSIDE_QUERY, point2D.relateTriangle(ax, ay, bx, by , cx, cy));
+    assertEquals(Component2D.WithinRelation.CANDIDATE,
+        point2D.withinTriangle(ax, ay, random().nextBoolean(), bx, by, random().nextBoolean(), cx, cy, random().nextBoolean()));
   }
+
 
   public void testRandomTriangles() {
     Component2D point2D = Point2D.create(new double[] {GeoTestUtil.nextLatitude(), GeoTestUtil.nextLongitude()});
@@ -74,6 +81,8 @@ public class TestPoint2D extends LuceneTestCase {
       Relation r = point2D.relate(tMinX, tMaxX, tMinY, tMaxY);
       if (r == Relation.CELL_OUTSIDE_QUERY) {
         assertEquals(Relation.CELL_OUTSIDE_QUERY, point2D.relateTriangle(ax, ay, bx, by, cx, cy));
+        assertEquals(Component2D.WithinRelation.DISJOINT,
+            point2D.withinTriangle(ax, ay, random().nextBoolean(), bx, by, random().nextBoolean(), cx, cy, random().nextBoolean()));
       }
     }
   }

--- a/lucene/core/src/test/org/apache/lucene/geo/TestPoint2D.java
+++ b/lucene/core/src/test/org/apache/lucene/geo/TestPoint2D.java
@@ -39,10 +39,10 @@ public class TestPoint2D extends LuceneTestCase {
     Component2D point2D = Point2D.create(new double[] {0, 0});
     double ax = 0.0;
     double ay = 0.0;
-    double bx = 0.0;
-    double by = 0.0;
-    double cx = 0.0;
-    double cy = 0.0;
+    double bx = 1;
+    double by = 0;
+    double cx = 0;
+    double cy = 1;
     assertEquals(Relation.CELL_INSIDE_QUERY, point2D.relateTriangle(ax, ay, bx, by , cx, cy));
     assertEquals(Component2D.WithinRelation.CANDIDATE,
         point2D.withinTriangle(ax, ay, random().nextBoolean(), bx, by, random().nextBoolean(), cx, cy, random().nextBoolean()));
@@ -50,12 +50,12 @@ public class TestPoint2D extends LuceneTestCase {
 
   public void testTriangleContains() {
     Component2D point2D = Point2D.create(new double[] {0, 0});
-    double ax = -1.0;
-    double ay = -1.0;
-    double bx = 1;
-    double by = -1;
+    double ax = 0.0;
+    double ay = 0.0;
+    double bx = 0;
+    double by = 0;
     double cx = 0;
-    double cy = 2;
+    double cy = 0;
     assertEquals(Relation.CELL_INSIDE_QUERY, point2D.relateTriangle(ax, ay, bx, by , cx, cy));
     assertEquals(Component2D.WithinRelation.CANDIDATE,
         point2D.withinTriangle(ax, ay, random().nextBoolean(), bx, by, random().nextBoolean(), cx, cy, random().nextBoolean()));


### PR DESCRIPTION
The logic is messed up, this PR fix it. It actually simplifies as well the logic for relateTriangle (I have no idea what I was thinking of in the first implementation :)