### PR TITLE
SOLR-14247 Remove unneeded sleeps

### DIFF
--- a/solr/test-framework/src/java/org/apache/solr/SolrTestCase.java
+++ b/solr/test-framework/src/java/org/apache/solr/SolrTestCase.java
@@ -17,15 +17,12 @@
 
 package org.apache.solr;
 
-import java.lang.invoke.MethodHandles;
 
 import org.apache.lucene.util.LuceneTestCase;
 import org.apache.solr.util.StartupLoggingUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.systemPropertyAsBoolean;
 
@@ -42,10 +39,7 @@ import static com.carrotsearch.randomizedtesting.RandomizedTest.systemPropertyAs
  */
 
 public class SolrTestCase extends LuceneTestCase {
-
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-
-  /** 
+  /**
    * Special hook for sanity checking if any tests trigger failures when an
    * Assumption failure occures in a {@link BeforeClass} method
    * @lucene.internal


### PR DESCRIPTION
This test is slow because it sleeps a lot. Removing the sleeps, it still passes consistently on my machine, but I would like other folks to confirm this on their different hardware as well.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [ ] ~I have added tests for my changes.~
- [ ] ~I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).~
