### PR TITLE
SOLR-14333: print readable version of CollapsedPostFilter query

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -281,6 +281,8 @@ Other Changes
 
 * SOLR-14876: Upgrade to zookeeper 3.6.2 (odidev via Erick Erickson)
 
+* SOLR-14333: Print readable version of CollapsedPostFilter query (Guna Sekhar Dora Kovvuru, Munendra S N, Mike Drob)
+
 ==================  8.6.2 ==================
 
 Consult the LUCENE_CHANGES.txt file for additional, low level, changes in this release.

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -281,7 +281,9 @@ Other Changes
 
 * SOLR-14876: Upgrade to zookeeper 3.6.2 (odidev via Erick Erickson)
 
-* SOLR-14333: Print readable version of CollapsedPostFilter query (Guna Sekhar Dora Kovvuru, Munendra S N, Mike Drob)
+* SOLR-14333: Implement toString in Collapse filter so that proper parsed queries returned in debug response.
+  Also, Deprecate unused constants NULL_COLLAPSE, NULL_IGNORE, NULL_EXPAND, HINT_MULTI_DOCVALUES in collapse parser.
+  (Guna Sekhar Dora Kovvuru, Munendra S N, Mike Drob)
 
 ==================  8.6.2 ==================
 

--- a/solr/core/src/java/org/apache/solr/search/CollapsingQParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/search/CollapsingQParserPlugin.java
@@ -188,6 +188,11 @@ public class CollapsingQParserPlugin extends QParserPlugin {
       return 17 * (31 + selectorText.hashCode()) * (31 + type.hashCode());
     }
 
+    @Override
+    public String toString(){
+      return "groupHeadSelectorText=" +this.selectorText + ", groupHeadSelectorType=" +this.type;
+    }
+
     /**
      * returns a new GroupHeadSelector based on the specified local params
      */
@@ -279,7 +284,20 @@ public class CollapsingQParserPlugin extends QParserPlugin {
     }
 
     public String toString(String s) {
-      return s;
+      return "{!collapse field=" + this.collapseField +
+          ", nullPolicy=" + getNullPolicyString(this.nullPolicy) + ", " +
+          this.groupHeadSelector.toString() +
+          (hint == null ? "": ", hint=" + this.hint) +
+          ", size=" + this.size
+          + "}";
+    }
+
+    private String getNullPolicyString(int nullPolicy) {
+      switch (nullPolicy) {
+        case NULL_POLICY_COLLAPSE: return NULL_COLLAPSE;
+        case NULL_POLICY_EXPAND: return NULL_EXPAND;
+        default: return NULL_IGNORE;
+      }
     }
 
     public CollapsingPostFilter(SolrParams localParams, SolrParams params, SolrQueryRequest request) {

--- a/solr/core/src/java/org/apache/solr/search/CollapsingQParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/search/CollapsingQParserPlugin.java
@@ -156,6 +156,21 @@ public class CollapsingQParserPlugin extends QParserPlugin {
     public int getCode() {
       return code;
     }
+
+    public static NullPolicy fromString(String nullPolicy) {
+      if (StringUtils.isEmpty(nullPolicy)) {
+        return DEFAULT_POLICY;
+      }
+      switch (nullPolicy) {
+        case "ignore": return IGNORE;
+        case "collapse": return COLLAPSE;
+        case "expand": return EXPAND;
+        default:
+          throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, "Invalid nullPolicy: " + nullPolicy);
+      }
+    }
+
+    static NullPolicy DEFAULT_POLICY = IGNORE;
   }
 
 
@@ -313,7 +328,7 @@ public class CollapsingQParserPlugin extends QParserPlugin {
     public String toString(String s) {
       return "CollapsingPostFilter[field=" + this.collapseField +
           ", nullPolicy=" + this.nullPolicy.getName() + ", " +
-          this.groupHeadSelector.toString() +
+          this.groupHeadSelector +
           (hint == null ? "": ", hint=" + this.hint) +
           ", size=" + this.size
           + "]";
@@ -391,12 +406,7 @@ public class CollapsingQParserPlugin extends QParserPlugin {
         }
       }
 
-      String nPolicy = localParams.get("nullPolicy",NullPolicy.IGNORE.getName());
-      try {
-        this.nullPolicy = NullPolicy.valueOf(nPolicy);
-      } catch (IllegalArgumentException e) {
-        throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, "Invalid nullPolicy: " + nPolicy);
-      }
+      this.nullPolicy = NullPolicy.fromString(localParams.get("nullPolicy"));
     }
 
     @SuppressWarnings({"unchecked"})

