### PR TITLE
LUCENE-8103: Use two-phase iteration in Query- and DoubleValuesSource

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/DoubleValuesSource.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DoubleValuesSource.java
@@ -608,25 +608,18 @@ public abstract class DoubleValuesSource implements SegmentCacheable {
       return new DoubleValues() {
         private final TwoPhaseIterator tpi = scorer.twoPhaseIterator();
         private final DocIdSetIterator disi = (tpi == null) ? scorer.iterator() : tpi.approximation();
-        private Boolean thisDocMatches = false;
 
         @Override
         public double doubleValue() throws IOException {
-          return thisDocMatches == Boolean.TRUE ? scorer.score() : Double.NaN;
+          return scorer.score();
         }
 
         @Override
         public boolean advanceExact(int doc) throws IOException {
           if (disi.docID() < doc) {
             disi.advance(doc);
-            thisDocMatches = null;
           }
-          if (disi.docID() == doc) {
-            if (thisDocMatches == null) {
-              thisDocMatches = tpi == null || tpi.matches();
-            }
-            return thisDocMatches;
-          } else return false;
+          return disi.docID() == doc && (tpi == null || tpi.matches());
         }
       };
     }

--- a/lucene/core/src/java/org/apache/lucene/search/DoubleValuesSource.java
+++ b/lucene/core/src/java/org/apache/lucene/search/DoubleValuesSource.java
@@ -612,7 +612,7 @@ public abstract class DoubleValuesSource implements SegmentCacheable {
 
         @Override
         public double doubleValue() throws IOException {
-          return (thisDocMatches != null && thisDocMatches) ? scorer.score() : Double.NaN;
+          return thisDocMatches == Boolean.TRUE ? scorer.score() : Double.NaN;
         }
 
         @Override

--- a/lucene/core/src/test/org/apache/lucene/search/TestDoubleValuesSource.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestDoubleValuesSource.java
@@ -274,7 +274,17 @@ public class TestDoubleValuesSource extends LuceneTestCase {
   }
 
   public void testQueryDoubleValuesSource() throws Exception {
-    Query q = new TermQuery(new Term("english", "two"));
+    Query iteratingQuery = new TermQuery(new Term("english", "two"));
+    Query approximatingQuery = new PhraseQuery.Builder()
+      .add(new Term("english", "hundred"), 0)
+      .add(new Term("english", "one"), 1)
+      .build();
+
+    doTestQueryDoubleValuesSources(iteratingQuery);
+    doTestQueryDoubleValuesSources(approximatingQuery);
+  }
+
+  private void doTestQueryDoubleValuesSources(Query q) throws Exception {
     DoubleValuesSource vs = DoubleValuesSource.fromQuery(q).rewrite(searcher);
     searcher.search(q, new SimpleCollector() {
 

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/QueryValueSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/QueryValueSource.java
@@ -138,7 +138,7 @@ class QueryDocValues extends FloatDocValues {
     lastDocRequested = doc;
 
     try {
-      if (scorer == null) {
+      if (disi == null) {
         scorer = weight.scorer(readerContext);
         if (scorer == null) {
           disi = DocIdSetIterator.empty();

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/QueryValueSource.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/valuesource/QueryValueSource.java
@@ -91,7 +91,6 @@ class QueryDocValues extends FloatDocValues {
   DocIdSetIterator disi;
   TwoPhaseIterator tpi;
   Boolean thisDocMatches;
-  boolean noMatches =false;
 
   // the last document requested
   int lastDocRequested=-1;
@@ -139,15 +138,14 @@ class QueryDocValues extends FloatDocValues {
     lastDocRequested = doc;
 
     try {
-      if (noMatches) return false;
       if (scorer == null) {
         scorer = weight.scorer(readerContext);
         if (scorer == null) {
-          noMatches = true;
-          return false;
+          disi = DocIdSetIterator.empty();
+        } else {
+          tpi = scorer.twoPhaseIterator();
+          disi = tpi == null ? scorer.iterator() : tpi.approximation();
         }
-        tpi = scorer.twoPhaseIterator();
-        disi = tpi==null ? scorer.iterator() : tpi.approximation();
         thisDocMatches = null;
       }
 

--- a/lucene/queries/src/test/org/apache/lucene/queries/function/TestValueSources.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/function/TestValueSources.java
@@ -379,6 +379,10 @@ public class TestValueSources extends LuceneTestCase {
     ValueSource vs = new QueryValueSource(new FunctionQuery(new ConstValueSource(2f)), 0f);
     assertHits(new FunctionQuery(vs), new float[] { 2f, 2f });
     assertAllExist(vs);
+
+    vs = new QueryValueSource(new FunctionRangeQuery(new IntFieldSource("int"), Integer.MIN_VALUE, Integer.MAX_VALUE, true, true), 0f);
+    assertHits(new FunctionQuery(vs), new float[] { 35f, 54f });
+    assertAllExist(vs);
   }
 
   public void testQuery() throws Exception {


### PR DESCRIPTION
# Description
QueryValueSource (in "queries" module) is a ValueSource representation of a Query; the score is the value. It ought to try to use a TwoPhaseIterator from the query if it can be offered.

# Solution
Always check whether a TwoPhaseIterator can be offered, and use it. Since its `matches()` function may only be called once, while there is no restrictions on QueryValueSource's or DoubleValuesSource's method calling, I unfortunately had to add some state.

# Tests

For each value source, I added a test case that makes use of a query that serves a TwoPhaseIterator. I don't think that's the best solution, but was not sure about how to solve this differently.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [x] I have added tests for my changes.