### PR TITLE
Jira/lucene-9004: Refactor the implementation of HNSW following Faiss

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HNSWGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HNSWGraph.java
@@ -19,7 +19,9 @@ package org.apache.lucene.util.hnsw;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -47,16 +49,79 @@ public final class HNSWGraph implements Accountable {
     this.layers = new ArrayList<>();
   }
 
+  Neighbor greedyUpdateNearest(final float[] query, Neighbor ep, int level, VectorValues vectorValues) throws IOException {
+    if (level >= layers.size()) {
+      throw new IllegalArgumentException("layer does not exist for the level: " + level);
+    }
+
+    final Layer layer = layers.get(level);
+    float nearestDist = ep.distance();
+    int nearestDocId = ep.docId();
+    for (; ; ) {
+      int prevNearestDocId = nearestDocId;
+      final Collection<Neighbor> friends = layer.getFriends(ep.docId());
+      for (Neighbor neighbor : friends) {
+        float qDist = distance(query, neighbor.docId(), vectorValues);
+        if (qDist < nearestDist) {
+          nearestDist = qDist;
+          nearestDocId = neighbor.docId();
+        }
+      }
+
+      if (nearestDocId == prevNearestDocId) {
+        return new ImmutableNeighbor(nearestDocId, nearestDist);
+      }
+    }
+  }
+
+  void addLinksStartingFrom(int docId, final float[] query, final FurthestNeighbors results, int ef,
+                            Neighbor ep, int level, VectorValues vectorValues, int mMax) throws IOException {
+    results.clear();
+    results.add(ep);
+
+    searchLayer(query, results, ef, level, vectorValues, false);
+
+    final Layer layer = layers.get(level);
+    assert layer != null;
+
+    Iterator<Neighbor> iterator;
+    if (results.size() > mMax) {
+      final TreeSet<Neighbor> neighbors = shrinkNeighbors(layer, results, mMax, vectorValues);
+      iterator = neighbors.iterator();
+    } else {
+      iterator = results.iterator();
+    }
+
+    while (iterator.hasNext()) {
+      final Neighbor neighbor = iterator.next();
+      layer.addLink(docId, neighbor.docId(), mMax, neighbor.distance(), this, vectorValues);
+      layer.addLink(neighbor.docId(), docId, mMax, neighbor.distance(), this, vectorValues);
+    }
+  }
+
+  private TreeSet<Neighbor> shrinkNeighbors(final Layer layer, final FurthestNeighbors results, int mMax,
+                                            VectorValues vectorValues) throws IOException {
+    assert results.size() > mMax;
+
+    final TreeSet<Neighbor> friends = new TreeSet<>();
+    while (results.size() > 0) { /// results are in descending order
+      friends.add(results.pop()); /// friends are now in ascending order
+    }
+
+    return layer.doShrink(friends, mMax, this, vectorValues);
+  }
+
   /**
    * Searches the nearest neighbors for a specified query at a level.
-   * @param query search query vector
-   * @param results on entry, has enter points to this level. On exit, the nearest neighbors in this level
-   * @param ef the number of nodes to be searched
-   * @param level graph level
+   *
+   * @param query        search query vector
+   * @param results      on entry, has enter points to this level. On exit, the nearest neighbors in this level
+   * @param ef           the number of nodes to be searched
+   * @param level        graph level
    * @param vectorValues vector values
    * @return number of candidates visited
    */
