### PR TITLE
SOLR-14252: avoid NPE in metric aggregation

### DIFF
--- a/solr/core/src/java/org/apache/solr/metrics/AggregateMetric.java
+++ b/solr/core/src/java/org/apache/solr/metrics/AggregateMetric.java
@@ -107,6 +107,9 @@ public class AggregateMetric implements Metric {
         res = n.doubleValue();
       }
     }
+    if (res == null) {
+      return 0;
+    }
     return res;
   }
 
@@ -127,6 +130,9 @@ public class AggregateMetric implements Metric {
       if (n.doubleValue() < res) {
         res = n.doubleValue();
       }
+    }
+    if (res == null) {
+      return 0;
     }
     return res;
   }

--- a/solr/core/src/test/org/apache/solr/util/stats/MetricUtilsTest.java
+++ b/solr/core/src/test/org/apache/solr/util/stats/MetricUtilsTest.java
@@ -79,11 +79,23 @@ public class MetricUtilsTest extends SolrTestCaseJ4 {
     meter.mark();
     Histogram histogram = registry.histogram("histogram");
     histogram.update(10);
-    AggregateMetric am = new AggregateMetric();
-    registry.register("aggregate", am);
-    am.set("foo", 10);
-    am.set("bar", 1);
-    am.set("bar", 2);
+
+    // SOLR-14252: check that negative values are supported correctly
+    // NB a-d represent the same metric from multiple nodes
+    AggregateMetric am1 = new AggregateMetric();
+    registry.register("aggregate1", am1);
+    am1.set("a", -10);
+    am1.set("b", 1);
+    am1.set("b", -2);
+    am1.set("c", -3);
+    am1.set("d", -5);
+
+    // SOLR-14252: check that aggregation of non-Number metrics don't trigger NullPointerException
+    AggregateMetric am2 = new AggregateMetric();
+    registry.register("aggregate2", am2);
+    am2.set("a", false);
+    am2.set("b", true);
+
     Gauge<String> gauge = () -> "foobar";
     registry.register("gauge", gauge);
     Gauge<Long> error = () -> {throw new InternalError("Memory Pool not found error");};
@@ -102,17 +114,26 @@ public class MetricUtilsTest extends SolrTestCaseJ4 {
         assertEquals(1L, v.get("count"));
       } else if (k.startsWith("histogram")) {
         assertEquals(1L, v.get("count"));
-      } else if (k.startsWith("aggregate")) {
-        assertEquals(2, v.get("count"));
+      } else if (k.startsWith("aggregate1")) {
+        assertEquals(4, v.get("count"));
         Map<String, Object> values = (Map<String, Object>)v.get("values");
         assertNotNull(values);
-        assertEquals(2, values.size());
-        Map<String, Object> update = (Map<String, Object>)values.get("foo");
-        assertEquals(10, update.get("value"));
+        assertEquals(4, values.size());
+        Map<String, Object> update = (Map<String, Object>)values.get("a");
+        assertEquals(-10, update.get("value"));
         assertEquals(1, update.get("updateCount"));
-        update = (Map<String, Object>)values.get("bar");
-        assertEquals(2, update.get("value"));
+        update = (Map<String, Object>)values.get("b");
+        assertEquals(-2, update.get("value"));
         assertEquals(2, update.get("updateCount"));
+        assertEquals(-10D, v.get("min"));
+        assertEquals(-2D, v.get("max"));
+        assertEquals(-5D, v.get("mean"));
+      } else if (k.startsWith("aggregate2")) {
+        // SOLR-14252: non-Number metric aggregations should return 0 rather than throwing NPE
+        assertEquals(2, v.get("count"));
+        assertEquals(0D, v.get("min"));
+        assertEquals(0D, v.get("max"));
+        assertEquals(0D, v.get("mean"));
       } else if (k.startsWith("memory.expected.error")) {
         assertNull(v);
       }
@@ -142,15 +163,15 @@ public class MetricUtilsTest extends SolrTestCaseJ4 {
           } else if (k.startsWith("aggregate")) {
             assertTrue(o instanceof Map);
             Map v = (Map)o;
-            assertEquals(2, v.get("count"));
+            assertEquals(4, v.get("count"));
             Map<String, Object> values = (Map<String, Object>)v.get("values");
             assertNotNull(values);
-            assertEquals(2, values.size());
-            Map<String, Object> update = (Map<String, Object>)values.get("foo");
-            assertEquals(10, update.get("value"));
+            assertEquals(4, values.size());
+            Map<String, Object> update = (Map<String, Object>)values.get("a");
+            assertEquals(-10, update.get("value"));
             assertEquals(1, update.get("updateCount"));
-            update = (Map<String, Object>)values.get("bar");
-            assertEquals(2, update.get("value"));
+            update = (Map<String, Object>)values.get("b");
+            assertEquals(-2, update.get("value"));
             assertEquals(2, update.get("updateCount"));
           } else if (k.startsWith("memory.expected.error")) {
             assertNull(o);

--- a/solr/solr-ref-guide/src/metrics-reporting.adoc
+++ b/solr/solr-ref-guide/src/metrics-reporting.adoc
@@ -519,7 +519,7 @@ Example configuration:
            </lst>
            <lst name="report">
              <str name="group">aggregated_shard_leaders</str>
-             <str name="registry">solr\.core\.(.*)\.leader</str>
+             <str name="registry">solr\.collection\.(.*)\.leader</str>
              <str name="label">leader.$1</str>
              <str name="filter">UPDATE\./update/.*</str>
            </lst>


### PR DESCRIPTION
# Description

The getMax and getMin methods in AggregateMetric can throw an NPE if _only_ non-Number values are present when it tries to cast a null Double to a double.

# Solution

This PR checks that the aggregation output is non-null before casting to a `double`. Null values become 0.

# Tests

Test suite has been updated to check that non-Number metrics can be aggregated (returning 0) and to ensure that negative values continue to be supported.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [x] I have added tests for my changes.
- [ ] (n/a) I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
