### PR TITLE
SOLR-14213: Allow enabling shared store to be scriptable

### DIFF
--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -1975,6 +1975,10 @@ if [ "$SOLR_MODE" == 'solrcloud' ]; then
 
     CLOUD_MODE_OPTS+=('-DzkRun')
   fi
+  
+  if [ -n "$SHARE_STORE_ENABLED" ]; then
+    CLOUD_MODE_OPTS+=("-DsharedStoreEnabled=$SHARE_STORE_ENABLED")
+  fi
 
   # and if collection1 needs to be bootstrapped
   if [ -e "$SOLR_HOME/collection1/core.properties" ]; then

--- a/solr/core/src/java/org/apache/solr/core/SharedStoreConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SharedStoreConfig.java
@@ -16,16 +16,13 @@
  */
 package org.apache.solr.core;
 
-import org.apache.solr.common.util.NamedList;
-import org.apache.solr.core.SolrXmlConfig;
-
 /**
  * Configuration class representing the configuration of Solr Cloud using shared storage
  * to persist index files. The configuration properties come from solr.xml and are loaded
  * via {@link SolrXmlConfig} at Solr startup. The presence of sharedStore section in the solr.xml
- * file of a Solr Cloud mode cluster indicates the user's intention to enable shared storage 
- * capabilities in the cluster and starts the necessary components required to create/support
- * shared-type Solr collections.
+ * file of a Solr Cloud mode cluster with the config sharedStoreEnabled set to true indicates the 
+ * user's intention to enable shared storage capabilities in the cluster and starts the necessary 
+ * components required to create/support shared-type Solr collections.
  * 
  * TODO: This class is bare bones until we convert the many hard coded configuration values
  * into configurable fields that can be specified under this section. The current responsibility
@@ -33,12 +30,4 @@ import org.apache.solr.core.SolrXmlConfig;
  * processes associated with it.
  */
 public class SharedStoreConfig {
-  
-  public static SharedStoreConfig loadSharedStoreConfig(NamedList<Object> nl) {
-    if (nl == null) {
-      // shared store is not configured
-      return null;
-    }
-    return new SharedStoreConfig();
-  }
 }

--- a/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
@@ -100,8 +100,8 @@ public class SolrXmlConfig {
     
     SharedStoreConfig sharedStoreConfig = null;
     if (config.getNodeList("solr/sharedStore", false).getLength() > 0) {
-      sharedStoreConfig = SharedStoreConfig.loadSharedStoreConfig(
-          readNodeListAsNamedList(config, "solr/sharedStore/*[@name]", "<sharedStore>"));
+      sharedStoreConfig = loadSharedStoreConfig(readNodeListAsNamedList(config, 
+          "solr/sharedStore/*[@name]", "<sharedStore>"));
     }
 
     NodeConfig.NodeConfigBuilder configBuilder = new NodeConfig.NodeConfigBuilder(nodeName, config.getResourceLoader());
@@ -567,5 +567,18 @@ public class SolrXmlConfig {
   private static PluginInfo getTracerPluginInfo(XmlConfigFile config) {
     Node node = config.getNode("solr/tracerConfig", false);
     return (node == null) ? null : new PluginInfo(node, "tracerConfig", false, true);
+  }
+  
+  private static SharedStoreConfig loadSharedStoreConfig(NamedList<Object> nl) {
+    if (nl == null) {
+      // shared store is not configured
+      return null;
+    } 
+    boolean enabled = Boolean.parseBoolean(
+        required("sharedStore", "sharedStoreEnabled", removeValue(nl, "sharedStoreEnabled")));
+    if (enabled) {
+      return new SharedStoreConfig();
+    }
+    return null;
   }
 }

--- a/solr/core/src/test-files/solr/solr-sharedstore.xml
+++ b/solr/core/src/test-files/solr/solr-sharedstore.xml
@@ -46,8 +46,8 @@
 	</solrcloud> 
 	
 	<sharedStore>
-	 <!-- The presence of this config section enables shared storage capabilities for the entire cluster if it
-	 is in Solr Cloud mode -->
+	 <!-- The default value is true and will enable shared storage capabilities across the cluster -->
+    <bool name="sharedStoreEnabled">${sharedStoreEnabled:true}</bool>
 	</sharedStore>
 	
 	<metrics> 

--- a/solr/core/src/test/org/apache/solr/cloud/api/collections/SimpleSharedStorageCollectionTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/api/collections/SimpleSharedStorageCollectionTest.java
@@ -87,6 +87,29 @@ public class SimpleSharedStorageCollectionTest extends SolrCloudSharedStoreTestC
   }
   
   /**
+   * Test that verifies that setting system property sharedStoreEnabled to false overrides 
+   * the sharedStore section in solr.xml assuming it is present and blob is initially enabled
+   */
+  @Test
+  public void testCreateCollectionSharedOveriddenDisabled() throws Exception {
+    System.setProperty("sharedStoreEnabled", "false");
+    setupCluster(1);
+    String collectionName = "BlobBasedCollectionName1";
+    CloudSolrClient cloudClient = cluster.getSolrClient();
+    
+    CollectionAdminRequest.Create create = CollectionAdminRequest.createCollection(collectionName, 1, 0).setSharedIndex(true).setSharedReplicas(1);
+    try {
+      create.process(cloudClient);
+      fail("Request should have failed");
+    } catch (SolrException ex) {
+      assertEquals(SolrException.ErrorCode.BAD_REQUEST.code, ex.code());
+      assertTrue(ex.getMessage().contains("shared storage is not enabled"));
+    } catch (Exception ex) {
+      fail("Unexpected exception thrown " + ex.getMessage());
+    }
+  }
+  
+  /**
    * Test that verifies that common collection api commands that create new shards will
    * initiate the metadataSuffix node in ZooKeeper
    */


### PR DESCRIPTION
Enhancing the configuration section to allow shared storage feature to be enabled via system properties vs just checking for presence of <sharedStore> section in solr.xml.
```
<sharedStore>
  <bool name="sharedStoreEnabled">${sharedStoreEnabled:false}</bool>
</sharedStore>
```
Shared storage is now only enabled if cloud mode is on, <sharedStore> section is present, and the field sharedStoreEnabled is present and set to true. If <sharedStore> is present but the field isn't, startup fails. The field supports system properties overriding whatever default is specified. This can be passed in via the solr binary such as 
`bin/solr start -e cloud -noprompt -DsharedStoreEnabled=true` 
or set by specifying the environment variable SHARE_STORE_ENABLED.