### PR TITLE
LUCENE-9217: Add validation to XYGeometries

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/geo/XYEncodingUtils.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/XYEncodingUtils.java
@@ -34,10 +34,11 @@ public final class XYEncodingUtils {
   }
 
   /** validates value is within +/-{@link Float#MAX_VALUE} coordinate bounds */
-  public static void checkVal(double x) {
+  public static double checkVal(double x) {
     if (Double.isNaN(x) || x < MIN_VAL_INCL || x > MAX_VAL_INCL) {
       throw new IllegalArgumentException("invalid value " + x + "; must be between " + MIN_VAL_INCL + " and " + MAX_VAL_INCL);
     }
+    return x;
   }
 
   /**
@@ -47,8 +48,7 @@ public final class XYEncodingUtils {
    * @throws IllegalArgumentException if value is out of bounds
    */
   public static int encode(double x) {
-    checkVal(x);
-    return NumericUtils.floatToSortableInt((float)x);
+    return NumericUtils.floatToSortableInt((float) checkVal(x));
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/geo/XYLine.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/XYLine.java
@@ -18,6 +18,8 @@ package org.apache.lucene.geo;
 
 import java.util.Arrays;
 
+import static org.apache.lucene.geo.XYEncodingUtils.checkVal;
+
 /**
  * Represents a line in cartesian space. You can construct the Line directly with {@code float[]}, {@code float[]} x, y arrays
  * coordinates.
@@ -54,6 +56,13 @@ public class XYLine extends XYGeometry {
       throw new IllegalArgumentException("at least 2 line points required");
     }
 
+    this.x = new double[x.length];
+    this.y = new double[y.length];
+    for (int i = 0; i < x.length; ++i) {
+      this.x[i] = checkVal(x[i]);
+      this.y[i] = checkVal(y[i]);
+    }
+
     // compute bounding box
     double minX = x[0];
     double minY = y[0];
@@ -66,12 +75,6 @@ public class XYLine extends XYGeometry {
       maxY = Math.max(y[i], maxY);
     }
 
-    this.x = new double[x.length];
-    this.y = new double[y.length];
-    for (int i = 0; i < x.length; ++i) {
-      this.x[i] = (double)x[i];
-      this.y[i] = (double)y[i];
-    }
     this.minX = minX;
     this.maxX = maxX;
     this.minY = minY;

--- a/lucene/core/src/java/org/apache/lucene/geo/XYPoint.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/XYPoint.java
@@ -17,6 +17,8 @@
 
 package org.apache.lucene.geo;
 
+import static org.apache.lucene.geo.XYEncodingUtils.checkVal;
+
 /**
  * Represents a point on the earth's surface.  You can construct the point directly with {@code double}
  * coordinates.
@@ -38,8 +40,8 @@ public final class XYPoint extends XYGeometry {
    * Creates a new Point from the supplied latitude/longitude.
    */
   public XYPoint(float x, float y) {
-    this.x = x;
-    this.y = y;
+    this.x = checkVal(x);
+    this.y = checkVal(y);
   }
 
   /** Returns latitude value at given index */

--- a/lucene/core/src/java/org/apache/lucene/geo/XYPolygon.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/XYPolygon.java
@@ -18,6 +18,8 @@ package org.apache.lucene.geo;
 
 import java.util.Arrays;
 
+import static org.apache.lucene.geo.XYEncodingUtils.checkVal;
+
 /**
  * Represents a polygon in cartesian space. You can construct the Polygon directly with {@code float[]}, {@code float[]} x, y arrays
  * coordinates.
@@ -72,8 +74,8 @@ public final class XYPolygon extends XYGeometry {
     this.x = new double[x.length];
     this.y = new double[y.length];
     for (int i = 0; i < x.length; ++i) {
-      this.x[i] = (double)x[i];
-      this.y[i] = (double)y[i];
+      this.x[i] = checkVal(x[i]);
+      this.y[i] = checkVal(y[i]);
     }
     this.holes = holes.clone();
 

--- a/lucene/core/src/java/org/apache/lucene/geo/XYRectangle.java
+++ b/lucene/core/src/java/org/apache/lucene/geo/XYRectangle.java
@@ -16,6 +16,8 @@
  */
 package org.apache.lucene.geo;
 
+import static org.apache.lucene.geo.XYEncodingUtils.checkVal;
+
 /** Represents a x/y cartesian rectangle. */
 public final class XYRectangle extends XYGeometry {
   /** minimum x value */
@@ -29,12 +31,16 @@ public final class XYRectangle extends XYGeometry {
 
   /** Constructs a bounding box by first validating the provided x and y coordinates */
   public XYRectangle(double minX, double maxX, double minY, double maxY) {
-    this.minX = minX;
-    this.maxX = maxX;
-    this.minY = minY;
-    this.maxY = maxY;
-    assert minX <= maxX;
-    assert minY <= maxY;
+    if (minX > maxX) {
+      throw new IllegalArgumentException("minX must be lower than maxX, got " + minX + " > " + maxX);
+    }
+    if (minY > maxY) {
+      throw new IllegalArgumentException("minY must be lower than maxY, got " + minY + " > " + maxY);
+    }
+    this.minX = checkVal(minX);
+    this.maxX = checkVal(maxX);
+    this.minY = checkVal(minY);
+    this.maxY = checkVal(maxY);
   }
 
   @Override

--- a/lucene/core/src/test/org/apache/lucene/geo/ShapeTestUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/geo/ShapeTestUtil.java
@@ -57,6 +57,17 @@ public class ShapeTestUtil {
     }
   }
 
+  public static XYLine nextLine() {
+    XYPolygon poly = ShapeTestUtil.nextPolygon();
+    float[] x = new float[poly.numPoints() - 1];
+    float[] y = new float[x.length];
+    for (int i = 0; i < x.length; ++i) {
+      x[i] = (float) poly.getPolyX(i);
+      y[i] = (float) poly.getPolyY(i);
+    }
+    return new XYLine(x, y);
+  }
+
   private static XYPolygon trianglePolygon(XYRectangle box) {
     final float[] polyX = new float[4];
     final float[] polyY = new float[4];

--- a/lucene/core/src/test/org/apache/lucene/geo/TestXYLine.java
+++ b/lucene/core/src/test/org/apache/lucene/geo/TestXYLine.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.geo;
+
+
+import org.apache.lucene.util.LuceneTestCase;
+
+public class TestXYLine extends LuceneTestCase {
+  
+  /** null x not allowed */
+  public void testLineNullXs() {
+    IllegalArgumentException expected = expectThrows(IllegalArgumentException.class, () -> {
+      new XYLine(null, new float[] { -66, -65, -65, -66, -66 });
+    });
+    assertTrue(expected.getMessage().contains("x must not be null"));
+  }
+  
+  /** null y not allowed */
+  public void testPolygonNullYs() {
+    IllegalArgumentException expected = expectThrows(IllegalArgumentException.class, () -> {
+      new XYLine(new float[] {18, 18, 19, 19, 18 }, null);
+    });
+    assertTrue(expected.getMessage().contains("y must not be null"));
+  }
+
+  /** needs at least 3 vertices */
+  public void testLineEnoughPoints() {
+    IllegalArgumentException expected = expectThrows(IllegalArgumentException.class, () -> {
+      new XYLine(new float[] {18}, new float[] { -66});
+    });
+    assertTrue(expected.getMessage().contains("at least 2 line points required"));
+  }
+
+  /** lines needs same number of x as y */
+  public void testLinesBogus() {
+    IllegalArgumentException expected = expectThrows(IllegalArgumentException.class, () -> {
+      new XYLine(new float[] { 18, 18, 19, 19 }, new float[] { -66, -65, -65, -66, -66 });
+    });
+    assertTrue(expected.getMessage().contains("must be equal length"));
+  }
+
+  /** line values cannot be NaN */
+  public void testLineNaN() {
+    IllegalArgumentException expected = expectThrows(IllegalArgumentException.class, () -> {
+      new XYLine(new float[] { 18, 18, 19, Float.NaN, 18 }, new float[] { -66, -65, -65, -66, -66 });
+    });
+    assertTrue(expected.getMessage(), expected.getMessage().contains("invalid value NaN"));
+  }
+
+  /** line values cannot be finite */
+  public void testLinePositiveInfinite() {
+    IllegalArgumentException expected = expectThrows(IllegalArgumentException.class, () -> {
+      new XYLine(new float[] { 18, 18, 19, 19, 18 }, new float[] { -66, Float.POSITIVE_INFINITY, -65, -66, -66 });
+    });
+    assertTrue(expected.getMessage(), expected.getMessage().contains("invalid value Inf"));
+  }
+
+  /** line values cannot be finite */
+  public void testLinenNegativeInfinite() {
+    IllegalArgumentException expected = expectThrows(IllegalArgumentException.class, () -> {
+      new XYLine(new float[] { 18, 18, 19, 19, 18 }, new float[] { -66, -65, -65, Float.NEGATIVE_INFINITY, -66 });
+    });
+    assertTrue(expected.getMessage(), expected.getMessage().contains("invalid value -Inf"));
+  }
+
+  /** equals and hashcode */
+  public void testEqualsAndHashCode() {
+    XYLine line = ShapeTestUtil.nextLine();
+    XYLine copy = new XYLine(doubleToFloat(line.getX()), doubleToFloat(line.getY()));
+    assertEquals(line, copy);
+    assertEquals(line.hashCode(), copy.hashCode());
+  }
+
+  private float[] doubleToFloat(double[] d) {
+    float[] f = new float[d.length];
+    for (int i = 0 ; i < d.length; i++) {
+      f[i] = (float) d[i];
+    }
+    return f;
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/geo/TestXYPoint.java
+++ b/lucene/core/src/test/org/apache/lucene/geo/TestXYPoint.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.geo;
+
+import org.apache.lucene.util.LuceneTestCase;
+
+public class TestXYPoint extends LuceneTestCase {
+
+  /** point values cannot be NaN */
+  public void testNaN() {
+    IllegalArgumentException expected = expectThrows(IllegalArgumentException.class, () -> {
+      new XYPoint(Float.NaN, 45.23f);
+    });
+    assertTrue(expected.getMessage().contains("invalid value NaN"));
+
+    expected = expectThrows(IllegalArgumentException.class, () -> {
+      new XYPoint(43.5f, Float.NaN);
+    });
+    assertTrue(expected.getMessage().contains("invalid value NaN"));
+  }
+
+  /** point values mist be finite */
+  public void testPositiveInf() {
+    IllegalArgumentException expected = expectThrows(IllegalArgumentException.class, () -> {
+      new XYPoint(Float.POSITIVE_INFINITY, 45.23f);
+    });
+    assertTrue(expected.getMessage().contains("invalid value Inf"));
+
+    expected = expectThrows(IllegalArgumentException.class, () -> {
+      new XYPoint(43.5f, Float.POSITIVE_INFINITY);
+    });
+    assertTrue(expected.getMessage().contains("invalid value Inf"));
+  }
+
+  /** point values mist be finite */
+  public void testNegativeInf() {
+    IllegalArgumentException expected = expectThrows(IllegalArgumentException.class, () -> {
+      new XYPoint(Float.NEGATIVE_INFINITY, 45.23f);
+    });
+    assertTrue(expected.getMessage().contains("invalid value -Inf"));
+
+    expected = expectThrows(IllegalArgumentException.class, () -> {
+      new XYPoint(43.5f, Float.NEGATIVE_INFINITY);
+    });
+    assertTrue(expected.getMessage().contains("invalid value -Inf"));
+  }
+
+  /** equals and hashcode */
+  public void testEqualsAndHashCode() {
+    XYPoint point = new XYPoint((float) ShapeTestUtil.nextDouble(random()), (float) ShapeTestUtil.nextDouble(random()));
+    XYPoint copy = new XYPoint((float) point.getX(), (float) point.getY());
+    assertEquals(point, copy);
+    assertEquals(point.hashCode(), copy.hashCode());
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/geo/TestXYPolygon.java
+++ b/lucene/core/src/test/org/apache/lucene/geo/TestXYPolygon.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.geo;
+
+
+import org.apache.lucene.util.LuceneTestCase;
+
+public class TestXYPolygon extends LuceneTestCase {
+  
+  /** null x not allowed */
+  public void testPolygonNullPolyLats() {
+    IllegalArgumentException expected = expectThrows(IllegalArgumentException.class, () -> {
+      new XYPolygon(null, new float[] { -66, -65, -65, -66, -66 });
+    });
+    assertTrue(expected.getMessage().contains("x must not be null"));
+  }
+  
+  /** null y not allowed */
+  public void testPolygonNullPolyLons() {
+    IllegalArgumentException expected = expectThrows(IllegalArgumentException.class, () -> {
+      new XYPolygon(new float[] {18, 18, 19, 19, 18 }, null);
+    });
+    assertTrue(expected.getMessage().contains("y must not be null"));
+  }
+  
+  /** polygon needs at least 3 vertices */
+  public void testPolygonLine() {
+    IllegalArgumentException expected = expectThrows(IllegalArgumentException.class, () -> {
+      new XYPolygon(new float[] { 18, 18, 18 }, new float[] { -66, -65, -66 });
+    });
+    assertTrue(expected.getMessage().contains("at least 4 polygon points required"));
+  }
+  
+  /** polygon needs same number of latitudes as longitudes */
+  public void testPolygonBogus() {
+    IllegalArgumentException expected = expectThrows(IllegalArgumentException.class, () -> {
+      new XYPolygon(new float[] { 18, 18, 19, 19 }, new float[] { -66, -65, -65, -66, -66 });
+    });
+    assertTrue(expected.getMessage().contains("must be equal length"));
+  }
+  
+  /** polygon must be closed */
+  public void testPolygonNotClosed() {
+    IllegalArgumentException expected = expectThrows(IllegalArgumentException.class, () -> {
+      new XYPolygon(new float[] { 18, 18, 19, 19, 19 }, new float[] { -66, -65, -65, -66, -67 });
+    });
+    assertTrue(expected.getMessage(), expected.getMessage().contains("it must close itself"));
+  }
+
+  /** polygon values cannot be NaN */
+  public void testPolygonNaN() {
+    IllegalArgumentException expected = expectThrows(IllegalArgumentException.class, () -> {
+      new XYPolygon(new float[] { 18, 18, 19, Float.NaN, 18 }, new float[] { -66, -65, -65, -66, -66 });
+    });
+    assertTrue(expected.getMessage(), expected.getMessage().contains("invalid value NaN"));
+  }
+
+  /** polygon values cannot be finite */
+  public void testPolygonPositiveInfinite() {
+    IllegalArgumentException expected = expectThrows(IllegalArgumentException.class, () -> {
+      new XYPolygon(new float[] { 18, 18, 19, 19, 18 }, new float[] { -66, Float.POSITIVE_INFINITY, -65, -66, -66 });
+    });
+    assertTrue(expected.getMessage(), expected.getMessage().contains("invalid value Inf"));
+  }
+
+  /** polygon values cannot be finite */
+  public void testPolygonNegativeInfinite() {
+    IllegalArgumentException expected = expectThrows(IllegalArgumentException.class, () -> {
+      new XYPolygon(new float[] { 18, 18, 19, 19, 18 }, new float[] { -66, -65, -65, Float.NEGATIVE_INFINITY, -66 });
+    });
+    assertTrue(expected.getMessage(), expected.getMessage().contains("invalid value -Inf"));
+  }
+
+  /** equals and hashcode */
+  public void testEqualsAndHashCode() {
+    XYPolygon polygon = ShapeTestUtil.nextPolygon();
+    XYPolygon copy = new XYPolygon(doubleToFloat(polygon.getPolyX()), doubleToFloat(polygon.getPolyY()));
+    assertEquals(polygon, copy);
+    assertEquals(polygon.hashCode(), copy.hashCode());
+  }
+
+  private float[] doubleToFloat(double[] d) {
+    float[] f = new float[d.length];
+    for (int i = 0 ; i < d.length; i++) {
+      f[i] = (float) d[i];
+    }
+    return f;
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/geo/TestXYRectangle.java
+++ b/lucene/core/src/test/org/apache/lucene/geo/TestXYRectangle.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.geo;
+
+
+import org.apache.lucene.util.LuceneTestCase;
+
+public class TestXYRectangle extends LuceneTestCase {
+
+  /** maxX must be gte minX */
+  public void tesInvalidMinMaxX() {
+    IllegalArgumentException expected = expectThrows(IllegalArgumentException.class, () -> {
+      new XYRectangle(5, 4, 3 ,4);
+    });
+    assertTrue(expected.getMessage().contains("5 > 4"));
+  }
+
+  /** maxY must be gte minY */
+  public void tesInvalidMinMaxY() {
+    IllegalArgumentException expected = expectThrows(IllegalArgumentException.class, () -> {
+      new XYRectangle(4, 5, 5 ,4);
+    });
+    assertTrue(expected.getMessage().contains("5 > 4"));
+  }
+
+  /** rectangle values cannot be NaN */
+  public void testNaN() {
+    IllegalArgumentException expected = expectThrows(IllegalArgumentException.class, () -> {
+      new XYRectangle(Float.NaN, 4, 3 ,4);
+    });
+    assertTrue(expected.getMessage().contains("invalid value NaN"));
+
+    expected = expectThrows(IllegalArgumentException.class, () -> {
+      new XYRectangle(3, Float.NaN, 3 ,4);
+    });
+    assertTrue(expected.getMessage().contains("invalid value NaN"));
+
+    expected = expectThrows(IllegalArgumentException.class, () -> {
+      new XYRectangle(3, 4, Float.NaN ,4);
+    });
+    assertTrue(expected.getMessage().contains("invalid value NaN"));
+
+    expected = expectThrows(IllegalArgumentException.class, () -> {
+      new XYRectangle(3, 4, 3 , Float.NaN);
+    });
+    assertTrue(expected.getMessage().contains("invalid value NaN"));
+  }
+
+  /** rectangle values must be finite */
+  public void testPositiveInf() {
+    IllegalArgumentException expected = expectThrows(IllegalArgumentException.class, () -> {
+      new XYRectangle(3, Float.POSITIVE_INFINITY, 3 ,4);
+    });
+    assertTrue(expected.getMessage().contains("invalid value Inf"));
+
+    expected = expectThrows(IllegalArgumentException.class, () -> {
+      new XYRectangle(3, 4, 3 , Float.POSITIVE_INFINITY);
+    });
+    assertTrue(expected.getMessage().contains("invalid value Inf"));
+  }
+
+  /** rectangle values must be finite */
+  public void testNegativeInf() {
+    IllegalArgumentException expected = expectThrows(IllegalArgumentException.class, () -> {
+      new XYRectangle(Float.NEGATIVE_INFINITY, 4, 3 ,4);
+    });
+    assertTrue(expected.getMessage().contains("invalid value -Inf"));
+
+    expected = expectThrows(IllegalArgumentException.class, () -> {
+      new XYRectangle(3, 4, Float.NEGATIVE_INFINITY ,4);
+    });
+    assertTrue(expected.getMessage().contains("invalid value -Inf"));
+  }
+
+  /** equals and hashcode */
+  public void testEqualsAndHashCode() {
+    XYRectangle rectangle = ShapeTestUtil.nextBox(random());
+    XYRectangle copy = new XYRectangle(rectangle.minX, rectangle.maxX, rectangle.minY, rectangle.maxY);
+    assertEquals(rectangle, copy);
+    assertEquals(rectangle.hashCode(), copy.hashCode());
+  }
+
+}


### PR DESCRIPTION
 This PR adds validation for XYGeometries, in particular checking for non-valid values like NaN, INF and -INF.