### PR TITLE
SOLR-13101: Every BLOB_PULL_STARTED should have a matching BLOB_PULL_FINISHED irrespective of failures

### DIFF
--- a/solr/core/src/java/org/apache/solr/store/blob/process/CorePullTask.java
+++ b/solr/core/src/java/org/apache/solr/store/blob/process/CorePullTask.java
@@ -310,7 +310,6 @@ public class CorePullTask implements DeduplicatingList.Deduplicatable<String> {
             pullCoreInfo.getCollectionName(), pullCoreInfo.getShardName(), pullCoreInfo.getCoreName()));
         syncStatus = CoreSyncStatus.SUCCESS_EQUIVALENT;
       }
-
       // The following call can fail if blob is corrupt (in non trivial ways, trivial ways are identified by other cases)
       // pull was successful
       // if (CorePullerFeeder.isEmptyCoreAwaitingPull(coreContainer, pullCoreInfo.getCoreName())) {
@@ -354,10 +353,10 @@ public class CorePullTask implements DeduplicatingList.Deduplicatable<String> {
             }
           }
         }
+        concurrencyController.recordState(pullCoreInfo.getCollectionName(), pullCoreInfo.getShardName(), pullCoreInfo.getCoreName(), SharedCoreStage.BLOB_PULL_FINISHED);
       }
     }
     this.callback.finishedPull(this, blobMetadata, syncStatus, message);
-    concurrencyController.recordState(pullCoreInfo.getCollectionName(), pullCoreInfo.getShardName(), pullCoreInfo.getCoreName(), SharedCoreStage.BLOB_PULL_FINISHED);
   }
 
   void finishedPull(BlobCoreMetadata blobCoreMetadata, CoreSyncStatus syncStatus, String message) throws InterruptedException {


### PR DESCRIPTION
# Description
If exception is thrown during core pull from blob store, there is no record of the pull finishing. This caused a failure in SharedCoreConcurrencyTest.testIndexingQueriesDeletes() when it identified a BLOB_PULL_STARTED without a matching BLOB_PULL_FINISHED, meaning the pulls are interleaved. We want to record pull as finished upon completion even if it was unsuccessful. 

# Solution
Move recording the state the pull as finished finally block so it will record pull as finished irrespective of failures.

# Tests
Reproduced failure by throwing an exception in pull code and verified that code change fixes the interleaved pull failure. Ran all tests.