### PR TITLE
SOLR-14317: HttpClusterStateProvider throws exception when only one node down

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -42,6 +42,8 @@ Other Changes
 
 * SOLR-14197: SolrResourceLoader: remove deprecated methods and do other improvements. (David Smiley)
 
+* SOLR-14317: HttpClusterStateProvider throws exception when only one node down.
+
 ==================  8.6.0 ==================
 
 Consult the LUCENE_CHANGES.txt file for additional, low level, changes in this release.

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/BaseHttpClusterStateProvider.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/BaseHttpClusterStateProvider.java
@@ -63,7 +63,7 @@ public abstract class BaseHttpClusterStateProvider implements ClusterStateProvid
         this.liveNodes = fetchLiveNodes(initialClient);
         liveNodesTimestamp = System.nanoTime();
         break;
-      } catch (IOException e) {
+      } catch (SolrServerException | IOException e) {
         log.warn("Attempt to fetch cluster state from {} failed.", solrUrl, e);
       }
     }


### PR DESCRIPTION

# Description

Catch SolrServerException as well since SolrServerException may throw from fetchLiveNodes(initialClient)

# Solution
Catch SolrServerException

# Tests

Provide solrUrls list with two nodes, and shutdown the first node in the list, CloudSolrClient can created successful.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [X] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
