### PR TITLE
SOLR-13807: Introduce a cache for term facet counts

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/SpatialHeatmapFacets.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SpatialHeatmapFacets.java
@@ -30,6 +30,7 @@ import org.apache.solr.common.util.SimpleOrderedMap;
 import org.apache.solr.search.DocSet;
 import org.apache.solr.search.facet.FacetHeatmap;
 import org.apache.solr.search.facet.FacetMerger;
+import org.apache.solr.search.facet.FacetModule;
 import org.apache.solr.search.facet.FacetRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,7 +48,7 @@ public class SpatialHeatmapFacets {
   /** Called by {@link org.apache.solr.request.SimpleFacets} to compute heatmap facets. */
   public static NamedList<Object> getHeatmapForField(String fieldKey, String fieldName, ResponseBuilder rb, SolrParams params, DocSet docSet) throws IOException {
     final FacetRequest facetRequest = createHeatmapRequest(fieldKey, fieldName, rb, params);
-    return (NamedList) facetRequest.process(rb.req, docSet);
+    return (NamedList) facetRequest.process(rb.req, FacetModule.getBaseFilters(rb), docSet);
   }
 
   private static FacetRequest createHeatmapRequest(String fieldKey, String fieldName, ResponseBuilder rb, SolrParams params) {

--- a/solr/core/src/java/org/apache/solr/request/DocValuesFacets.java
+++ b/solr/core/src/java/org/apache/solr/request/DocValuesFacets.java
@@ -17,10 +17,14 @@
 package org.apache.solr.request;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Predicate;
 
 import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.IndexReader.CacheKey;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.MultiDocValues.MultiSortedSetDocValues;
 import org.apache.lucene.index.MultiDocValues;
@@ -29,6 +33,7 @@ import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.search.DocIdSet;
 import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.store.ByteBuffersDataOutput;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.CharsRefBuilder;
@@ -36,12 +41,19 @@ import org.apache.lucene.util.LongValues;
 import org.apache.lucene.util.UnicodeUtil;
 import org.apache.solr.common.params.FacetParams;
 import org.apache.solr.common.util.NamedList;
+import org.apache.solr.handler.component.ResponseBuilder;
+import org.apache.solr.request.TermFacetCache.FacetCacheKey;
+import org.apache.solr.request.TermFacetCache.SegmentCacheEntry;
+import static org.apache.solr.request.TermFacetCache.mergeCachedSegmentCounts;
 import org.apache.solr.schema.FieldType;
 import org.apache.solr.schema.SchemaField;
 import org.apache.solr.search.DocSet;
 import org.apache.solr.search.Filter;
+import org.apache.solr.search.QueryResultKey;
+import org.apache.solr.search.SolrCache;
 import org.apache.solr.search.SolrIndexSearcher;
 import org.apache.solr.search.facet.FacetDebugInfo;
+import org.apache.solr.search.facet.FacetModule;
 import org.apache.solr.util.LongPriorityQueue;
 
 /**
@@ -58,13 +70,8 @@ import org.apache.solr.util.LongPriorityQueue;
  */
 public class DocValuesFacets {
   private DocValuesFacets() {}
-
-  public static NamedList<Integer> getCounts(SolrIndexSearcher searcher, DocSet docs, String fieldName, int offset, int limit, int mincount, boolean missing, String sort, String prefix, String contains, boolean ignoreCase, FacetDebugInfo fdebug) throws IOException {
-    final Predicate<BytesRef> termFilter = new SubstringBytesRefFilter(contains, ignoreCase);
-    return getCounts(searcher, docs, fieldName, offset, limit, mincount, missing, sort, prefix, termFilter, fdebug);
-  }
   
-  public static NamedList<Integer> getCounts(SolrIndexSearcher searcher, DocSet docs, String fieldName, int offset, int limit, int mincount, boolean missing, String sort, String prefix, Predicate<BytesRef> termFilter, FacetDebugInfo fdebug) throws IOException {
+  public static NamedList<Integer> getCounts(SolrIndexSearcher searcher, DocSet docs, String fieldName, int offset, int limit, int mincount, boolean missing, String sort, String prefix, Predicate<BytesRef> termFilter, FacetDebugInfo fdebug, long facetCacheThreshold, ResponseBuilder rb) throws IOException {
     SchemaField schemaField = searcher.getSchema().getField(fieldName);
     FieldType ft = schemaField.getType();
     NamedList<Integer> res = new NamedList<>();
@@ -105,6 +112,7 @@ public class DocValuesFacets {
     }
     
     int startTermIndex, endTermIndex;
+    final boolean doMissing;
     if (prefix!=null) {
       startTermIndex = (int) si.lookupTerm(prefixRef.get());
       if (startTermIndex<0) startTermIndex=-startTermIndex-1;
@@ -112,57 +120,96 @@ public class DocValuesFacets {
       endTermIndex = (int) si.lookupTerm(prefixRef.get());
       assert endTermIndex < 0;
       endTermIndex = -endTermIndex-1;
+      doMissing = false;
     } else {
-      startTermIndex=-1;
+      startTermIndex=0;
       endTermIndex=(int) si.getValueCount();
+      doMissing = true;
     }
 
     final int nTerms=endTermIndex-startTermIndex;
+    final int maxSlots = doMissing ? nTerms + 1 : nTerms;
     int missingCount = -1; 
     final CharsRefBuilder charsRef = new CharsRefBuilder();
-    if (nTerms>0 && docs.size() >= mincount) {
-
-      // count collection array only needs to be as big as the number of terms we are
-      // going to collect counts for.
-      final int[] counts = new int[nTerms];
-      if (fdebug != null) {
-        fdebug.putInfoItem("numBuckets", nTerms);
-      }
-
-      Filter filter = docs.getTopFilter();
-      List<LeafReaderContext> leaves = searcher.getTopReaderContext().leaves();
-      for (int subIndex = 0; subIndex < leaves.size(); subIndex++) {
-        LeafReaderContext leaf = leaves.get(subIndex);
-        DocIdSet dis = filter.getDocIdSet(leaf, null); // solr docsets already exclude any deleted docs
-        DocIdSetIterator disi = null;
-        if (dis != null) {
-          disi = dis.iterator();
-        }
-        if (disi != null) {
-          if (multiValued) {
-            SortedSetDocValues sub = leaf.reader().getSortedSetDocValues(fieldName);
-            if (sub == null) {
-              sub = DocValues.emptySortedSet();
-            }
-            final SortedDocValues singleton = DocValues.unwrapSingleton(sub);
-            if (singleton != null) {
-              // some codecs may optimize SORTED_SET storage for single-valued fields
-              accumSingle(counts, startTermIndex, singleton, disi, subIndex, ordinalMap);
-            } else {
-              accumMulti(counts, startTermIndex, sub, disi, subIndex, ordinalMap);
-            }
-          } else {
-            SortedDocValues sub = leaf.reader().getSortedDocValues(fieldName);
-            if (sub == null) {
-              sub = DocValues.emptySorted();
-            }
-            accumSingle(counts, startTermIndex, sub, disi, subIndex, ordinalMap);
+    if (maxSlots>0 && docs.size() >= mincount) {
+      Map<CacheKey, SegmentCacheEntry> segmentCache = null;
+      if (facetCacheThreshold >= 0 && docs.size() > facetCacheThreshold) {
+        SolrCache<FacetCacheKey, Map<CacheKey, SegmentCacheEntry>> facetCache = searcher.getCache(TermFacetCache.NAME);
+        if (facetCache != null) {
+          FacetCacheKey facetCacheKey = new FacetCacheKey(new QueryResultKey(null, Arrays.asList(FacetModule.getBaseFilters(rb)), null, 0), fieldName);
+          segmentCache = facetCache.get(facetCacheKey);
+          if (segmentCache == null) {
+            segmentCache = new HashMap<>();
+            facetCache.put(facetCacheKey, segmentCache);
           }
         }
       }
 
-      if (startTermIndex == -1) {
-        missingCount = counts[0];
+      // count collection array only needs to be as big as the number of terms we are
+      // going to collect counts for.
+      final int[] counts;
+      if (fdebug != null) {
+        fdebug.putInfoItem("numBuckets", maxSlots);
+      }
+
+      Filter filter = docs.getTopFilter();
+      SegmentCacheEntry topLevelCacheEntry;
+      CacheKey topLevelReaderKey = searcher.getIndexReader().getReaderCacheHelper().getKey();
+      if (segmentCache != null && (topLevelCacheEntry = segmentCache.get(topLevelReaderKey)) != null) {
+        counts = topLevelCacheEntry.topLevelCounts;
+      } else {
+        counts = new int[maxSlots];
+        List<LeafReaderContext> leaves = searcher.getTopReaderContext().leaves();
+        for (int subIndex = 0; subIndex < leaves.size(); subIndex++) {
+          LeafReaderContext leaf = leaves.get(subIndex);
+          CacheKey segKey = null;
+          if (segmentCache != null) {
+            segKey = leaf.reader().getReaderCacheHelper().getKey();
+            SegmentCacheEntry cacheEntry = segmentCache.get(segKey);
+            if (cacheEntry != null) {
+              mergeCachedSegmentCounts(counts, cacheEntry.counts, ordinalMap.getGlobalOrds(subIndex));
+              continue;
+            }
+          }
+          DocIdSet dis = filter.getDocIdSet(leaf, null); // solr docsets already exclude any deleted docs
+          DocIdSetIterator disi = null;
+          if (dis != null) {
+            disi = dis.iterator();
+          }
+          if (disi != null) {
+            byte[] cacheSegCounts;
+            if (multiValued) {
+              SortedSetDocValues sub = leaf.reader().getSortedSetDocValues(fieldName);
+              if (sub == null) {
+                sub = DocValues.emptySortedSet();
+              }
+              final SortedDocValues singleton = DocValues.unwrapSingleton(sub);
+              if (singleton != null) {
+                // some codecs may optimize SORTED_SET storage for single-valued fields
+                cacheSegCounts = accumSingle(counts, doMissing, startTermIndex, singleton, disi, subIndex, ordinalMap, segmentCache != null);
+              } else {
+                cacheSegCounts = accumMulti(counts, doMissing, startTermIndex, sub, disi, subIndex, ordinalMap, segmentCache != null);
+              }
+            } else {
+              SortedDocValues sub = leaf.reader().getSortedDocValues(fieldName);
+              if (sub == null) {
+                sub = DocValues.emptySorted();
+              }
+              cacheSegCounts = accumSingle(counts, doMissing, startTermIndex, sub, disi, subIndex, ordinalMap, segmentCache != null);
+            }
+            if (cacheSegCounts != null) {
+              segmentCache.put(segKey, new SegmentCacheEntry(cacheSegCounts));
+            }
+          }
+        }
+
+        if (segmentCache != null) {
+          segmentCache.put(topLevelReaderKey, new SegmentCacheEntry(counts, doMissing));
+        }
+      }
+
+      if (doMissing) {
+        missingCount = counts[counts.length - 1];
       }
 
       // IDEA: we could also maintain a count of "other"... everything that fell outside
@@ -181,7 +228,7 @@ public class DocValuesFacets {
         LongPriorityQueue queue = new LongPriorityQueue(Math.min(maxsize,1000), maxsize, Long.MIN_VALUE);
 
         int min=mincount-1;  // the smallest value in the top 'N' values
-        for (int i=(startTermIndex==-1)?1:0; i<nTerms; i++) {
+        for (int i=0; i<nTerms; i++) {
           int c = counts[i];
           if (c>min) {
             // NOTE: we use c>min rather than c>=min as an optimization because we are going in
@@ -222,7 +269,7 @@ public class DocValuesFacets {
       
       } else {
         // add results in index order
-        int i=(startTermIndex==-1)?1:0;
+        int i = 0;
         if (mincount<=0 && termFilter == null) {
           // if mincount<=0 and we're not examining the values for the term filter, then
           // we won't discard any terms and we know exactly where to start.
@@ -250,7 +297,6 @@ public class DocValuesFacets {
         }
       }
     }
-    
     return finalize(res, searcher, schemaField, docs, missingCount, missing);
   }
   
@@ -267,29 +313,34 @@ public class DocValuesFacets {
   }
   
   /** accumulates per-segment single-valued facet counts */
-  static void accumSingle(int counts[], int startTermIndex, SortedDocValues si, DocIdSetIterator disi, int subIndex, OrdinalMap map) throws IOException {
-    if (startTermIndex == -1 && (map == null || si.getValueCount() < disi.cost()*10)) {
+  static byte[] accumSingle(int counts[], boolean doMissing, int startTermIndex, SortedDocValues si, DocIdSetIterator disi, int subIndex, OrdinalMap map, boolean cachePerSeg) throws IOException {
+    if (doMissing && (map == null || cachePerSeg || si.getValueCount() < disi.cost()*10)) {
       // no prefixing, not too many unique values wrt matching docs (lucene/facets heuristic): 
       //   collect separately per-segment, then map to global ords
-      accumSingleSeg(counts, si, disi, subIndex, map);
+      return accumSingleSeg(counts, si, disi, subIndex, map, cachePerSeg);
     } else {
       // otherwise: do collect+map on the fly
-      accumSingleGeneric(counts, startTermIndex, si, disi, subIndex, map);
+      accumSingleGeneric(counts, doMissing, startTermIndex, si, disi, subIndex, map);
+      return null;
     }
   }
   
   /** accumulates per-segment single-valued facet counts, mapping to global ordinal space on-the-fly */
-  static void accumSingleGeneric(int counts[], int startTermIndex, SortedDocValues si, DocIdSetIterator disi, int subIndex, OrdinalMap map) throws IOException {
+  static void accumSingleGeneric(int counts[], boolean doMissing, int startTermIndex, SortedDocValues si, DocIdSetIterator disi, int subIndex, OrdinalMap map) throws IOException {
     final LongValues ordmap = map == null ? null : map.getGlobalOrds(subIndex);
+    final int missingIdx = doMissing ? counts.length - 1 : -1;
     int doc;
     while ((doc = disi.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
       int term;
       if (si.advanceExact(doc)) {
         term = si.ordValue();
       } else {
-        term = -1;
+        if (doMissing) {
+          counts[missingIdx]++;
+        }
+        continue;
       }
-      if (map != null && term >= 0) {
+      if (map != null) {
         term = (int) ordmap.get(term);
       }
       int arrIdx = term-startTermIndex;
@@ -298,7 +349,7 @@ public class DocValuesFacets {
   }
   
   /** "typical" single-valued faceting: not too many unique values, no prefixing. maps to global ordinals as a separate step */
-  static void accumSingleSeg(int counts[], SortedDocValues si, DocIdSetIterator disi, int subIndex, OrdinalMap map) throws IOException {
+  static byte[] accumSingleSeg(int counts[], SortedDocValues si, DocIdSetIterator disi, int subIndex, OrdinalMap map, boolean cachePerSeg) throws IOException {
     // First count in seg-ord space:
     final int segCounts[];
     if (map == null) {
@@ -307,36 +358,45 @@ public class DocValuesFacets {
       segCounts = new int[1+si.getValueCount()];
     }
     
+    final int missingIdx = segCounts.length - 1;
     int doc;
     while ((doc = disi.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
       if (si.advanceExact(doc)) {
-        segCounts[1+si.ordValue()]++;
+        segCounts[si.ordValue()]++;
       } else {
-        segCounts[0]++;
+        segCounts[missingIdx]++;
       }
     }
     
     // migrate to global ords (if necessary)
     if (map != null) {
-      migrateGlobal(counts, segCounts, subIndex, map);
+      migrateGlobal(counts, segCounts, map.getGlobalOrds(subIndex));
+    }
+    if (!cachePerSeg) {
+      return null;
+    } else {
+      ByteBuffersDataOutput cachedSegCountsBuilder = new ByteBuffersDataOutput(segCounts.length * 2);
+      return TermFacetCache.encodeCounts(segCounts, cachedSegCountsBuilder);
     }
   }
   
   /** accumulates per-segment multi-valued facet counts */
-  static void accumMulti(int counts[], int startTermIndex, SortedSetDocValues si, DocIdSetIterator disi, int subIndex, OrdinalMap map) throws IOException {
-    if (startTermIndex == -1 && (map == null || si.getValueCount() < disi.cost()*10)) {
+  static byte[] accumMulti(int counts[], boolean doMissing, int startTermIndex, SortedSetDocValues si, DocIdSetIterator disi, int subIndex, OrdinalMap map, boolean cachePerSeg) throws IOException {
+    if (doMissing && (map == null || cachePerSeg || si.getValueCount() < disi.cost()*10)) {
       // no prefixing, not too many unique values wrt matching docs (lucene/facets heuristic): 
       //   collect separately per-segment, then map to global ords
-      accumMultiSeg(counts, si, disi, subIndex, map);
+      return accumMultiSeg(counts, si, disi, subIndex, map, cachePerSeg);
     } else {
       // otherwise: do collect+map on the fly
-      accumMultiGeneric(counts, startTermIndex, si, disi, subIndex, map);
+      accumMultiGeneric(counts, doMissing, startTermIndex, si, disi, subIndex, map);
+      return null;
     }
   }
     
   /** accumulates per-segment multi-valued facet counts, mapping to global ordinal space on-the-fly */
-  static void accumMultiGeneric(int counts[], int startTermIndex, SortedSetDocValues si, DocIdSetIterator disi, int subIndex, OrdinalMap map) throws IOException {
+  static void accumMultiGeneric(int counts[], boolean doMissing, int startTermIndex, SortedSetDocValues si, DocIdSetIterator disi, int subIndex, OrdinalMap map) throws IOException {
     final LongValues ordMap = map == null ? null : map.getGlobalOrds(subIndex);
+    final int missingIdx = doMissing ? counts.length - 1 : -1;
     int doc;
     while ((doc = disi.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
       if (si.advanceExact(doc)) {
@@ -349,14 +409,14 @@ public class DocValuesFacets {
           int arrIdx = term-startTermIndex;
           if (arrIdx>=0 && arrIdx<counts.length) counts[arrIdx]++;
         } while ((term = (int) si.nextOrd()) >= 0);
-      } else if (startTermIndex == -1) {
-        counts[0]++; // missing count
+      } else if (doMissing) {
+        counts[missingIdx]++; // missing count
       }
     }
   }
   
   /** "typical" multi-valued faceting: not too many unique values, no prefixing. maps to global ordinals as a separate step */
-  static void accumMultiSeg(int counts[], SortedSetDocValues si, DocIdSetIterator disi, int subIndex, OrdinalMap map) throws IOException {
+  static byte[] accumMultiSeg(int counts[], SortedSetDocValues si, DocIdSetIterator disi, int subIndex, OrdinalMap map, boolean cachePerSeg) throws IOException {
     // First count in seg-ord space:
     final int segCounts[];
     if (map == null) {
@@ -365,35 +425,42 @@ public class DocValuesFacets {
       segCounts = new int[1+(int)si.getValueCount()];
     }
     
+    final int missingIdx = segCounts.length - 1;
     int doc;
     while ((doc = disi.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
       if (si.advanceExact(doc)) {
         int term = (int) si.nextOrd();
         do {
-          segCounts[1+term]++;
+          segCounts[term]++;
         } while ((term = (int)si.nextOrd()) >= 0);
       } else {
-        counts[0]++; // missing
+        segCounts[missingIdx]++; // missing
       }
     }
     
     // migrate to global ords (if necessary)
     if (map != null) {
-      migrateGlobal(counts, segCounts, subIndex, map);
+      migrateGlobal(counts, segCounts, map.getGlobalOrds(subIndex));
+    }
+    if (!cachePerSeg) {
+      return null;
+    } else {
+      ByteBuffersDataOutput cachedSegCountsBuilder = new ByteBuffersDataOutput(segCounts.length * 2);
+      return TermFacetCache.encodeCounts(segCounts, cachedSegCountsBuilder);
     }
   }
   
   /** folds counts in segment ordinal space (segCounts) into global ordinal space (counts) */
-  static void migrateGlobal(int counts[], int segCounts[], int subIndex, OrdinalMap map) {
-    final LongValues ordMap = map.getGlobalOrds(subIndex);
+  public static void migrateGlobal(int counts[], int segCounts[], LongValues ordMap) {
     // missing count
-    counts[0] += segCounts[0];
+    int ord = segCounts.length - 1;
+    counts[counts.length - 1] += segCounts[ord];
     
     // migrate actual ordinals
-    for (int ord = 1; ord < segCounts.length; ord++) {
+    while (ord-- > 0) {
       int count = segCounts[ord];
       if (count != 0) {
-        counts[1+(int) ordMap.get(ord-1)] += count;
+        counts[(int) ordMap.get(ord)] += count;
       }
     }
   }

--- a/solr/core/src/java/org/apache/solr/request/SimpleFacets.java
+++ b/solr/core/src/java/org/apache/solr/request/SimpleFacets.java
@@ -98,6 +98,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.solr.common.params.CommonParams.SORT;
+import org.apache.solr.search.facet.FacetModule;
 
 /**
  * A class that generates simple Facet information for a request.
@@ -554,6 +555,7 @@ public class SimpleFacets {
             jsonFacet.put("allBuckets", params.getFieldBool(field, "allBuckets", false));
             jsonFacet.put("method", "uif");
             jsonFacet.put("cacheDf", 0);
+            jsonFacet.put("countCacheDf", params.getFieldInt(field, "countCacheDf", 0));
             jsonFacet.put("perSeg", false);
             
             final String sortVal;
@@ -571,7 +573,7 @@ public class SimpleFacets {
 
             //TODO do we handle debug?  Should probably already be handled by the legacy code
 
-            Object resObj = FacetRequest.parseOneFacetReq(req, jsonFacet).process(req, docs);
+            Object resObj = FacetRequest.parseOneFacetReq(req, jsonFacet).process(req, FacetModule.getBaseFilters(rb), docs);
             //Go through the response to build the expected output for SimpleFacets
             counts = new NamedList<>();
             if(resObj != null) {
@@ -588,7 +590,15 @@ public class SimpleFacets {
             }
           break;
         case FC:
-          counts = DocValuesFacets.getCounts(searcher, docs, field, offset,limit, mincount, missing, sort, prefix, termFilter, fdebug);
+          int threshold = params.getFieldInt(field, "countCacheDf", 0);
+          if (threshold < 0 || (prefix != null && !prefix.isEmpty())) {
+            // facet cache disabled
+            threshold = Integer.MAX_VALUE;
+          } else if (threshold == 0) {
+            // allow 0 as an explicit default value.
+            threshold = TermFacetCache.DEFAULT_THRESHOLD;
+          }
+          counts = DocValuesFacets.getCounts(searcher, docs, field, offset,limit, mincount, missing, sort, prefix, termFilter, fdebug, threshold, rb);
           break;
         default:
           throw new AssertionError();

--- a/solr/core/src/java/org/apache/solr/request/TermFacetCache.java
+++ b/solr/core/src/java/org/apache/solr/request/TermFacetCache.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.request;
+
+import java.io.IOException;
+import org.apache.lucene.store.ByteArrayDataInput;
+import org.apache.lucene.store.ByteBuffersDataOutput;
+import org.apache.lucene.util.LongValues;
+import org.apache.solr.search.QueryResultKey;
+
+/**
+ *
+ */
+public class TermFacetCache {
+
+  public static final String NAME = "termFacetCache";
+  public static int DEFAULT_THRESHOLD = 5000; // non-final to support setting by tests
+
+
+  public static final class FacetCacheKey {
+
+    private final QueryResultKey qrk;
+    private final String fieldName;
+
+    public FacetCacheKey(QueryResultKey qrk, String fieldName) {
+      this.qrk = qrk;
+      this.fieldName = fieldName;
+    }
+
+    @Override
+    public int hashCode() {
+      return qrk == null ? fieldName.hashCode() : qrk.hashCode() ^ fieldName.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      FacetCacheKey other = (FacetCacheKey)obj;
+      return fieldName.equals(other.fieldName) && (qrk == null ? other.qrk == null : qrk.equals(other.qrk));
+    }
+
+  }
+
+  public static final class SegmentCacheEntry {
+
+    public final byte[] counts;
+    public final int[] topLevelCounts;
+    public final boolean hasMissingSlot;
+
+    public SegmentCacheEntry(byte[] counts) {
+      this.counts = counts;
+      this.topLevelCounts = null;
+      this.hasMissingSlot = false;
+    }
+
+    public SegmentCacheEntry(int[] topLevelCounts, boolean includesMissingCount) {
+      this.counts = null;
+      this.topLevelCounts = topLevelCounts;
+      this.hasMissingSlot = includesMissingCount;
+    }
+
+  }
+
+  public static interface CacheUpdater {
+    boolean incrementFromCachedSegment(LongValues toGlobal);
+    void updateLeaf(int[] leafCounts);
+    void updateTopLevel();
+  }
+
+  public static final byte[] encodeCounts(int[] segCounts, ByteBuffersDataOutput cachedSegCountsBuilder) {
+    try {
+      for (int c : segCounts) {
+        cachedSegCountsBuilder.writeVInt(c);
+      }
+    } catch (IOException ex) {
+      throw new RuntimeException(ByteBuffersDataOutput.class + " should not throw IOException in practice", ex);
+    }
+    return cachedSegCountsBuilder.toArrayCopy();
+  }
+
+  public static void mergeCachedSegmentCounts(int[] counts, byte[] cachedSegCounts, LongValues ordMap) {
+    ByteArrayDataInput segCounts = new ByteArrayDataInput(cachedSegCounts);
+    if (!segCounts.eof()) {
+      int ord = 0;
+      int count = segCounts.readVInt();
+      while (!segCounts.eof()) {
+        if (count != 0) {
+          counts[(int)ordMap.get(ord)] += count;
+        }
+        ord++;
+        count = segCounts.readVInt();
+      }
+      // missing count
+      counts[counts.length - 1] += count;
+    }
+  }
+
+}

--- a/solr/core/src/java/org/apache/solr/request/TermFacetCacheRegenerator.java
+++ b/solr/core/src/java/org/apache/solr/request/TermFacetCacheRegenerator.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.request;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.WeakHashMap;
+import org.apache.lucene.index.IndexReader.CacheKey;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.solr.request.TermFacetCache.SegmentCacheEntry;
+import org.apache.solr.search.CacheRegenerator;
+import org.apache.solr.search.SolrCache;
+import org.apache.solr.search.SolrIndexSearcher;
+
+/**
+ *
+ */
+public class TermFacetCacheRegenerator implements CacheRegenerator {
+  private final Map<CacheKey, Set<CacheKey>> activeSegments;
+
+  public TermFacetCacheRegenerator() {
+    activeSegments = new WeakHashMap<>();
+  }
+
+  @Override
+  public boolean regenerateItem(SolrIndexSearcher newSearcher, SolrCache nc, SolrCache oc, Object oldKey, Object oldVal) throws IOException {
+    Set<CacheKey> segmentKeys;
+    CacheKey topLevelKey = newSearcher.getIndexReader().getReaderCacheHelper().getKey();
+    synchronized (activeSegments) {
+      segmentKeys = activeSegments.get(topLevelKey);
+      if (segmentKeys == null) {
+        List<LeafReaderContext> leaves = newSearcher.getTopReaderContext().leaves();
+        segmentKeys = new HashSet<>(leaves.size());
+        for (LeafReaderContext leaf : leaves) {
+          segmentKeys.add(leaf.reader().getReaderCacheHelper().getKey());
+        }
+        activeSegments.clear();
+        activeSegments.put(topLevelKey, segmentKeys);
+      }
+    }
+    Map<CacheKey, SegmentCacheEntry> oldSegmentCache = (Map<CacheKey, SegmentCacheEntry>)oldVal;
+    Map<CacheKey, SegmentCacheEntry> newSegmentCache = new HashMap<>(segmentKeys.size());
+    for (Entry<CacheKey, SegmentCacheEntry> e : oldSegmentCache.entrySet()) {
+      CacheKey segmentKey = e.getKey();
+      if (segmentKeys.contains(segmentKey)) {
+        newSegmentCache.put(segmentKey, e.getValue());
+      }
+    }
+    if (!newSegmentCache.isEmpty()) {
+      nc.put(oldKey, newSegmentCache);
+    }
+    return true;
+  }
+}

--- a/solr/core/src/java/org/apache/solr/search/QueryResultKey.java
+++ b/solr/core/src/java/org/apache/solr/search/QueryResultKey.java
@@ -50,7 +50,7 @@ public final class QueryResultKey implements Accountable {
     this.filters = filters;
     this.nc_flags = nc_flags;
 
-    int h = query.hashCode();
+    int h = query == null ? 0 : query.hashCode();
 
     if (filters != null) {
       for (Query filt : filters)
@@ -94,7 +94,7 @@ public final class QueryResultKey implements Accountable {
     // check for the thing most likely to be different (and the fastest things)
     // first.
     if (this.sfields.length != other.sfields.length) return false;
-    if (!this.query.equals(other.query)) return false;
+    if (this.query == null ? other.query != null : !this.query.equals(other.query)) return false;
     if (!unorderedCompare(this.filters, other.filters)) return false;
 
     for (int i=0; i<sfields.length; i++) {

--- a/solr/core/src/java/org/apache/solr/search/facet/CacheUpdateCountSlotAcc.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/CacheUpdateCountSlotAcc.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.search.facet;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.function.IntFunction;
+import org.apache.lucene.index.IndexReader.CacheKey;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.store.ByteBuffersDataOutput;
+import org.apache.lucene.util.LongValues;
+import static org.apache.solr.request.TermFacetCache.mergeCachedSegmentCounts;
+import org.apache.solr.request.TermFacetCache;
+import org.apache.solr.request.TermFacetCache.CacheUpdater;
+import org.apache.solr.request.TermFacetCache.FacetCacheKey;
+import org.apache.solr.request.TermFacetCache.SegmentCacheEntry;
+import org.apache.solr.search.SolrCache;
+
+final class CacheUpdateCountSlotAcc extends CountSlotAcc implements CacheUpdater {
+
+  private final int[] topLevelCounts;
+  private final Map<CacheKey, SegmentCacheEntry> cachedSegments;
+  private final ByteBuffersDataOutput dataOutput;
+  private final CacheKey topLevelCacheKey;
+  private final SolrCache<FacetCacheKey, Map<CacheKey, SegmentCacheEntry>> facetCache;
+  private final FacetCacheKey facetCacheKey;
+  private final boolean includesMissingCount;
+  private CacheKey leafCacheKey;
+  private SegmentCacheEntry cached;
+
+  CacheUpdateCountSlotAcc(FacetContext fcontext, int numSlots, Map<CacheKey, SegmentCacheEntry> cachedSegments,
+      CacheKey topLevelCacheKey, SolrCache<FacetCacheKey, Map<CacheKey, SegmentCacheEntry>> facetCache,
+      FacetCacheKey facetCacheKey, boolean includesMissingCount) {
+    super(fcontext);
+    this.topLevelCounts = new int[numSlots];
+    this.cachedSegments = cachedSegments;
+    final int initialBackingByteArraySize = numSlots; // probably ok as a rough initial size estimate
+    this.dataOutput = new ByteBuffersDataOutput(initialBackingByteArraySize);
+    this.topLevelCacheKey = topLevelCacheKey;
+    this.facetCache = facetCache;
+    this.facetCacheKey = facetCacheKey;
+    this.includesMissingCount = includesMissingCount;
+  }
+
+  @Override
+  public void setNextReader(LeafReaderContext ctx) throws IOException {
+    leafCacheKey = ctx.reader().getReaderCacheHelper().getKey();
+    cached = cachedSegments.get(leafCacheKey);
+  }
+
+  @Override
+  public boolean incrementFromCachedSegment(LongValues toGlobal) {
+    if (cached == null) {
+      return false;
+    } else {
+      mergeCachedSegmentCounts(topLevelCounts, cached.counts, toGlobal);
+      return true;
+    }
+  }
+
+  @Override
+  public void updateLeaf(int[] leafCounts) {
+    if (cached != null) {
+      // we don't need to update this leaf
+      return;
+    }
+    dataOutput.reset();
+    cachedSegments.put(leafCacheKey, new SegmentCacheEntry(TermFacetCache.encodeCounts(leafCounts, dataOutput)));
+  }
+
+  @Override
+  public void updateTopLevel() {
+    cachedSegments.put(topLevelCacheKey, new SegmentCacheEntry(topLevelCounts, includesMissingCount));
+    facetCache.put(facetCacheKey, cachedSegments);
+  }
+
+  @Override
+  public int getCount(int slot) {
+    return topLevelCounts[slot];
+  }
+
+  @Override
+  public int compare(int slotA, int slotB) {
+    return Integer.compare(topLevelCounts[slotA], topLevelCounts[slotB]);
+  }
+
+  @Override
+  public Object getValue(int slotNum) throws IOException {
+    return topLevelCounts[slotNum];
+  }
+
+  @Override
+  public void incrementCount(int slot, int increment) {
+    if (cached != null) {
+      return;
+    }
+    topLevelCounts[slot] += increment;
+  }
+
+  @Override
+  public void reset() throws IOException {
+    throw new UnsupportedOperationException("reset not supported for cached count");
+  }
+
+  @Override
+  public void resize(Resizer resizer) {
+    throw new UnsupportedOperationException("resize not supported for cached count");
+  }
+
+  @Override
+  public void collect(int doc, int slot, IntFunction<SlotContext> slotContext) throws IOException {
+    throw new UnsupportedOperationException("collect not supported for cached count");
+  }
+}

--- a/solr/core/src/java/org/apache/solr/search/facet/CachedCountSlotAcc.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/CachedCountSlotAcc.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.search.facet;
+
+import java.io.IOException;
+import java.util.function.IntFunction;
+import org.apache.lucene.util.LongValues;
+import org.apache.solr.request.TermFacetCache.CacheUpdater;
+
+final class CachedCountSlotAcc extends CountSlotAcc implements CacheUpdater {
+
+  private final int[] topLevelCounts;
+
+  CachedCountSlotAcc(FacetContext fcontext, int[] topLevelCounts) {
+    super(fcontext);
+    this.topLevelCounts = topLevelCounts;
+  }
+
+  @Override
+  public boolean incrementFromCachedSegment(LongValues toGlobal) {
+    return true;
+  }
+
+  @Override
+  public void updateLeaf(int[] leafCounts) {
+    //NoOp
+  }
+
+  @Override
+  public void updateTopLevel() {
+    //NoOp
+  }
+
+  @Override
+  public int getCount(int slot) {
+    return topLevelCounts[slot];
+  }
+
+  @Override
+  public int compare(int slotA, int slotB) {
+    return Integer.compare(topLevelCounts[slotA], topLevelCounts[slotB]);
+  }
+
+  @Override
+  public Object getValue(int slotNum) throws IOException {
+    return topLevelCounts[slotNum];
+  }
+
+  @Override
+  public void incrementCount(int slot, int increment) {
+    //NoOp
+  }
+
+  @Override
+  public void collect(int doc, int slot, IntFunction<SlotContext> slotContext) throws IOException {
+    //NoOp
+  }
+
+  @Override
+  public void reset() throws IOException {
+    //NoOp
+  }
+
+  @Override
+  public void resize(Resizer resizer) {
+    //NoOp
+  }
+}

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetField.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetField.java
@@ -77,6 +77,7 @@ public class FacetField extends FacetRequestSorted {
   String prefix;
   FacetMethod method;
   int cacheDf;  // 0 means "default", -1 means "never cache"
+  int countCacheDf = 0; // 0 means "default", -1 means "never cache"
 
   // experimental - force perSeg collection when using dv method, currently for testing purposes only.
   Boolean perSeg;

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetFieldProcessorByArrayDV.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetFieldProcessorByArrayDV.java
@@ -33,7 +33,6 @@ import org.apache.lucene.util.LongValues;
 import org.apache.lucene.util.UnicodeUtil;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.schema.SchemaField;
-import org.apache.solr.search.Filter;
 import org.apache.solr.uninverting.FieldCacheImpl;
 
 /**
@@ -95,7 +94,7 @@ class FacetFieldProcessorByArrayDV extends FacetFieldProcessorByArray {
     }
 
     // TODO: refactor some of this logic into a base class
-    boolean countOnly = collectAcc==null && allBucketsAcc==null;
+    boolean countOnly = (collectAcc==null || collectAcc instanceof SweepAcc) && allBucketsAcc==null;
     boolean fullRange = startTermIndex == 0 && endTermIndex == si.getValueCount();
 
     // Are we expecting many hits per bucket?
@@ -118,16 +117,35 @@ class FacetFieldProcessorByArrayDV extends FacetFieldProcessorByArray {
 
     if (freq.perSeg != null) accumSeg = canDoPerSeg && freq.perSeg;  // internal - override perSeg heuristic
 
+    final FilterCtStruct[] filters = getSweepFilters();
     final List<LeafReaderContext> leaves = fcontext.searcher.getIndexReader().leaves();
-    Filter filter = fcontext.base.getTopFilter();
+    final DocIdSetIterator[] subIterators = new DocIdSetIterator[filters.length];
+    final CountSlotAcc[] activeCountAccs = new CountSlotAcc[filters.length];
 
     for (int subIdx = 0; subIdx < leaves.size(); subIdx++) {
       LeafReaderContext subCtx = leaves.get(subIdx);
 
       setNextReaderFirstPhase(subCtx);
 
-      DocIdSet dis = filter.getDocIdSet(subCtx, null); // solr docsets already exclude any deleted docs
-      DocIdSetIterator disi = dis.iterator();
+      final SweepDISI disi;
+      int activeCt = 0;
+      LongValues toGlobal = ordinalMap == null ? null : ordinalMap.getGlobalOrds(subIdx);
+      for (int i = 0; i < filters.length; i++) {
+        FilterCtStruct filterEntry = filters[i];
+        DocIdSet docIdSet = filterEntry.filter.getDocIdSet(subCtx, null);
+        subIterators[activeCt] = docIdSet.iterator();
+        activeCountAccs[activeCt++] = filterEntry.countAcc;
+      }
+      switch (activeCt) {
+        case 0:
+          continue;
+        case 1:
+          disi = new SingletonDISI(subIterators[0], activeCountAccs); // solr docsets already exclude any deleted docs
+          break;
+        default:
+          disi = new UnionDISI(subIterators, activeCountAccs, activeCt);
+          break;
+      }
 
       SortedDocValues singleDv = null;
       SortedSetDocValues multiDv = null;
@@ -135,7 +153,13 @@ class FacetFieldProcessorByArrayDV extends FacetFieldProcessorByArray {
         // TODO: get sub from multi?
         multiDv = subCtx.reader().getSortedSetDocValues(sf.getName());
         if (multiDv == null) {
-          multiDv = DocValues.emptySortedSet();
+          if (countOnly) {
+            continue;
+          } else {
+            multiDv = DocValues.emptySortedSet();
+          }
+        } else if (countOnly && multiDv.getValueCount() < 1){
+          continue;
         }
         // some codecs may optimize SortedSet storage for single-valued fields
         // this will be null if this is not a wrapped single valued docvalues.
@@ -145,11 +169,15 @@ class FacetFieldProcessorByArrayDV extends FacetFieldProcessorByArray {
       } else {
         singleDv = subCtx.reader().getSortedDocValues(sf.getName());
         if (singleDv == null) {
-          singleDv = DocValues.emptySorted();
+          if (countOnly) {
+            continue;
+          } else {
+            singleDv = DocValues.emptySorted();
+          }
+        } else if (countOnly && singleDv.getValueCount() < 1) {
+          continue;
         }
       }
-
-      LongValues toGlobal = ordinalMap == null ? null : ordinalMap.getGlobalOrds(subIdx);
 
       if (singleDv != null) {
         if (accumSeg) {
@@ -174,7 +202,7 @@ class FacetFieldProcessorByArrayDV extends FacetFieldProcessorByArray {
       }
     }
 
-    reuse = null;  // better GC
+    Arrays.fill(reuse, null);  // better GC
   }
 
   @Override
@@ -182,9 +210,9 @@ class FacetFieldProcessorByArrayDV extends FacetFieldProcessorByArray {
     return si.lookupOrd(ord);
   }
 
-  private void collectPerSeg(SortedDocValues singleDv, DocIdSetIterator disi, LongValues toGlobal) throws IOException {
-    int segMax = singleDv.getValueCount() + 1;
-    final int[] counts = getCountArr( segMax );
+  private void collectPerSeg(SortedDocValues singleDv, SweepDISI disi, LongValues toGlobal) throws IOException {
+    int segMax = singleDv.getValueCount();
+    final SegCountPerSeg segCounter = getSegCountPerSeg(disi, segMax);
 
     /** alternate trial implementations
      // ord
@@ -202,73 +230,184 @@ class FacetFieldProcessorByArrayDV extends FacetFieldProcessorByArray {
     if (singleDv instanceof FieldCacheImpl.SortedDocValuesImpl.Iter) {
       FieldCacheImpl.SortedDocValuesImpl.Iter fc = (FieldCacheImpl.SortedDocValuesImpl.Iter) singleDv;
       while ((doc = disi.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
-        counts[fc.getOrd(doc) + 1]++;
+        final int segOrd = fc.getOrd(doc);
+        if (segOrd >= 0) {
+          final int maxIdx = disi.registerCounts(segCounter);
+          segCounter.incrementCount(segOrd, 1, maxIdx);
+        }
       }
     } else {
       while ((doc = disi.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
         if (singleDv.advanceExact(doc)) {
-          counts[singleDv.ordValue() + 1]++;
+          final int segOrd = singleDv.ordValue();
+          if (segOrd >= 0) {
+            final int maxIdx = disi.registerCounts(segCounter);
+            segCounter.incrementCount(segOrd, 1, maxIdx);
+          }
         }
       }
     }
 
     // convert segment-local counts to global counts
-    for (int i=1; i<segMax; i++) {
-      int segCount = counts[i];
-      if (segCount > 0) {
-        int slot = toGlobal == null ? (i - 1) : (int) toGlobal.get(i - 1);
-        countAcc.incrementCount(slot, segCount);
-      }
-    }
+    segCounter.register(disi.countAccs, toGlobal, segMax - 1);
   }
 
-  private void collectPerSeg(SortedSetDocValues multiDv, DocIdSetIterator disi, LongValues toGlobal) throws IOException {
+  private SegCountPerSeg getSegCountPerSeg(SweepDISI disi, int segMax) {
+    return new SegCountPerSeg(this, segMax, disi.size);
+  }
+
+  private SegCountGlobal getSegCountGlobal(SweepDISI disi, SortedDocValues dv) {
+    return new SegCountGlobal(disi.countAccs);
+  }
+
+  private SegCountGlobal getSegCountGlobal(SweepDISI disi, SortedSetDocValues dv) {
+    return new SegCountGlobal(disi.countAccs);
+  }
+
+  private void collectPerSeg(SortedSetDocValues multiDv, SweepDISI disi, LongValues toGlobal) throws IOException {
     int segMax = (int)multiDv.getValueCount();
-    final int[] counts = getCountArr( segMax );
+    final SegCountPerSeg segCounter = getSegCountPerSeg(disi, segMax);
 
     int doc;
     while ((doc = disi.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
       if (multiDv.advanceExact(doc)) {
-        for(;;) {
+        final int maxIdx = disi.registerCounts(segCounter);
+        for (;;) {
           int segOrd = (int)multiDv.nextOrd();
           if (segOrd < 0) break;
-          counts[segOrd]++;
+          segCounter.incrementCount(segOrd, 1, maxIdx);
         }
       }
     }
 
-    for (int i=0; i<segMax; i++) {
-      int segCount = counts[i];
-      if (segCount > 0) {
-        int slot = toGlobal == null ? (i) : (int) toGlobal.get(i);
-        countAcc.incrementCount(slot, segCount);
-      }
-    }
+    segCounter.register(disi.countAccs, toGlobal, segMax - 1);
   }
 
-  private int[] reuse;
-  private int[] getCountArr(int maxNeeded) {
-    if (reuse == null) {
+  private boolean[] reuseBool;
+  private boolean[] getBoolArr(int maxNeeded) {
+    if (reuseBool == null) {
       // make the count array large enough for any segment
       // FUTURE: (optionally) directly use the array of the CountAcc for an optimized index..
-      reuse = new int[(int) si.getValueCount() + 1];
+      reuseBool = new boolean[(int) si.getValueCount() + 1];
     } else {
-      Arrays.fill(reuse, 0, maxNeeded, 0);
+      Arrays.fill(reuseBool, 0, maxNeeded, false);
     }
-    return reuse;
+    return reuseBool;
   }
 
-  private void collectDocs(SortedDocValues singleDv, DocIdSetIterator disi, LongValues toGlobal) throws IOException {
-    int doc;
-    while ((doc = disi.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
-      if (singleDv.advanceExact(doc)) {
-        int segOrd = singleDv.ordValue();
-        collect(doc, segOrd, toGlobal);
+  private int[][] reuse = new int[12][];
+  private int[] getCountArr(int maxNeeded, int idx) {
+    if (idx >= reuse.length) {
+      reuse = Arrays.copyOf(reuse, idx + 1);
+    }
+    if (reuse[idx] == null) {
+      // make the count array large enough for any segment
+      // FUTURE: (optionally) directly use the array of the CountAcc for an optimized index..
+      reuse[idx] = new int[(int) si.getValueCount() + 1];
+    } else {
+      Arrays.fill(reuse[idx], 0, maxNeeded, 0);
+    }
+    return reuse[idx];
+  }
+
+  private int[][] getSegmentCountArrays(int segMax, int size) {
+    int[][] ret = new int[size][];
+    int i = size - 1;
+    do {
+      ret[i] = getCountArr(segMax, i);
+    } while (i-- > 0);
+    return ret;
+  }
+
+  static interface SegCounter {
+    void map(int allIdx, int activeIdx);
+  }
+
+  static class SegCountGlobal implements SegCounter {
+    private final CountSlotAcc[] allCounts;
+    private final CountSlotAcc[] activeCounts;
+
+    public SegCountGlobal(CountSlotAcc[] allCounts) {
+      this.allCounts = allCounts;
+      this.activeCounts = Arrays.copyOf(allCounts, allCounts.length);
+    }
+
+    @Override
+    public void map(int allIdx, int activeIdx) {
+      activeCounts[activeIdx] = allCounts[allIdx];
+    }
+
+    public final void incrementCount(int segOrd, int globalOrd, int inc, int maxIdx) {
+      int i = maxIdx;
+      do {
+        incrementIdxCount(i, segOrd, globalOrd, inc);
+      } while (i-- > 0);
+    }
+
+    protected void incrementIdxCount(int idx, int segOrd, int globalOrd, int inc) {
+      activeCounts[idx].incrementCount(globalOrd, inc);
+    }
+  }
+
+  static class SegCountPerSeg implements SegCounter {
+    protected final int[][] allSegCounts;
+    private final int[][] activeSegCounts;
+    private final boolean[] seen;
+
+    public SegCountPerSeg(FacetFieldProcessorByArrayDV parent, int segMax, int size) {
+      this.allSegCounts = parent.getSegmentCountArrays(segMax, size);
+      this.activeSegCounts = Arrays.copyOf(this.allSegCounts, size);
+      this.seen = parent.getBoolArr(segMax);
+    }
+
+    @Override
+    public final void map(int allIdx, int activeIdx) {
+      activeSegCounts[activeIdx] = allSegCounts[allIdx];
+    }
+
+    public final void incrementCount(int segOrd, int inc, int maxIdx) {
+      seen[segOrd] = true;
+      int i = maxIdx;
+      do {
+        activeSegCounts[i][segOrd] += inc;
+      } while (i-- > 0);
+    }
+
+    public void register(CountSlotAcc[] countAccs, LongValues toGlobal, int maxSegOrd) {
+      int segOrd = maxSegOrd;
+      final int maxIdx = countAccs.length - 1;
+      for (;;) {
+        if (seen[segOrd]) {
+          int i = maxIdx;
+          int slot = toGlobal == null ? segOrd : (int)toGlobal.get(segOrd);
+          do {
+            final int inc = allSegCounts[i][segOrd];
+            if (inc > 0) {
+              countAccs[i].incrementCount(slot, inc);
+            }
+          } while (i-- > 0);
+        }
+        if (--segOrd < 0) {
+          break;
+        }
       }
     }
   }
 
-  private void collectCounts(SortedDocValues singleDv, DocIdSetIterator disi, LongValues toGlobal) throws IOException {
+  private void collectDocs(SortedDocValues singleDv, SweepDISI disi, LongValues toGlobal) throws IOException {
+    int doc;
+    final SegCountGlobal segCounter = getSegCountGlobal(disi, singleDv);
+    while ((doc = disi.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+      if (singleDv.advanceExact(doc)) {
+        final int maxIdx = disi.registerCounts(segCounter);
+        int segOrd = singleDv.ordValue();
+        collect(doc, segOrd, toGlobal, segCounter, maxIdx);
+      }
+    }
+  }
+
+  private void collectCounts(SortedDocValues singleDv, SweepDISI disi, LongValues toGlobal) throws IOException {
+    final SegCountGlobal segCounter = getSegCountGlobal(disi, singleDv);
     int doc;
     if (singleDv instanceof FieldCacheImpl.SortedDocValuesImpl.Iter) {
 
@@ -277,7 +416,8 @@ class FacetFieldProcessorByArrayDV extends FacetFieldProcessorByArray {
         int segOrd = fc.getOrd(doc);
         if (segOrd < 0) continue;
         int ord = (int)toGlobal.get(segOrd);
-        countAcc.incrementCount(ord, 1);
+        int maxIdx = disi.registerCounts(segCounter);
+        segCounter.incrementCount(segOrd, ord, 1, maxIdx);
       }
 
     } else {
@@ -286,48 +426,52 @@ class FacetFieldProcessorByArrayDV extends FacetFieldProcessorByArray {
         if (singleDv.advanceExact(doc)) {
           int segOrd = singleDv.ordValue();
           int ord = (int) toGlobal.get(segOrd);
-          countAcc.incrementCount(ord, 1);
+          int maxIdx = disi.registerCounts(segCounter);
+          segCounter.incrementCount(segOrd, ord, 1, maxIdx);
         }
       }
-
     }
   }
 
-  private void collectDocs(SortedSetDocValues multiDv, DocIdSetIterator disi, LongValues toGlobal) throws IOException {
+  private void collectDocs(SortedSetDocValues multiDv, SweepDISI disi, LongValues toGlobal) throws IOException {
+    final SegCountGlobal segCounter = getSegCountGlobal(disi, multiDv);
     int doc;
     while ((doc = disi.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
       if (multiDv.advanceExact(doc)) {
+        final int maxIdx = disi.registerCounts(segCounter);
         for(;;) {
           int segOrd = (int)multiDv.nextOrd();
           if (segOrd < 0) break;
-          collect(doc, segOrd, toGlobal);
+          collect(doc, segOrd, toGlobal, segCounter, maxIdx);
         }
       }
     }
   }
 
-  private void collectCounts(SortedSetDocValues multiDv, DocIdSetIterator disi, LongValues toGlobal) throws IOException {
+  private void collectCounts(SortedSetDocValues multiDv, SweepDISI disi, LongValues toGlobal) throws IOException {
+    final SegCountGlobal segCounter = getSegCountGlobal(disi, multiDv);
     int doc;
     while ((doc = disi.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
       if (multiDv.advanceExact(doc)) {
+        final int maxIdx = disi.registerCounts(segCounter);
         for(;;) {
           int segOrd = (int)multiDv.nextOrd();
           if (segOrd < 0) break;
           int ord = (int)toGlobal.get(segOrd);
-          countAcc.incrementCount(ord, 1);
+          segCounter.incrementCount(segOrd, ord, 1, maxIdx);
         }
       }
     }
   }
 
-  private void collect(int doc, int segOrd, LongValues toGlobal) throws IOException {
+  private void collect(int doc, int segOrd, LongValues toGlobal, SegCountGlobal segCounter, int maxIdx) throws IOException {
     int ord = (toGlobal != null && segOrd >= 0) ? (int)toGlobal.get(segOrd) : segOrd;
 
     int arrIdx = ord - startTermIndex;
     // This code handles faceting prefixes, which narrows the range of ords we want to collect.
     // It’s not an error for an ord to fall outside this range… we simply want to skip it.
     if (arrIdx >= 0 && arrIdx < nTerms) {
-      countAcc.incrementCount(arrIdx, 1);
+      segCounter.incrementCount(segOrd, arrIdx, 1, maxIdx);
       if (collectAcc != null) {
         collectAcc.collect(doc, arrIdx, slotContext);
       }

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetFieldProcessorByHashDV.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetFieldProcessorByHashDV.java
@@ -247,7 +247,7 @@ class FacetFieldProcessorByHashDV extends FacetFieldProcessor {
 
     collectDocs();
 
-    return super.findTopSlots(table.numSlots(), table.cardinality(),
+    return super.findTopSlots(table.numSlots(), table.cardinality(), -1,
         slotNum -> calc.bitsToValue(table.vals[slotNum]), // getBucketValFromSlotNum
         val -> calc.formatValue(val)); // getFieldQueryVal
   }

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetModule.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetModule.java
@@ -22,6 +22,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.lucene.search.Query;
 
 import org.apache.solr.client.solrj.SolrResponse;
 import org.apache.solr.common.SolrException;
@@ -117,6 +118,19 @@ public class FacetModule extends SearchComponent {
   }
 
 
+  public static Query[] getBaseFilters(ResponseBuilder rb) {
+    final Query mainQ = rb.getQuery();
+    final List<Query> filters = rb.getFilters();
+    if (filters == null) {
+      return new Query[]{mainQ};
+    } else {
+      int lastIdx = filters.size();
+      Query[] ret = filters.toArray(new Query[lastIdx + 1]);
+      ret[lastIdx] = mainQ;
+      return ret;
+    }
+  }
+
   @Override
   public void process(ResponseBuilder rb) throws IOException {
     // if this is null, faceting is not enabled
@@ -127,6 +141,7 @@ public class FacetModule extends SearchComponent {
 
     FacetContext fcontext = new FacetContext();
     fcontext.base = rb.getResults().docSet;
+    fcontext.baseFilters = getBaseFilters(rb);
     fcontext.req = rb.req;
     fcontext.searcher = rb.req.getSearcher();
     fcontext.qcontext = QueryContext.newContext(fcontext.searcher);

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetRequest.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetRequest.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.lucene.search.Query;
+import org.apache.lucene.util.ArrayUtil;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.FacetParams;
 import org.apache.solr.common.params.SolrParams;
@@ -394,12 +395,13 @@ public abstract class FacetRequest {
    * Process this facet request against the given domain of docs.
    * Note: this is currently used externally by {@link org.apache.solr.request.SimpleFacets}.
    */
-  public final Object process(SolrQueryRequest req, DocSet domain) throws IOException {
+  public final Object process(SolrQueryRequest req, Query[] baseFilters, DocSet domain) throws IOException {
     //TODO check for FacetDebugInfo?  and if so set on fcontext
     //  rb.req.getContext().get("FacetDebugInfo");
     //TODO should the SolrQueryRequest be held on the FacetRequest?  It was created from parse(req,...) so is known.
     FacetContext fcontext = new FacetContext();
     fcontext.base = domain;
+    fcontext.baseFilters = baseFilters;
     fcontext.req = req;
     fcontext.searcher = req.getSearcher();
     fcontext.qcontext = QueryContext.newContext(fcontext.searcher);
@@ -452,6 +454,7 @@ class FacetContext {
   SolrQueryRequest req;  // TODO: replace with params?
   SolrIndexSearcher searcher;
   Query filter;  // TODO: keep track of as a DocSet or as a Query?
+  Query[] baseFilters;
   DocSet base;
   FacetContext parent;
   int flags;
@@ -469,6 +472,29 @@ class FacetContext {
     return (flags & IS_SHARD) != 0;
   }
 
+  static Query[] append(Query[] base, Query append) {
+    if (append == null) {
+      return base;
+    } else if (base == null) {
+      return new Query[]{append};
+    }
+    Query[] ret = ArrayUtil.growExact(base, base.length + 1);
+    ret[base.length] = append;
+    return ret;
+  }
+
+  static Query[] append(Query[] base, List<Query> append) {
+    if (append == null || append.isEmpty()) {
+      return base;
+    } else if (base == null) {
+      return append.toArray(new Query[append.size()]);
+    }
+    Query[] ret = new Query[append.size() + base.length];
+    append.toArray(ret);
+    System.arraycopy(base, 0, ret, append.size(), base.length);
+    return ret;
+  }
+
   /**
    * @param filter The filter for the bucket that resulted in this context/domain.  Can be null if this is the root context.
    * @param domain The resulting set of documents for this facet.
@@ -477,6 +503,7 @@ class FacetContext {
     FacetContext ctx = new FacetContext();
     ctx.parent = this;
     ctx.base = domain;
+    ctx.baseFilters = append(baseFilters, filter);
     ctx.filter = filter;
 
     // carry over from parent
@@ -990,6 +1017,7 @@ class FacetFieldParser extends FacetParser<FacetField> {
       facet.allBuckets = getBoolean(m, "allBuckets", facet.allBuckets);
       facet.method = FacetField.FacetMethod.fromString(getString(m, "method", null));
       facet.cacheDf = (int)getLong(m, "cacheDf", facet.cacheDf);
+      facet.countCacheDf = (int)getLong(m, "countCacheDf", facet.countCacheDf);
 
       // TODO: pull up to higher level?
       facet.refine = FacetField.RefineMethod.fromObj(m.get("refine"));

--- a/solr/core/src/java/org/apache/solr/search/facet/ReadOnlyCountSlotAcc.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/ReadOnlyCountSlotAcc.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.search.facet;
+
+import java.io.IOException;
+import java.util.function.IntFunction;
+
+abstract class ReadOnlyCountSlotAcc extends CountSlotAcc {
+
+  ReadOnlyCountSlotAcc(FacetContext fcontext) {
+    super(fcontext);
+  }
+
+  @Override
+  public final void incrementCount(int slot, int increment) {
+    throw new UnsupportedOperationException("Not supported.");
+  }
+
+  @Override
+  public void collect(int doc, int slot, IntFunction<SlotContext> slotContext) throws IOException {
+    throw new UnsupportedOperationException("Not supported.");
+  }
+
+  @Override
+  public final void reset() throws IOException {
+    throw new UnsupportedOperationException("Not supported.");
+  }
+
+  @Override
+  public final void resize(Resizer resizer) {
+    throw new UnsupportedOperationException("Not supported.");
+  }
+
+}

--- a/solr/core/src/java/org/apache/solr/search/facet/ReadOnlyCountSlotAccWrapper.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/ReadOnlyCountSlotAccWrapper.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.search.facet;
+
+import java.io.IOException;
+
+final class ReadOnlyCountSlotAccWrapper extends ReadOnlyCountSlotAcc {
+
+  private final CountSlotAcc backing;
+
+  ReadOnlyCountSlotAccWrapper(FacetContext fcontext, CountSlotAcc backing) {
+    super(fcontext);
+    this.backing = backing;
+  }
+
+  @Override
+  public int getCount(int slot) {
+    return backing.getCount(slot);
+  }
+
+  @Override
+  public int compare(int slotA, int slotB) {
+    return backing.compare(slotA, slotB);
+  }
+
+  @Override
+  public Object getValue(int slotNum) throws IOException {
+    return backing.getValue(slotNum);
+  }
+}

--- a/solr/core/src/java/org/apache/solr/search/facet/RelatednessAgg.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/RelatednessAgg.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
@@ -42,6 +43,7 @@ import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
 import org.apache.solr.search.DocSet;
 import org.apache.solr.search.QParser;
+import org.apache.solr.search.QueryResultKey;
 import org.apache.solr.search.WrappedQuery;
 import org.apache.solr.search.facet.FacetFieldProcessor.SweepAcc;
 
@@ -184,8 +186,8 @@ public class RelatednessAgg extends AggValueSource {
 
       final FacetFieldProcessor ffp = (FacetFieldProcessor) fcontext.processor;
       return new SweepSKGSlotAcc(min_pop, fcontext, numSlots, fgSet.size(), bgSet.size(),
-          ffp.getSweepCountAcc(fgSet, numSlots),
-          ffp.getSweepCountAcc(bgSet, numSlots));
+          ffp.getSweepCountAcc(new QueryResultKey(null, fgFilters, null, 0), fgSet, numSlots),
+          ffp.getSweepCountAcc(new QueryResultKey(null, Collections.singletonList(bgQ), null, 0), bgSet, numSlots));
     } else {
       return new SKGSlotAcc(this, fcontext, numSlots, fgSet, bgSet);
     }

--- a/solr/core/src/java/org/apache/solr/search/facet/RelatednessAgg.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/RelatednessAgg.java
@@ -20,14 +20,20 @@ import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Map;
 import java.util.function.IntFunction;
+import org.apache.lucene.index.LeafReader;
 
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.queries.function.FunctionValues;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.util.BytesRef;
 
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.ShardParams;
@@ -36,6 +42,8 @@ import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
 import org.apache.solr.search.DocSet;
 import org.apache.solr.search.QParser;
+import org.apache.solr.search.WrappedQuery;
+import org.apache.solr.search.facet.FacetFieldProcessor.SweepAcc;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,6 +64,7 @@ public class RelatednessAgg extends AggValueSource {
   private static final String RELATEDNESS = "relatedness";
   private static final String FG_POP = "foreground_popularity";
   private static final String BG_POP = "background_popularity";
+  private static final String DISABLE_SWEEP_COLLECTION = "disable_sweep_collection";
 
   // needed for distrib calculation
   private static final String FG_SIZE = "foreground_size";
@@ -66,6 +75,7 @@ public class RelatednessAgg extends AggValueSource {
   final protected Query fgQ;
   final protected Query bgQ;
   protected double min_pop = 0.0D;
+  private boolean disableSweepCollection = false;
   
   public static final String NAME = RELATEDNESS;
   public RelatednessAgg(Query fgQ, Query bgQ) {
@@ -88,6 +98,7 @@ public class RelatednessAgg extends AggValueSource {
     final boolean isShard = parser.getReq().getParams().getBool(ShardParams.IS_SHARD, false);
     SolrParams opts = parser.getLocalParams();
     if (null != opts) {
+      this.disableSweepCollection = opts.getBool(DISABLE_SWEEP_COLLECTION, false);
       if (!isShard) { // ignore min_pop if this is a shard request
         this.min_pop = opts.getDouble("min_popularity", 0.0D);
       }
@@ -155,7 +166,29 @@ public class RelatednessAgg extends AggValueSource {
     
     DocSet fgSet = fcontext.searcher.getDocSet(fgFilters);
     DocSet bgSet = fcontext.searcher.getDocSet(bgQ);
-    return new SKGSlotAcc(this, fcontext, numSlots, fgSet, bgSet);
+    if (numSlots > 1 && fcontext.processor instanceof FacetFieldProcessorByArray && !disableSweepCollection) {
+      // Sweep counts are only relevant where relatedness is required for primary sort, and thus must be calculated
+      // for *all* buckets (numSlots > 1).
+      //
+      // Of the four concrete implementations of FacetFieldProcessor (FacetFieldProcessorByArrayDV,
+      // FacetFieldProcessorByArrayUIF, FacetFieldProcessorByEnumTermsStream, and FacetFieldProcessorByHashDV)
+      // only the first two (each a subclass of FacetFieldProcessorByArray) are supported.
+      //
+      // Because FacetFieldProcessorByEnumTermsStream is sorted strictly in "index" order, numSlots here would
+      // never be >1, so combination with SweepSKGSlotAcc would be meaningless, and is not supported.
+      //
+      // FacetFieldProcessorByHashDV *is* used in high-cardinality field contexts; however, it is only beneficial
+      // when *domain* cardinality is low. Because sweep collection effectively induces a composite domain that is
+      // a union with the background set (which is normally high-cardinality), combination with SweepSKGSlotAcc
+      // would in most cases be an antipattern, and is not currently supported.
+
+      final FacetFieldProcessor ffp = (FacetFieldProcessor) fcontext.processor;
+      return new SweepSKGSlotAcc(min_pop, fcontext, numSlots, fgSet.size(), bgSet.size(),
+          ffp.getSweepCountAcc(fgSet, numSlots),
+          ffp.getSweepCountAcc(bgSet, numSlots));
+    } else {
+      return new SKGSlotAcc(this, fcontext, numSlots, fgSet, bgSet);
+    }
   }
 
   @Override
@@ -163,6 +196,88 @@ public class RelatednessAgg extends AggValueSource {
     return new Merger(this);
   }
   
+  private static final class SweepSKGSlotAcc extends SlotAcc implements SweepAcc {
+
+    private final int minCount; // pre-calculate for a given min_popularity
+    private final int fgSize;
+    private final int bgSize;
+    private final CountSlotAcc fgCount;
+    private final CountSlotAcc bgCount;
+    private double[] relatedness;
+
+    public SweepSKGSlotAcc(double minPopularity, FacetContext fcontext, int numSlots, int fgSize, int bgSize, CountSlotAcc fgCount, CountSlotAcc bgCount) {
+      super(fcontext);
+      this.minCount = (int) Math.ceil(minPopularity * bgSize);
+      this.fgSize = fgSize;
+      this.bgSize = bgSize;
+      this.fgCount = fgCount;
+      this.bgCount = bgCount;
+      relatedness = new double[numSlots];
+      Arrays.fill(relatedness, 0, numSlots, Double.NaN);
+    }
+
+    @Override
+    public void collect(int perSegDocId, int slot, IntFunction<SlotContext> slotContext) throws IOException {
+      //No-op
+    }
+
+    @Override
+    public int collect(DocSet docs, int slot, IntFunction<SlotContext> slotContext) throws IOException {
+      return docs.size();
+    }
+
+    private double getRelatedness(int slot) {
+      final double cachedRelatedness = relatedness[slot];
+      if (Double.isNaN(cachedRelatedness)) {
+        final int fg_count = fgCount.getCount(slot);
+        final int bg_count = bgCount.getCount(slot);
+        if (minCount > 0) {
+          // if min_pop is configured, and either (fg|bg) popularity is lower then that value
+          // then "this.relatedness=-Infinity" so it sorts below any "valid" relatedness scores
+          if (fg_count < minCount || bg_count < minCount) {
+            return relatedness[slot] = Double.NEGATIVE_INFINITY;
+          }
+        }
+        return relatedness[slot] = computeRelatedness(fg_count, fgSize, bg_count, bgSize);
+      } else {
+        return cachedRelatedness;
+      }
+    }
+
+    public int compare(int slotA, int slotB) {
+      int r = Double.compare(getRelatedness(slotA), getRelatedness(slotB));
+      if (0 == r) {
+        r = Long.compare(fgCount.getCount(slotA), fgCount.getCount(slotB));
+      }
+      if (0 == r) {
+        r = Long.compare(bgCount.getCount(slotA), bgCount.getCount(slotB));
+      }
+      return r;
+    }
+
+    @Override
+    public Object getValue(int slotNum) {
+      BucketData slotVal = new BucketData(fgCount.getCount(slotNum), fgSize, bgCount.getCount(slotNum), bgSize, getRelatedness(slotNum));
+      SimpleOrderedMap res = slotVal.externalize(fcontext.isShard());
+      return res;
+    }
+
+    @Override
+    public void reset() throws IOException {
+      Arrays.fill(relatedness, Double.NaN);
+    }
+
+    @Override
+    public void resize(Resizer resizer) {
+      relatedness = resizer.resize(relatedness, Double.NaN);
+    }
+
+    @Override
+    public void close() throws IOException {
+      relatedness = null;
+    }
+  }
+
   private static final class SKGSlotAcc extends SlotAcc {
     private final RelatednessAgg agg;
     private BucketData[] slotvalues;
@@ -182,6 +297,83 @@ public class RelatednessAgg extends AggValueSource {
       this.slotvalues = new BucketData[numSlots];
       reset();
     }
+
+    // XXXXXX temporary!
+    // The following (LEAF_BY_MAX_DOC, shouldCache(), and initializeForMinDf are for comparison with extant
+    // implementation with SOLR-13108 patch applied (use filterCache, but respect minDf)
+    // All these methods can/should be removed if/when sweep facet count collection is adopted (recommended)
+    private int minDfFilterCache = Integer.MIN_VALUE;
+    private WrappedQuery noCacheQ;
+    private static final Comparator<LeafReaderContext> LEAF_BY_MAX_DOC = new Comparator<LeafReaderContext>() {
+
+      @Override
+      public int compare(LeafReaderContext o1, LeafReaderContext o2) {
+        return Integer.compare(o2.reader().maxDoc(), o1.reader().maxDoc());
+      }
+    };
+    private static final int ALWAYS_CACHE = Integer.MIN_VALUE + 1;
+    private static final float SHORTCIRCUIT_THRESHOLD_ACCEPT_FACTOR = 0.5f;
+    private static final float SHORTCIRCUIT_THRESHOLD_REJECT_FACTOR = 2.0f;
+    private TermsEnum[] tes;
+    private int[] shortcircuitThresholdsAccept;
+    private int[] shortcircuitThresholdsReject;
+    private boolean shouldCache(BytesRef term) throws IOException {
+      int docFreq = 0;
+      for (int i = 0; i < tes.length; i++) {
+        TermsEnum te = tes[i];
+        if (te.seekExact(term) && ((docFreq += te.docFreq()) >= minDfFilterCache || docFreq >= shortcircuitThresholdsAccept[i])) {
+          return true;
+        } else if (docFreq < shortcircuitThresholdsReject[i]) {
+          return false;
+        }
+      }
+      return false;
+    }
+
+    /**
+     * Initialize for checking minDf, including shortcircuit thresholds. Set shortcircuit thresholds such that an
+     * assumption that a given term will occur at a frequency in unexamined segments at 
+     * <code>SHORTCIRCUIT_THRESHOLD_[ACCEPT|REJECT]_FACTOR</code> * the frequency in already-examined segments would
+     * result in the minDf threshold ultimately being met.
+     * @param field the field for which to initialize
+     * @throws IOException from underlying LeafReaders used to determine df for caching determination
+     */
+    private void initializeForMinDf(String field) throws IOException {
+      List<LeafReaderContext> leaves = fcontext.searcher.getIndexReader().leaves();
+      final int leafCount = leaves.size();
+      LeafReaderContext[] sortedLeaves = leaves.toArray(new LeafReaderContext[leafCount]);
+      Arrays.sort(sortedLeaves, LEAF_BY_MAX_DOC);
+      tes = new TermsEnum[leafCount];
+      shortcircuitThresholdsAccept = new int[leafCount];
+      shortcircuitThresholdsReject = new int[leafCount];
+      int i = 0;
+      int totalMaxDoc = 0;
+      for (LeafReaderContext ctx : sortedLeaves) {
+        LeafReader reader = ctx.reader();
+        Terms terms = reader.terms(field);
+        if (terms != null) {
+          int maxDoc = reader.maxDoc();
+          totalMaxDoc += maxDoc;
+          shortcircuitThresholdsAccept[i] = maxDoc;
+          tes[i++] = terms.iterator();
+        }
+      }
+      final int limit = i;
+      int maxDocToHere = 0;
+      for (i = 0; i < limit; i++) {
+        final int maxDoc = shortcircuitThresholdsAccept[i];
+        maxDocToHere += maxDoc;
+        final int maxDocRemaining = totalMaxDoc - maxDocToHere;
+        shortcircuitThresholdsAccept[i] = (int)((minDfFilterCache / (1 + ((maxDocRemaining * SHORTCIRCUIT_THRESHOLD_ACCEPT_FACTOR) / maxDocToHere))) + 1);
+        shortcircuitThresholdsReject[i] = (int)((minDfFilterCache / (1 + ((maxDocRemaining * SHORTCIRCUIT_THRESHOLD_REJECT_FACTOR) / maxDocToHere))) + 1);
+      }
+      if (i < leafCount) {
+        tes = Arrays.copyOf(tes, i);
+        shortcircuitThresholdsAccept = Arrays.copyOf(shortcircuitThresholdsAccept, i);
+        shortcircuitThresholdsReject = Arrays.copyOf(shortcircuitThresholdsReject, i);
+      }
+    }
+
     private void processSlot(int slot, IntFunction<SlotContext> slotContext) throws IOException {
       
       assert null != slotContext;
@@ -196,7 +388,44 @@ public class RelatednessAgg extends AggValueSource {
         assert null == fcontext.filter;
       }
       // ...and in which case we should just use the current base
-      final DocSet slotSet = null == slotQ ? fcontext.base : fcontext.searcher.getDocSet(slotQ);
+      final DocSet slotSet;
+      if (null == slotQ) {
+        slotSet = fcontext.base;
+      } else {
+        switch (minDfFilterCache) {
+          case ALWAYS_CACHE:
+            break;
+          case Integer.MIN_VALUE:
+            if (fcontext.processor.freq instanceof FacetField) {
+              FacetField ffield = (FacetField)fcontext.processor.freq;
+              noCacheQ = new WrappedQuery(null);
+              noCacheQ.setCache(false);
+              // Minimum term docFreq in order to use the filterCache for that term.
+              if (ffield.cacheDf == -1) { // -1 means never cache
+                minDfFilterCache = Integer.MAX_VALUE;
+                noCacheQ.setWrappedQuery(slotQ);
+                slotQ = noCacheQ;
+                break;
+              } else if (ffield.cacheDf == 0) { // default; compute as fraction of maxDoc
+                minDfFilterCache = Math.max(fcontext.searcher.maxDoc() >> 4, 3);  // (minimum of 3 is for test coverage purposes)
+              } else {
+                minDfFilterCache = ffield.cacheDf;
+              }
+              initializeForMinDf(ffield.field);
+            } else {
+              minDfFilterCache = ALWAYS_CACHE;
+              break;
+            }
+          default:
+            if (!(slotQ instanceof TermQuery) || shouldCache(((TermQuery)slotQ).getTerm().bytes())) {
+              break;
+            }
+          case Integer.MAX_VALUE:
+            noCacheQ.setWrappedQuery(slotQ);
+            slotQ = noCacheQ;
+        }
+        slotSet = fcontext.searcher.getDocSet(slotQ);
+      }
 
       final BucketData slotVal = new BucketData(agg);
       slotVal.incSizes(fgSize, bgSize);
@@ -204,7 +433,7 @@ public class RelatednessAgg extends AggValueSource {
                         bgSet.intersectionSize(slotSet));
       slotvalues[slot] = slotVal;
     }
-    
+
     @Override
     public void collect(int perSegDocId, int slot, IntFunction<SlotContext> slotContext) throws IOException {
       // NOTE: we don't actaully care about the individual docs being collected
@@ -305,6 +534,16 @@ public class RelatednessAgg extends AggValueSource {
     
     public BucketData(final RelatednessAgg agg) {
       this.agg = agg;
+    }
+
+    public BucketData(long fg_count, long fg_size, long bg_count, long bg_size, double relatedness) {
+      this.fg_count = fg_count;
+      this.fg_size = fg_size;
+      this.fg_pop = roundTo5Digits((double) fg_count / bg_size); // yes, BACKGROUND size is intentional
+      this.bg_count = bg_count;
+      this.bg_size = bg_size;
+      this.bg_pop = roundTo5Digits((double) bg_count / bg_size);
+      this.relatedness = relatedness;
     }
 
     /** 

--- a/solr/core/src/java/org/apache/solr/search/facet/SingletonDISI.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/SingletonDISI.java
@@ -18,21 +18,29 @@ package org.apache.solr.search.facet;
 
 import java.io.IOException;
 import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.solr.request.TermFacetCache.CacheUpdater;
 import org.apache.solr.search.facet.FacetFieldProcessorByArrayDV.SegCountGlobal;
 import org.apache.solr.search.facet.FacetFieldProcessorByArrayDV.SegCountPerSeg;
 
 final class SingletonDISI extends SweepDISI {
 
+  private final boolean isBase;
   private final DocIdSetIterator backing;
 
-  SingletonDISI(DocIdSetIterator backing, CountSlotAcc[] countAccs) {
-    super(1, countAccs);
+  SingletonDISI(DocIdSetIterator backing, CountSlotAcc[] countAccs, CacheUpdater[] cacheUpdaters, boolean isBase) {
+    super(1, countAccs, cacheUpdaters);
+    this.isBase = isBase;
     this.backing = backing;
   }
 
   @Override
   public int nextDoc() throws IOException {
     return backing.nextDoc();
+  }
+
+  @Override
+  public boolean collectBase() {
+    return isBase;
   }
 
   @Override

--- a/solr/core/src/java/org/apache/solr/search/facet/SingletonDISI.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/SingletonDISI.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.search.facet;
+
+import java.io.IOException;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.solr.search.facet.FacetFieldProcessorByArrayDV.SegCountGlobal;
+import org.apache.solr.search.facet.FacetFieldProcessorByArrayDV.SegCountPerSeg;
+
+final class SingletonDISI extends SweepDISI {
+
+  private final DocIdSetIterator backing;
+
+  SingletonDISI(DocIdSetIterator backing, CountSlotAcc[] countAccs) {
+    super(1, countAccs);
+    this.backing = backing;
+  }
+
+  @Override
+  public int nextDoc() throws IOException {
+    return backing.nextDoc();
+  }
+
+  @Override
+  public int registerCounts(SegCountGlobal segCounter) {
+    return 0;
+  }
+
+  @Override
+  public int registerCounts(SegCountPerSeg segCounter) {
+    return 0;
+  }
+
+}

--- a/solr/core/src/java/org/apache/solr/search/facet/SingletonDocIterator.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/SingletonDocIterator.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.search.facet;
+
+import org.apache.solr.search.DocIterator;
+import org.apache.solr.search.facet.FacetFieldProcessorByArrayDV.SegCountGlobal;
+import org.apache.solr.search.facet.FacetFieldProcessorByArrayDV.SegCountPerSeg;
+
+final class SingletonDocIterator extends SweepDocIterator {
+
+  private final DocIterator backing;
+
+  SingletonDocIterator(DocIterator backing) {
+    super(1);
+    this.backing = backing;
+  }
+
+  @Override
+  public boolean hasNext() {
+    return backing.hasNext();
+  }
+
+  @Override
+  public int nextDoc() {
+    return backing.nextDoc();
+  }
+
+  @Override
+  public int registerCounts(SegCountGlobal segCounts) {
+    return 0;
+  }
+
+  @Override
+  public int registerCounts(SegCountPerSeg segCounts) {
+    return 0;
+  }
+
+}

--- a/solr/core/src/java/org/apache/solr/search/facet/SingletonDocIterator.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/SingletonDocIterator.java
@@ -23,10 +23,12 @@ import org.apache.solr.search.facet.FacetFieldProcessorByArrayDV.SegCountPerSeg;
 final class SingletonDocIterator extends SweepDocIterator {
 
   private final DocIterator backing;
+  private final boolean isBase;
 
-  SingletonDocIterator(DocIterator backing) {
+  SingletonDocIterator(DocIterator backing, boolean isBase) {
     super(1);
     this.backing = backing;
+    this.isBase = isBase;
   }
 
   @Override
@@ -37,6 +39,11 @@ final class SingletonDocIterator extends SweepDocIterator {
   @Override
   public int nextDoc() {
     return backing.nextDoc();
+  }
+
+  @Override
+  public boolean collectBase() {
+    return isBase;
   }
 
   @Override

--- a/solr/core/src/java/org/apache/solr/search/facet/SweepCountAware.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/SweepCountAware.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.search.facet;
+
+import java.io.IOException;
+import org.apache.solr.search.facet.FacetFieldProcessorByArrayDV.SegCountGlobal;
+import org.apache.solr.search.facet.FacetFieldProcessorByArrayDV.SegCountPerSeg;
+
+interface SweepCountAware {
+
+  int registerCounts(SegCountGlobal segCounts) throws IOException;
+
+  int registerCounts(SegCountPerSeg segCounts) throws IOException;
+
+}

--- a/solr/core/src/java/org/apache/solr/search/facet/SweepCountAware.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/SweepCountAware.java
@@ -22,6 +22,8 @@ import org.apache.solr.search.facet.FacetFieldProcessorByArrayDV.SegCountPerSeg;
 
 interface SweepCountAware {
 
+  boolean collectBase();
+
   int registerCounts(SegCountGlobal segCounts) throws IOException;
 
   int registerCounts(SegCountPerSeg segCounts) throws IOException;

--- a/solr/core/src/java/org/apache/solr/search/facet/SweepDISI.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/SweepDISI.java
@@ -18,15 +18,18 @@ package org.apache.solr.search.facet;
 
 import java.io.IOException;
 import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.solr.request.TermFacetCache.CacheUpdater;
 
 public abstract class SweepDISI extends DocIdSetIterator implements SweepCountAware {
 
   public final int size;
   final CountSlotAcc[] countAccs;
+  final CacheUpdater[] cacheUpdaters;
 
-  public SweepDISI(int size, CountSlotAcc[] countAccs) {
+  public SweepDISI(int size, CountSlotAcc[] countAccs, CacheUpdater[] cacheUpdaters) {
     this.size = size;
     this.countAccs = countAccs;
+    this.cacheUpdaters = cacheUpdaters;
   }
 
   @Override

--- a/solr/core/src/java/org/apache/solr/search/facet/SweepDISI.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/SweepDISI.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.search.facet;
+
+import java.io.IOException;
+import org.apache.lucene.search.DocIdSetIterator;
+
+public abstract class SweepDISI extends DocIdSetIterator implements SweepCountAware {
+
+  public final int size;
+  final CountSlotAcc[] countAccs;
+
+  public SweepDISI(int size, CountSlotAcc[] countAccs) {
+    this.size = size;
+    this.countAccs = countAccs;
+  }
+
+  @Override
+  public int docID() {
+    throw new UnsupportedOperationException("Not supported.");
+  }
+
+  @Override
+  public int advance(int target) throws IOException {
+    throw new UnsupportedOperationException("Not supported.");
+  }
+
+  @Override
+  public long cost() {
+    throw new UnsupportedOperationException("Not supported.");
+  }
+
+}

--- a/solr/core/src/java/org/apache/solr/search/facet/SweepDocIterator.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/SweepDocIterator.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.search.facet;
+
+import org.apache.solr.search.DocIterator;
+import org.apache.solr.search.facet.FacetFieldProcessorByArrayDV.SegCountGlobal;
+import org.apache.solr.search.facet.FacetFieldProcessorByArrayDV.SegCountPerSeg;
+
+abstract class SweepDocIterator implements DocIterator, SweepCountAware {
+
+  public final int size;
+
+  public SweepDocIterator(int size) {
+    this.size = size;
+  }
+
+  @Override
+  public float score() {
+    throw new UnsupportedOperationException("Not supported.");
+  }
+
+  @Override
+  public Integer next() {
+    throw new UnsupportedOperationException("Not supported.");
+  }
+
+  @Override
+  public abstract int registerCounts(SegCountGlobal segCounts); // override to not throw IOException
+
+  @Override
+  public abstract int registerCounts(SegCountPerSeg segCounts); // override to not throw IOException
+
+}

--- a/solr/core/src/java/org/apache/solr/search/facet/UnionDISI.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/UnionDISI.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.search.facet;
+
+import java.io.IOException;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.util.PriorityQueue;
+import org.apache.solr.search.facet.FacetFieldProcessorByArrayDV.SegCountGlobal;
+import org.apache.solr.search.facet.FacetFieldProcessorByArrayDV.SegCountPerSeg;
+
+final class UnionDISI extends SweepDISI {
+
+  final int maxIdx;
+  private final PriorityQueue<SubIterStruct> queue;
+  private SubIterStruct top;
+  private int docId = -1;
+
+  private static final class SubIterStruct {
+    private final DocIdSetIterator sub;
+    private final int index;
+    private int docId;
+    public SubIterStruct(DocIdSetIterator sub, int index) throws IOException {
+      this.sub = sub;
+      this.index = index;
+      nextDoc();
+    }
+    public void nextDoc() throws IOException {
+      docId = sub.nextDoc();
+    }
+  }
+  UnionDISI(DocIdSetIterator[] subIterators, CountSlotAcc[] countAccs, int size) throws IOException {
+    super(size, countAccs);
+    this.maxIdx = size - 1;
+    queue = new PriorityQueue<SubIterStruct>(size) {
+      @Override
+      protected boolean lessThan(SubIterStruct a, SubIterStruct b) {
+        return a.docId < b.docId;
+      }
+    };
+    int i = maxIdx;
+    do {
+      queue.add(new SubIterStruct(subIterators[i], i));
+    } while (i-- > 0);
+    top = queue.top();
+  }
+
+  @Override
+  public int nextDoc() throws IOException {
+    if (top.docId == docId) {
+      do {
+        top.nextDoc();
+      } while ((top = queue.updateTop()).docId == docId);
+    }
+    return docId = top.docId;
+  }
+
+  @Override
+  public int registerCounts(SegCountGlobal segCounter) throws IOException {
+    int i = -1;
+    do {
+      segCounter.map(top.index, ++i);
+      top.nextDoc();
+    } while ((top = queue.updateTop()).docId == docId);
+    return i;
+  }
+
+  @Override
+  public int registerCounts(SegCountPerSeg segCounter) throws IOException {
+    int i = -1;
+    do {
+      segCounter.map(top.index, ++i);
+      top.nextDoc();
+    } while ((top = queue.updateTop()).docId == docId);
+    return i;
+  }
+
+}

--- a/solr/core/src/java/org/apache/solr/search/facet/UnionDocIterator.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/UnionDocIterator.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.search.facet;
+
+import java.io.IOException;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.solr.search.DocIterator;
+import org.apache.lucene.util.PriorityQueue;
+import org.apache.solr.search.facet.FacetFieldProcessorByArrayDV.SegCountGlobal;
+import org.apache.solr.search.facet.FacetFieldProcessorByArrayDV.SegCountPerSeg;
+
+final class UnionDocIterator extends SweepDocIterator {
+
+  private final int maxIdx;
+  private final PriorityQueue<SubIterStruct> queue;
+  private SubIterStruct top;
+  private int docId = -1;
+
+  private static final class SubIterStruct {
+    private final DocIterator sub;
+    private final int index;
+    private int docId;
+    public SubIterStruct(DocIterator sub, int index) throws IOException {
+      this.sub = sub;
+      this.index = index;
+      nextDoc();
+    }
+    public void nextDoc() {
+      docId = sub.hasNext() ? sub.nextDoc() : DocIdSetIterator.NO_MORE_DOCS;
+    }
+  }
+  UnionDocIterator(DocIterator[] subIterators) throws IOException {
+    super(subIterators.length);
+    this.maxIdx = size - 1;
+    queue = new PriorityQueue<SubIterStruct>(size) {
+      @Override
+      protected boolean lessThan(SubIterStruct a, SubIterStruct b) {
+        return a.docId < b.docId;
+      }
+    };
+    int i = maxIdx;
+    do {
+      queue.add(new SubIterStruct(subIterators[i], i));
+    } while (i-- > 0);
+    top = queue.top();
+  }
+
+  @Override
+  public int nextDoc() {
+    if (top.docId == docId) {
+      do {
+        top.nextDoc();
+      } while ((top = queue.updateTop()).docId == docId);
+    }
+    return docId = top.docId;
+  }
+
+  @Override
+  public boolean hasNext() {
+    if (top.docId == docId) {
+      do {
+        top.nextDoc();
+      } while ((top = queue.updateTop()).docId == docId);
+    }
+    return top.docId != DocIdSetIterator.NO_MORE_DOCS;
+  }
+
+  @Override
+  public int registerCounts(SegCountGlobal segCounts) {
+    int i = -1;
+    do {
+      segCounts.map(top.index, ++i);
+      top.nextDoc();
+    } while ((top = queue.updateTop()).docId == docId);
+    return i;
+  }
+
+  @Override
+  public int registerCounts(SegCountPerSeg segCounts) {
+    int i = -1;
+    do {
+      segCounts.map(top.index, ++i);
+      top.nextDoc();
+    } while ((top = queue.updateTop()).docId == docId);
+    return i;
+  }
+
+}

--- a/solr/core/src/test-files/solr/collection1/conf/schema_latest.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/schema_latest.xml
@@ -295,6 +295,10 @@
   <field name="signatureField" type="string" indexed="true" stored="false"/>
   <dynamicField name="*_sS" type="string" indexed="false" stored="true"/>
 
+
+  <!-- Indexed and uninvertible, but NOT docValues -->
+  <field name="where_s_multi_uninvert" type="string" indexed="true" stored="false" docValues="false" uninvertible="true" multiValued="true" />
+  <field name="where_s_single_uninvert" type="string" indexed="true" stored="false" docValues="false" uninvertible="true" multiValued="false" />
   <!-- Indexed, but NOT uninvertible -->
   <field name="where_s_multi_not_uninvert" type="string" indexed="true" stored="false" docValues="false" uninvertible="false" multiValued="true" />
   <field name="where_s_single_not_uninvert" type="string" indexed="true" stored="false" docValues="false" uninvertible="false" multiValued="false" />
@@ -334,6 +338,8 @@
   <!-- Create a string version of author for faceting -->
   <copyField source="author" dest="author_s"/>
   
+  <copyField source="where_s" dest="where_s_multi_uninvert"/>
+  <copyField source="where_s" dest="where_s_single_uninvert"/>
   <copyField source="where_s" dest="where_s_multi_not_uninvert"/>
   <copyField source="where_s" dest="where_s_multi_not_uninvert_dv"/>
   <copyField source="where_s" dest="where_s_single_not_uninvert"/>

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-tlog.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-tlog.xml
@@ -162,6 +162,16 @@
       autowarmCount="10"
       regenerator="solr.NoOpRegenerator" />
 
+    <!-- nocommit: Need new jira for enabled=true|false support in generic caches
+         nocommit: CacheConfig.getMultipleConfigs doesn't look at enabled
+    -->
+    <cache name="termFacetCache"
+           enabled="${tests.termFacetCache.enabled:false}"
+           class="solr.CaffeineCache"
+           size="200"
+           initialSize="200"
+           autowarmCount="200"
+           regenerator="solr.request.TermFacetCacheRegenerator" />
   </query>
 
   <initParams path="/select">

--- a/solr/solr-ref-guide/src/json-facet-api.adoc
+++ b/solr/solr-ref-guide/src/json-facet-api.adoc
@@ -918,6 +918,10 @@ NOTE: While it's very common to define the Background Set as `\*:*`, or some oth
 
 When using the extended `type:func` syntax for specifying a `relatedness()` aggregation, an optional `min_popularity` (float) option can be used to specify a lower bound on the `foreground_popularity` and `background_popularity` values, that must be met in order for the `relatedness` score to be valid -- If this `min_popularity` is not met, then the `relatedness` score will be `-Infinity`.
 
+`relatedness()` calculates correlation of facet counts across three different DocSet domains (base, foreground, and background). The default implementation of facet count collection depends on the type of facet being calculated. Generic facet count collection is based on retrieving DocSet for a bucket-associated query, consulting the `filterCache`. For term facets (especially over high-cardinality fields) this can lead to `filterCache` thrashing; accordingly, term facet count collection defaults where possible to a specialized approach that collects facet counts over all three domains in a single sweep. It is possible to disable this "single sweep" collection by setting the extended `type:func` syntax `disable_sweep_collection` option to `true`.
+
+In the case where `relatedness()` is calculated over term facets, the `cacheDf` argument of the associated term facet uses approximate doc frequency to determine whether to consult the `filterCache` for the query associated with a given term. N.b., this affects term faceting and refinement requests; it only applies to bulk facet count collection when `disable_sweep_collection` is `true`.
+
 [source,json]
 ----
 { "type": "func",

--- a/solr/solr-ref-guide/src/json-facet-api.adoc
+++ b/solr/solr-ref-guide/src/json-facet-api.adoc
@@ -225,6 +225,7 @@ This parameter indicates the facet algorithm to use:
 * "smart" Pick the best method for the field type (this is the default)
 
 |prelim_sort |An optional parameter for specifying an approximation of the final `sort` to use during initial collection of top buckets when the <<json-facet-api.adoc#sorting-facets-by-nested-functions,`sort` parameter is very costly>>.
+|countCacheDf |When `termFacetCache` is enabled, this parameter sets a threshold doc frequency (domain size) below which the `termFacetCache` will _not_ be consulted for term facets over a given domain. `-1` never consults the cache; `0` is an alias for the static default (currently 5000). Setting to `1` will in effect _always_ consult the cache.
 |===
 
 === Query Facet

--- a/solr/solr-ref-guide/src/performance-statistics-reference.adoc
+++ b/solr/solr-ref-guide/src/performance-statistics-reference.adoc
@@ -187,6 +187,14 @@ This cache is used for filters for unordered sets of all documents that match a 
 
 You can get the statistics shown in the table below with an API request such as `\http://localhost:8983/solr/admin/metrics?group=core&prefix=CACHE.searcher.filterCache`.
 
+=== Term Facet Cache
+
+This cache is used for arrays containing term facet counts keyed on particular domain filters.
+
+*Registry and Path:* `solr.<core>:CACHE.searcher.termFacetCache`
+
+You can get the statistics shown in the table below with an API request such as `\http://localhost:8983/solr/admin/metrics?group=core&prefix=CACHE.searcher.termFacetCache`.
+
 === Statistics for Caches
 
 The following statistics are available for each of the caches mentioned above:


### PR DESCRIPTION
See issue [SOLR-13807](https://issues.apache.org/jira/browse/SOLR-13807). The latter of the two commits pushed here is the one associated with this PR/issue; the former commit is a "shim" introducing changes from upstream dependency [SOLR-13132](https://issues.apache.org/jira/browse/SOLR-13132) (PR #751).