### PR TITLE
SOLR-14240: Clean up znodes after shard deletion is invoked

### DIFF
--- a/solr/core/src/test/org/apache/solr/cloud/DeleteShardTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/DeleteShardTest.java
@@ -34,6 +34,7 @@ import org.apache.solr.common.cloud.ZkNodeProps;
 import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.common.util.Utils;
 import org.apache.solr.util.FileUtils;
+import org.apache.zookeeper.KeeperException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -79,6 +80,9 @@ public class DeleteShardTest extends SolrCloudTestCase {
     waitForState("Expected 'shard1' to be removed", collection, (n, c) -> {
       return c.getSlice("shard1") == null;
     });
+    
+    // verify shard1 znodes are deleted
+    assertShardZnodesDeleted(collection, "shard1");
 
     // Can delete a shard under construction
     setSliceState(collection, "shard2", Slice.State.CONSTRUCTION);
@@ -86,7 +90,9 @@ public class DeleteShardTest extends SolrCloudTestCase {
     waitForState("Expected 'shard2' to be removed", collection, (n, c) -> {
       return c.getSlice("shard2") == null;
     });
-
+    
+    // verify shard2 znodes are deleted
+    assertShardZnodesDeleted(collection, "shard");
   }
 
   protected void setSliceState(String collection, String slice, State state) throws Exception {
@@ -155,5 +161,11 @@ public class DeleteShardTest extends SolrCloudTestCase {
     assertEquals(1, getCollectionState(collection).getActiveSlices().size());
     assertTrue("Instance directory still exists", FileUtils.fileExists(coreStatus.getInstanceDirectory()));
     assertTrue("Data directory still exists", FileUtils.fileExists(coreStatus.getDataDirectory()));
+  }
+  
+  private void assertShardZnodesDeleted(String collection, String sliceId) throws KeeperException, InterruptedException {
+    assertFalse(cluster.getZkClient().exists(ZkStateReader.COLLECTIONS_ZKNODE + "/" + collection + "/leader_elect/" + sliceId, true));
+    assertFalse(cluster.getZkClient().exists(ZkStateReader.COLLECTIONS_ZKNODE + "/" + collection + "/leaders/" + sliceId, true));
+    assertFalse(cluster.getZkClient().exists(ZkStateReader.COLLECTIONS_ZKNODE + "/" + collection + "/terms/" + sliceId, true));
   }
 }


### PR DESCRIPTION
# Description

Delete left over znodes on zookeeper that aren't removed after a delete shard command is issued.

# Solution

In DeleteShardCmd, use the zk client to issue a recursive delete from the specified root and its children (including that root).

# Tests

Added assertions to DeleteShardTest to verify the znodes no longer exist. Ran the full test suite via `ant test` and finally did a manual test via the same steps described in the jira description.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
