### PR TITLE
SOLR-14363: Separate /get requests into their own type designation

### DIFF
--- a/solr/core/src/java/org/apache/solr/util/SolrLogPostTool.java
+++ b/solr/core/src/java/org/apache/solr/util/SolrLogPostTool.java
@@ -301,7 +301,7 @@ public class SolrLogPostTool {
       } else if(path != null && params.contains("/replication")) {
         doc.addField("type_s", "replication");
       } else if (path != null && path.contains("/get")) {
-        doc.addField("type_s", "rtg");
+        doc.addField("type_s", "get");
       } else {
         doc.addField("type_s", "query");
       }

--- a/solr/core/src/java/org/apache/solr/util/SolrLogPostTool.java
+++ b/solr/core/src/java/org/apache/solr/util/SolrLogPostTool.java
@@ -28,6 +28,7 @@ import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.request.UpdateRequest;
 import org.apache.solr.common.SolrInputDocument;
+import org.apache.solr.common.SolrInputField;
 
 
 /**
@@ -277,6 +278,9 @@ public class SolrLogPostTool {
       doc.addField("qtime_i", parseQTime(line));
       doc.addField("status_s", parseStatus(line));
 
+      String path = parsePath(line);
+      doc.addField("path_s", path);
+
       if(line.contains("hits=")) {
         doc.addField("hits_l", parseHits(line));
       }
@@ -291,12 +295,13 @@ public class SolrLogPostTool {
       doc.addField("shard_s", parseShard(line));
       doc.addField("replica_s", parseReplica(line));
 
-      String path = parsePath(line);
-      doc.addField("path_s", path);
+
       if(path != null && path.contains("/admin")) {
         doc.addField("type_s", "admin");
       } else if(path != null && params.contains("/replication")) {
         doc.addField("type_s", "replication");
+      } else if (path != null && path.contains("/get")) {
+        doc.addField("type_s", "rtg");
       } else {
         doc.addField("type_s", "query");
       }
@@ -487,7 +492,7 @@ public class SolrLogPostTool {
           doc.addField("shards_s", "true");
         }
 
-        if(parts[0].equals("ids")) {
+        if(parts[0].equals("ids") && ! isRTGRequest(doc)) {
           doc.addField("ids_s", "true");
         }
 
@@ -523,6 +528,14 @@ public class SolrLogPostTool {
       if(doc.getField("ids_s") == null) {
         doc.addField("ids_s", "false");
       }
+    }
+
+    private boolean isRTGRequest(SolrInputDocument doc) {
+      final SolrInputField path = doc.getField("path_s");
+      if (path == null) return false;
+
+
+      return "/get".equals(path.getValue());
     }
   }
 }

--- a/solr/core/src/test/org/apache/solr/util/SolrLogPostToolTest.java
+++ b/solr/core/src/test/org/apache/solr/util/SolrLogPostToolTest.java
@@ -69,7 +69,27 @@ public class SolrLogPostToolTest extends SolrTestCaseJ4 {
     assertEquals(isShard.getValue(), "true");
     assertEquals(ids.getValue(), "false");
     assertEquals(shards.getValue(), "false");
+  }
 
+  @Test
+  public void testRTGRecord() throws Exception {
+    final String record = "2020-03-19 20:00:30.845 INFO  (qtp1635378213-20354) [c:logs4 s:shard8 r:core_node63 x:logs4_shard8_replica_n60] o.a.s.c.S.Request [logs4_shard8_replica_n60]  webapp=/solr path=/get params={qt=/get&_stateVer_=logs4:104&ids=id1&ids=id2&ids=id3&wt=javabin&version=2} status=0 QTime=61";
+
+    List<SolrInputDocument> docs = readDocs(record);
+    assertEquals(docs.size(), 1);
+    SolrInputDocument doc = docs.get(0);
+
+    assertEquals(doc.getField("type_s").getValue(), "rtg");
+    assertEquals(doc.getField("date_dt").getValue(), "2020-03-19T20:00:30.845");
+    assertEquals(doc.getField("collection_s").getValue(), "logs4");
+    assertEquals(doc.getField("path_s").getValue(), "/get");
+    assertEquals(doc.getField("status_s").getValue(), "0");
+    assertEquals(doc.getField("shard_s").getValue(), "shard8");
+    assertEquals(doc.getField("replica_s").getValue(), "core_node63");
+    assertEquals(doc.getField("core_s").getValue(), "logs4_shard8_replica_n60");
+    assertEquals(doc.getField("wt_s").getValue(), "javabin");
+    assertEquals(doc.getField("distrib_s").getValue(), "true");
+    assertEquals(doc.getField("ids_s").getValue(), "false");
   }
 
   @Test

--- a/solr/core/src/test/org/apache/solr/util/SolrLogPostToolTest.java
+++ b/solr/core/src/test/org/apache/solr/util/SolrLogPostToolTest.java
@@ -79,7 +79,7 @@ public class SolrLogPostToolTest extends SolrTestCaseJ4 {
     assertEquals(docs.size(), 1);
     SolrInputDocument doc = docs.get(0);
 
-    assertEquals(doc.getField("type_s").getValue(), "rtg");
+    assertEquals(doc.getField("type_s").getValue(), "get");
     assertEquals(doc.getField("date_dt").getValue(), "2020-03-19T20:00:30.845");
     assertEquals(doc.getField("collection_s").getValue(), "logs4");
     assertEquals(doc.getField("path_s").getValue(), "/get");


### PR DESCRIPTION
# Description
The SolrLogParseTool parses most log records containing the string "QTime=" as being a query. While this is useful, the designation would be a little more helpful if operations with a different performance profile were broken out into their own "type_s" value. That gives users the ability to view them together or separately, as they prefer.

# Solution

Change the parsing code in SolrLogParseTool to check specifically for "/get" requests when parsing query requests.  Other than settings "type_s" and "id_s" all other fields are handled in a way identical to other queries

# Tests
A unit test for the new "rtg" type_s value.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
