### PR TITLE
Cleanup DWPT for readability

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/DefaultIndexingChain.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DefaultIndexingChain.java
@@ -77,7 +77,7 @@ final class DefaultIndexingChain extends DocConsumer {
 
   private final Set<String> finishedDocValues = new HashSet<>();
 
-  public DefaultIndexingChain(DocumentsWriterPerThread docWriter) throws IOException {
+  public DefaultIndexingChain(DocumentsWriterPerThread docWriter) {
     this.docWriter = docWriter;
     this.fieldInfos = docWriter.getFieldInfosBuilder();
     this.docState = docWriter.docState;

--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterPerThread.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterPerThread.java
@@ -77,7 +77,7 @@ final class DocumentsWriterPerThread {
   static final IndexingChain defaultIndexingChain = new IndexingChain() {
 
     @Override
-    DocConsumer getChain(DocumentsWriterPerThread documentsWriterPerThread) throws IOException {
+    DocConsumer getChain(DocumentsWriterPerThread documentsWriterPerThread) {
       return new DefaultIndexingChain(documentsWriterPerThread);
     }
   };
@@ -194,11 +194,11 @@ final class DocumentsWriterPerThread {
     if (INFO_VERBOSE && infoStream.isEnabled("DWPT")) {
       infoStream.message("DWPT", Thread.currentThread().getName() + " init seg=" + segmentName + " delQueue=" + deleteQueue);  
     }
+    this.enableTestPoints = enableTestPoints;
+    this.indexVersionCreated = indexVersionCreated;
     // this should be the last call in the ctor 
     // it really sucks that we need to pull this within the ctor and pass this ref to the chain!
     consumer = indexWriterConfig.getIndexingChain().getChain(this);
-    this.enableTestPoints = enableTestPoints;
-    this.indexVersionCreated = indexVersionCreated;
   }
   
   public FieldInfos.Builder getFieldInfosBuilder() {
@@ -466,7 +466,7 @@ final class DocumentsWriterPerThread {
     return filesToDelete;
   }
 
-  private FixedBitSet sortLiveDocs(Bits liveDocs, Sorter.DocMap sortMap) throws IOException {
+  private FixedBitSet sortLiveDocs(Bits liveDocs, Sorter.DocMap sortMap) {
     assert liveDocs != null && sortMap != null;
     FixedBitSet sortedLiveDocs = new FixedBitSet(liveDocs.length());
     sortedLiveDocs.set(0, liveDocs.length());

--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterPerThread.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterPerThread.java
@@ -259,7 +259,7 @@ final class DocumentsWriterPerThread {
         if (!allDocsIndexed && !aborted) {
           // the iterator threw an exception that is not aborting
           // go and mark all docs from this block as deleted
-          deleteLastDocs(numDocsInRAM-docsInRamBefore);
+          deleteLastDocs(numDocsInRAM - docsInRamBefore);
         }
         docState.clear();
       }
@@ -299,8 +299,13 @@ final class DocumentsWriterPerThread {
     return seqNo;
   }
 
-  // Buffer a specific docID for deletion. Currently only
-  // used when we hit an exception when adding a document
+  // This method marks the last N docs as deleted. This is used
+  // in the case of a non-aborting exception. There are several cases
+  // where we fail a document ie. due to an exception during analysis
+  // that causes the doc to be rejected but won't cause the DWPT to be
+  // stale nor the entire IW to abort and shutdown. In such a case
+  // we only mark these docs as deleted and turn it into a livedocs
+  // during flush
   private void deleteLastDocs(int docCount) {
     for (int docId = numDocsInRAM - docCount; docId < numDocsInRAM; docId++) {
       pendingUpdates.addDocID(docId);


### PR DESCRIPTION
DWPT had some complicated logic to account for failures etc.
This change cleans up this logic and simplifies the document processing
loop.