### PR TITLE
ivy settings: local maven repo pattern needs classifier

### DIFF
--- a/lucene/default-nested-ivy-settings.xml
+++ b/lucene/default-nested-ivy-settings.xml
@@ -38,7 +38,7 @@
 
     <filesystem name="local-maven-2" m2compatible="true" local="true">
       <artifact
-          pattern="${local-maven2-dir}/[organisation]/[module]/[revision]/[module]-[revision].[ext]" />
+          pattern="${local-maven2-dir}/[organisation]/[module]/[revision]/[module]-[revision](-[classifier]).[ext]" />
       <ivy
           pattern="${local-maven2-dir}/[organisation]/[module]/[revision]/[module]-[revision].pom" />
     </filesystem>


### PR DESCRIPTION
The ivy settings config has a local maven repo resolver (added by @dweiss 8 years ago).  It's commented out so it's not essential that we get it right.  It has a bug in the pattern that forgot the classifier.
https://stackoverflow.com/questions/8617963/ivysettings-xml-add-local-maven-path
Locally I configure the build to use the local maven repo and this has been a problem because spatial4j's main JAR file is resolved when trying to get the test JAR!

(I don't think I need a JIRA for this but I can create one if someone really wants that ceremony)