### PR TITLE
LUCENE-8962: Fix intermittent test failures

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3343,9 +3343,8 @@ public class IndexWriter implements Closeable, TwoPhaseCommit, Accountable,
               }
             }
           }
-        } catch (InterruptedException e) {
-          Thread.interrupted();
-          throw new IOException("Interrupted waiting for merges");
+        } catch (InterruptedException ie) {
+          throw new ThreadInterruptedException(ie);
         } finally {
           if (infoStream.isEnabled("IW")) {
             infoStream.message("IW", String.format(Locale.ROOT, "Waited %.1f ms for commit merges",


### PR DESCRIPTION
1. TestIndexWriterMergePolicy.testMergeOnCommit will fail if the last
   commit (the one that should trigger the full merge) doesn't have any
   pending changes (which could occur if the last indexing thread
   commits at the end). We can fix that by adding one more document
   before that commit.
2. The previous implementation was throwing IOException if the commit
   thread gets interrupted while waiting for merges to complete. This
   violates IndexWriter's documented behavior of throwing
   ThreadInterruptedException.

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

This fixes intermittent test failures related to the previous commit on LUCENE-8962.

# Solution

There were two separate bugs in the previous commit:

1. TestIndexWriterMergePolicy.testMergeOnCommit could sometimes fail the last assertion, because the final commit in the test method triggered no merges. This could happen if multiple indexing threads committed after adding their last documents. To guarantee that the final commit in the test method triggers a merge, we can add one more document (so there is a change to commit).
2. TestIndexWriter. testThreadInterruptDeadlock verifies IndexWriter's documented behavior of throwing ThreadInterruptedException when interrupted. The previous commit for LUCENE-8962 violated this behavior. This commit fixes that.

# Tests

After applying these fixes, I have run both TestIndexWriter and TestIndexWriterMergePolicy multiple times with previously-failing seeds and random seeds, and have not seen the test failures occur again.

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [X] I have developed this patch against the `master` branch.
- [X] I have run `ant precommit` and the appropriate test suite.
- [X] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
