### PR TITLE
SOLR-8306: Enhance ExpandComponent to allow expand.hits=0

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -153,6 +153,8 @@ Improvements
 * SOLR-13965: In GraphHandler, support <expressible> configuration and deprecate <streamFunctions> configuration.
    (Eric Pugh via Christine Poerschke)
 
+* SOLR-8306: Enhance ExpandComponent to allow expand.hits=0 (Marshall Sanders, Amelia Henderson)
+
 Optimizations
 ---------------------
 

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -57,7 +57,7 @@ Improvements
 
 Optimizations
 ---------------------
-* SOLR-8306: Enhance ExpandComponent to allow expand.hits=0 (Marshall Sanders, Amelia Henderson)
+* SOLR-8306: Do not collect expand documents when expand.rows=0 (Marshall Sanders, Amelia Henderson)
 
 Bug Fixes
 ---------------------

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -57,7 +57,7 @@ Improvements
 
 Optimizations
 ---------------------
-(No changes)
+* SOLR-8306: Enhance ExpandComponent to allow expand.hits=0 (Marshall Sanders, Amelia Henderson)
 
 Bug Fixes
 ---------------------
@@ -152,8 +152,6 @@ Improvements
 
 * SOLR-13965: In GraphHandler, support <expressible> configuration and deprecate <streamFunctions> configuration.
    (Eric Pugh via Christine Poerschke)
-
-* SOLR-8306: Enhance ExpandComponent to allow expand.hits=0 (Marshall Sanders, Amelia Henderson)
 
 Optimizations
 ---------------------

--- a/solr/core/src/java/org/apache/solr/handler/component/ExpandComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/ExpandComponent.java
@@ -53,6 +53,7 @@ import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TopDocsCollector;
 import org.apache.lucene.search.TopFieldCollector;
 import org.apache.lucene.search.TopScoreDocCollector;
+import org.apache.lucene.search.TotalHitCountCollector;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.util.BitSetIterator;
 import org.apache.lucene.util.BytesRef;
