### PR TITLE
SOLR-14326 Number of tlog replicas off by one when restoring collections

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/RestoreCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/RestoreCmd.java
@@ -333,7 +333,7 @@ public class RestoreCmd implements OverseerCollectionMessageHandler.Cmd {
           // We already created either a NRT or an TLOG replica as leader
           if (numNrtReplicas > 0) {
             createdNrtReplicas++;
-          } else if (createdTlogReplicas > 0) {
+          } else if (numTlogReplicas > 0) {
             createdTlogReplicas++;
           }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-14326

When making a request to restore a collection, the quantity of tlog replicas will always be off by one when restoring a collection that doesn't contain nrt replicas or when specifying the quantity of replicas in the request itself.

This is due to a flawed comparison where an int meant to be an iterator for tlog replicas is checked if it is greater than zero, however, since that variable was initialized as 0 just prior it will never be greater than zero. The fix is to compare the desired number of tlog replicas (like nrt) rather than the iterator.