### PR TITLE
SOLR-14044: Delete collection bug fix by changing sharedShardName to use the same blob delimiter

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/Assign.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/Assign.java
@@ -55,6 +55,7 @@ import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.common.params.CollectionAdminParams;
 import org.apache.solr.common.util.StrUtils;
 import org.apache.solr.common.util.Utils;
+import org.apache.solr.store.blob.client.BlobClientUtils;
 import org.apache.solr.util.NumberUtils;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
@@ -187,7 +188,7 @@ public class Assign {
    * exclusively for shared store-based collections.
    */
   public static String buildSharedShardName(String collectionName, String shard) {
-    return collectionName + "_" + shard;
+    return collectionName + BlobClientUtils.BLOB_FILE_PATH_DELIMITER + shard;
   }
 
   private static int defaultCounterValue(DocCollection collection, boolean newCollection, String shard) {

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/DeleteCollectionCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/DeleteCollectionCmd.java
@@ -168,7 +168,7 @@ public class DeleteCollectionCmd implements OverseerCollectionMessageHandler.Cmd
           t = ex;
         }
         if (t != null || !result.isSuccess()) {
-          throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "Could not complete deleting collection" + 
+          throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "Could not complete deleting collection " + 
               collection + " from shared store, files belonging to this collection"
                   + " may be orphaned.", t);
         }

--- a/solr/core/src/java/org/apache/solr/store/blob/client/LocalStorageClient.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/client/LocalStorageClient.java
@@ -241,7 +241,6 @@ public class LocalStorageClient implements CoreStorageClient {
       
   }
   
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   @Override
   public List<String> listCoreBlobFiles(String prefix) throws BlobException {
     try {

--- a/solr/core/src/java/org/apache/solr/store/blob/process/BlobDeleteProcessor.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/process/BlobDeleteProcessor.java
@@ -108,8 +108,8 @@ public class BlobDeleteProcessor implements Closeable {
    * @param allowRetry flag indicating if the task should be retried if it fails
    */
   public CompletableFuture<BlobDeleterTaskResult> deleteCollection(String collectionName, boolean allowRetry) {
-    BlobDeleterTask task = new BlobPrefixedFileDeletionTask(client, collectionName, collectionName, 
-        allowRetry, maxDeleteAttempts);
+    BlobDeleterTask task = new BlobPrefixedFileDeletionTask(client, collectionName, 
+        collectionName + BlobClientUtils.BLOB_FILE_PATH_DELIMITER, allowRetry, maxDeleteAttempts);
     return enqueue(task, false);
   }
   

--- a/solr/core/src/test/org/apache/solr/cloud/api/collections/SharedStorageShardMetadataTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/api/collections/SharedStorageShardMetadataTest.java
@@ -26,6 +26,7 @@ import org.apache.solr.common.cloud.DocCollection;
 import org.apache.solr.common.cloud.Replica.Type;
 import org.apache.solr.common.cloud.Slice;
 import org.apache.solr.common.cloud.ZkStateReader;
+import org.apache.solr.store.blob.client.BlobClientUtils;
 import org.apache.solr.store.blob.client.CoreStorageClient;
 import org.apache.solr.store.shared.SolrCloudSharedStoreTestCase;
 import org.junit.AfterClass;
@@ -152,7 +153,7 @@ public class SharedStorageShardMetadataTest extends SolrCloudSharedStoreTestCase
     
     // single shard sanity check; <shardname>_<counter> is the nomenclature for sub shards
     Slice slice = collection.getActiveSlicesMap().get("shard1_1");
-    assertEquals(collectionName + "_shard1_1", slice.getProperties().get(ZkStateReader.SHARED_SHARD_NAME));
+    assertEquals(collectionName + BlobClientUtils.BLOB_FILE_PATH_DELIMITER + "shard1_1", slice.getProperties().get(ZkStateReader.SHARED_SHARD_NAME));
         
     // check them all
     assertSharedCollectionMetadataExists(collection);

--- a/solr/core/src/test/org/apache/solr/store/blob/metadata/CorePushPullTest.java
+++ b/solr/core/src/test/org/apache/solr/store/blob/metadata/CorePushPullTest.java
@@ -27,6 +27,7 @@ import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.cloud.api.collections.Assign;
 import org.apache.solr.core.CoreContainer;
 import org.apache.solr.core.SolrCore;
+import org.apache.solr.store.blob.client.BlobClientUtils;
 import org.apache.solr.store.blob.client.BlobCoreMetadata;
 import org.apache.solr.store.blob.client.BlobCoreMetadataBuilder;
 import org.apache.solr.store.blob.client.CoreStorageClient;
@@ -52,7 +53,7 @@ public class CorePushPullTest extends SolrTestCaseJ4 {
   private static CoreStorageClient storageClient;
   private static Path localBlobDir;
   
-  private String sharedBlobName = "collectionTest_shardTest";
+  private String sharedBlobName = "collectionTest" + BlobClientUtils.BLOB_FILE_PATH_DELIMITER + "shardTest";
   private String collectionName = "collectionTest";
   private String shardName = "shardTest";
   private String metadataSuffix = "metadataSuffix";

--- a/solr/core/src/test/org/apache/solr/update/processor/DistributedZkUpdateProcessorTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/DistributedZkUpdateProcessorTest.java
@@ -70,7 +70,6 @@ public class DistributedZkUpdateProcessorTest extends SolrCloudSharedStoreTestCa
   
   @After
   public void teardownTest() throws Exception {
-    cluster.deleteAllCollections();
     shutdownCluster();
     File blobPath = sharedStoreRootPath.toFile();
     FileUtils.cleanDirectory(blobPath);


### PR DESCRIPTION
In shared storage, deletion from the blob store works by listing files beginning with a certain prefix and reading from a blob store requires knowing some or all of the file name.

The sharedShardName, or the identifier prefixing all blob storage files per shard works by concatenating the collection name (uniqueness assumption in solr cloud overall) and the shard name with "_" joining the two. "_" is allowed in collection names which allows for a bug in listing files from other collections unintentionally.

This change changes the delimiter to use "/" which is more consistent with how index files stored in blob are structured anyway <collection identifier>/<index_file_blob_name>. Piggy-backed a minor unrelated test fix in DistributedZkUpdateProcessorTest.java that I missed earlier.

Change Summary
- Use "/" in sharedShardName
- Update tests
- Fix DistributedZkUpdateProcessorTest which tries to delete all collections after every test. In the same cleanup method the entire tmp directory we use as a local blob store gets deleted at the same time so the collection deletion errors out and leaks threads. This is a test setup issue vs a functional one. We spin up a new cluster in the different test cases anyway so we don't need to delete all collections.
