### PR TITLE
LUCENE-9114: Improve ValueSourceScorer's Default Cost Implementation

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -79,6 +79,8 @@ Improvements
   Nepali, Serbian, and Tamil. New stoplist: Indonesian. Adds gradle 'snowball'
   task to regenerate and ease future upgrades. (Robert Muir, Dawid Weiss)
 
+* LUCENE-9114: Improve ValueSourceScorer's Default Cost Implementation (Atri Sharma)
+
 Bug fixes
 
 * LUCENE-8663: NRTCachingDirectory.slowFileExists may open a file while 

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/FunctionValues.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/FunctionValues.java
@@ -41,6 +41,8 @@ import org.apache.lucene.util.mutable.MutableValueFloat;
 //   want the Query carrying around big objects
 public abstract class FunctionValues {
 
+  public static final int DEFAULT_COST = 100;
+
   public byte byteVal(int doc) throws IOException { throw new UnsupportedOperationException(); }
   public short shortVal(int doc) throws IOException { throw new UnsupportedOperationException(); }
 
@@ -90,6 +92,9 @@ public abstract class FunctionValues {
    * @return the number of unique sort ordinals this instance has
    */
   public int numOrd() { throw new UnsupportedOperationException(); }
+
+  public float cost() { return DEFAULT_COST; }
+
   public abstract String toString(int doc) throws IOException;
 
   /**

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/FunctionValues.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/FunctionValues.java
@@ -41,9 +41,6 @@ import org.apache.lucene.util.mutable.MutableValueFloat;
 //   want the Query carrying around big objects
 public abstract class FunctionValues {
 
-  // Default cost for FunctionValues -- ideally should be overriden by concrete implementations
-  public static final int DEFAULT_COST = 100;
-
   public byte byteVal(int doc) throws IOException { throw new UnsupportedOperationException(); }
   public short shortVal(int doc) throws IOException { throw new UnsupportedOperationException(); }
 
@@ -101,7 +98,7 @@ public abstract class FunctionValues {
    * comparing two numbers and indexing an array.
    * The returned value must be positive.
    */
-  public float cost() { return DEFAULT_COST; }
+  public float cost() { return 100; }
 
   public abstract String toString(int doc) throws IOException;
 
@@ -165,8 +162,7 @@ public abstract class FunctionValues {
         return true;
       }
       @Override
-      public float costEvaluationFunction() {
-        // Match everything
+      public float matchCost() {
         return 0f;
       }
     };

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/FunctionValues.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/FunctionValues.java
@@ -94,6 +94,13 @@ public abstract class FunctionValues {
    */
   public int numOrd() { throw new UnsupportedOperationException(); }
 
+  /**
+   * An estimate of the expected cost to return a value for a document.
+   * It's intended to be used by TwoPhaseIterator.matchCost implementations.
+   * Returns an expected cost in number of simple operations like addition, multiplication,
+   * comparing two numbers and indexing an array.
+   * The returned value must be positive.
+   */
   public float cost() { return DEFAULT_COST; }
 
   public abstract String toString(int doc) throws IOException;

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/FunctionValues.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/FunctionValues.java
@@ -164,6 +164,11 @@ public abstract class FunctionValues {
       public boolean matches(int doc) {
         return true;
       }
+      @Override
+      public float costEvaluationFunction() {
+        // Match everything
+        return 0f;
+      }
     };
   }
 

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/FunctionValues.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/FunctionValues.java
@@ -41,6 +41,7 @@ import org.apache.lucene.util.mutable.MutableValueFloat;
 //   want the Query carrying around big objects
 public abstract class FunctionValues {
 
+  // Default cost for FunctionValues -- ideally should be overriden by concrete implementations
   public static final int DEFAULT_COST = 100;
 
   public byte byteVal(int doc) throws IOException { throw new UnsupportedOperationException(); }

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/ValueSourceScorer.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/ValueSourceScorer.java
@@ -58,7 +58,7 @@ public abstract class ValueSourceScorer extends Scorer {
 
       @Override
       public float matchCost() {
-        return costEvaluationFunction();
+        return ValueSourceScorer.this.matchCost();
       }
     };
     this.disi = TwoPhaseIterator.asDocIdSetIterator(twoPhaseIterator);
@@ -106,7 +106,7 @@ public abstract class ValueSourceScorer extends Scorer {
    *
    * @lucene.experimental
    */
-  protected float costEvaluationFunction() {
+  protected float matchCost() {
     // Cost of iteration is fixed cost + cost exposed by delegated FunctionValues instance
     return DEF_COST + values.cost();
   }

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/ValueSourceScorer.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/ValueSourceScorer.java
@@ -39,7 +39,9 @@ import org.apache.lucene.search.Weight;
  * @lucene.experimental
  */
 public abstract class ValueSourceScorer extends Scorer {
+  // Fixed cost for a single iteration of the TwoPhaseIterator instance
   private static final int DEF_COST = 5;
+
   protected final FunctionValues values;
   private final TwoPhaseIterator twoPhaseIterator;
   private final DocIdSetIterator disi;
@@ -62,6 +64,7 @@ public abstract class ValueSourceScorer extends Scorer {
           return externallyMutableCost;
         }
 
+        // Cost of iteration is fixed cost + cost exposed by delegated FunctionValues instance
         return DEF_COST + values.cost();
       }
     };
@@ -104,7 +107,7 @@ public abstract class ValueSourceScorer extends Scorer {
   /**
    * Used to externally set a mutable cost for this instance. If set, this cost gets preference over the FunctionValues's cost
    *
-   * @expert
+   * @lucene.experimental
    */
   public void setExternallyMutableCost(float cost) {
     externallyMutableCost = cost;

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/ValueSourceScorer.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/ValueSourceScorer.java
@@ -45,7 +45,6 @@ public abstract class ValueSourceScorer extends Scorer {
   protected final FunctionValues values;
   private final TwoPhaseIterator twoPhaseIterator;
   private final DocIdSetIterator disi;
-  private Float matchCost;
 
   protected ValueSourceScorer(Weight weight, LeafReaderContext readerContext, FunctionValues values) {
     super(weight);
@@ -59,11 +58,6 @@ public abstract class ValueSourceScorer extends Scorer {
 
       @Override
       public float matchCost() {
-        // If an external cost is set, use that
-        if (matchCost != 0.0) {
-          return matchCost;
-        }
-
         return costEvaluationFunction();
       }
     };
@@ -101,16 +95,6 @@ public abstract class ValueSourceScorer extends Scorer {
   @Override
   public float getMaxScore(int upTo) throws IOException {
     return Float.POSITIVE_INFINITY;
-  }
-
-  /**
-   * Used to externally set a mutable cost for this instance. If set, this cost gets preference over the FunctionValues's cost
-   * The value set here is used by {@link TwoPhaseIterator#matchCost()} for the TwoPhaseIterator owned by this class
-   *
-   * @lucene.experimental
-   */
-  public void setMatchCost(float cost) {
-    matchCost = cost;
   }
 
   /**

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/ValueSourceScorer.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/ValueSourceScorer.java
@@ -39,6 +39,7 @@ import org.apache.lucene.search.Weight;
  * @lucene.experimental
  */
 public abstract class ValueSourceScorer extends Scorer {
+  private static final int DEF_COST = 5;
   protected final FunctionValues values;
   private final TwoPhaseIterator twoPhaseIterator;
   private final DocIdSetIterator disi;
@@ -55,7 +56,7 @@ public abstract class ValueSourceScorer extends Scorer {
 
       @Override
       public float matchCost() {
-        return 100; // TODO: use cost of ValueSourceScorer.this.matches()
+        return DEF_COST + values.getScorer(weight, readerContext).twoPhaseIterator().matchCost();
       }
     };
     this.disi = TwoPhaseIterator.asDocIdSetIterator(twoPhaseIterator);


### PR DESCRIPTION
This commit makes ValueSourceScorer's costing algorithm also take the delegated FunctionValues's cost into consideration when calculating its cost.