### PR TITLE
SOLR-13101: Create metadataSuffix znode only at common shard creating api calls

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/CreateCollectionCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/CreateCollectionCmd.java
@@ -195,7 +195,7 @@ public class CreateCollectionCmd implements OverseerCollectionMessageHandler.Cmd
       if (sharedIndex) {
         for (String shardName : shardNames) {
           ocmh.overseer.getCoreContainer().getSharedStoreManager()
-            .getSharedShardMetadataController().initiateMetadataNode(collectionName, shardName);
+            .getSharedShardMetadataController().createMetadataNode(collectionName, shardName);
         }
       }
 

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/CreateCollectionCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/CreateCollectionCmd.java
@@ -191,6 +191,13 @@ public class CreateCollectionCmd implements OverseerCollectionMessageHandler.Cmd
       if (!created) {
         throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "Could not fully create collection: " + collectionName);
       }
+      
+      if (sharedIndex) {
+        for (String shardName : shardNames) {
+          ocmh.overseer.getCoreContainer().getSharedStoreManager()
+            .getSharedShardMetadataController().initiateMetadataNode(collectionName, shardName);
+        }
+      }
 
       // refresh cluster state
       clusterState = ocmh.cloudManager.getClusterStateProvider().getClusterState();

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/CreateShardCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/CreateShardCmd.java
@@ -93,7 +93,7 @@ public class CreateShardCmd implements OverseerCollectionMessageHandler.Cmd {
       message = message.plus(ZkStateReader.SHARED_SHARD_NAME, sharedShardName);
       // create the shard metadata znode
       ocmh.overseer.getCoreContainer().getSharedStoreManager()
-        .getSharedShardMetadataController().initiateMetadataNode(collectionName, sliceName);
+        .getSharedShardMetadataController().createMetadataNode(collectionName, sliceName);
     }
 
     //ZkStateReader zkStateReader = ocmh.zkStateReader;

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/CreateShardCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/CreateShardCmd.java
@@ -91,6 +91,9 @@ public class CreateShardCmd implements OverseerCollectionMessageHandler.Cmd {
       String sharedShardName = Assign.buildSharedShardName(collectionName, sliceName);
       // this is a bit inefficient since we do a full copy of the properties
       message = message.plus(ZkStateReader.SHARED_SHARD_NAME, sharedShardName);
+      // create the shard metadata znode
+      ocmh.overseer.getCoreContainer().getSharedStoreManager()
+        .getSharedShardMetadataController().initiateMetadataNode(collectionName, sliceName);
     }
 
     //ZkStateReader zkStateReader = ocmh.zkStateReader;

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/SplitShardCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/SplitShardCmd.java
@@ -320,7 +320,7 @@ public class SplitShardCmd implements OverseerCollectionMessageHandler.Cmd {
         if (collection.getSharedIndex()) {
           propMap.put(ZkStateReader.SHARED_SHARD_NAME, Assign.buildSharedShardName(collectionName, subSlice));
           ocmh.overseer.getCoreContainer().getSharedStoreManager()
-            .getSharedShardMetadataController().initiateMetadataNode(collectionName, subSlice);
+            .getSharedShardMetadataController().createMetadataNode(collectionName, subSlice);
         }
 
         ocmh.overseer.offerStateUpdate(Utils.toJSON(new ZkNodeProps(propMap)));

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/SplitShardCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/SplitShardCmd.java
@@ -319,6 +319,8 @@ public class SplitShardCmd implements OverseerCollectionMessageHandler.Cmd {
 
         if (collection.getSharedIndex()) {
           propMap.put(ZkStateReader.SHARED_SHARD_NAME, Assign.buildSharedShardName(collectionName, subSlice));
+          ocmh.overseer.getCoreContainer().getSharedStoreManager()
+            .getSharedShardMetadataController().initiateMetadataNode(collectionName, subSlice);
         }
 
         ocmh.overseer.offerStateUpdate(Utils.toJSON(new ZkNodeProps(propMap)));

--- a/solr/core/src/java/org/apache/solr/handler/admin/RequestApplyUpdatesOp.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/RequestApplyUpdatesOp.java
@@ -94,8 +94,6 @@ class RequestApplyUpdatesOp implements CoreAdminHandler.CoreAdminOp {
       String shardName = cloudDesc.getShardId();
       String coreName = core.getName();
       SharedShardMetadataController metadataController = cc.getSharedStoreManager().getSharedShardMetadataController();
-      // creates the metadata node
-      metadataController.ensureMetadataNodeExists(collectionName, shardName);
       SharedShardVersionMetadata shardVersionMetadata = metadataController.readMetadataValue(collectionName, shardName);
       // TODO: We should just be initialized to a default value since this is a new shard.  
       //       As of now we are only taking care of basic happy path. We still need to evaluate what will happen

--- a/solr/core/src/java/org/apache/solr/store/shared/SharedStoreManager.java
+++ b/solr/core/src/java/org/apache/solr/store/shared/SharedStoreManager.java
@@ -51,7 +51,7 @@ public class SharedStoreManager {
     blobDeleteManager = new BlobDeleteManager(getBlobStorageProvider().getClient());
     corePullTracker = new CorePullTracker();
     sharedShardMetadataController = new SharedShardMetadataController(zkController.getSolrCloudManager());
-    sharedCoreConcurrencyController = new SharedCoreConcurrencyController(sharedShardMetadataController);
+    sharedCoreConcurrencyController = new SharedCoreConcurrencyController();
     blobCoreSyncer = new BlobCoreSyncer();
     blobProcessUtil = new BlobProcessUtil();
   }

--- a/solr/core/src/java/org/apache/solr/store/shared/metadata/SharedShardMetadataController.java
+++ b/solr/core/src/java/org/apache/solr/store/shared/metadata/SharedShardMetadataController.java
@@ -1,4 +1,5 @@
 /*
+
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -54,11 +55,12 @@ public class SharedShardMetadataController {
   /**
    * Creates a new metadata node if it doesn't exist for shared shared index whose correctness metadata 
    * is managed by ZooKeeper. This node should only be created during Shard creation or Recovery events
+   * and the method will throw an exception if the node already exists.
    *  
    * @param collectionName name of the collection that needs a metadata node
    * @param shardName name of the shard that needs a metadata node
    */
-  public void initiateMetadataNode(String collectionName, String shardName) throws IOException {
+  public void createMetadataNode(String collectionName, String shardName) throws IOException {
     ClusterState clusterState = cloudManager.getClusterStateProvider().getClusterState();
     DocCollection collection = clusterState.getCollection(collectionName);
     if (!collection.getSharedIndex()) {
@@ -70,7 +72,7 @@ public class SharedShardMetadataController {
     Map<String, Object> nodeProps = new HashMap<>();
     nodeProps.put(SUFFIX_NODE_NAME, METADATA_NODE_DEFAULT_VALUE);
     
-    createPersistentNodeIfNonExistent(metadataPath, Utils.toJSON(nodeProps));
+    createPersistentNode(metadataPath, Utils.toJSON(nodeProps));
   }
 
   /**
@@ -146,20 +148,18 @@ public class SharedShardMetadataController {
     }
   }
 
-  private void createPersistentNodeIfNonExistent(String path, byte[] data) {
+  private void createPersistentNode(String path, byte[] data) {
     try {
       if (!stateManager.hasData(path)) {
-        try {
-          stateManager.makePath(path, data, CreateMode.PERSISTENT, /* failOnExists */ false);
-        } catch (AlreadyExistsException e) {
-          // it's okay if another beats us creating the node
-        }
+        stateManager.makePath(path, data, CreateMode.PERSISTENT, /* failOnExists */ true);
+      } else {
+        throw new AlreadyExistsException("Node already exists!");
       }
     } catch (InterruptedException e) {
       Thread.interrupted();
       throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "Error creating path " + path
           + " in Zookeeper", e);
-    } catch (IOException | KeeperException e) {
+    } catch (IOException | AlreadyExistsException | KeeperException e) {
       throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "Error creating path " + path
           + " in Zookeeper", e);
     }