@@ -420,35 +421,46 @@ public class ExpandComponent extends SearchComponent implements PluginInfoInitia
     CharsRefBuilder charsRef = new CharsRefBuilder();
     for (LongObjectCursor<Collector> cursor : groups) {
       long groupValue = cursor.key;
-      TopDocsCollector<?> topDocsCollector = TopDocsCollector.class.cast(cursor.value);
-      TopDocs topDocs = topDocsCollector.topDocs();
-      ScoreDoc[] scoreDocs = topDocs.scoreDocs;
-      if (scoreDocs.length > 0) {
-        if (returnFields.wantsScore() && sort != null) {
-          TopFieldCollector.populateScores(scoreDocs, searcher, query);
+      if (cursor.value instanceof TopDocsCollector) {
+        TopDocsCollector<?> topDocsCollector = TopDocsCollector.class.cast(cursor.value);
+        TopDocs topDocs = topDocsCollector.topDocs();
+        ScoreDoc[] scoreDocs = topDocs.scoreDocs;
+        if (scoreDocs.length > 0) {
+          if (returnFields.wantsScore() && sort != null) {
+            TopFieldCollector.populateScores(scoreDocs, searcher, query);
+          }
+          int[] docs = new int[scoreDocs.length];
+          float[] scores = new float[scoreDocs.length];
+          for (int i = 0; i < docs.length; i++) {
+            ScoreDoc scoreDoc = scoreDocs[i];
+            docs[i] = scoreDoc.doc;
+            scores[i] = scoreDoc.score;
+          }
+          assert topDocs.totalHits.relation == TotalHits.Relation.EQUAL_TO;
+          DocSlice slice = new DocSlice(0, docs.length, docs, scores, topDocs.totalHits.value, Float.NaN);
+          addGroupSliceToOutputMap(fieldType, ordBytes, outMap, charsRef, groupValue, slice);
         }
-        int[] docs = new int[scoreDocs.length];
-        float[] scores = new float[scoreDocs.length];
-        for (int i = 0; i < docs.length; i++) {
-          ScoreDoc scoreDoc = scoreDocs[i];
-          docs[i] = scoreDoc.doc;
-          scores[i] = scoreDoc.score;
-        }
-        assert topDocs.totalHits.relation == TotalHits.Relation.EQUAL_TO;
-        DocSlice slice = new DocSlice(0, docs.length, docs, scores, topDocs.totalHits.value, Float.NaN);
-
-        if(fieldType instanceof StrField) {
-          final BytesRef bytesRef = ordBytes.get((int)groupValue);
-          fieldType.indexedToReadable(bytesRef, charsRef);
-          String group = charsRef.toString();
-          outMap.add(group, slice);
-        } else {
-          outMap.add(numericToString(fieldType, groupValue), slice);
+      } else {
+        int totalHits = ((TotalHitCountCollector) cursor.value).getTotalHits();
+        if (totalHits > 0) {
+          DocSlice slice = new DocSlice(0, 0, null, null, totalHits, 0);
+          addGroupSliceToOutputMap(fieldType, ordBytes, outMap, charsRef, groupValue, slice);
         }
       }
     }
 
     rb.rsp.add("expanded", outMap);
+  }
+
+  private void addGroupSliceToOutputMap(FieldType fieldType, IntObjectHashMap<BytesRef> ordBytes, NamedList outMap, CharsRefBuilder charsRef, long groupValue, DocSlice slice) {
+    if(fieldType instanceof StrField) {
+      final BytesRef bytesRef = ordBytes.get((int)groupValue);
+      fieldType.indexedToReadable(bytesRef, charsRef);
+      String group = charsRef.toString();
+      outMap.add(group, slice);
+    } else {
+      outMap.add(numericToString(fieldType, groupValue), slice);
+    }
   }
 
   @Override
@@ -533,8 +545,7 @@ public class ExpandComponent extends SearchComponent implements PluginInfoInitia
       DocIdSetIterator iterator = new BitSetIterator(groupBits, 0); // cost is not useful here
       int group;
       while ((group = iterator.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
-        Collector collector = (sort == null) ? TopScoreDocCollector.create(limit, Integer.MAX_VALUE) : TopFieldCollector.create(sort, limit, Integer.MAX_VALUE);
-        groups.put(group, collector);
+        groups.put(group, getExpandCollector(limit, sort));
       }
 
       this.collapsedSet = collapsedSet;
@@ -614,11 +625,8 @@ public class ExpandComponent extends SearchComponent implements PluginInfoInitia
       int numGroups = collapsedSet.size();
       this.nullValue = nullValue;
       groups = new LongObjectHashMap<>(numGroups);
-      Iterator<LongCursor> iterator = groupSet.iterator();
-      while (iterator.hasNext()) {
-        LongCursor cursor = iterator.next();
-        Collector collector = (sort == null) ? TopScoreDocCollector.create(limit, Integer.MAX_VALUE) : TopFieldCollector.create(sort, limit, Integer.MAX_VALUE);
-        groups.put(cursor.value, collector);
+      for (LongCursor cursor : groupSet) {
+        groups.put(cursor.value, getExpandCollector(limit, sort));
       }
 
       this.field = field;
@@ -666,6 +674,18 @@ public class ExpandComponent extends SearchComponent implements PluginInfoInitia
       return groups;
     }
 
+  }
+
+  private static Collector getExpandCollector(int limit, Sort sort) throws IOException {
+    Collector collector;
+    if (limit == 0) {
+      collector = new TotalHitCountCollector();
+    } else if (sort == null) {
+      collector = TopScoreDocCollector.create(limit, Integer.MAX_VALUE);
+    } else {
+      collector = TopFieldCollector.create(sort, limit, Integer.MAX_VALUE);
+    }
+    return collector;
   }
 
   //TODO lets just do simple abstract base class -- a fine use of inheritance

--- a/solr/core/src/java/org/apache/solr/search/DocSlice.java
+++ b/solr/core/src/java/org/apache/solr/search/DocSlice.java
@@ -56,7 +56,7 @@ public class DocSlice implements DocList, Accountable {
     this.scores=scores;
     this.matches=matches;
     this.maxScore=maxScore;
-    this.ramBytesUsed = BASE_RAM_BYTES_USED + ((long)docs.length << 2) + (scores == null ? 0 : ((long)scores.length<<2)+RamUsageEstimator.NUM_BYTES_ARRAY_HEADER);
+    this.ramBytesUsed = BASE_RAM_BYTES_USED + (docs == null ? 0 : ((long)docs.length << 2)) + (scores == null ? 0 : ((long)scores.length<<2)+RamUsageEstimator.NUM_BYTES_ARRAY_HEADER);
   }
 
   @Override

--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedExpandComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedExpandComponentTest.java
@@ -162,6 +162,7 @@ public class DistributedExpandComponentTest extends BaseDistributedSearchTestCas
     params.add("bf", "field(test_i)");
     params.add("expand", "true");
     params.add("expand.rows", "0");
+    params.add("fl", "id");
     setDistributedParams(params);
     rsp = queryServer(params);
     results = rsp.getExpandedResults();
@@ -169,6 +170,24 @@ public class DistributedExpandComponentTest extends BaseDistributedSearchTestCas
     assertExpandGroupCountAndOrder("group1", 0, results);
     assertExpandGroupCountAndOrder("group2", 0, results);
     assertExpandGroupCountAndOrder("group3", 0, results);
+    assertExpandGroupCountAndOrder("group4", 0, results);
+
+    //Test expand.rows = 0 with expand.field
+
+    params = new ModifiableSolrParams();
+    params.add("q", "*:*");
+    params.add("fq", "test_l:10");
+    params.add("defType", "edismax");
+    params.add("expand", "true");
+    params.add("expand.fq", "test_f:2000");
+    params.add("expand.field", group);
+    params.add("expand.rows", "0");
+    params.add("fl", "id,score");
+    setDistributedParams(params);
+    rsp = queryServer(params);
+    results = rsp.getExpandedResults();
+    assertExpandGroups(results, "group1", "group4");
+    assertExpandGroupCountAndOrder("group1", 0, results);
     assertExpandGroupCountAndOrder("group4", 0, results);
 
     //Test key-only fl

--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedExpandComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedExpandComponentTest.java
@@ -153,6 +153,23 @@ public class DistributedExpandComponentTest extends BaseDistributedSearchTestCas
     assertExpandGroupCountAndOrder("group3", 1, results, "9");
     assertExpandGroupCountAndOrder("group4", 1, results, "14");
 
+    //Test expand.rows = 0 - no docs only expand count
+
+    params = new ModifiableSolrParams();
+    params.add("q", "*:*");
+    params.add("fq", "{!collapse field="+group+"}");
+    params.add("defType", "edismax");
+    params.add("bf", "field(test_i)");
+    params.add("expand", "true");
+    params.add("expand.rows", "0");
+    setDistributedParams(params);
+    rsp = queryServer(params);
+    results = rsp.getExpandedResults();
+    assertExpandGroups(results, "group1","group2", "group3", "group4");
+    assertExpandGroupCountAndOrder("group1", 0, results);
+    assertExpandGroupCountAndOrder("group2", 0, results);
+    assertExpandGroupCountAndOrder("group3", 0, results);
+    assertExpandGroupCountAndOrder("group4", 0, results);
 
     //Test key-only fl
 

--- a/solr/core/src/test/org/apache/solr/handler/component/TestExpandComponent.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/TestExpandComponent.java
@@ -250,6 +250,45 @@ public class TestExpandComponent extends SolrTestCaseJ4 {
             "/response/result/doc[2]/str[@name='id'][.='6']"
     );
 
+    //Test expand.rows = 0 with expand.field
+    params = new ModifiableSolrParams();
+    params.add("q", "*:*");
+    params.add("fq", "type_s:parent");
+    params.add("defType", "edismax");
+    params.add("bf", "field(test_i)");
+    params.add("expand", "true");
+    params.add("expand.fq", "type_s:child");
+    params.add("expand.field", group);
+    params.add("expand.rows", "0");
+    assertQ(req(params, "fl", "id"), "*[count(/response/result/doc)=2]",
+            "*[count(/response/lst[@name='expanded']/result)=2]",
+            "*[count(/response/lst[@name='expanded']/result[@name='1"+floatAppend+"']/doc)=0]",
+            "*[count(/response/lst[@name='expanded']/result[@name='2"+floatAppend+"']/doc)=0]",
+            "/response/result/doc[1]/str[@name='id'][.='1']",
+            "/response/result/doc[2]/str[@name='id'][.='5']"
+    );
+
+    //Test score with expand.rows = 0
+    params = new ModifiableSolrParams();
+    params.add("q", "*:*");
+    params.add("fq", "type_s:parent");
+    params.add("defType", "edismax");
+    params.add("bf", "field(test_i)");
+    params.add("expand", "true");
+    params.add("expand.fq", "*:*");
+    params.add("expand.field", group);
+    params.add("expand.rows", "0");
+    assertQ(req(params, "fl", "id,score"), "*[count(/response/result/doc)=2]",
+            "*[count(/response/lst[@name='expanded']/result)=2]",
+            "*[count(/response/lst[@name='expanded']/result[@name='1"+floatAppend+"']/doc)=0]",
+            "*[count(/response/lst[@name='expanded']/result[@name='2"+floatAppend+"']/doc)=0]",
+            "*[count(/response/lst[@name='expanded']/result[@maxScore])=0]", //maxScore should not be available
+            "/response/result/doc[1]/str[@name='id'][.='1']",
+            "/response/result/doc[2]/str[@name='id'][.='5']",
+            "count(//*[@name='score' and .='NaN'])=0"
+
+    );
+
     //Test no group results
     params = new ModifiableSolrParams();
     params.add("q", "test_i:5");

--- a/solr/core/src/test/org/apache/solr/handler/component/TestExpandComponent.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/TestExpandComponent.java
@@ -234,6 +234,21 @@ public class TestExpandComponent extends SolrTestCaseJ4 {
         "/response/lst[@name='expanded']/result[@name='2"+floatAppend+"']/doc[1]/str[@name='id'][.='8']"
     );
 
+    //Test expand.rows = 0 - no docs only expand count
+    params = new ModifiableSolrParams();
+    params.add("q", "*:*");
+    params.add("fq", "{!collapse field="+group+hint+"}");
+    params.add("defType", "edismax");
+    params.add("bf", "field(test_i)");
+    params.add("expand", "true");
+    params.add("expand.rows", "0");
+    assertQ(req(params), "*[count(/response/result/doc)=2]",
+            "*[count(/response/lst[@name='expanded']/result)=2]",
+            "*[count(/response/lst[@name='expanded']/result[@name='1"+floatAppend+"']/doc)=0]",
+            "*[count(/response/lst[@name='expanded']/result[@name='2"+floatAppend+"']/doc)=0]",
+            "/response/result/doc[1]/str[@name='id'][.='2']",
+            "/response/result/doc[2]/str[@name='id'][.='6']"
+    );
 
     //Test no group results
     params = new ModifiableSolrParams();

--- a/solr/solr-ref-guide/src/collapse-and-expand-results.adoc
+++ b/solr/solr-ref-guide/src/collapse-and-expand-results.adoc
@@ -149,6 +149,7 @@ Orders the documents within the expanded groups. The default is `score desc`.
 
 `expand.rows`::
 The number of rows to display in each group. The default is 5 rows.
+
 [IMPORTANT]
 ====
 When `expand.rows=0`, then only the number of documents found for each expanded value is returned. Hence, scores won't be computed even if requested. `maxScore` is set to 0

--- a/solr/solr-ref-guide/src/collapse-and-expand-results.adoc
+++ b/solr/solr-ref-guide/src/collapse-and-expand-results.adoc
@@ -142,6 +142,8 @@ The “expand=true” parameter turns on the ExpandComponent. The ExpandComponen
 
 Inside the expanded section there is a _map_ with each group head pointing to the expanded documents that are within the group. As applications iterate the main collapsed result set, they can access the _expanded_ map to retrieve the expanded groups.
 
+If you would like to have only the number of documents found from the groups in the expanded section returned and not the actual documents, you can set "expand.rows=0". Note that when using "expand.rows=0", score won’t be computed for the expanded section even when requested so maxScore will not be available.
+
 The ExpandComponent has the following parameters:
 
 `expand.sort`::

--- a/solr/solr-ref-guide/src/collapse-and-expand-results.adoc
+++ b/solr/solr-ref-guide/src/collapse-and-expand-results.adoc
@@ -142,8 +142,6 @@ The “expand=true” parameter turns on the ExpandComponent. The ExpandComponen
 
 Inside the expanded section there is a _map_ with each group head pointing to the expanded documents that are within the group. As applications iterate the main collapsed result set, they can access the _expanded_ map to retrieve the expanded groups.
 
-If you would like to have only the number of documents found from the groups in the expanded section returned and not the actual documents, you can set "expand.rows=0". Note that when using "expand.rows=0", score won’t be computed for the expanded section even when requested so maxScore will not be available.
-
 The ExpandComponent has the following parameters:
 
 `expand.sort`::
@@ -151,6 +149,10 @@ Orders the documents within the expanded groups. The default is `score desc`.
 
 `expand.rows`::
 The number of rows to display in each group. The default is 5 rows.
+[IMPORTANT]
+====
+When `expand.rows=0`, then only the number of documents found for each expanded value is returned. Hence, scores won't be computed even if requested. `maxScore` is set to 0
+====
 
 `expand.q`::
 Overrides the main query (`q`), determines which documents to include in the main group. The default is to use the main query.


### PR DESCRIPTION
<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

Enables ExpandComponent to allow expand.hits=0 for those who don't want an expanded document returned and only want the numFound returned from the expand section.

# Solution

Please provide a short description of the approach taken to implement your solution.

# Tests

We have been using this patch in our internal fork of SOLR for years so this has been thoroughly tested to ensure this functionality works as desired. Unit tests have been added for this functionality and all tests pass.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [x] I have added tests for my changes.
- [x] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
