### PR TITLE
SOLR-14387: SolrClient.getById() does not escape parameter separators within ids

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/client/solrj/SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/SolrClient.java
@@ -42,6 +42,7 @@ import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.NamedList;
+import org.apache.solr.common.util.StrUtils;
 
 /**
  * Abstraction through which all communication with a Solr server may be routed
@@ -1239,8 +1240,7 @@ public abstract class SolrClient implements Serializable, Closeable {
     if (StringUtils.isEmpty(reqParams.get(CommonParams.QT))) {
       reqParams.set(CommonParams.QT, "/get");
     }
-    reqParams.set("ids", ids.toArray(new String[ids.size()]));
-
+    reqParams.set("ids", ids.stream().map(id -> StrUtils.escapeTextWithSeparator(id, ',')).toArray(String[]::new));
     return query(collection, reqParams).getResults();
   }
 

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/GetByIdTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/GetByIdTest.java
@@ -42,7 +42,9 @@ public class GetByIdTest extends EmbeddedSolrServerTestBase {
     getSolrClient().add(Arrays.asList(
         sdoc("id", "1", "term_s", "Microsoft", "term2_s", "MSFT"),
         sdoc("id", "2", "term_s", "Apple", "term2_s", "AAPL"),
-        sdoc("id", "3", "term_s", "Yahoo", "term2_s", "YHOO")));
+        sdoc("id", "3", "term_s", "Yahoo", "term2_s", "YHOO"),
+        sdoc("id", ",", "term_s", "b00m! 1", "term2_s", "id separator escape test document 1"),
+        sdoc("id", "1,2", "term_s", "b00m! 2", "term2_s", "id separator escape test document 2")));
 
     getSolrClient().commit(true, true);
   }
@@ -61,6 +63,21 @@ public class GetByIdTest extends EmbeddedSolrServerTestBase {
     assertEquals("2", rsp.get("id"));
     assertEquals("Apple", rsp.get("term_s"));
     assertEquals("AAPL", rsp.get("term2_s"));
+  }
+
+  @Test
+  public void testGetIdWithSeparator() throws Exception {
+    SolrDocument rsp = getSolrClient().getById(",");
+    assertNotNull(rsp);
+    assertEquals(",", rsp.get("id"));
+    assertEquals("b00m! 1", rsp.get("term_s"));
+    assertEquals("id separator escape test document 1", rsp.get("term2_s"));
+
+    rsp = getSolrClient().getById("1,2");
+    assertNotNull(rsp);
+    assertEquals("1,2", rsp.get("id"));
+    assertEquals("b00m! 2", rsp.get("term_s"));
+    assertEquals("id separator escape test document 2", rsp.get("term2_s"));
   }
 
   @Test
@@ -96,6 +113,14 @@ public class GetByIdTest extends EmbeddedSolrServerTestBase {
     assertEquals("3", rsp.get(2).get("id"));
     assertEquals("Yahoo", rsp.get(2).get("term_s"));
     assertEquals("YHOO", rsp.get(2).get("term2_s"));
+  }
+
+  @Test
+  public void testGetIdsWithSeparator() throws Exception {
+    SolrDocumentList rsp = getSolrClient().getById(Arrays.asList(",", "1,2"));
+    assertEquals(2, rsp.getNumFound());
+    assertEquals(",", rsp.get(0).get("id"));
+    assertEquals("1,2", rsp.get(1).get("id"));
   }
 
   @Test


### PR DESCRIPTION
# Description
Having a solr document with a comma in its id (e.g. "A,B"), SolrClient.getById() is not able to retrieve this document, because it queries `/get?ids=A,B` instead of `/get?ids=A\,B`.

# Solution
Fix SolrClient to escape the parts of the `ids` parameter properly

# Tests
Adds testcases for documents with separators in their id field to `GetByIdTest`.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [x] I have added tests for my changes.
- [ ] ~I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).~
