### PR TITLE
LUCENE-9201: Port documentation-lint task to Gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,7 @@ apply from: file('gradle/validation/validate-source-patterns.gradle')
 apply from: file('gradle/validation/config-file-sanity.gradle')
 apply from: file('gradle/validation/rat-sources.gradle')
 apply from: file('gradle/validation/owasp-dependency-check.gradle')
+apply from: file('gradle/validation/documentation-lint.gradle')
 
 // Source or data regeneration tasks
 apply from: file('gradle/generation/jflex.gradle')

--- a/gradle/validation/documentation-lint.gradle
+++ b/gradle/validation/documentation-lint.gradle
@@ -1,0 +1,99 @@
+import java.nio.file.Files
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This adds top-level 'documentation-lint' task.
+
+configure(rootProject) {
+  configurations {
+    ecj
+  }
+  dependencies {
+    ecj 'org.eclipse.jdt:ecj:3.19.0'
+  }
+}
+
+def luceneProjects = subprojects.findAll{ it.path.startsWith(":lucene") }
+def solrProjects = subprojects.findAll{ it.path.startsWith(":solr") } - [ project(':solr:server'), project(':solr:webapp'), project(':solr:solr-ref-guide') ]
+
+configure(luceneProjects) {
+  plugins.withType(JavaPlugin) {
+    task("documentationLint", type: DocumentationLintTask) {
+      group = "Verification"
+      description = "Runs documentation linters"
+      dependsOn ':lucene:build'
+    }
+  }
+}
+
+configure(solrProjects) {
+  plugins.withType(JavaPlugin) {
+    task("documentationLint", type: DocumentationLintTask) {
+      group = "Verification"
+      dependsOn ':solr:build'
+    }
+  }
+}
+
+class DocumentationLintTask extends DefaultTask {
+
+  @Input
+  String srcMainDir = "src/java"
+
+  @Input
+  String srcTestDir = "src/test"
+
+  def ecjJavadocLint(String srcDir, String dstDir, String cp) {
+    project.javaexec {
+      classpath {
+        project.rootProject.configurations.ecj.asPath
+      }
+      main = "org.eclipse.jdt.internal.compiler.batch.Main"
+      args += [
+        "-classpath", cp,
+        "-d", dstDir,
+        "-encoding", "UTF-8",
+        "-source", "11",
+        "-target", "11",
+        "-nowarn",
+        "-enableJavadoc",
+        "-properties", "${project.rootProject.rootDir}/lucene/tools/javadoc/ecj.javadocs.prefs",
+        srcDir
+      ]
+    }
+  }
+
+  @TaskAction
+  def lint() {
+    def dstDir = Files.createTempDirectory("ecj")
+    def cp = project.configurations.compileClasspath.findAll().join(":")
+    // add dstDir to test classpath because 'testCompileClasspath' doesn't include main classes in 'src/java'
+    def testcp = project.configurations.testCompileClasspath.findAll().join(":") + ":" + dstDir
+    try {
+      // TODO: should output Compiler WARNING (the same as ant's ECJ macro)
+      ecjJavadocLint(srcMainDir, dstDir.toString(), cp)
+      ecjJavadocLint(srcTestDir, dstDir.toString(), testcp)
+
+      // TODO: port ant's "-documentation-lint" task
+    } finally {
+      dstDir.deleteDir()
+    }
+  }
+}
+
+

--- a/gradle/validation/documentation-lint.gradle
+++ b/gradle/validation/documentation-lint.gradle
@@ -137,12 +137,13 @@ class EcjLintTask extends DefaultTask {
             "-classpath", sourceSet.compileClasspath.toList().join(':') + project.configurations.testCompileClasspath.findAll().join(":"),
             "-d", dstDir,
             "-encoding", "UTF-8",
-            "-source", "11", // How this can be obtained from sourceSet or project?
+            "-source", "11", // FIXME: How this can be obtained from sourceSet or project?
             "-target", "11",
             "-nowarn",
             "-enableJavadoc",
             "-properties", "${project.rootProject.rootDir}/lucene/tools/javadoc/ecj.javadocs.prefs",
-            "src/java" // ... or "src/test". How this can be obtained from sourceSet or project?
+            // FIXME: How this can be obtained from sourceSet or project?
+            "src/java" // ... or "src/test".
           ]
         }
       }
