### PR TITLE
SOLR-14340 - ZkStateReader.readConfigName is doing too much work

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/CloudConfigSetService.java
+++ b/solr/core/src/java/org/apache/solr/cloud/CloudConfigSetService.java
@@ -68,7 +68,6 @@ public class CloudConfigSetService extends ConfigSetService {
     // The configSet is read from ZK and populated.  Ignore CD's pre-existing configSet; only populated in standalone
     final String configSetName;
     try {
-      //TODO readConfigName() also validates the configSet exists but seems needless.  We'll get errors soon enough.
       configSetName = zkController.getZkStateReader().readConfigName(colName);
       cd.setConfigSet(configSetName);
     } catch (KeeperException ex) {

--- a/solr/core/src/test/org/apache/solr/cloud/api/collections/TestCollectionAPI.java
+++ b/solr/core/src/test/org/apache/solr/cloud/api/collections/TestCollectionAPI.java
@@ -269,7 +269,6 @@ public class TestCollectionAPI extends ReplicaPropertiesBase {
       NamedList<Object> collections = (NamedList<Object>) cluster.get("collections");
       assertNotNull("Collections should not be null in cluster state", collections);
       assertNotNull("Testing to insure collections are returned", collections.get(COLLECTION_NAME1));
-      assertNull("Should have failed to find: " + collection + " because the configset was delted. ", collections.get(collection));
     }
   }
 

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/ZkStateReader.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/ZkStateReader.java
@@ -294,10 +294,6 @@ public class ZkStateReader implements SolrCloseable {
     log.debug("Loading collection config from: [{}]", path);
 
     try {
-      if (zkClient.exists(path, true) == false) {
-        log.warn("No collection found at path {}.", path);
-        throw new KeeperException.NoNodeException("No collection found at path: " + path);
-      }
       byte[] data = zkClient.getData(path, null, null, true);
       if (data == null) {
         log.warn("No config data found at path {}.", path);
@@ -310,14 +306,6 @@ public class ZkStateReader implements SolrCloseable {
       if (configName == null) {
         log.warn("No config data found at path{}. ", path);
         throw new KeeperException.NoNodeException("No config data found at path: " + path);
-      }
-
-      String configPath = CONFIGS_ZKNODE + "/" + configName;
-      if (zkClient.exists(configPath, true) == false) {
-        log.error("Specified config=[{}] does not exist in ZooKeeper at location=[{}]", configName, configPath);
-        throw new KeeperException.NoNodeException("Specified config=[" + configName + "] does not exist in ZooKeeper at location=[" + configPath + "]");
-      } else {
-        log.debug("path=[{}] [{}]=[{}] specified config exists in ZooKeeper", configPath, CONFIGNAME_PROP, configName);
       }
     } catch (InterruptedException e) {
       SolrZkClient.checkInterrupted(e);


### PR DESCRIPTION
# Description

Reduced the scope of ZkStateReader.readConfigName() as described in the JIRA by David.


# Solution

* Removed the check to ensure that the Zk Node exists.
* Removed the check for the existence of the Configset entry.
In a local test with 600 collections, it saved 2/5 of the GETCLUSTERSTATUS  execution time.

# Tests

Removed an assert in TestCollectionAPI that tests that a collection with missing configset are not returned. That behavior will not happen anymore.

# Checklist

Please review the following and check all that apply:

- [ X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [  ] I have created a Jira issue and added the issue ID to my pull request title.
- [  ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ X] I have developed this patch against the `master` branch.
- [ X] I have run `ant precommit` and the appropriate test suite.
- [  ] I have added tests for my changes.
- [  ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
