### PR TITLE
Fix TestXYPoint#testEqualsAndHashCode

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/geo/TestXYPoint.java
+++ b/lucene/core/src/test/org/apache/lucene/geo/TestXYPoint.java
@@ -68,7 +68,7 @@ public class TestXYPoint extends LuceneTestCase {
     XYPoint otherPoint = new XYPoint(ShapeTestUtil.nextFloat(random()), ShapeTestUtil.nextFloat(random()));
     if (point.getX() != otherPoint.getX() || point.getY() != otherPoint.getY()) {
       assertNotEquals(point, otherPoint);
-      assertNotEquals(point.hashCode(), otherPoint.hashCode());
+      // it is possible to have hashcode collisions
     } else {
       assertEquals(point, otherPoint);
       assertEquals(point.hashCode(), otherPoint.hashCode());


### PR DESCRIPTION
The test should not assume that different objects have always different hashcodes.