@@ -175,7 +176,7 @@ class CheckBrokenJavadocsLinksTask extends DefaultTask {
             include '**/*.css'
             includeEmptyDirs false
           }
-          into "${tmpJavadocDir}/${prj.path.replace(':', '/')}"
+          into "${tmpJavadocDir}/${prj.path.replace(':', '/')}"  // FIXME: this doesn't work for analyzers-xxx modules...
         }
       })
     }

--- a/gradle/validation/documentation-lint.gradle
+++ b/gradle/validation/documentation-lint.gradle
@@ -20,7 +20,7 @@ import java.nio.file.Files
 // This adds top-level 'documentation-lint' task.
 
 def includes = allprojects.findAll { it.file('src/java').exists() }
-def tmpJavadocDir = Files.createTempDirectory("javadoc")
+def tmpJavadocDir = Files.createTempDirectory('javadoc')
 
 // Change the log level for the STDOUT to INFO (default is QUIET)
 // so that lint scripts' output will be printed without --debug option
@@ -31,36 +31,39 @@ configure(rootProject) {
   configurations {
     ecj
   }
+
   dependencies {
     ecj 'org.eclipse.jdt:ecj:3.19.0'
   }
 
-  task("documentationLint") {
-    group "Verification"
-    description "Runs documentation linters."
+  // the main task
+  task('documentationLint') {
+    group 'Verification'
+    description 'Runs documentation linters.'
 
     dependsOn ':checkBrokenLinks'
     dependsOn includes.collect { prj ->
       prj.tasks.matching { task ->
         task.name in [
           'ecjJavadocLint',
-          'checkMissingJavadocsClass',
-          'checkMissingJavadocsMethod'
+          'checkMissingJavadocs'
         ]
       }
     }
   }
 
-  task("checkBrokenLinks", type: Exec) {
+  // checking broken links in Javadocs
+  task('checkBrokenLinks', type: Exec) {
     (includes).each {
+      // before checking, collect all built Javadocs to temporary dir
       dependsOn "${it.path}:copyBuiltJavadocs"
     }
 
-    executable "python3"
+    executable 'python3'
     args "-B", "${rootDir}/dev-tools/scripts/checkJavadocLinks.py", tmpJavadocDir
   }
 
-  task ("cleanUpJavadocDir", type: Delete) {
+  task ('cleanUpJavadocDir', type: Delete) {
     delete tmpJavadocDir
   }
 
@@ -70,12 +73,12 @@ configure(rootProject) {
 
 configure(includes) { prj ->
   plugins.withType(JavaPlugin) {
-    task("ecjJavadocLint", type: EcjJavadocLintTask) {
+
+    task('ecjJavadocLint', type: EcjJavadocLintTask) {
       dependsOn ':build'
     }
 
-    // copy Javadocs to temporary directory for the task 'checkBrokenLinks'
-    task ("copyBuiltJavadocs", type: Copy, dependsOn: 'javadoc') {
+    task('copyBuiltJavadocs', type: Copy, dependsOn: 'javadoc') {
       from('build/docs/javadoc') {
         include '**/*.html'
         include '**/*.js'
@@ -84,21 +87,70 @@ configure(includes) { prj ->
       }
       into "${tmpJavadocDir}/${project.path.replace(':', '/')}"
     }
+  }
 
-    task ("checkMissingJavadocsClass", type: Exec, dependsOn: 'javadoc') {
-      executable "python3"
-      args "-B", "${project.rootProject.rootDir}/dev-tools/scripts/checkJavaDocs.py", "${buildDir}/docs/javadoc", "class"
-    }
+}
 
-    task ("checkMissingJavadocsMethod", type: Exec, dependsOn: 'javadoc') {
-      executable "python3"
-      args "-B", "${project.rootProject.rootDir}/dev-tools/scripts/checkJavaDocs.py", "${buildDir}/docs/javadoc", "method"
-    }
-
+// check missing javadocs
+allprojects {
+  task('checkMissingJavadocs', type: CheckMissingJavadocsTask, dependsOn: 'javadoc') {
   }
 }
 
+// todo: add missing docs for all classes and bump this to level=class
+def packageLevelCheckProjects = includes.findAll { it.path.startsWith(':solr') }
+configure(packageLevelCheckProjects) {
+  checkMissingJavadocs {
+    dirs += [ new Tuple2("${buildDir}/docs/javadoc", "package") ]
+  }
+}
 
+// too many classes to fix overall to just enable the above to be level="method" right now,
+// but we can prevent the modules that don't have problems from getting any worse
+def methodLevelCheckProjects = [
+  project(':lucene:analysis:icu'),
+  project(':lucene:analysis:morfologik'),
+  project(':lucene:analysis:phonetic'),
+  project(':lucene:analysis:stempel'),
+  project(':lucene:classification'),
+  project(':lucene:demo'),
+  project(':lucene:expressions'),
+  project(':lucene:facet'),
+  project(':lucene:join'),
+  project(':lucene:memory'),
+  project(':lucene:suggest'),
+  project(':lucene:spatial3d')
+]
+
+def prjLuceneCore = project(':lucene:core')
+def classLevelCheckProjects = includes.findAll { it.path.startsWith(':lucene') } - methodLevelCheckProjects - [ prjLuceneCore ]
+
+configure(classLevelCheckProjects) {
+  checkMissingJavadocs {
+    dirs += [ new Tuple2("${buildDir}/docs/javadoc", "class") ]
+  }
+}
+
+configure(methodLevelCheckProjects) {
+  checkMissingJavadocs {
+    dirs += [ new Tuple2("${buildDir}/docs/javadoc", "method") ]
+  }
+}
+
+// too much to fix core/ for now, but enforce full javadocs for key packages
+configure(prjLuceneCore) {
+  checkMissingJavadocs {
+    dirs += [
+      new Tuple2("${buildDir}/docs/javadoc", "class"),
+      new Tuple2("${buildDir}/docs/javadoc/org/apache/lucene/util/automaton", "method"),
+      new Tuple2("${buildDir}/docs/javadoc/org/apache/lucene/analysis", "method"),
+      new Tuple2("${buildDir}/docs/javadoc/org/apache/lucene/document", "method"),
+      new Tuple2("${buildDir}/docs/javadoc/org/apache/lucene/search/similarities", "method"),
+      new Tuple2("${buildDir}/docs/javadoc/org/apache/lucene/index", "method"),
+      new Tuple2("${buildDir}/docs/javadoc/org/apache/lucene/codecs", "method"),
+    ]
+  }
+}
 
 class EcjJavadocLintTask extends DefaultTask {
 
@@ -144,4 +196,31 @@ class EcjJavadocLintTask extends DefaultTask {
   }
 }
 
+class CheckMissingJavadocsTask extends DefaultTask {
 
+  // list of (directory_to_be_checked, level)
+  @Input
+  List<Tuple2<String, String>> dirs = [];
+
+  def checkMissingJavadocs(String dir, String level) {
+    project.exec {
+      executable "python3"
+      args = [
+        "-B",
+        "${project.rootProject.rootDir}/dev-tools/scripts/checkJavaDocs.py",
+        dir,
+        level
+      ]
+    }
+  }
+
+  @TaskAction
+  def lint() {
+    if (dirs != null && dirs.size() > 0) {
+      for (tup in dirs) {
+        println("Checking for missing docs... (dir=${tup.first}, level=${tup.second})")
+        checkMissingJavadocs(tup.first, tup.second)
+      }
+    }
+  }
+}

--- a/gradle/validation/documentation-lint.gradle
+++ b/gradle/validation/documentation-lint.gradle
@@ -19,8 +19,8 @@ import java.nio.file.Files
 
 // This adds top-level 'documentation-lint' task.
 
+// target projects for javadoc linting
 def includes = allprojects.findAll { it.file('src/java').exists() }
-def tmpJavadocDir = Files.createTempDirectory('javadoc')
 
 // Change the log level for the STDOUT to INFO (default is QUIET)
 // so that lint scripts' output will be printed without --debug option
@@ -52,49 +52,19 @@ configure(rootProject) {
     }
   }
 
-  // checking broken links in Javadocs
-  task('checkBrokenLinks', type: Exec) {
-    (includes).each {
-      // before checking, collect all built Javadocs to temporary dir
-      dependsOn "${it.path}:copyBuiltJavadocs"
+  task('checkBrokenLinks', type: CheckBrokenJavadocsLinksTask) {
+    includes.each {
+      dependsOn "${it.path}:javadoc"
     }
-
-    executable 'python3'
-    args "-B", "${rootDir}/dev-tools/scripts/checkJavadocLinks.py", tmpJavadocDir
   }
-
-  task ('cleanUpJavadocDir', type: Delete) {
-    delete tmpJavadocDir
-  }
-
-  checkBrokenLinks.finalizedBy cleanUpJavadocDir
-
 }
 
 configure(includes) { prj ->
-  plugins.withType(JavaPlugin) {
-
-    task('ecjJavadocLint', type: EcjJavadocLintTask) {
-      dependsOn ':build'
-    }
-
-    task('copyBuiltJavadocs', type: Copy, dependsOn: 'javadoc') {
-      from('build/docs/javadoc') {
-        include '**/*.html'
-        include '**/*.js'
-        include '**/*.css'
-        includeEmptyDirs false
-      }
-      into "${tmpJavadocDir}/${project.path.replace(':', '/')}"
-    }
-  }
-
+  task('ecjJavadocLint', type: EcjJavadocLintTask, dependsOn: 'classes')
 }
 
-// check missing javadocs
 allprojects {
-  task('checkMissingJavadocs', type: CheckMissingJavadocsTask, dependsOn: 'javadoc') {
-  }
+  task('checkMissingJavadocs', type: CheckMissingJavadocsTask, dependsOn: 'javadoc')
 }
 
 // todo: add missing docs for all classes and bump this to level=class
@@ -192,6 +162,49 @@ class EcjJavadocLintTask extends DefaultTask {
       ecjJavadocLint(srcTestDir, dstDir.toString(), testcp)
     } finally {
       dstDir.deleteDir()
+    }
+  }
+}
+
+class CheckBrokenJavadocsLinksTask extends DefaultTask {
+
+  // collect all built Javadocs to temp dir for linting
+  def copyAllJavadocs(String tmpJavadocDir) {
+    def prjWithJavadoc = project.allprojects.findAll { it.file('src/java').exists() && it.file('build/docs/javadoc').exists() }
+    prjWithJavadoc.each { prj ->
+      prj.copy {
+        from('build/docs/javadoc') {
+          include '**/*.html'
+          include '**/*.js'
+          include '**/*.css'
+          includeEmptyDirs false
+        }
+        into "${tmpJavadocDir}/${prj.path.replace(':', '/')}"
+      }
+    }
+  }
+
+  def checkBrokenJavadocLinks(dir) {
+    project.exec {
+      executable "python3"
+      args = [
+        "-B",
+        "${project.rootProject.rootDir}/dev-tools/scripts/checkJavadocLinks.py",
+        dir
+      ]
+    }
+  }
+
+  @TaskAction
+  def lint() {
+    def tmpJavadocDir = Files.createTempDirectory("javadoc")
+    try {
+      copyAllJavadocs(tmpJavadocDir.toString())
+      println("Checking for broken links...")
+      checkBrokenJavadocLinks("${tmpJavadocDir.toString()}/lucene")
+      checkBrokenJavadocLinks("${tmpJavadocDir.toString()}/solr")
+    } finally {
+      tmpJavadocDir.deleteDir()
     }
   }
 }

--- a/gradle/validation/documentation-lint.gradle
+++ b/gradle/validation/documentation-lint.gradle
@@ -166,17 +166,18 @@ class CheckBrokenJavadocsLinksTask extends DefaultTask {
 
   // collect all built Javadocs to temp dir for linting
   def copyAllJavadocs(String tmpJavadocDir) {
-    def prjWithJavadoc = project.allprojects.findAll { it.file('src/java').exists() && it.file('build/docs/javadoc').exists() }
-    prjWithJavadoc.each { prj ->
-      prj.copy {
-        from('build/docs/javadoc') {
-          include '**/*.html'
-          include '**/*.js'
-          include '**/*.css'
-          includeEmptyDirs false
+    project.allprojects.each { prj ->
+      prj.plugins.withId('java', {
+        prj.copy {
+          from("${prj.buildDir}/docs/javadoc") {
+            include '**/*.html'
+            include '**/*.js'
+            include '**/*.css'
+            includeEmptyDirs false
+          }
+          into "${tmpJavadocDir}/${prj.path.replace(':', '/')}"
         }
-        into "${tmpJavadocDir}/${prj.path.replace(':', '/')}"
-      }
+      })
     }
   }
 

--- a/gradle/validation/documentation-lint.gradle
+++ b/gradle/validation/documentation-lint.gradle
@@ -19,9 +19,6 @@ import java.nio.file.Files
 
 // This adds top-level 'documentation-lint' task.
 
-// target projects for javadoc linting
-def includes = allprojects.findAll { it.file('src/java').exists() }
-
 // Change the log level for the STDOUT to INFO (default is QUIET)
 // so that lint scripts' output will be printed without --debug option
 logging.captureStandardOutput LogLevel.INFO
@@ -42,10 +39,10 @@ configure(rootProject) {
     description 'Runs documentation linters.'
 
     dependsOn ':checkBrokenLinks'
-    dependsOn includes.collect { prj ->
+    dependsOn subprojects.collect { prj ->
       prj.tasks.matching { task ->
         task.name in [
-          'ecjJavadocLint',
+          'ecjLint',
           'checkMissingJavadocs'
         ]
       }
@@ -53,25 +50,28 @@ configure(rootProject) {
   }
 
   task('checkBrokenLinks', type: CheckBrokenJavadocsLinksTask) {
-    includes.each {
-      dependsOn "${it.path}:javadoc"
+    dependsOn subprojects.collect { prj ->
+      prj.tasks.matching { task ->
+        task.name == 'javadoc'
+      }
     }
   }
 }
 
-configure(includes) { prj ->
-  task('ecjJavadocLint', type: EcjJavadocLintTask, dependsOn: 'classes')
-}
-
-allprojects {
-  task('checkMissingJavadocs', type: CheckMissingJavadocsTask, dependsOn: 'javadoc')
+allprojects { prj ->
+  task('ecjLint', type: EcjLintTask)
+  task('checkMissingJavadocs', type: CheckMissingJavadocsTask) {
+    plugins.withId('java', {
+      dependsOn 'javadoc'
+    })
+  }
 }
 
 // todo: add missing docs for all classes and bump this to level=class
-def packageLevelCheckProjects = includes.findAll { it.path.startsWith(':solr') }
-configure(packageLevelCheckProjects) {
+def packageLevelCheckProjects = allprojects.findAll { it.path.startsWith(':solr') && it.plugins.contains(JavaPlugin) }
+configure(packageLevelCheckProjects) { prj ->
   checkMissingJavadocs {
-    dirs += [ new Tuple2("${buildDir}/docs/javadoc", "package") ]
+    dirs += [new Tuple2("${buildDir}/docs/javadoc", "package")]
   }
 }
 
@@ -93,7 +93,7 @@ def methodLevelCheckProjects = [
 ]
 
 def prjLuceneCore = project(':lucene:core')
-def classLevelCheckProjects = includes.findAll { it.path.startsWith(':lucene') } - methodLevelCheckProjects - [ prjLuceneCore ]
+def classLevelCheckProjects = allprojects.findAll { it.path.startsWith(':lucene') && it.plugins.contains(JavaPlugin) } - methodLevelCheckProjects - [ prjLuceneCore ]
 
 configure(classLevelCheckProjects) {
   checkMissingJavadocs {
@@ -122,48 +122,44 @@ configure(prjLuceneCore) {
   }
 }
 
-class EcjJavadocLintTask extends DefaultTask {
+class EcjLintTask extends DefaultTask {
 
-  @Input
-  String srcMainDir = "src/java"
-
-  @Input
-  String srcTestDir = "src/test"
-
-  def ecjJavadocLint(String srcDir, String dstDir, String cp) {
-    project.javaexec {
-      classpath {
-        project.rootProject.configurations.ecj.asPath
+  def ecjJavadocLint(String dstDir) {
+    project.plugins.withId('java', {
+      project.sourceSets.each { sourceSet ->
+        project.javaexec {
+          classpath {
+            project.rootProject.configurations.ecj.asPath
+          }
+          main = "org.eclipse.jdt.internal.compiler.batch.Main"
+          args += [
+            // Unfortunately, 'testCompileClasspath' is not available from sourceSet, so without the second term test classes cannot be compiled.
+            "-classpath", sourceSet.compileClasspath.toList().join(':') + project.configurations.testCompileClasspath.findAll().join(":"),
+            "-d", dstDir,
+            "-encoding", "UTF-8",
+            "-source", "11", // How this can be obtained from sourceSet or project?
+            "-target", "11",
+            "-nowarn",
+            "-enableJavadoc",
+            "-properties", "${project.rootProject.rootDir}/lucene/tools/javadoc/ecj.javadocs.prefs",
+            "src/java" // ... or "src/test". How this can be obtained from sourceSet or project?
+          ]
+        }
       }
-      main = "org.eclipse.jdt.internal.compiler.batch.Main"
-      args += [
-        "-classpath", cp,
-        "-d", dstDir,
-        "-encoding", "UTF-8",
-        "-source", "11",
-        "-target", "11",
-        "-nowarn",
-        "-enableJavadoc",
-        "-properties", "${project.rootProject.rootDir}/lucene/tools/javadoc/ecj.javadocs.prefs",
-        srcDir
-      ]
-    }
+    })
   }
 
   @TaskAction
   def lint() {
     def dstDir = Files.createTempDirectory("ecj")
-    def cp = project.configurations.compileClasspath.findAll().join(":")
-    // add dstDir to test classpath because 'testCompileClasspath' doesn't include main classes in 'src/java'
-    def testcp = project.configurations.testCompileClasspath.findAll().join(":") + ":" + dstDir
     try {
       // TODO: should output Compiler WARNING (the same as ant's ECJ macro)?
-      ecjJavadocLint(srcMainDir, dstDir.toString(), cp)
-      ecjJavadocLint(srcTestDir, dstDir.toString(), testcp)
+      ecjJavadocLint(dstDir.toString())
     } finally {
       dstDir.deleteDir()
     }
   }
+
 }
 
 class CheckBrokenJavadocsLinksTask extends DefaultTask {
@@ -237,3 +233,4 @@ class CheckMissingJavadocsTask extends DefaultTask {
     }
   }
 }
+

--- a/gradle/validation/documentation-lint.gradle
+++ b/gradle/validation/documentation-lint.gradle
@@ -1,5 +1,3 @@
-import java.nio.file.Files
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -17,40 +15,92 @@ import java.nio.file.Files
  * limitations under the License.
  */
 
+import java.nio.file.Files
+
 // This adds top-level 'documentation-lint' task.
 
+def includes = allprojects.findAll { it.file('src/java').exists() }
+def tmpJavadocDir = Files.createTempDirectory("javadoc")
+
+// Change the log level for the STDOUT to INFO (default is QUIET)
+// so that lint scripts' output will be printed without --debug option
+logging.captureStandardOutput LogLevel.INFO
+
 configure(rootProject) {
+
   configurations {
     ecj
   }
   dependencies {
     ecj 'org.eclipse.jdt:ecj:3.19.0'
   }
+
+  task("documentationLint") {
+    group "Verification"
+    description "Runs documentation linters."
+
+    dependsOn ':checkBrokenLinks'
+    dependsOn includes.collect { prj ->
+      prj.tasks.matching { task ->
+        task.name in [
+          'ecjJavadocLint',
+          'checkMissingJavadocsClass',
+          'checkMissingJavadocsMethod'
+        ]
+      }
+    }
+  }
+
+  task("checkBrokenLinks", type: Exec) {
+    (includes).each {
+      dependsOn "${it.path}:copyBuiltJavadocs"
+    }
+
+    executable "python3"
+    args "-B", "${rootDir}/dev-tools/scripts/checkJavadocLinks.py", tmpJavadocDir
+  }
+
+  task ("cleanUpJavadocDir", type: Delete) {
+    delete tmpJavadocDir
+  }
+
+  checkBrokenLinks.finalizedBy cleanUpJavadocDir
+
 }
 
-def luceneProjects = subprojects.findAll{ it.path.startsWith(":lucene") }
-def solrProjects = subprojects.findAll{ it.path.startsWith(":solr") } - [ project(':solr:server'), project(':solr:webapp'), project(':solr:solr-ref-guide') ]
-
-configure(luceneProjects) {
+configure(includes) { prj ->
   plugins.withType(JavaPlugin) {
-    task("documentationLint", type: DocumentationLintTask) {
-      group = "Verification"
-      description = "Runs documentation linters"
-      dependsOn ':lucene:build'
+    task("ecjJavadocLint", type: EcjJavadocLintTask) {
+      dependsOn ':build'
     }
+
+    // copy Javadocs to temporary directory for the task 'checkBrokenLinks'
+    task ("copyBuiltJavadocs", type: Copy, dependsOn: 'javadoc') {
+      from('build/docs/javadoc') {
+        include '**/*.html'
+        include '**/*.js'
+        include '**/*.css'
+        includeEmptyDirs false
+      }
+      into "${tmpJavadocDir}/${project.path.replace(':', '/')}"
+    }
+
+    task ("checkMissingJavadocsClass", type: Exec, dependsOn: 'javadoc') {
+      executable "python3"
+      args "-B", "${project.rootProject.rootDir}/dev-tools/scripts/checkJavaDocs.py", "${buildDir}/docs/javadoc", "class"
+    }
+
+    task ("checkMissingJavadocsMethod", type: Exec, dependsOn: 'javadoc') {
+      executable "python3"
+      args "-B", "${project.rootProject.rootDir}/dev-tools/scripts/checkJavaDocs.py", "${buildDir}/docs/javadoc", "method"
+    }
+
   }
 }
 
-configure(solrProjects) {
-  plugins.withType(JavaPlugin) {
-    task("documentationLint", type: DocumentationLintTask) {
-      group = "Verification"
-      dependsOn ':solr:build'
-    }
-  }
-}
 
-class DocumentationLintTask extends DefaultTask {
+
+class EcjJavadocLintTask extends DefaultTask {
 
   @Input
   String srcMainDir = "src/java"
@@ -85,11 +135,9 @@ class DocumentationLintTask extends DefaultTask {
     // add dstDir to test classpath because 'testCompileClasspath' doesn't include main classes in 'src/java'
     def testcp = project.configurations.testCompileClasspath.findAll().join(":") + ":" + dstDir
     try {
-      // TODO: should output Compiler WARNING (the same as ant's ECJ macro)
+      // TODO: should output Compiler WARNING (the same as ant's ECJ macro)?
       ecjJavadocLint(srcMainDir, dstDir.toString(), cp)
       ecjJavadocLint(srcTestDir, dstDir.toString(), testcp)
-
-      // TODO: port ant's "-documentation-lint" task
     } finally {
       dstDir.deleteDir()
     }


### PR DESCRIPTION
# Description

This PR adds an equivalent to "documentation-lint" to Gradle build.

https://issues.apache.org/jira/browse/LUCENE-9201

# Solution

The `gradle/validation/documentation-lint.gradle` includes 
- `documentationLint` task that supposed to be called from `precommit` task,
- a root project level sub-task `checkBrokenLinks`, 
- sub-project level sub-tasks `ecjJavadocLint`, `checkMissingJavadocs`

# Note

For now, Python linters - `checkBrokenLinks` and `checkMissingJavadocs` - will fail because the Gradle-generated Javadocs seems to be slightly different to Ant-generated ones.
e.g.; 
- Javadoc directory structure: "ant documentation" generates "analyzers-common" docs dir for "analysis/common" module, but "gradlew javadoc" generates "analysis/common" for the same module. I think we can adjust the structure, but where is the suitable place to do so? 
- Package summary: "ant documentation" uses "package.html" as package summary description, but "gradlew javadoc" ignores "package.html" (so some packages lacks summary description in "package-summary.html" when building javadocs by Gradle). We might be able to make Gradle Javadoc task to properly handle "package.html" files with some options. Or, should we replace all "package.html" with "package-info.java" at this time? 