### PR TITLE
Add back assertions removed by LUCENE-9187.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/compress/LZ4.java
+++ b/lucene/core/src/java/org/apache/lucene/util/compress/LZ4.java
@@ -29,7 +29,6 @@ package org.apache.lucene.util.compress;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
-import java.util.Random;
 
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.DataOutput;
@@ -205,7 +204,6 @@ public final class LZ4 {
     abstract int previous(int off);
 
     // For testing
-    abstract void randomize(Random random);
     abstract boolean assertReset();
   }
 
@@ -266,20 +264,6 @@ public final class LZ4 {
     @Override
     public int previous(int off) {
       return -1;
-    }
-
-    @Override
-    void randomize(Random random) {
-      if (hashTable == null) {
-        // trigger the creation of the hash table
-        reset(new byte[1000], 3, 900);
-      }
-      if (hashTable != null) {
-        final int bpv = hashTable.getBitsPerValue();
-        for (int i = 0; i < hashTable.size(); ++i) {
-          hashTable.set(i, bpv >= 31 ? random.nextInt() & 0x7FFFFFFF : random.nextInt(1 << bpv));
-        }
-      }
     }
 
     @Override
@@ -392,20 +376,6 @@ public final class LZ4 {
         }
       }
       return -1;
-    }
-
-    @Override
-    void randomize(Random random) {
-      base = random.nextBoolean() ? random.nextInt(100) : 65536 * 2 - random.nextInt(100);
-      if (random.nextBoolean()) { // simulate compressing a short array previously
-        end = base + 100;
-        for (int i = base; i < end - LAST_LITERALS; ++i) {
-          chainTable[i & MASK] = (short) (1 + random.nextInt(10));
-        }
-      } else { // simulate compressing a long array previously
-        end = base + 100000;
-        Arrays.fill(chainTable, (short) 42);
-      }
     }
 
     @Override

--- a/lucene/core/src/test/org/apache/lucene/util/compress/LZ4TestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/compress/LZ4TestCase.java
@@ -55,11 +55,6 @@ public abstract class LZ4TestCase extends LuceneTestCase {
     }
 
     @Override
-    void randomize(Random random) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
     boolean assertReset() {
       throw new UnsupportedOperationException();
     }

--- a/lucene/core/src/test/org/apache/lucene/util/compress/LZ4TestCase.java
+++ b/lucene/core/src/test/org/apache/lucene/util/compress/LZ4TestCase.java
@@ -30,6 +30,42 @@ public abstract class LZ4TestCase extends LuceneTestCase {
 
   protected abstract LZ4.HashTable newHashTable();
 
+  protected static class AssertingHashTable extends LZ4.HashTable {
+
+    private final LZ4.HashTable in;
+
+    AssertingHashTable(LZ4.HashTable in) {
+      this.in = in;
+    }
+
+    @Override
+    void reset(byte[] b, int off, int len) {
+      in.reset(b, off, len);
+      assertTrue(in.assertReset());
+    }
+
+    @Override
+    int get(int off) {
+      return in.get(off);
+    }
+
+    @Override
+    int previous(int off) {
+      return in.previous(off);
+    }
+
+    @Override
+    void randomize(Random random) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    boolean assertReset() {
+      throw new UnsupportedOperationException();
+    }
+
+  }
+
   private void doTest(byte[] data, LZ4.HashTable hashTable) throws IOException {
     int offset = random().nextBoolean()
         ? random().nextInt(10)

--- a/lucene/core/src/test/org/apache/lucene/util/compress/TestFastLZ4.java
+++ b/lucene/core/src/test/org/apache/lucene/util/compress/TestFastLZ4.java
@@ -16,8 +16,6 @@
  */
 package org.apache.lucene.util.compress;
 
-import java.util.Random;
-
 import org.apache.lucene.util.compress.LZ4.HashTable;
 
 public class TestFastLZ4 extends LZ4TestCase {
@@ -25,10 +23,6 @@ public class TestFastLZ4 extends LZ4TestCase {
   @Override
   protected HashTable newHashTable() {
     LZ4.HashTable hashTable = new LZ4.FastCompressionHashTable();
-    Random random = random();
-    if (usually(random)) {
-      hashTable.randomize(random);
-    }
     return new AssertingHashTable(hashTable);
   }
 

--- a/lucene/core/src/test/org/apache/lucene/util/compress/TestFastLZ4.java
+++ b/lucene/core/src/test/org/apache/lucene/util/compress/TestFastLZ4.java
@@ -16,13 +16,20 @@
  */
 package org.apache.lucene.util.compress;
 
+import java.util.Random;
+
 import org.apache.lucene.util.compress.LZ4.HashTable;
 
 public class TestFastLZ4 extends LZ4TestCase {
 
   @Override
   protected HashTable newHashTable() {
-    return new LZ4.FastCompressionHashTable();
+    LZ4.HashTable hashTable = new LZ4.FastCompressionHashTable();
+    Random random = random();
+    if (usually(random)) {
+      hashTable.randomize(random);
+    }
+    return new AssertingHashTable(hashTable);
   }
 
 }

--- a/lucene/core/src/test/org/apache/lucene/util/compress/TestHighLZ4.java
+++ b/lucene/core/src/test/org/apache/lucene/util/compress/TestHighLZ4.java
@@ -16,8 +16,6 @@
  */
 package org.apache.lucene.util.compress;
 
-import java.util.Random;
-
 import org.apache.lucene.util.compress.LZ4.HashTable;
 
 public class TestHighLZ4 extends LZ4TestCase {
@@ -25,10 +23,6 @@ public class TestHighLZ4 extends LZ4TestCase {
   @Override
   protected HashTable newHashTable() {
     LZ4.HashTable hashTable =  new LZ4.HighCompressionHashTable();
-    Random random = random();
-    if (usually(random)) {
-      hashTable.randomize(random);
-    }
     return new AssertingHashTable(hashTable);
   }
 

--- a/lucene/core/src/test/org/apache/lucene/util/compress/TestHighLZ4.java
+++ b/lucene/core/src/test/org/apache/lucene/util/compress/TestHighLZ4.java
@@ -16,13 +16,20 @@
  */
 package org.apache.lucene.util.compress;
 
+import java.util.Random;
+
 import org.apache.lucene.util.compress.LZ4.HashTable;
 
 public class TestHighLZ4 extends LZ4TestCase {
 
   @Override
   protected HashTable newHashTable() {
-    return new LZ4.HighCompressionHashTable();
+    LZ4.HashTable hashTable =  new LZ4.HighCompressionHashTable();
+    Random random = random();
+    if (usually(random)) {
+      hashTable.randomize(random);
+    }
+    return new AssertingHashTable(hashTable);
   }
 
 }


### PR DESCRIPTION
This time they would only apply to TestFastLZ4/TestHighLZ4 and avoid slowing
down all tests.