### PR TITLE
LUCENE-9211 Add compression for Binary doc value fields

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -122,6 +122,8 @@ New Features
 Improvements
 ---------------------
 
+* LUCENE-9211: Add compression for Binary doc value fields. (Mark Harwood)
+
 * LUCENE-9149: Increase data dimension limit in BKD. (Nick Knize)
 
 * LUCENE-9102: Add maxQueryLength option to DirectSpellchecker. (Andy Webb via Bruno Roustant)

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene80/Lucene80DocValuesConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene80/Lucene80DocValuesConsumer.java
@@ -360,7 +360,7 @@ final class Lucene80DocValuesConsumer extends DocValuesConsumer implements Close
     }
   }
 
-  class CompressedBinaryBlockWriter  implements Closeable {
+  class CompressedBinaryBlockWriter implements Closeable {
     FastCompressionHashTable ht = new LZ4.FastCompressionHashTable();    
     int uncompressedBlockLength = 0;
     int maxUncompressedBlockLength = 0;
@@ -384,7 +384,7 @@ final class Lucene80DocValuesConsumer extends DocValuesConsumer implements Close
       }
     }
 
-    void  addDoc(int doc, BytesRef v) throws IOException {
+    void addDoc(int doc, BytesRef v) throws IOException {
       if (blockAddressesStart < 0) {
         blockAddressesStart = data.getFilePointer();
       }
@@ -399,7 +399,7 @@ final class Lucene80DocValuesConsumer extends DocValuesConsumer implements Close
     }
 
     private void flushData() throws IOException {
-      if(numDocsInCurrentBlock > 0) {
+      if (numDocsInCurrentBlock > 0) {
         // Write offset to this block to temporary offsets file
         totalChunks++;
         long thisBlockStartPointer = data.getFilePointer();
@@ -444,7 +444,7 @@ final class Lucene80DocValuesConsumer extends DocValuesConsumer implements Close
             fp += filePointersIn.readVLong();
           }
           if (maxPointer < fp) {
-            throw new CorruptIndexException("File pointers don't add up", filePointersIn);
+            throw new CorruptIndexException("File pointers don't add up ("+fp+" vs expected "+maxPointer+")", filePointersIn);
           }
           filePointers.finish();
         } catch (Throwable e) {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene80/Lucene80DocValuesFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene80/Lucene80DocValuesFormat.java
@@ -151,7 +151,8 @@ public final class Lucene80DocValuesFormat extends DocValuesFormat {
   static final String META_CODEC = "Lucene80DocValuesMetadata";
   static final String META_EXTENSION = "dvm";
   static final int VERSION_START = 0;
-  static final int VERSION_CURRENT = VERSION_START;
+  static final int VERSION_BIN_COMPRESSED = 1;  
+  static final int VERSION_CURRENT = VERSION_BIN_COMPRESSED;
 
   // indicates docvalues type
   static final byte NUMERIC = 0;
@@ -165,6 +166,9 @@ public final class Lucene80DocValuesFormat extends DocValuesFormat {
   static final int NUMERIC_BLOCK_SHIFT = 14;
   static final int NUMERIC_BLOCK_SIZE = 1 << NUMERIC_BLOCK_SHIFT;
 
+  static final int BINARY_BLOCK_SHIFT = 5;
+  static final int BINARY_DOCS_PER_COMPRESSED_BLOCK = 1 << BINARY_BLOCK_SHIFT;
+  
   static final int TERMS_DICT_BLOCK_SHIFT = 4;
   static final int TERMS_DICT_BLOCK_SIZE = 1 << TERMS_DICT_BLOCK_SHIFT;
   static final int TERMS_DICT_BLOCK_MASK = TERMS_DICT_BLOCK_SIZE - 1;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene80/Lucene80DocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene80/Lucene80DocValuesProducer.java
@@ -46,6 +46,7 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.LongValues;
 import org.apache.lucene.util.RamUsageEstimator;
+import org.apache.lucene.util.compress.LZ4;
 import org.apache.lucene.util.packed.DirectMonotonicReader;
 import org.apache.lucene.util.packed.DirectReader;
 
@@ -59,6 +60,7 @@ final class Lucene80DocValuesProducer extends DocValuesProducer implements Close
   private long ramBytesUsed;
   private final IndexInput data;
   private final int maxDoc;
+  private int version = -1;
 
   /** expert: instantiates a new reader */
   Lucene80DocValuesProducer(SegmentReadState state, String dataCodec, String dataExtension, String metaCodec, String metaExtension) throws IOException {
@@ -66,11 +68,10 @@ final class Lucene80DocValuesProducer extends DocValuesProducer implements Close
     this.maxDoc = state.segmentInfo.maxDoc();
     ramBytesUsed = RamUsageEstimator.shallowSizeOfInstance(getClass());
 
-    int version = -1;
-
     // read in the entries from the metadata file.
     try (ChecksumIndexInput in = state.directory.openChecksumInput(metaName, state.context)) {
       Throwable priorE = null;
+      
       try {
         version = CodecUtil.checkIndexHeader(in, metaCodec,
                                         Lucene80DocValuesFormat.VERSION_START,
@@ -182,10 +183,20 @@ final class Lucene80DocValuesProducer extends DocValuesProducer implements Close
     entry.numDocsWithField = meta.readInt();
     entry.minLength = meta.readInt();
     entry.maxLength = meta.readInt();
-    if (entry.minLength < entry.maxLength) {
+    if ((version >= Lucene80DocValuesFormat.VERSION_BIN_COMPRESSED && entry.numDocsWithField >0)||  entry.minLength < entry.maxLength) {
       entry.addressesOffset = meta.readLong();
+
+      // Old count of uncompressed addresses 
+      long numAddresses = entry.numDocsWithField + 1L;
+      // New count of compressed addresses - the number of compresseed blocks
+      if (version >= Lucene80DocValuesFormat.VERSION_BIN_COMPRESSED) {
+        entry.numCompressedChunks = meta.readInt();
+        entry.maxUncompressedChunkSize = meta.readInt();
+        numAddresses = entry.numCompressedChunks;
+      }      
+      
       final int blockShift = meta.readVInt();
-      entry.addressesMeta = DirectMonotonicReader.loadMeta(meta, entry.numDocsWithField + 1L, blockShift);
+      entry.addressesMeta = DirectMonotonicReader.loadMeta(meta, numAddresses, blockShift);
       ramBytesUsed += entry.addressesMeta.ramBytesUsed();
       entry.addressesLength = meta.readLong();
     }
@@ -303,6 +314,8 @@ final class Lucene80DocValuesProducer extends DocValuesProducer implements Close
     long addressesOffset;
     long addressesLength;
     DirectMonotonicReader.Meta addressesMeta;
+    int numCompressedChunks;
+    int maxUncompressedChunkSize;
   }
 
   private static class TermsDictEntry {
@@ -664,9 +677,9 @@ final class Lucene80DocValuesProducer extends DocValuesProducer implements Close
       return disi.advanceExact(target);
     }
   }
-
-  @Override
-  public BinaryDocValues getBinary(FieldInfo field) throws IOException {
+  
+  // BWC - old binary format 
+  private BinaryDocValues getUncompressedBinary(FieldInfo field) throws IOException {
     BinaryEntry entry = binaries.get(field.name);
     if (entry.docsWithFieldOffset == -2) {
       return DocValues.emptyBinary();
@@ -741,6 +754,107 @@ final class Lucene80DocValuesProducer extends DocValuesProducer implements Close
           }
         };
       }
+    }
+  }  
+  
+  // Decompresses blocks of binary values to retrieve content
+  class BinaryDecoder {
+    
+    private final LongValues addresses;
+    private final IndexInput compressedData;
+    // Cache of last uncompressed block 
+    private long lastBlockId = -1;
+    private int []uncompressedDocEnds = new int[Lucene80DocValuesFormat.BINARY_DOCS_PER_COMPRESSED_BLOCK];
+    private int uncompressedBlockLength = 0;        
+    private int numDocsInBlock = 0;
+    private final byte[] uncompressedBlock;
+    private BytesRef uncompressedBytesRef;
+    
+    public BinaryDecoder(LongValues addresses, IndexInput compressedData, int biggestUncompressedBlockSize) {
+      super();
+      this.addresses = addresses;
+      this.compressedData = compressedData;
+      // pre-allocate a byte array large enough for the biggest uncompressed block needed.
+      this.uncompressedBlock = new byte[biggestUncompressedBlockSize];
+      
+    }
+
+    BytesRef decode(int docNumber) throws IOException {
+      int blockId = docNumber >> Lucene80DocValuesFormat.BINARY_BLOCK_SHIFT; 
+      int docInBlockId = docNumber % Lucene80DocValuesFormat.BINARY_DOCS_PER_COMPRESSED_BLOCK;
+      assert docInBlockId < Lucene80DocValuesFormat.BINARY_DOCS_PER_COMPRESSED_BLOCK;
+      
+      
+      // already read and uncompressed?
+      if ( blockId != lastBlockId) {
+        lastBlockId = blockId;
+        long blockStartOffset = addresses.get(blockId);
+        compressedData.seek(blockStartOffset);
+        
+        numDocsInBlock = compressedData.readVInt();
+        assert numDocsInBlock <= Lucene80DocValuesFormat.BINARY_DOCS_PER_COMPRESSED_BLOCK;
+        uncompressedDocEnds = new int[numDocsInBlock];
+        uncompressedBlockLength = 0;        
+        for (int i = 0; i < numDocsInBlock; i++) {
+          uncompressedBlockLength += compressedData.readVInt();
+          uncompressedDocEnds[i] = uncompressedBlockLength;
+        }
+        
+        if (uncompressedBlockLength == 0) {
+          uncompressedBytesRef = new BytesRef(BytesRef.EMPTY_BYTES);
+        } else {
+          assert uncompressedBlockLength <= uncompressedBlock.length;
+          LZ4.decompress(compressedData, uncompressedBlockLength, uncompressedBlock, 0);
+          uncompressedBytesRef = new BytesRef(uncompressedBlock);
+        }
+      }
+      
+      // Position the Bytes ref to the relevant part of the uncompressed block
+      if (docInBlockId > 0) {
+        uncompressedBytesRef.offset = uncompressedDocEnds[docInBlockId - 1];        
+      }
+      uncompressedBytesRef.length = uncompressedDocEnds[docInBlockId] - uncompressedBytesRef.offset;
+      return uncompressedBytesRef;
+    }    
+  }
+  
+
+  @Override
+  public BinaryDocValues getBinary(FieldInfo field) throws IOException {
+    if (version < Lucene80DocValuesFormat.VERSION_BIN_COMPRESSED) {
+      return getUncompressedBinary(field);
+    }
+    
+    BinaryEntry entry = binaries.get(field.name);
+    if (entry.docsWithFieldOffset == -2) {
+      return DocValues.emptyBinary();
+    }
+    if (entry.docsWithFieldOffset == -1) {
+      // dense
+      final RandomAccessInput addressesData = this.data.randomAccessSlice(entry.addressesOffset, entry.addressesLength);
+      final LongValues addresses = DirectMonotonicReader.getInstance(entry.addressesMeta, addressesData);
+      return new DenseBinaryDocValues(maxDoc) {
+        BinaryDecoder decoder = new BinaryDecoder(addresses, data.clone(), entry.maxUncompressedChunkSize);
+
+        @Override
+        public BytesRef binaryValue() throws IOException {          
+          return decoder.decode(doc);
+        }
+      };
+    } else {
+      // sparse
+      final IndexedDISI disi = new IndexedDISI(data, entry.docsWithFieldOffset, entry.docsWithFieldLength,
+          entry.jumpTableEntryCount, entry.denseRankPower, entry.numDocsWithField);
+      final RandomAccessInput addressesData = this.data.randomAccessSlice(entry.addressesOffset, entry.addressesLength);
+      final LongValues addresses = DirectMonotonicReader.getInstance(entry.addressesMeta, addressesData);
+      return new SparseBinaryDocValues(disi) {
+        BinaryDecoder decoder = new BinaryDecoder(addresses, data.clone(), entry.maxUncompressedChunkSize);
+
+        @Override
+        public BytesRef binaryValue() throws IOException {
+          return decoder.decode(disi.index());
+        }
+      };
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene80/Lucene80DocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene80/Lucene80DocValuesProducer.java
@@ -786,7 +786,7 @@ final class Lucene80DocValuesProducer extends DocValuesProducer implements Close
       
       
       // already read and uncompressed?
-      if ( blockId != lastBlockId) {
+      if (blockId != lastBlockId) {
         lastBlockId = blockId;
         long blockStartOffset = addresses.get(blockId);
         compressedData.seek(blockStartOffset);
@@ -809,7 +809,7 @@ final class Lucene80DocValuesProducer extends DocValuesProducer implements Close
         }
       }
       
-      // Position the Bytes ref to the relevant part of the uncompressed block
+      // Position the BytesRef to the relevant part of the uncompressed block
       if (docInBlockId > 0) {
         uncompressedBytesRef.offset = uncompressedDocEnds[docInBlockId - 1];        
       }

--- a/lucene/test-framework/src/java/org/apache/lucene/index/BaseDocValuesFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/index/BaseDocValuesFormatTestCase.java
@@ -246,6 +246,57 @@ public abstract class BaseDocValuesFormatTestCase extends BaseIndexFileFormatTes
     ireader.close();
     directory.close();
   }
+  
+  public void testVariouslyCompressibleBinaryValues() throws IOException {
+    Directory directory = newDirectory();
+    RandomIndexWriter iwriter = new RandomIndexWriter(random(), directory);
+    int numDocs = 1 + random().nextInt(100);
+
+    HashMap<Integer,BytesRef> writtenValues = new HashMap<>(numDocs);
+    
+    // Small vocabulary ranges will be highly compressible 
+    int vocabRange = random().nextInt(Byte.MAX_VALUE);
+
+    for (int i = 0; i < numDocs; i++) {
+      Document doc = new Document();
+      
+      // Generate random-sized byte array with random choice of bytes in vocab range
+      byte[] value = new byte[500 + random().nextInt(1024)];
+      for (int j = 0; j < value.length; j++) {
+        value[j] = (byte) random().nextInt(vocabRange);
+      }
+      BytesRef bytesRef = new BytesRef(value);
+      writtenValues.put(i, bytesRef);
+      doc.add(newTextField("id", Integer.toString(i), Field.Store.YES));
+      doc.add(new BinaryDocValuesField("dv1", bytesRef));
+      iwriter.addDocument(doc);
+    }
+    iwriter.forceMerge(1);
+    iwriter.close();
+
+    // Now search the index:
+    IndexReader ireader = DirectoryReader.open(directory); // read-only=true
+    IndexSearcher isearcher = new IndexSearcher(ireader);
+
+    for (int i = 0; i < numDocs; i++) {
+      String id = Integer.toString(i);
+      Query query = new TermQuery(new Term("id", id));
+      TopDocs hits = isearcher.search(query, 1);
+      assertEquals(1, hits.totalHits.value);
+      // Iterate through the results:
+      int hitDocID = hits.scoreDocs[0].doc;
+      Document hitDoc = isearcher.doc(hitDocID);
+      assertEquals(id, hitDoc.get("id"));
+      assert ireader.leaves().size() == 1;
+      BinaryDocValues dv = ireader.leaves().get(0).reader().getBinaryDocValues("dv1");
+      assertEquals(hitDocID, dv.advance(hitDocID));
+      BytesRef scratch = dv.binaryValue();
+      assertEquals(writtenValues.get(i), scratch);
+    }
+
+    ireader.close();
+    directory.close();
+  }  
 
   public void testTwoFieldsMixed() throws IOException {
     Directory directory = newDirectory();


### PR DESCRIPTION
This PR stores groups of 32 doc values in LZ4 compressed blocks. 

### Write performance
Test results for loading 680mb of log data (1.8m docs) are as follows:

Branch | Load time (seconds, single thread) | Resulting index size (mb)
----|----|----
master| 16| 680
this PR| 11| 78

### Read performance
Time taken to read 5,000 random doc IDs from above indices

Branch | Read time (milliseconds, single thread) 
----|----
master| 284
this PR| 63

On this particular test, the read + write speeds and resulting index size were all improved over the current master implementation. Obviously performance will vary with other tests with the main factors for changes being:
* size of fields, 
* compress-ability of field contents,
* read access patterns (hitting same compressed blocks vs different ones)
* variation from doc-to-doc in field value sizes,
