### PR TITLE
SOLR-14256: replaced EMPTY with empty() to fix deadlock

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/DocSet.java
+++ b/solr/core/src/java/org/apache/solr/search/DocSet.java
@@ -36,6 +36,21 @@ public abstract class DocSet implements Accountable, Cloneable /* extends Collec
     assert this instanceof BitDocSet || this instanceof SortedIntDocSet;
   }
 
+  // we can't simply use a trivial static initializer "= new SortedIntDocSet" because it can lead to classloader deadlock
+  private static DocSet EMPTY;
+
+  /** An empty instance. */
+  public static DocSet empty() {
+    // The static field EMPTY is set with an immutable instance lazily.  SortedIntDocSet is an "effectively final" class
+    //  and so this is thread-safe, as it will not be partially-constructed.  It's no big deal to create more than
+    //  if multiple threads create this as they are relatively cheap and equivalent.
+    DocSet empty = EMPTY;
+    if (empty == null) {
+      empty = EMPTY = new SortedIntDocSet(new int[0]);
+    }
+    return empty;
+  }
+
   /**
    * Returns the number of documents in the set.
    */
@@ -114,8 +129,6 @@ public abstract class DocSet implements Accountable, Cloneable /* extends Collec
 
 
   public abstract DocSet clone();
-
-  public static final DocSet EMPTY = new SortedIntDocSet(new int[0], 0);
 
   /**
    * A {@link Bits} that has fast random access (as is generally required of Bits).

--- a/solr/core/src/java/org/apache/solr/search/DocSet.java
+++ b/solr/core/src/java/org/apache/solr/search/DocSet.java
@@ -36,19 +36,14 @@ public abstract class DocSet implements Accountable, Cloneable /* extends Collec
     assert this instanceof BitDocSet || this instanceof SortedIntDocSet;
   }
 
-  // we can't simply use a trivial static initializer "= new SortedIntDocSet" because it can lead to classloader deadlock
-  private static DocSet EMPTY;
+  // can't use a trivial static initializer "EMPTY = new SortedIntDocSet" because it can lead to classloader deadlock
+  private static class EmptyLazyHolder {
+    static final DocSet INSTANCE = new SortedIntDocSet(new int[0]);
+  }
 
-  /** An empty instance. */
+  /** An empty instance (has no docs). */
   public static DocSet empty() {
-    // The static field EMPTY is set with an immutable instance lazily.  SortedIntDocSet is an "effectively final" class
-    //  and so this is thread-safe, as it will not be partially-constructed.  It's no big deal to create more than
-    //  if multiple threads create this as they are relatively cheap and equivalent.
-    DocSet empty = EMPTY;
-    if (empty == null) {
-      empty = EMPTY = new SortedIntDocSet(new int[0]);
-    }
-    return empty;
+    return EmptyLazyHolder.INSTANCE;
   }
 
   /**

--- a/solr/core/src/java/org/apache/solr/search/DocSetUtil.java
+++ b/solr/core/src/java/org/apache/solr/search/DocSetUtil.java
@@ -180,7 +180,7 @@ public class DocSetUtil {
 
     DocSet answer = null;
     if (maxCount == 0) {
-      answer = DocSet.EMPTY;
+      answer = DocSet.empty();
     } else if (maxCount <= smallSetSize) {
       answer = createSmallSet(leaves, postList, maxCount, firstReader);
     } else {

--- a/solr/core/src/java/org/apache/solr/search/JoinQParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/search/JoinQParserPlugin.java
@@ -387,7 +387,7 @@ class JoinQuery extends Query {
       fromSearcher.search(q, collector);
       Query resultQ = collector.getResultQuery(toSchemaField, false);
       // don't cache the resulting docSet... the query may be very large.  Better to cache the results of the join query itself
-      DocSet result = resultQ==null ? DocSet.EMPTY : toSearcher.getDocSetNC(resultQ, null);
+      DocSet result = resultQ==null ? DocSet.empty() : toSearcher.getDocSetNC(resultQ, null);
       return result;
     }
 
@@ -421,7 +421,7 @@ class JoinQuery extends Query {
       LeafReader toReader = fromSearcher==toSearcher ? fromReader : toSearcher.getSlowAtomicReader();
       Terms terms = fromReader.terms(fromField);
       Terms toTerms = toReader.terms(toField);
-      if (terms == null || toTerms==null) return DocSet.EMPTY;
+      if (terms == null || toTerms==null) return DocSet.empty();
       String prefixStr = TrieField.getMainValuePrefix(fromSearcher.getSchema().getFieldType(fromField));
       BytesRef prefix = prefixStr == null ? null : new BytesRef(prefixStr);
 
@@ -576,7 +576,7 @@ class JoinQuery extends Query {
       }
 
       if (resultList.size()==0) {
-        return DocSet.EMPTY;
+        return DocSet.empty();
       }
 
       if (resultList.size() == 1) {

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -1179,7 +1179,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       bitsSet += upto;
       result = new BitDocSet(fbs, bitsSet);
     } else {
-      result = upto == 0 ? DocSet.EMPTY : new SortedIntDocSet(Arrays.copyOf(docs, upto));
+      result = upto == 0 ? DocSet.empty() : new SortedIntDocSet(Arrays.copyOf(docs, upto));
     }
 
     if (useCache) {

--- a/solr/core/src/java/org/apache/solr/search/join/XCJFQuery.java
+++ b/solr/core/src/java/org/apache/solr/search/join/XCJFQuery.java
@@ -167,7 +167,7 @@ public class XCJFQuery extends Query {
     public DocSet getDocSet() throws IOException {
       Query query = getResultQuery(searcher.getSchema().getField(toField), false);
       if (query == null) {
-        return DocSet.EMPTY;
+        return DocSet.empty();
       }
       return DocSetUtil.createDocSet(searcher, query, null);
     }
@@ -276,7 +276,7 @@ public class XCJFQuery extends Query {
       } else {
         Terms terms = searcher.getSlowAtomicReader().terms(toField);
         if (terms == null) {
-          return DocSet.EMPTY;
+          return DocSet.empty();
         }
         collector = new TermsJoinKeyCollector(fieldType, terms, searcher);
       }


### PR DESCRIPTION
The previous change has caused sporadic test failures relating to class loading race conditions.  Basically an abstract base class cannot declare a static field initialized to that of a subclass.  Apparently on interfaces, this is okay -- DocSet was an interface before.  I had changed from an interface to abstract class before as a simplification and because I wanted to lock down the implementations to the only two that existed, and additionally many methods took a pair of DocSets and made assumptions bout the only implementations that exist.  I still like that, even if I need to not have a public static final EMPTY.