### PR TITLE
SOLR-13101: Make dir hash computation optional and resilient

### DIFF
--- a/solr/core/src/java/org/apache/solr/store/blob/metadata/ServerSideMetadata.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/metadata/ServerSideMetadata.java
@@ -211,16 +211,6 @@ public class ServerSideMetadata {
     return this.generation;
   }
 
-  /**
-   * @throw IllegalStateException is this instance was not created with a computed directoryHash 
-   */
-  public String getDirectoryHash() {
-    if (this.directoryHash == null) {
-      throw new IllegalStateException("Directory hash was not computed for the given core");
-    }
-    return this.directoryHash;
-  }
-
   public ImmutableCollection<CoreFileData> getLatestCommitFiles(){
     return this.latestCommitFiles;
   }
@@ -237,7 +227,7 @@ public class ServerSideMetadata {
    * Passing in the Directory (expected to be the directory of the same core used during construction) because it seems
    * safer than trying to get it again here...
    * 
-   * @throw IllegalStateException is this instance was not created with a computed directoryHash 
+   * @throw IllegalStateException if this instance was not created with a computed directoryHash 
    */
   public boolean isSameDirectoryContent(Directory coreDir) throws NoSuchAlgorithmException, IOException {
     if (directoryHash == null) {

--- a/solr/core/src/java/org/apache/solr/store/blob/metadata/ServerSideMetadata.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/metadata/ServerSideMetadata.java
@@ -212,9 +212,12 @@ public class ServerSideMetadata {
   }
 
   /**
-   * @return Null if the directory hash was not computed for the given Core 
+   * @throw IllegalStateException is this instance was not created with a computed directoryHash 
    */
   public String getDirectoryHash() {
+    if (this.directoryHash == null) {
+      throw new IllegalStateException("Directory hash was not computed for the given core");
+    }
     return this.directoryHash;
   }
 
@@ -229,13 +232,18 @@ public class ServerSideMetadata {
   /**
    * Returns <code>true</code> if the contents of the directory passed into this method is identical to the contents of
    * the directory of the Solr core of this instance, taken at instance creation time. If the directory hash was not 
-   * computed at the instance creation time, then this returns <code>false</code>
+   * computed at the instance creation time, then we throw an IllegalStateException indicating a programming error.
    *
    * Passing in the Directory (expected to be the directory of the same core used during construction) because it seems
    * safer than trying to get it again here...
+   * 
+   * @throw IllegalStateException is this instance was not created with a computed directoryHash 
    */
   public boolean isSameDirectoryContent(Directory coreDir) throws NoSuchAlgorithmException, IOException {
-    return directoryHash != null ? directoryHash.equals(getSolrDirectoryHash(coreDir, coreDir.listAll())) : false;
+    if (directoryHash == null) {
+      throw new IllegalStateException("Directory hash was not computed for the given core");
+    }
+    return directoryHash.equals(getSolrDirectoryHash(coreDir, coreDir.listAll()));
   }
 
   /**

--- a/solr/core/src/java/org/apache/solr/store/blob/process/CorePullTask.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/process/CorePullTask.java
@@ -286,7 +286,7 @@ public class CorePullTask implements DeduplicatingList.Deduplicatable<String> {
       }
 
       // Get local metadata + resolve with blob metadata. Given we're doing a pull, don't need to reserve commit point
-      ServerSideMetadata serverMetadata = new ServerSideMetadata(pullCoreInfo.getCoreName(), storeManager.getCoreContainer(), false);
+      ServerSideMetadata serverMetadata = new ServerSideMetadata(pullCoreInfo.getCoreName(), storeManager.getCoreContainer(), false, true);
       SharedMetadataResolutionResult resolutionResult = SharedStoreResolutionUtil.resolveMetadata(
           serverMetadata, blobMetadata);
       

--- a/solr/core/src/java/org/apache/solr/store/blob/process/CorePullTask.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/process/CorePullTask.java
@@ -286,7 +286,10 @@ public class CorePullTask implements DeduplicatingList.Deduplicatable<String> {
       }
 
       // Get local metadata + resolve with blob metadata. Given we're doing a pull, don't need to reserve commit point
-      ServerSideMetadata serverMetadata = new ServerSideMetadata(pullCoreInfo.getCoreName(), storeManager.getCoreContainer(), false, true);
+      // We do need to compute a directory hash to verify after pulling or before switching index dirs that no local 
+      // changes occurred concurrently
+      ServerSideMetadata serverMetadata = new ServerSideMetadata(pullCoreInfo.getCoreName(), storeManager.getCoreContainer(), 
+          /* reserveCommit */ false, /* captureDirHash */ true);
       SharedMetadataResolutionResult resolutionResult = SharedStoreResolutionUtil.resolveMetadata(
           serverMetadata, blobMetadata);
       

--- a/solr/core/src/java/org/apache/solr/store/blob/process/CorePusher.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/process/CorePusher.java
@@ -130,7 +130,10 @@ public class CorePusher {
           log.info("Push to shared store initiating with PushPullData= " + pushPullData.toString());
           // Resolve the differences (if any) between the local shard index data and shard index data on shared store
           // Reserving the commit point so it can be saved while pushing files to Blob store.
-          ServerSideMetadata localCoreMetadata = new ServerSideMetadata(coreName, coreContainer, true, false);
+          // We don't need to compute a directory hash for the push scenario as we only need it to verify local 
+          // index changes during pull
+          ServerSideMetadata localCoreMetadata = new ServerSideMetadata(coreName, coreContainer, 
+              /* reserveCommit */ true, /* captureDirHash */ false);
           SharedMetadataResolutionResult resolutionResult = SharedStoreResolutionUtil.resolveMetadata(
               localCoreMetadata, coreVersionMetadata.getBlobCoreMetadata());
 

--- a/solr/core/src/java/org/apache/solr/store/blob/process/CorePusher.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/process/CorePusher.java
@@ -130,7 +130,7 @@ public class CorePusher {
           log.info("Push to shared store initiating with PushPullData= " + pushPullData.toString());
           // Resolve the differences (if any) between the local shard index data and shard index data on shared store
           // Reserving the commit point so it can be saved while pushing files to Blob store.
-          ServerSideMetadata localCoreMetadata = new ServerSideMetadata(coreName, coreContainer, true);
+          ServerSideMetadata localCoreMetadata = new ServerSideMetadata(coreName, coreContainer, true, false);
           SharedMetadataResolutionResult resolutionResult = SharedStoreResolutionUtil.resolveMetadata(
               localCoreMetadata, coreVersionMetadata.getBlobCoreMetadata());
 

--- a/solr/core/src/java/org/apache/solr/store/blob/util/BlobStoreUtils.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/util/BlobStoreUtils.java
@@ -136,7 +136,7 @@ public class BlobStoreUtils {
           }
 
           // Get local metadata + resolve with blob metadata. Given we're doing a pull, don't need to reserve commit point
-          ServerSideMetadata serverMetadata = new ServerSideMetadata(coreName, coreContainer, false);
+          ServerSideMetadata serverMetadata = new ServerSideMetadata(coreName, coreContainer, false, true);
           SharedMetadataResolutionResult resolutionResult = SharedStoreResolutionUtil.resolveMetadata(serverMetadata, blobstoreMetadata);
           PushPullData pushPullData = new PushPullData.Builder()
               .setCollectionName(collectionName)

--- a/solr/core/src/java/org/apache/solr/store/blob/util/BlobStoreUtils.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/util/BlobStoreUtils.java
@@ -136,7 +136,10 @@ public class BlobStoreUtils {
           }
 
           // Get local metadata + resolve with blob metadata. Given we're doing a pull, don't need to reserve commit point
-          ServerSideMetadata serverMetadata = new ServerSideMetadata(coreName, coreContainer, false, true);
+          // We do need to compute a directory hash to verify after pulling or before switching index dirs that no local 
+          // changes occurred concurrently
+          ServerSideMetadata serverMetadata = new ServerSideMetadata(coreName, coreContainer, 
+              /* reserveCommit */ false, /* captureDirHash */ true);
           SharedMetadataResolutionResult resolutionResult = SharedStoreResolutionUtil.resolveMetadata(serverMetadata, blobstoreMetadata);
           PushPullData pushPullData = new PushPullData.Builder()
               .setCollectionName(collectionName)

--- a/solr/core/src/test/org/apache/solr/store/blob/metadata/CorePushPullTest.java
+++ b/solr/core/src/test/org/apache/solr/store/blob/metadata/CorePushPullTest.java
@@ -276,7 +276,7 @@ public class CorePushPullTest extends SolrTestCaseJ4 {
         BlobCoreMetadataBuilder.buildEmptyCoreMetadata(sharedBlobName));
 
     // build the require metadata
-    ServerSideMetadata solrServerMetadata = new ServerSideMetadata(core.getName(), h.getCoreContainer(), /* takeSnapshot */ true);
+    ServerSideMetadata solrServerMetadata = new ServerSideMetadata(core.getName(), h.getCoreContainer(), /* takeSnapshot */ true, false);
     
     // empty bcm means we should push everything we have locally 
     BlobCoreMetadata bcm = BlobCoreMetadataBuilder.buildEmptyCoreMetadata(sharedBlobName);
@@ -304,7 +304,7 @@ public class CorePushPullTest extends SolrTestCaseJ4 {
   
   private SharedMetadataResolutionResult doPull(SolrCore core, BlobCoreMetadata bcm) throws Exception {
     // build the require metadata
-    ServerSideMetadata solrServerMetadata = new ServerSideMetadata(core.getName(), h.getCoreContainer(), false);
+    ServerSideMetadata solrServerMetadata = new ServerSideMetadata(core.getName(), h.getCoreContainer(), false, true);
     
     PushPullData ppd = new PushPullData.Builder()
         .setCollectionName(collectionName)


### PR DESCRIPTION
Slight optimizations in ServerSideMetadata given that push operations do not require computing a directory hash of a core's index directory. This change makes the computation optional and resilient by also moving the optional computation to the latest commit capture's retry loop. 

If we hit an exception (file not found, etc) either capturing files from the latest commit or during the hash computation (if captureDirHash=true), we should try and recompute both snapshots anyway.