### PR TITLE
LUCENE-9267 Replace getQueryBuildTime time unit from ms to ns

### DIFF
--- a/lucene/monitor/src/java/org/apache/lucene/monitor/MatchingQueries.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/MatchingQueries.java
@@ -67,7 +67,7 @@ public class MatchingQueries<T extends QueryMatch> {
   }
 
   /**
-   * @return how long (in ms) it took to build the Presearcher query for the matcher run
+   * @return how long (in ns) it took to build the Presearcher query for the matcher run
    */
   public long getQueryBuildTime() {
     return queryBuildTime;

--- a/lucene/monitor/src/java/org/apache/lucene/monitor/MultiMatchingQueries.java
+++ b/lucene/monitor/src/java/org/apache/lucene/monitor/MultiMatchingQueries.java
@@ -82,7 +82,7 @@ public class MultiMatchingQueries<T extends QueryMatch> {
   }
 
   /**
-   * @return how long (in ms) it took to build the Presearcher query for the matcher run
+   * @return how long (in ns) it took to build the Presearcher query for the matcher run
    */
   public long getQueryBuildTime() {
     return queryBuildTime;


### PR DESCRIPTION
# Description

Change the documentation of getQueryBuildTime to report nanoseconds instead of milliseconds.

see https://issues.apache.org/jira/browse/LUCENE-9267

# Solution

Update the javadoc.

# Tests

N/A

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [x] I have added tests for my changes.
- [x] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
