### PR TITLE
LUCENE-8962: Split test case

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3159,7 +3159,7 @@ public class IndexWriter implements Closeable, TwoPhaseCommit, Accountable,
           // Commit thread timed out waiting for this merge and moved on. No need to manipulate toCommit.
           return;
         }
-        if (isAborted() == false) {
+        if (committed) {
           deleter.incRef(this.info.files());
           // Resolve "live" SegmentInfos segments to their toCommit cloned equivalents, based on segment name.
           Set<String> mergedSegmentNames = new HashSet<>();
@@ -4076,6 +4076,7 @@ public class IndexWriter implements Closeable, TwoPhaseCommit, Accountable,
     }
 
     try (Closeable finalizer = this::checkpoint) {
+      merge.committed = true;
       // Must close before checkpoint, otherwise IFD won't be
       // able to delete the held-open files from the merge
       // readers:

--- a/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
@@ -225,6 +225,8 @@ public abstract class MergePolicy {
     public final int totalMaxDoc;
     Throwable error;
 
+    boolean committed; // Set by IndexWriter once the merge has been committed to disk
+
     /** Sole constructor.
      * @param segments List of {@link SegmentCommitInfo}s
      *        to be merged. */


### PR DESCRIPTION
The testMergeOnCommit test case was trying to verify too many things
at once: basic semantics of merge on commit and proper behavior when
a bunch of indexing threads are writing and committing all at once.

Splitting the test into two should make the tests more robust - one
will verify basic behavior, with strict assertions on invariants, while
the other just verifies that everything gets indexed and we don't throw
an exception when multiple threads are indexing and merging on commit.

Also, the part of the test that is now testMultithreadedMergeOnCommit
can take several seconds to run, so moving it to the @Nightly set.

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

Fixing an intermittent test failure on testMergeOnCommit.

# Solution

Split the logic from testMergeOnCommit into two test cases. The basic test has consistently passed, and actually verifies the merge on commit invariants. The more complicated, more potentially-brittle multithreaded test doesn't necessarily satisfy clear invariants (as we may be merging on commit from multiple threads, which could result in multiple segments in the end), but it should never throw an exception or lose any updates.

# Tests

Split existing test case into two test cases. Ran tests multiple times.

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [X] I have developed this patch against the `master` branch.
- [X] I have run `ant precommit` and the appropriate test suite.
- [X] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
