### PR TITLE
Lucene-9004: bug fix for searching the nearest one neighbor in higher layers

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HNSWGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HNSWGraph.java
@@ -19,7 +19,6 @@ package org.apache.lucene.util.hnsw;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -73,8 +72,8 @@ public final class HNSWGraph implements Accountable {
     Neighbor f = results.top();
     while (candidates.size() > 0) {
       Neighbor c = candidates.pollFirst();
-      assert c.isDeferred() == false;
-      assert f.isDeferred() == false;
+      assert !c.isDeferred();
+      assert !f.isDeferred();
       if (c.distance() > f.distance() && results.size() >= ef) {
         break;
       }
@@ -85,6 +84,9 @@ public final class HNSWGraph implements Accountable {
         visited.add(e.docId());
         float dist = distance(query, e.docId(), vectorValues);
         if (dist < f.distance() || results.size() < ef) {
+          if (results.size() == ef) {
+            results.pop();
+          }
           Neighbor n = new ImmutableNeighbor(e.docId(), dist);
           candidates.add(n);
           results.insertWithOverflow(n);


### PR DESCRIPTION
`if (dist < f.distance() || results.size() < ef) {
   Neighbor n = new ImmutableNeighbor(e.docId(), dist);
   candidates.add(n);
   results.insertWithOverflow(n);
   f = results.top();
}` 

If (dist < f.distance()) but results.size() >= ef, the "Neighbor n" would be added to "results" ("results" is a sub-type of PriorityQueue). The actual size of "results" would be between "ef" and results' max queue size, while its expected size is "ef". Moreover, this bug could have negative effect on performance.

Consider the following situation in [HNSWGraphReader](https://github.com/apache/lucene-solr/blob/jira/lucene-9004-aknn-2/lucene/core/src/java/org/apache/lucene/util/hnsw/HNSWGraphReader.java):

`FurthestNeighbors neighbors = new FurthestNeighbors(ef, ep);
  for (int l = hnsw.topLevel(); l > 0; l--) {
    visitedCount += hnsw.searchLayer(query, neighbors, 1, l, vectorValues);
  }
  visitedCount += hnsw.searchLayer(query, neighbors, ef, 0, vectorValues);`

where the max size of "neighbors" ("neighbors" is also a sub-type of PriorityQueue) is ef (assume ef > 1. Note that the meaning of "ef" is different in the above two code segments). When search over a non-zero layer, we are going to find the nearest one neighbor by `hnsw.searchLayer(query, neighbors, 1, l, vectorValues);`, where l is the layer and layer > 0. The actual size of "neighbors" may be larger than 1.

Assume that "results.size() <= ef" (always meet in HNSW), I think "results.pop();" when "results.size() == ef" can solve this problem.

