### PR TITLE
Remove some unused lines from addBackcompatIndexes.py related to svn

### DIFF
--- a/dev-tools/scripts/addBackcompatIndexes.py
+++ b/dev-tools/scripts/addBackcompatIndexes.py
@@ -92,11 +92,6 @@ def create_and_add_index(source, indextype, index_version, current_version, temp
   print('  adding %s...' % filename, end='', flush=True)
   scriptutil.run('cp %s %s' % (bc_index_file, os.path.join(base_dir, index_dir)))
   os.chdir(base_dir)
-  output = scriptutil.run('svn status %s' % test_file)
-  if not output.strip():
-    # make sure to only add if the file isn't already in svn (we might be regenerating)
-    scriptutil.run('svn add %s' % test_file)
-  os.chdir(base_dir)
   scriptutil.run('rm -rf %s' % bc_index_dir)
   print('done')
 


### PR DESCRIPTION
This is dead code in a python script. We don't use svn anymore. I did not add corresponding git commands since the releaseWizard explicitly does an add after running the script, and noone has complained for so long time :) 

Tagging @sarowe since it seems you have touched this script in the past