### PR TITLE
LUCENE-9287:Add DocValuesFieldExistsQuery as a never cache query in UsageTrackingQueryCachingPolicy

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -127,6 +127,9 @@ Optimizations
 * LUCENE-8103: DoubleValuesSource and QueryValueSource now use a TwoPhaseIterator if one is provided by the Query.
   (Michele Palmia, David Smiley)
 
+* LUCENE-9287:Add DocValuesFieldExistsQuery as a never cache query in UsageTrackingQueryCachingPolicy.
+  (Ignacio Vera)
+
 Bug Fixes
 ---------------------
 * LUCENE-9259: Fix wrong NGramFilterFactory argument name for preserveOriginal option (Paul Pazderski)

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -127,8 +127,7 @@ Optimizations
 * LUCENE-8103: DoubleValuesSource and QueryValueSource now use a TwoPhaseIterator if one is provided by the Query.
   (Michele Palmia, David Smiley)
 
-* LUCENE-9287:Add DocValuesFieldExistsQuery as a never cache query in UsageTrackingQueryCachingPolicy.
-  (Ignacio Vera)
+* LUCENE-9287: UsageTrackingQueryCachingPolicy no longer caches DocValuesFieldExistsQuery. (Ignacio Vera)
 
 Bug Fixes
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/search/UsageTrackingQueryCachingPolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/search/UsageTrackingQueryCachingPolicy.java
@@ -60,6 +60,11 @@ public class UsageTrackingQueryCachingPolicy implements QueryCachingPolicy {
       return true;
     }
 
+    if (query instanceof DocValuesFieldExistsQuery) {
+      // We do not bother caching DocValuesFieldExistsQuery queries since they are already plenty fast.
+      return true;
+    }
+
     if (query instanceof MatchAllDocsQuery) {
       // MatchAllDocsQuery has an iterator that is faster than what a bit set could do.
       return true;

--- a/lucene/core/src/test/org/apache/lucene/search/TestUsageTrackingFilterCachingPolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestUsageTrackingFilterCachingPolicy.java
@@ -54,6 +54,15 @@ public class TestUsageTrackingFilterCachingPolicy extends LuceneTestCase {
     assertFalse(policy.shouldCache(q));
   }
 
+  public void testNeverCacheDocValuesFieldExistsFilter() throws IOException {
+    Query q = new DocValuesFieldExistsQuery("foo");
+    UsageTrackingQueryCachingPolicy policy = new UsageTrackingQueryCachingPolicy();
+    for (int i = 0; i < 1000; ++i) {
+      policy.onUse(q);
+    }
+    assertFalse(policy.shouldCache(q));
+  }
+
   public void testBooleanQueries() throws IOException {
     Directory dir = newDirectory();
     RandomIndexWriter w = new RandomIndexWriter(random(), dir);


### PR DESCRIPTION
see https://issues.apache.org/jira/browse/LUCENE-9287