--- a/solr/core/src/java/org/apache/solr/store/shared/metadata/SharedShardMetadataController.java
+++ b/solr/core/src/java/org/apache/solr/store/shared/metadata/SharedShardMetadataController.java
@@ -53,12 +53,12 @@ public class SharedShardMetadataController {
   
   /**
    * Creates a new metadata node if it doesn't exist for shared shared index whose correctness metadata 
-   * is managed by ZooKeeper
+   * is managed by ZooKeeper. This node should only be created during Shard creation or Recovery events
    *  
    * @param collectionName name of the collection that needs a metadata node
    * @param shardName name of the shard that needs a metadata node
    */
-  public void ensureMetadataNodeExists(String collectionName, String shardName) throws IOException {
+  public void initiateMetadataNode(String collectionName, String shardName) throws IOException {
     ClusterState clusterState = cloudManager.getClusterStateProvider().getClusterState();
     DocCollection collection = clusterState.getCollection(collectionName);
     if (!collection.getSharedIndex()) {

--- a/solr/core/src/test/org/apache/solr/store/blob/metadata/CorePushPullTest.java
+++ b/solr/core/src/test/org/apache/solr/store/blob/metadata/CorePushPullTest.java
@@ -269,12 +269,7 @@ public class CorePushPullTest extends SolrTestCaseJ4 {
   private BlobCoreMetadata doPush(SolrCore core) throws Exception {
     String sharedBlobName = Assign.buildSharedShardName(collectionName, shardName);
     // initialize metadata info to match initial zk version
-    SharedCoreConcurrencyController concurrencyController =  new SharedCoreConcurrencyController(null){
-      @Override
-      protected void ensureShardVersionMetadataNodeExists(String collectionName, String shardName) {
-        
-      }
-    };
+    SharedCoreConcurrencyController concurrencyController =  new SharedCoreConcurrencyController();
     concurrencyController.updateCoreVersionMetadata(collectionName, shardName, core.getName(), 
         new SharedShardVersionMetadata(0, SharedShardMetadataController.METADATA_NODE_DEFAULT_VALUE),
         BlobCoreMetadataBuilder.buildEmptyCoreMetadata(sharedBlobName));

--- a/solr/core/src/test/org/apache/solr/store/shared/SharedCoreConcurrencyTest.java
+++ b/solr/core/src/test/org/apache/solr/store/shared/SharedCoreConcurrencyTest.java
@@ -590,8 +590,7 @@ public class SharedCoreConcurrencyTest extends SolrCloudSharedStoreTestCase {
    */
   private void configureTestSharedConcurrencyControllerForProcess(
       JettySolrRunner solrProcess, ConcurrentHashMap<String, ConcurrentLinkedQueue<String>> coreConcurrencyStagesMap) {
-    SharedCoreConcurrencyController concurrencyController = new SharedCoreConcurrencyController
-        (solrProcess.getCoreContainer().getSharedStoreManager().getSharedShardMetadataController()) {
+    SharedCoreConcurrencyController concurrencyController = new SharedCoreConcurrencyController() {
       @Override
       public void recordState(String collectionName, String shardName, String coreName, SharedCoreStage stage) {
         super.recordState(collectionName, shardName, coreName, stage);

--- a/solr/core/src/test/org/apache/solr/store/shared/metadata/SharedShardMetadataControllerTest.java
+++ b/solr/core/src/test/org/apache/solr/store/shared/metadata/SharedShardMetadataControllerTest.java
@@ -77,7 +77,7 @@ public class SharedShardMetadataControllerTest extends SolrCloudSharedStoreTestC
    */
   @Test
   public void testSetupMetadataNode() throws Exception {    
-    shardMetadataController.ensureMetadataNodeExists(TEST_COLLECTION_NAME, TEST_SHARD_NAME);
+    shardMetadataController.initiateMetadataNode(TEST_COLLECTION_NAME, TEST_SHARD_NAME);
     assertTrue(cluster.getZkClient().exists(metadataNodePath, false));
   }
   
@@ -94,7 +94,7 @@ public class SharedShardMetadataControllerTest extends SolrCloudSharedStoreTestC
     
     waitForState("Timed-out wait for collection to be created", nonSharedCollectionName, clusterShape(1, 1));
     try {
-      shardMetadataController.ensureMetadataNodeExists(nonSharedCollectionName, "notSharedShard");
+      shardMetadataController.initiateMetadataNode(nonSharedCollectionName, "notSharedShard");
       fail();
     } catch (SolrException ex) {
       // we should fail
@@ -108,7 +108,7 @@ public class SharedShardMetadataControllerTest extends SolrCloudSharedStoreTestC
    */
   @Test
   public void testUpdateMetadataNode() throws Exception {    
-    shardMetadataController.ensureMetadataNodeExists(TEST_COLLECTION_NAME, TEST_SHARD_NAME);
+    shardMetadataController.initiateMetadataNode(TEST_COLLECTION_NAME, TEST_SHARD_NAME);
     assertTrue(cluster.getZkClient().exists(metadataNodePath, false));
     
     String testMetadataValue = "testValue";
@@ -127,7 +127,7 @@ public class SharedShardMetadataControllerTest extends SolrCloudSharedStoreTestC
    */
   @Test
   public void testConditionalUpdateOnMetadataNode() throws Exception {    
-    shardMetadataController.ensureMetadataNodeExists(TEST_COLLECTION_NAME, TEST_SHARD_NAME);
+    shardMetadataController.initiateMetadataNode(TEST_COLLECTION_NAME, TEST_SHARD_NAME);
     assertTrue(cluster.getZkClient().exists(metadataNodePath, false));
     
     String testMetadataValue = "testValue1";
@@ -171,7 +171,7 @@ public class SharedShardMetadataControllerTest extends SolrCloudSharedStoreTestC
    * Test reading the metadata node returns the expected value
    */
   public void testReadMetadataNode() throws Exception {
-    shardMetadataController.ensureMetadataNodeExists(TEST_COLLECTION_NAME, TEST_SHARD_NAME);
+    shardMetadataController.initiateMetadataNode(TEST_COLLECTION_NAME, TEST_SHARD_NAME);
     assertTrue(cluster.getZkClient().exists(metadataNodePath, false));
     
     String testMetadataValue = "testValue1";

--- a/solr/core/src/test/org/apache/solr/store/shared/metadata/SharedShardMetadataControllerTest.java
+++ b/solr/core/src/test/org/apache/solr/store/shared/metadata/SharedShardMetadataControllerTest.java
@@ -77,8 +77,24 @@ public class SharedShardMetadataControllerTest extends SolrCloudSharedStoreTestC
    */
   @Test
   public void testSetupMetadataNode() throws Exception {    
-    shardMetadataController.initiateMetadataNode(TEST_COLLECTION_NAME, TEST_SHARD_NAME);
+    shardMetadataController.createMetadataNode(TEST_COLLECTION_NAME, TEST_SHARD_NAME);
     assertTrue(cluster.getZkClient().exists(metadataNodePath, false));
+  }
+  
+  /**
+   * Test if we try to create the same metadat anode twice, we faile
+   */
+  @Test
+  public void testSetupMetadataNodeFails() throws Exception {    
+    shardMetadataController.createMetadataNode(TEST_COLLECTION_NAME, TEST_SHARD_NAME);
+    assertTrue(cluster.getZkClient().exists(metadataNodePath, false));
+    
+    try {
+      shardMetadataController.createMetadataNode(TEST_COLLECTION_NAME, TEST_SHARD_NAME);
+      fail("We should have failed to create the metadata node again");
+    } catch (Exception ex) {
+      // method fails
+    }
   }
   
   /**
@@ -94,7 +110,7 @@ public class SharedShardMetadataControllerTest extends SolrCloudSharedStoreTestC
     
     waitForState("Timed-out wait for collection to be created", nonSharedCollectionName, clusterShape(1, 1));
     try {
-      shardMetadataController.initiateMetadataNode(nonSharedCollectionName, "notSharedShard");
+      shardMetadataController.createMetadataNode(nonSharedCollectionName, "notSharedShard");
       fail();
     } catch (SolrException ex) {
       // we should fail
@@ -108,7 +124,7 @@ public class SharedShardMetadataControllerTest extends SolrCloudSharedStoreTestC
    */
   @Test
   public void testUpdateMetadataNode() throws Exception {    
-    shardMetadataController.initiateMetadataNode(TEST_COLLECTION_NAME, TEST_SHARD_NAME);
+    shardMetadataController.createMetadataNode(TEST_COLLECTION_NAME, TEST_SHARD_NAME);
     assertTrue(cluster.getZkClient().exists(metadataNodePath, false));
     
     String testMetadataValue = "testValue";
@@ -127,7 +143,7 @@ public class SharedShardMetadataControllerTest extends SolrCloudSharedStoreTestC
    */
   @Test
   public void testConditionalUpdateOnMetadataNode() throws Exception {    
-    shardMetadataController.initiateMetadataNode(TEST_COLLECTION_NAME, TEST_SHARD_NAME);
+    shardMetadataController.createMetadataNode(TEST_COLLECTION_NAME, TEST_SHARD_NAME);
     assertTrue(cluster.getZkClient().exists(metadataNodePath, false));
     
     String testMetadataValue = "testValue1";
@@ -171,7 +187,7 @@ public class SharedShardMetadataControllerTest extends SolrCloudSharedStoreTestC
    * Test reading the metadata node returns the expected value
    */
   public void testReadMetadataNode() throws Exception {
-    shardMetadataController.initiateMetadataNode(TEST_COLLECTION_NAME, TEST_SHARD_NAME);
+    shardMetadataController.createMetadataNode(TEST_COLLECTION_NAME, TEST_SHARD_NAME);
     assertTrue(cluster.getZkClient().exists(metadataNodePath, false));
     
     String testMetadataValue = "testValue1";


### PR DESCRIPTION
Shared collections make use of something called the metadataSuffix znode per shard in ZooKeeper to understand what core.metadata file to pull from blob store and hydrate a replica with the most up-to-date and correct index data. Shared collections would create the node on-demand with a default value (e.g. indexing) but this is not correct behavior when considering restore operations in the future. We'll want to create the node with a non-default value down the line. 

This change initiates the node when we create the shard in common collection API commands and includes CREATE, CREATESHARD, SPLITSHARD. Other operations such as RESTORE are not currently supported by solr shared storage so are not in scope of this change. 