--- a/solr/core/src/java/org/apache/solr/search/CollapsingQParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/search/CollapsingQParserPlugin.java
@@ -235,7 +235,7 @@ public class CollapsingQParserPlugin extends QParserPlugin {
 
     @Override
     public String toString(){
-      return "GroupHeadSelector[selectorText=" + this.selectorText + ", type=" +this.type + "]";
+      return "GroupHeadSelector(selectorText=" + this.selectorText + ", type=" +this.type + ")";
     }
 
     /**
@@ -326,12 +326,12 @@ public class CollapsingQParserPlugin extends QParserPlugin {
     }
 
     public String toString(String s) {
-      return "CollapsingPostFilter[field=" + this.collapseField +
+      return "CollapsingPostFilter(field=" + this.collapseField +
           ", nullPolicy=" + this.nullPolicy.getName() + ", " +
           this.groupHeadSelector +
           (hint == null ? "": ", hint=" + this.hint) +
           ", size=" + this.size
-          + "]";
+          + ")";
     }
 
     public CollapsingPostFilter(SolrParams localParams, SolrParams params, SolrQueryRequest request) {

--- a/solr/core/src/java/org/apache/solr/search/CollapsingQParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/search/CollapsingQParserPlugin.java
@@ -208,7 +208,7 @@ public class CollapsingQParserPlugin extends QParserPlugin {
 
     @Override
     public String toString(){
-      return "groupHeadSelectorText=" +this.selectorText + ", groupHeadSelectorType=" +this.type;
+      return "GroupHeadSelector[selectorText=" + this.selectorText + ", type=" +this.type + "]";
     }
 
     /**
@@ -299,12 +299,12 @@ public class CollapsingQParserPlugin extends QParserPlugin {
     }
 
     public String toString(String s) {
-      return "{!collapse field=" + this.collapseField +
+      return "CollapsingPostFilter[field=" + this.collapseField +
           ", nullPolicy=" + this.nullPolicy.getName() + ", " +
           this.groupHeadSelector.toString() +
           (hint == null ? "": ", hint=" + this.hint) +
           ", size=" + this.size
-          + "}";
+          + "]";
     }
 
     public CollapsingPostFilter(SolrParams localParams, SolrParams params, SolrQueryRequest request) {

--- a/solr/core/src/java/org/apache/solr/search/CollapsingQParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/search/CollapsingQParserPlugin.java
@@ -124,6 +124,18 @@ public class CollapsingQParserPlugin extends QParserPlugin {
   public static final String NAME = "collapse";
   public static final String HINT_TOP_FC = "top_fc";
 
+  /**
+   * @deprecated use {@link NullPolicy} instead.
+   */
+  @Deprecated
+  public static final String NULL_COLLAPSE = "collapse";
+  @Deprecated
+  public static final String NULL_IGNORE = "ignore";
+  @Deprecated
+  public static final String NULL_EXPAND = "expand";
+  @Deprecated
+  public static final String HINT_MULTI_DOCVALUES = "multi_docvalues";
+
   public enum NullPolicy {
     IGNORE("ignore", 0),
     COLLAPSE("collapse", 1),

--- a/solr/core/src/test/org/apache/solr/search/TestRandomCollapseQParserPlugin.java
+++ b/solr/core/src/test/org/apache/solr/search/TestRandomCollapseQParserPlugin.java
@@ -219,10 +219,10 @@ public class TestRandomCollapseQParserPlugin extends SolrTestCaseJ4 {
     final SolrParams solrParams = params("q", query, "debug", "true", "fq", filterQuery);
     final QueryResponse response = SOLR.query(solrParams);
     final Object actualParsedFilterQuery = response.getDebugMap().get("parsed_filter_queries");
-    final String expectedParsedFilterString = "CollapsingPostFilter({!collapse field=id, " +
-        "nullPolicy=" + nullPolicy + ", groupHeadSelectorText=" + groupHeadSort.substring(1,
-        groupHeadSort.length() - 1) + ", groupHeadSelectorType=SORT" +
-        ", hint=" + collapseHint + ", size=" + collapseSize + "})";
+    final String expectedParsedFilterString = "CollapsingPostFilter([CollapsingPostFilter field=id, " +
+        "nullPolicy=" + nullPolicy + ", GroupHeadSelector[selectorText=" + groupHeadSort.substring(1,
+        groupHeadSort.length() - 1) + ", type=SORT" +
+        "], hint=" + collapseHint + ", size=" + collapseSize + "})";
     final ArrayList<String> expectedParsedFilterQuery = new ArrayList<>();
     expectedParsedFilterQuery.add(expectedParsedFilterString);
 

--- a/solr/core/src/test/org/apache/solr/search/TestRandomCollapseQParserPlugin.java
+++ b/solr/core/src/test/org/apache/solr/search/TestRandomCollapseQParserPlugin.java
@@ -219,10 +219,10 @@ public class TestRandomCollapseQParserPlugin extends SolrTestCaseJ4 {
 
     QueryResponse response = SOLR.query(solrParams);
     // Query name is occurring twice, this should be handled in QueryParsing.toString
-    String expectedParsedFilterString = "CollapsingPostFilter(CollapsingPostFilter[field=id, " +
-        "nullPolicy=" + nullPolicy + ", GroupHeadSelector[selectorText=" + groupHeadSort.substring(1,
+    String expectedParsedFilterString = "CollapsingPostFilter(CollapsingPostFilter(field=id, " +
+        "nullPolicy=" + nullPolicy + ", GroupHeadSelector(selectorText=" + groupHeadSort.substring(1,
         groupHeadSort.length() - 1) + ", type=SORT" +
-        "], hint=" + collapseHint + ", size=" + collapseSize + "])";
+        "), hint=" + collapseHint + ", size=" + collapseSize + "))";
     List<String> expectedParsedFilterQuery = Collections.singletonList(expectedParsedFilterString);
     assertEquals(expectedParsedFilterQuery, response.getDebugMap().get("parsed_filter_queries"));
     assertEquals(Collections.singletonList(filterQuery), response.getDebugMap().get("filter_queries"));


### PR DESCRIPTION
<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

Prints a readable version of parsed_filter_queries in CollapsedPostFilter query

# Solution

The debug response will now be in the lines of
```
"parsed_filter_queries": [
"CollapsingPostFilter({!collapse field=id, nullPolicy=expand, groupHeadSelectorText=_version_ asc, groupHeadSelectorType=SORT, hint=top_fc, size=5000})"
]
```

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [x] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