-  int searchLayer(float[] query, FurthestNeighbors results, int ef, int level, VectorValues vectorValues) throws IOException {
+  int searchLayer(float[] query, FurthestNeighbors results, int ef, int level, VectorValues vectorValues, boolean ensureResultSize) throws IOException {
     if (level >= layers.size()) {
       throw new IllegalArgumentException("layer does not exist for the level: " + level);
     }
@@ -74,8 +139,16 @@ public final class HNSWGraph implements Accountable {
       Neighbor c = candidates.pollFirst();
       assert !c.isDeferred();
       assert !f.isDeferred();
-      if (c.distance() > f.distance() && results.size() >= ef) {
-        break;
+      if (c.distance() > f.distance()) {
+        /// for insertion
+        if (!ensureResultSize) {
+          break;
+        }
+
+        /// for search
+        if (results.size() >= ef) {
+          break;
+        }
       }
       for (Neighbor e : layer.getFriends(c.docId())) {
         if (visited.contains(e.docId())) {
@@ -89,7 +162,7 @@ public final class HNSWGraph implements Accountable {
           }
           Neighbor n = new ImmutableNeighbor(e.docId(), dist);
           candidates.add(n);
-          results.insertWithOverflow(n);
+          results.add(n);
           f = results.top();
         }
       }
@@ -100,26 +173,21 @@ public final class HNSWGraph implements Accountable {
     return visited.size();
   }
 
+  float distance(int doc1, int doc2, VectorValues vectorValues) throws IOException {
+    final float[] docValue = getVectorValues(doc1, vectorValues);
+    return distance(docValue, doc2, vectorValues);
+  }
+
   private float distance(float[] query, int docId, VectorValues vectorValues) throws IOException {
-      if (!vectorValues.seek(docId)) {
-        throw new IllegalStateException("docId=" + docId + " has no vector value");
-      }
-    float[] other = vectorValues.vectorValue();
+    final float[] other = getVectorValues(docId, vectorValues);
     return VectorValues.distance(query, other, distFunc);
   }
 
-  static NearestNeighbors pickNearestNeighbor(Neighbors queue) {
-    NearestNeighbors nearests = new NearestNeighbors(queue.size());
-    Set<Integer> addedDocs = new HashSet<>();
-    int ef = queue.size();
-    while (addedDocs.size() < ef && queue.size() > 0) {
-      Neighbor c = queue.pop();
-      if (!addedDocs.contains(c.docId())) {
-        nearests.add(c);
-        addedDocs.add(c.docId());
-      }
+  private float[] getVectorValues(int docId, VectorValues vectorValues) throws IOException {
+    if (!vectorValues.seek(docId)) {
+      throw new IllegalStateException("docId=" + docId + " has no vector value");
     }
-    return nearests;
+    return vectorValues.vectorValue();
   }
 
   public void ensureLevel(int level) {
@@ -200,27 +268,9 @@ public final class HNSWGraph implements Accountable {
     layer.addNodeIfAbsent(node);
   }
 
-  /** Connects two nodes; this is supposed to be called when indexing */
-  public void connectNodes(int level, int node1, int node2, float dist, int maxConnections) {
-    if (frozen) {
-      throw new IllegalStateException("graph is already freezed!");
-    }
-    assert level >= 0;
-    assert node1 >= 0 && node2 >= 0;
-    assert node1 != node2;
-
-    Layer layer = layers.get(level);
-    if (layer == null) {
-      throw new IllegalArgumentException("layer does not exist for level: " + level);
-    }
-    layer.connectNodes(node1, node2, dist);
-    // ensure friends size <= maxConnections
-    if (maxConnections > 0) {
-      layer.shrink(node2, maxConnections);
-    }
-  }
-
-  /** Connects two nodes; this is supposed to be called when searching */
+  /**
+   * Connects two nodes; this is supposed to be called when searching
+   */
   public void connectNodes(int level, int node1, int node2) {
     if (frozen) {
       throw new IllegalStateException("graph is already freezed!");
@@ -237,7 +287,7 @@ public final class HNSWGraph implements Accountable {
   }
 
   public void finish() {
-    while (layers.isEmpty() == false && layers.get(layers.size() - 1).size() == 0) {
+    while (!layers.isEmpty() && layers.get(layers.size() - 1).size() == 0) {
       // remove empty top layers
       layers.remove(layers.size() - 1);
     }

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HNSWGraph.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HNSWGraph.java
@@ -19,7 +19,6 @@ package org.apache.lucene.util.hnsw;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -73,8 +72,8 @@ public final class HNSWGraph implements Accountable {
     Neighbor f = results.top();
     while (candidates.size() > 0) {
       Neighbor c = candidates.pollFirst();
-      assert c.isDeferred() == false;
-      assert f.isDeferred() == false;
+      assert !c.isDeferred();
+      assert !f.isDeferred();
       if (c.distance() > f.distance() && results.size() >= ef) {
         break;
       }
@@ -85,6 +84,9 @@ public final class HNSWGraph implements Accountable {
         visited.add(e.docId());
         float dist = distance(query, e.docId(), vectorValues);
         if (dist < f.distance() || results.size() < ef) {
+          if (results.size() == ef) {
+            results.pop();
+          }
           Neighbor n = new ImmutableNeighbor(e.docId(), dist);
           candidates.add(n);
           results.insertWithOverflow(n);

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HNSWGraphReader.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HNSWGraphReader.java
@@ -18,10 +18,8 @@
 package org.apache.lucene.util.hnsw;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.lucene.index.FieldInfo;
@@ -61,11 +59,12 @@ public final class HNSWGraphReader {
     }
 
     Neighbor ep = new ImmutableNeighbor(enterPoint, VectorValues.distance(query, vectorValues.vectorValue(), distFunc));
-    FurthestNeighbors neighbors = new FurthestNeighbors(ef, ep);
     for (int l = hnsw.topLevel(); l > 0; l--) {
-      visitedCount += hnsw.searchLayer(query, neighbors, 1, l, vectorValues);
+      ep = hnsw.greedyUpdateNearest(query, ep, l, vectorValues);
     }
-    visitedCount += hnsw.searchLayer(query, neighbors, ef, 0, vectorValues);
+
+    final FurthestNeighbors neighbors = new FurthestNeighbors(ef, ep);
+    visitedCount += hnsw.searchLayer(query, neighbors, ef, 0, vectorValues, true);
     return neighbors;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HNSWGraphWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HNSWGraphWriter.java
@@ -20,9 +20,7 @@ package org.apache.lucene.util.hnsw;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.apache.lucene.index.VectorValues;
 import org.apache.lucene.util.Accountable;
@@ -112,11 +110,12 @@ public final class HNSWGraphWriter implements Accountable {
     Neighbor ep = new ImmutableNeighbor(enterPoint, distFromEp);
 
     int level = levelGenerator.randomLevel();
-    FurthestNeighbors results = new FurthestNeighbors(efConst, ep);
     // down to the level from the hnsw's top level
     for (int l = hnsw.topLevel(); l > level; l--) {
-      hnsw.searchLayer(value, results, 1, l, vectorValues);
+      ep = hnsw.greedyUpdateNearest(value, ep, l, vectorValues);
     }
+
+    final FurthestNeighbors results = new FurthestNeighbors(efConst, ep);
 
     // down to level 0 with placing the doc to each layer
     hnsw.ensureLevel(level);
@@ -126,14 +125,7 @@ public final class HNSWGraphWriter implements Accountable {
         continue;
       }
 
-      hnsw.searchLayer(value, results, efConst, l, vectorValues);
-      int maxConnections = l == 0 ? maxConn0 : maxConn;
-      while (results.size() > maxConnections) {
-        results.pop();
-      }
-      for (Neighbor n : results) {
-        hnsw.connectNodes(l, docId, n.docId(), n.distance(), maxConnections);
-      }
+      hnsw.addLinksStartingFrom(docId, value, results, efConst, ep, l, vectorValues, l == 0 ? maxConn0 : maxConn);
     }
   }
 
@@ -168,7 +160,7 @@ public final class HNSWGraphWriter implements Accountable {
     }
 
     @Override
-    public float[] vectorValue() throws IOException {
+    public float[] vectorValue() {
       return value;
     }
 

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/Layer.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/Layer.java
@@ -17,15 +17,17 @@
 
 package org.apache.lucene.util.hnsw;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeSet;
 
+import org.apache.lucene.index.VectorValues;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.RamUsageEstimator;
 
@@ -56,13 +58,10 @@ final class Layer implements Accountable {
     friendsMap.putIfAbsent(node, new TreeSet<>());
   }
 
-  void connectNodes(int node1, int node2, float distance) {
-    addNodeIfAbsent(node1);
-    addNodeIfAbsent(node2);
-    Neighbor neighbor1 = new ImmutableNeighbor(node2, distance);
-    friendsMap.get(node1).add(neighbor1);
-    Neighbor neighbor2 = new ImmutableNeighbor(node1, distance);
-    friendsMap.get(node2).add(neighbor2);
+  void connectNode(int src, int dest, float distance) {
+    addNodeIfAbsent(src);
+    Neighbor neighbor1 = new ImmutableNeighbor(dest, distance);
+    friendsMap.get(src).add(neighbor1);
   }
 
   void connectNodes(int node1, int node2) {
@@ -74,33 +73,49 @@ final class Layer implements Accountable {
     friendsMap.get(node2).add(neighbor2);
   }
 
-  void shrink(int node, int maxFriends) {
-    TreeSet<Neighbor> friends = friendsMap.get(node);
-    if (friends == null) {
-      throw new IllegalArgumentException("node " + node + " does not exist at this layer: " + level);
-    }
-    if (friends.size() > maxFriends) {
-      TreeSet<Neighbor> newFriends = new TreeSet<>();
-      Iterator<Neighbor> itr = friends.iterator();
-      while(itr.hasNext()) {
-        Neighbor n = itr.next();
-        if (newFriends.size() < maxFriends || friendsMap.get(n.docId()).size() == 1) {
-          newFriends.add(n);
-        } else {
-          friendsMap.get(n.docId()).removeIf(n2 -> n2.docId() == node);
+  TreeSet<Neighbor> doShrink(final TreeSet<Neighbor> results, int mMax,
+                             HNSWGraph graph, VectorValues vectorValues) throws IOException {
+    final TreeSet<Neighbor> friends = new TreeSet<>();
+    while (!results.isEmpty()) {
+      final Neighbor v1 = results.pollFirst();
+      float v1qDist = v1.distance();
+
+      boolean good = true;
+      for (final Neighbor v2 : friends) {
+        float v1v2Dist = graph.distance(v1.docId(), v2.docId(), vectorValues);
+
+        if (v1v2Dist < v1qDist) {
+          good = false;
+          break;
         }
       }
-      friendsMap.put(node, newFriends);
+
+      if (good) {
+        friends.add(v1);
+        if (friends.size() >= mMax) {
+          break;
+        }
+      }
     }
+
+    return friends;
+  }
+
+  void addLink(int srcId, int destId, int mMax, float distance, HNSWGraph graph, VectorValues vectorValues) throws IOException {
+    /// connect from dest to src
+    connectNode(srcId, destId, distance);
+    final TreeSet<Neighbor> friends = friendsMap.get(srcId);
+    if (friends.size() <= mMax) {
+      return;
+    }
+
+    final TreeSet<Neighbor> newNeighbors = doShrink(friends, mMax, graph, vectorValues);
+    friendsMap.put(srcId, newNeighbors);
   }
 
   Collection<Neighbor> getFriends(int node) {
     Collection<Neighbor> friends = friendsMap.get(node);
-    if (friends != null) {
-      return friends;
-    } else {
-      return NO_FRIENDS;
-    }
+    return Objects.requireNonNullElse(friends, NO_FRIENDS);
   }
 
   int size() {

--- a/lucene/core/src/test/org/apache/lucene/index/TestKnnGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestKnnGraph.java
@@ -297,7 +297,7 @@ public class TestKnnGraph extends LuceneTestCase {
           assertTrue("Graph has " + graphSize + " nodes, but one of them has no neighbors", graphSize > 1);
         }
         // assert that the graph in each leaf is connected and undirected (ie links are reciprocated)
-        assertReciprocal(graph);
+        // assertReciprocal(graph);
         assertConnected(graph);
         totalGraphDocs += graphSize;
       }

--- a/lucene/core/src/test/org/apache/lucene/util/hnsw/KnnGraphSiftTester.java
+++ b/lucene/core/src/test/org/apache/lucene/util/hnsw/KnnGraphSiftTester.java
@@ -1,0 +1,306 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.util.hnsw;
+
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Random;
+
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.document.VectorField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SerialMergeScheduler;
+import org.apache.lucene.index.VectorValues;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.KnnGraphQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.similarities.AssertingSimilarity;
+import org.apache.lucene.search.similarities.RandomSimilarity;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSDirectory;
+
+public class KnnGraphSiftTester {
+  private static final String HNSW_INDEX_DIR = "/tmp/hnsw";
+
+  private static final String KNN_VECTOR_FIELD = "vector";
+
+  private static final Random random = new Random();
+
+  /**
+   * @param args the first arg is the file path of test data set，the second is the query file path and the third is the groundtruth file path.
+   */
+  public static void main(String[] args) {
+    if (args.length < 3) {
+      PrintHelp();
+    }
+
+    try {
+      final List<float[]> siftDataset = SiftDataReader.fvecReadAll(args[0]);
+      assert !siftDataset.isEmpty();
+
+      final List<float[]> queryDataset = SiftDataReader.fvecReadAll(args[1]);
+      assert !queryDataset.isEmpty();
+
+      final List<int[]> groundTruthVects = SiftDataReader.ivecReadAll(args[2], queryDataset.size());
+      assert !groundTruthVects.isEmpty();
+
+      evaluateRecallRatio(siftDataset, queryDataset, groundTruthVects);
+
+    } catch (IOException e) {
+      e.printStackTrace();
+      System.exit(1);
+    }
+  }
+
+  private static void evaluateRecallRatio(final List<float[]> siftDataset, final List<float[]> queryDataset,
+                                          final List<int[]> groundTruthVects) {
+    runCase(siftDataset.size(), siftDataset.get(0).length, HNSW_INDEX_DIR,
+        siftDataset, queryDataset, groundTruthVects);
+  }
+
+  public static boolean runCase(int numDoc, int dimension, String indexDir, List<float[]> randomVectors,
+                                final List<float[]> queryDataset,
+                                final List<int[]> groundTruthVects) {
+    safeDelete(indexDir);
+
+    try (Directory dir = FSDirectory.open(Paths.get(indexDir)); IndexWriter iw = new IndexWriter(
+        dir, new IndexWriterConfig(new StandardAnalyzer()).setSimilarity(new AssertingSimilarity(new RandomSimilarity(new Random())))
+        .setMaxBufferedDocs(1500000).setRAMBufferSizeMB(4096).setMergeScheduler(new SerialMergeScheduler()).setUseCompoundFile(false)
+        .setReaderPooling(false).setCodec(Codec.forName("Lucene90")))) {
+      long totalIndexTime = 0, commitTime = 0, forceMergeTime = 0;
+      long addStartTime = System.currentTimeMillis();
+      for (int i = 0; i < numDoc; ++i) {
+        KnnTestHelper.add(iw, i, randomVectors.get(i));
+      }
+
+      long addEndTime = System.currentTimeMillis();
+      iw.commit();
+      long commitEndTime = System.currentTimeMillis();
+
+      iw.forceMerge(1);
+      long forceEndTime = System.currentTimeMillis();
+
+      System.out.println("[***HNSW***] [ADD] cost " + (addEndTime - addStartTime) + " msec, [COMMIT] cost "
+          + (commitEndTime - addEndTime) + " msec, [ForceMerge1] cost " + (forceEndTime - commitEndTime) + " msec, total cost "
+          + (forceEndTime - commitEndTime) + " msec");
+
+      assertResult(numDoc, dimension, dir, queryDataset, groundTruthVects,
+          randomVectors, groundTruthVects.get(0).length);
+    } catch (IOException e) {
+      e.printStackTrace();
+      return false;
+    }
+
+    safeDelete(indexDir);
+
+    return true;
+  }
+
+  public static void assertResult(int numDoc, int dimension, Directory dir, final List<float[]> queryDataset,
+                                  final List<int[]> groundTruthVects, final List<float[]> totalVecs,
+                                  int topK) throws IOException {
+    long totalCostTime = 0;
+    int totalRecallCnt = 0;
+    QueryResult result;
+    int querySize = queryDataset.size();
+    try (IndexReader reader = DirectoryReader.open(dir)) {
+      for (int i = 0; i < querySize; ++i) {
+        result = KnnTestHelper.assertRecall(reader, topK, queryDataset.get(i),
+            groundTruthVects.get(i), totalVecs);
+        totalCostTime += result.costTime;
+        totalRecallCnt += result.recallCnt;
+      }
+    }
+
+    System.out.println("[***HNSW***] Total number of docs -> " + numDoc +
+        ", dimension -> " + dimension + ", number of recall experiments -> " + queryDataset.size() +
+        ", exact recall times -> " + totalRecallCnt + ", total search time -> " +
+        totalCostTime + "msec, avg search time -> " + 1.0F * totalCostTime / queryDataset.size() +
+        "msec, recall percent -> " + 100.0F * totalRecallCnt / (queryDataset.size() * topK) + "%");
+  }
+
+  private static void safeDelete(final String indexDir) {
+    try {
+      Files.walk(Paths.get(indexDir)).sorted(Comparator.reverseOrder())
+          .map(Path::toFile).forEach(File::deleteOnExit);
+    } catch (NoSuchFileException ignored) {
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+  private static void PrintHelp() {
+    /// sift data path should be indicated
+    System.err.println("Usage: KnnIvfAndGraphPerformTester ${baseVecPath} ${queryVecPath} ${groundTruthPath}");
+    System.exit(1);
+  }
+
+  private static final class SiftDataReader {
+    private SiftDataReader() {
+    }
+
+    public static List<float[]> fvecReadAll(final String fileName) throws IOException {
+      final List<float[]> vectors = new ArrayList<>();
+      try (FileInputStream stream = new FileInputStream(fileName);
+           InputStream fileStream = new DataInputStream(stream)) {
+        byte[] allBytes = fileStream.readAllBytes();
+        ByteBuffer byteBuffer = ByteBuffer.wrap(allBytes);
+        while (byteBuffer.hasRemaining()) {
+          int vecDims = byteBuffer.order(ByteOrder.LITTLE_ENDIAN).getInt();
+          assert vecDims > 0;
+
+          float[] vec = new float[vecDims];
+          for (int i = 0; i < vecDims; ++i) {
+            vec[i] = byteBuffer.order(ByteOrder.LITTLE_ENDIAN).getFloat();
+          }
+          vectors.add(vec);
+        }
+      }
+
+      return vectors;
+    }
+
+    public static List<int[]> ivecReadAll(final String fileName, int expectSize) throws IOException {
+      final List<int[]> vectors = new ArrayList<>(expectSize);
+      try (FileInputStream stream = new FileInputStream(fileName);
+           InputStream fileStream = new DataInputStream(stream)) {
+        byte[] allBytes = fileStream.readAllBytes();
+        ByteBuffer byteBuffer = ByteBuffer.wrap(allBytes);
+        while (byteBuffer.hasRemaining()) {
+          int vecDims = byteBuffer.order(ByteOrder.LITTLE_ENDIAN).getInt();
+          assert vecDims > 0;
+
+          int[] vec = new int[vecDims];
+          for (int i = 0; i < vecDims; ++i) {
+            vec[i] = byteBuffer.order(ByteOrder.LITTLE_ENDIAN).getInt();
+          }
+          vectors.add(vec);
+        }
+      }
+
+      return vectors;
+    }
+  }
+
+  private static final class KnnTestHelper {
+    private KnnTestHelper() {
+    }
+
+    public static void add(IndexWriter iw, int id, float[] vector) throws IOException {
+      Document doc = new Document();
+      if (vector != null) {
+        doc.add(new VectorField(KNN_VECTOR_FIELD, vector, VectorValues.DistanceFunction.EUCLIDEAN));
+      }
+      doc.add(new StringField("id", Integer.toString(id), Field.Store.YES));
+      iw.addDocument(doc);
+    }
+
+    public static float[][] randomVectors(int numDocs, int numDims) {
+      float[][] vectors = new float[numDocs][];
+      for (int i = 0; i < numDocs; ++i) {
+        vectors[i] = randomVector(numDims);
+      }
+
+      return vectors;
+    }
+
+    private static float[] randomVector(int numDims) {
+      float[] vector = new float[numDims];
+      for (int i = 0; i < numDims; i++) {
+        vector[i] = random.nextFloat();
+      }
+
+      return vector;
+    }
+
+    public static QueryResult assertRecall(IndexReader reader, int topK, float[] value,
+                                           int[] truth, final List<float[]> totalVecs) throws IOException {
+      IndexSearcher searcher = new IndexSearcher(reader, null);
+      Query query = new KnnGraphQuery(KNN_VECTOR_FIELD, value, topK);
+
+      long startTime = System.currentTimeMillis();
+      TopDocs result = searcher.search(query, topK);
+      long costTime = System.currentTimeMillis() - startTime;
+
+      int totalRecallCnt = 0, exactRecallCnt = 0;
+      final List<float[]> recallVecs = new ArrayList<>(result.scoreDocs.length);
+      for (LeafReaderContext ctx : reader.leaves()) {
+        VectorValues vector = ctx.reader().getVectorValues(KNN_VECTOR_FIELD);
+        for (ScoreDoc doc : result.scoreDocs) {
+          if (vector.seek(doc.doc - ctx.docBase)) {
+            ++totalRecallCnt;
+            recallVecs.add(vector.vectorValue().clone());
+          }
+        }
+      }
+      assert topK == totalRecallCnt;
+
+      boolean[] matched = new boolean[truth.length];
+      Arrays.fill(matched, false);
+
+      for (float[] vec : recallVecs) {
+        for (int i = 0; i < truth.length; ++i) {
+          if (matched[i]) {
+            continue;
+          }
+          if (Arrays.equals(vec, totalVecs.get(truth[i]))) {
+            ++exactRecallCnt;
+            matched[i] = true;
+
+            break;
+          }
+        }
+      }
+
+      return new QueryResult(exactRecallCnt, costTime);
+    }
+  }
+
+  public static final class QueryResult {
+    public int recallCnt;
+    public long costTime;
+
+    public QueryResult(int recall, long costTime) {
+      this.recallCnt = recall;
+      this.costTime = costTime;
+    }
+  }
+}


### PR DESCRIPTION
There were some misunderstandings in the implementation of HNSW algorithm, making the recall of Lucene HNSW about [5% lower](https://github.com/jtibshirani/ann-benchmarks/pull/1) than Faiss. This PR is meant to implement the HNSW algorithm in a way similar to Faiss. Here're some reasons that why I consider refactoring the implementation,
1) The major target is to improve the recall percent and develop a correct implementation;
2) Actually , the relationship between neighborhood is not symmetric. Taking the following picture for example, assume that max connection = 2, for Node3 its nearest neighbors are Node1 and Node2, but the nearest neighbors of Node1 are Node2 and Node4. So I think the connectNodes and shrink operations in current implementation is incorrect!
![image](https://user-images.githubusercontent.com/8521429/76395621-c04fb880-63b2-11ea-9a35-bcce5ac95e84.png);
3) When insert a node at layer l, HNSW tries to greedy search the nearest one Nnearest node from max level layer to (l + 1) layer. Starting from layer l to layer 0, HNSW uses Nnearest rather than all the neighbors of previous layer to search efContruction nearest neighbors. In Faiss, Nnearest keeps unchanged from layer l to layer 0, while re-selecting the nearest node in each layer in nmslib. I followed the implementation of [Faiss HNSW](https://github.com/facebookresearch/faiss/blob/master/impl/HNSW.cpp) since it's much easier and more efficient.
4) The neighborhood shrinkage strategy is incorrect. It should follow triangle inequality.

It is likely not the best implementation. Further suggestions and discussions are welcomed.

