### PR TITLE
LUCENE-9171: Add BoostAttribute handling to QueryBuilder

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/QueryBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/util/QueryBuilder.java
@@ -65,10 +65,18 @@ public class QueryBuilder {
   protected boolean enableGraphQueries = true;
   protected boolean autoGenerateMultiTermSynonymsPhraseQuery = false;
 
+  /**
+   * Wraps a term and boost
+   */
   public static class TermAndBoost {
+    /** the term */
     public final Term term;
+    /** the boost */
     public final float boost;
 
+    /**
+     * Creates a new TermAndBoost
+     */
     public TermAndBoost(Term term, float boost) {
       this.term = term;
       this.boost = boost;

--- a/lucene/core/src/test/org/apache/lucene/util/TestQueryBuilder.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestQueryBuilder.java
@@ -30,7 +30,6 @@ import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
-import org.apache.lucene.analysis.tokenattributes.TypeAttribute;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;

--- a/lucene/core/src/test/org/apache/lucene/util/TestQueryBuilder.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestQueryBuilder.java
@@ -20,6 +20,7 @@ package org.apache.lucene.util;
 import java.io.IOException;
 
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.AnalyzerWrapper;
 import org.apache.lucene.analysis.CannedBinaryTokenStream;
 import org.apache.lucene.analysis.MockAnalyzer;
 import org.apache.lucene.analysis.MockSynonymFilter;
@@ -29,9 +30,12 @@ import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
+import org.apache.lucene.analysis.tokenattributes.TypeAttribute;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.BoostAttribute;
+import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MultiPhraseQuery;
 import org.apache.lucene.search.PhraseQuery;
@@ -506,5 +510,52 @@ public class TestQueryBuilder extends LuceneTestCase {
     try (TokenStream ts = new CannedBinaryTokenStream(tokens)) {
       expectThrows(IndexSearcher.TooManyClauses.class, () -> qb.analyzeGraphPhrase(ts, "", 0));
     }
+  }
+
+  private static final class MockBoostTokenFilter extends TokenFilter {
+
+    final BoostAttribute boostAtt = addAttribute(BoostAttribute.class);
+    final CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
+
+    protected MockBoostTokenFilter(TokenStream input) {
+      super(input);
+    }
+
+    @Override
+    public boolean incrementToken() throws IOException {
+      if (input.incrementToken() == false) {
+        return false;
+      }
+      if (termAtt.length() == 3) {
+        boostAtt.setBoost(0.5f);
+      }
+      return true;
+    }
+  }
+
+  public void testTokenStreamBoosts() {
+    Analyzer msa = new MockSynonymAnalyzer();
+    Analyzer a = new AnalyzerWrapper(msa.getReuseStrategy()) {
+      @Override
+      protected Analyzer getWrappedAnalyzer(String fieldName) {
+        return msa;
+      }
+      @Override
+      protected TokenStreamComponents wrapComponents(String fieldName, TokenStreamComponents components) {
+        return new TokenStreamComponents(components.getSource(), new MockBoostTokenFilter(components.getTokenStream()));
+      }
+    };
+
+    QueryBuilder builder = new QueryBuilder(a);
+    Query q = builder.createBooleanQuery("field", "hot dogs");
+    Query expected = new BooleanQuery.Builder()
+        .add(new BoostQuery(new TermQuery(new Term("field", "hot")), 0.5f), BooleanClause.Occur.SHOULD)
+        .add(new SynonymQuery.Builder("field")
+            .addTerm(new Term("field", "dogs"))
+            .addTerm(new Term("field", "dog"), 0.5f)
+            .build(), BooleanClause.Occur.SHOULD)
+        .build();
+
+    assertEquals(expected, q);
   }
 }

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/complexPhrase/ComplexPhraseQueryParser.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/complexPhrase/ComplexPhraseQueryParser.java
@@ -147,7 +147,7 @@ public class ComplexPhraseQueryParser extends QueryParser {
   // to throw a runtime exception here if a term for another field is embedded
   // in phrase query
   @Override
-  protected Query newTermQuery(Term term) {
+  protected Query newTermQuery(Term term, float boost) {
     if (isPass2ResolvingPhrases) {
       try {
         checkPhraseClauseIsForSameField(term.field());
@@ -155,7 +155,7 @@ public class ComplexPhraseQueryParser extends QueryParser {
         throw new RuntimeException("Error parsing complex phrase", pe);
       }
     }
-    return super.newTermQuery(term);
+    return super.newTermQuery(term, boost);
   }
 
   // Helper method used to report on any clauses that appear in query syntax

--- a/solr/core/src/java/org/apache/solr/parser/SolrQueryParserBase.java
+++ b/solr/core/src/java/org/apache/solr/parser/SolrQueryParserBase.java
@@ -601,19 +601,19 @@ public abstract class SolrQueryParserBase extends QueryBuilder {
   }
 
   @Override
-  protected Query newSynonymQuery(Term terms[]) {
+  protected Query newSynonymQuery(TermAndBoost[] terms) {
     switch (synonymQueryStyle) {
       case PICK_BEST:
         List<Query> currPosnClauses = new ArrayList<Query>(terms.length);
-        for (Term term : terms) {
-          currPosnClauses.add(newTermQuery(term));
+        for (TermAndBoost term : terms) {
+          currPosnClauses.add(newTermQuery(term.term, term.boost));
         }
         DisjunctionMaxQuery dm = new DisjunctionMaxQuery(currPosnClauses, 0.0f);
         return dm;
       case AS_DISTINCT_TERMS:
         BooleanQuery.Builder builder = new BooleanQuery.Builder();
-        for (Term term : terms) {
-          builder.add(newTermQuery(term), BooleanClause.Occur.SHOULD);
+        for (TermAndBoost term : terms) {
+          builder.add(newTermQuery(term.term, term.boost), BooleanClause.Occur.SHOULD);
         }
         return builder.build();
       case AS_SAME_TERM:


### PR DESCRIPTION
This commit allows QueryBuilder to add boosts to term queries and synonym queries 
when a boost is specified on a particular term via a BoostAttribute.