### PR TITLE
SOLR-14316 Remove unchecked type conversion warning in JavaBinCodec's readMapEntry's equals() squashed

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -52,7 +52,8 @@ New Features
 
 Improvements
 ---------------------
-(No changes)
+* SOLR-14316: Remove unchecked type conversion warning in JavaBinCodec's readMapEntry's equals() method
+ (Aroop Ganguly, Tomás Fernández Löbbe, Noble Paul, Anshum Gupta)
 
 Optimizations
 ---------------------

--- a/solr/solrj/src/java/org/apache/solr/common/util/JavaBinCodec.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/JavaBinCodec.java
@@ -867,11 +867,11 @@ public class JavaBinCodec implements PushWriter {
         if(this == obj) {
           return true;
         }
-        if(!(obj instanceof Entry)) {
-          return false;
+        if (obj instanceof Map.Entry<?, ?>) {
+          Entry<?, ?> entry = (Entry<?, ?>) obj;
+          return (this.getKey().equals(entry.getKey()) && this.getValue().equals(entry.getValue()));
         }
-        Map.Entry<Object, Object> entry = (Entry<Object, Object>) obj;
-        return (this.getKey().equals(entry.getKey()) && this.getValue().equals(entry.getValue()));
+        return false;
       }
     };
   }

--- a/solr/solrj/src/test/org/apache/solr/common/util/TestJavaBinCodec.java
+++ b/solr/solrj/src/test/org/apache/solr/common/util/TestJavaBinCodec.java
@@ -52,6 +52,9 @@ public class TestJavaBinCodec extends SolrTestCaseJ4 {
   private static final String SOLRJ_JAVABIN_BACKCOMPAT_BIN_CHILD_DOCS = "/solrj/javabin_backcompat_child_docs.bin";
   private static final String BIN_FILE_LOCATION_CHILD_DOCS = "./solr/solrj/src/test-files/solrj/javabin_backcompat_child_docs.bin";
 
+  private static final String SOLRJ_DOCS_1 = "/solrj/docs1.xml";
+  private static final String SOLRJ_DOCS_2 = "/solrj/sampleClusteringResponse.xml";
+
   public void testStrings() throws Exception {
     for (int i = 0; i < 10000 * RANDOM_MULTIPLIER; i++) {
       String s = TestUtil.randomUnicodeString(random());
@@ -287,6 +290,52 @@ public class TestJavaBinCodec extends SolrTestCaseJ4 {
     );
   }
 
+  @Test
+  public void testReadMapEntryTextStreamSource() throws IOException {
+    Map.Entry<Object, Object> entryFromTextDoc1 = getMapFromJavaBinCodec(SOLRJ_DOCS_1);
+    Map.Entry<Object, Object> entryFromTextDoc1_clone = getMapFromJavaBinCodec(SOLRJ_DOCS_1);
+
+    Map.Entry<Object, Object> entryFromTextDoc2 = getMapFromJavaBinCodec(SOLRJ_DOCS_2);
+    Map.Entry<Object, Object> entryFromTextDoc2_clone = getMapFromJavaBinCodec(SOLRJ_DOCS_2);
+
+    // exactly same document read twice should have same content
+    assertEquals ("text-doc1 exactly same document read twice should have same content",entryFromTextDoc1,entryFromTextDoc1_clone);
+    // doc1 and doc2 are 2 text files with different content on line 1
+    assertNotEquals ("2 text streams with 2 different contents should be unequal",entryFromTextDoc2,entryFromTextDoc1);
+    // exactly same document read twice should have same content
+    assertEquals ("text-doc2 exactly same document read twice should have same content",entryFromTextDoc2,entryFromTextDoc2_clone);
+  }
+
+  @Test
+  public void  testReadMapEntryBinaryStreamSource() throws IOException {
+    // now lets look at binary files
+    Map.Entry<Object, Object> entryFromBinFileA = getMapFromJavaBinCodec(SOLRJ_JAVABIN_BACKCOMPAT_BIN);
+    Map.Entry<Object, Object> entryFromBinFileA_clone = getMapFromJavaBinCodec(SOLRJ_JAVABIN_BACKCOMPAT_BIN);
+
+    assertEquals("same map entry references should be equal",entryFromBinFileA,entryFromBinFileA);
+
+    // Commenting-out this test as it may have inadvertent effect on someone changing this in future
+    // but keeping this in code to make a point, that even the same exact bin file,
+    // there could be sub-objects in the key or value of the maps, with types that do not implement equals
+    // and in these cases equals would fail as these sub-objects would be equated on their memory-references which is highly probbale to be unique
+    // and hence the top-level map's equals will also fail
+    // assertNotEquals("2 different references even though from same source are un-equal",entryFromBinFileA,entryFromBinFileA_clone);
+
+
+    // read in a different binary file and this should definitely not be equal to the other bi file
+    Map.Entry<Object, Object> entryFromBinFileB = getMapFromJavaBinCodec(SOLRJ_JAVABIN_BACKCOMPAT_BIN_CHILD_DOCS);
+    assertNotEquals("2 different references from 2 different source bin streams should still be unequal",entryFromBinFileA,entryFromBinFileB);
+  }
+
+  private Map.Entry<Object, Object> getMapFromJavaBinCodec(String fileName) throws IOException {
+    try (InputStream is = getClass().getResourceAsStream(fileName)) {
+      try (DataInputInputStream dis = new FastInputStream(is)) {
+        try (JavaBinCodec javabin = new JavaBinCodec()) {
+          return javabin.readMapEntry(dis);
+        }
+      }
+    }
+  }
 
   private static Object serializeAndDeserialize(Object o) throws IOException {
     return getObject(getBytes(o));


### PR DESCRIPTION
# Description

there was an unchecked type conversion warning in JavaBinCodec's readMapEntry's equals() method

# Solution
fixed an unchecked type conversion warning in JavaBinCodec's readMapEntry's equals() method

# Tests

added tests per @noblepaul 's comments on the previous pr [https://github.com/apache/lucene-solr/pull/1335]

- please do note that no tests existed for this api prior to this so I had to think how to set a baseline here
- however now we have a a test case for this api oh JavaBinCodec, with decent boundary value code coverage
- I tested for backward compatibility between the code change by running the same boundary value analysis of tests, with the new and old api implementation and the test results are the same

Some Observations
- so from these tests, one can surmise that the JavaBinCodec.readMapEntry() method's current behavior is to create/expect new Objects to be created from binary streams.
- What the tests do reveal is that its possible to use this api to read text streams too where the api does not generate object but uses primitive string comparisons.
- Which is fine as I think this api was and is meant to be used for binary file renditions only.
- however one may think that this should be more formally enforced ?

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [x] I have run `gradlew precommit` and the appropriate test suite.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
