### PR TITLE
Use QueryUtils.combineQueryAndFilter more

### DIFF
--- a/solr/contrib/analytics/src/java/org/apache/solr/analytics/facet/QueryFacet.java
+++ b/solr/contrib/analytics/src/java/org/apache/solr/analytics/facet/QueryFacet.java
@@ -19,15 +19,14 @@ package org.apache.solr.analytics.facet;
 import java.util.Map;
 import java.util.function.Consumer;
 
-import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.solr.analytics.function.ReductionCollectionManager.ReductionDataCollection;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrException.ErrorCode;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.search.Filter;
 import org.apache.solr.search.QParser;
+import org.apache.solr.search.QueryUtils;
 
 /**
  * A facet that breaks down the data by additional Solr Queries.
@@ -51,10 +50,7 @@ public class QueryFacet extends AbstractSolrQueryFacet {
       }
       // The searcher sends docIds to the QueryFacetAccumulator which forwards
       // them to <code>collectQuery()</code> in this class for collection.
-      Query queryQuery = new BooleanQuery.Builder()
-          .add(q, Occur.MUST)
-          .add(filter, Occur.FILTER)
-          .build();
+      Query queryQuery = QueryUtils.combineQueryAndFilter(q, filter);
 
       ReductionDataCollection dataCol = collectionManager.newDataCollection();
       reductionData.put(queryName, dataCol);

--- a/solr/contrib/analytics/src/java/org/apache/solr/analytics/facet/RangeFacet.java
+++ b/solr/contrib/analytics/src/java/org/apache/solr/analytics/facet/RangeFacet.java
@@ -20,9 +20,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.function.Consumer;
 
-import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.solr.analytics.function.ReductionCollectionManager.ReductionDataCollection;
 import org.apache.solr.analytics.util.FacetRangeGenerator;
 import org.apache.solr.analytics.util.FacetRangeGenerator.FacetRange;
@@ -31,6 +29,7 @@ import org.apache.solr.common.params.FacetParams.FacetRangeOther;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.schema.SchemaField;
 import org.apache.solr.search.Filter;
+import org.apache.solr.search.QueryUtils;
 
 /**
  * A facet that groups data by a discrete set of ranges.
@@ -66,10 +65,7 @@ public class RangeFacet extends AbstractSolrQueryFacet {
       Query q = sf.getType().getRangeQuery(null, sf, range.lower, range.upper, range.includeLower,range.includeUpper);
       // The searcher sends docIds to the RangeFacetAccumulator which forwards
       // them to <code>collectRange()</code> in this class for collection.
-      Query rangeQuery = new BooleanQuery.Builder()
-          .add(q, Occur.MUST)
-          .add(filter, Occur.FILTER)
-          .build();
+      Query rangeQuery = QueryUtils.combineQueryAndFilter(q, filter);
 
       ReductionDataCollection dataCol = collectionManager.newDataCollection();
       reductionData.put(range.toString(), dataCol);

--- a/solr/core/src/java/org/apache/solr/request/SimpleFacets.java
+++ b/solr/core/src/java/org/apache/solr/request/SimpleFacets.java
@@ -335,9 +335,7 @@ public class SimpleFacets {
     }
 
     AllGroupsCollector collector = new AllGroupsCollector<>(new TermGroupSelector(groupField));
-    Filter mainQueryFilter = docSet.getTopFilter(); // This returns a filter that only matches documents matching with q param and fq params
-    Query filteredFacetQuery = QueryUtils.combineQueryAndFilter(facetQuery, mainQueryFilter);
-    searcher.search(filteredFacetQuery, collector);
+    searcher.search(QueryUtils.combineQueryAndFilter(facetQuery, docSet.getTopFilter()), collector);
     return collector.getGroupCount();
   }
 

--- a/solr/core/src/java/org/apache/solr/request/SimpleFacets.java
+++ b/solr/core/src/java/org/apache/solr/request/SimpleFacets.java
@@ -80,7 +80,6 @@ import org.apache.solr.schema.SchemaField;
 import org.apache.solr.schema.TrieField;
 import org.apache.solr.search.BitDocSet;
 import org.apache.solr.search.DocSet;
-import org.apache.solr.search.Filter;
 import org.apache.solr.search.Grouping;
 import org.apache.solr.search.Insanity;
 import org.apache.solr.search.QParser;

--- a/solr/core/src/java/org/apache/solr/request/SimpleFacets.java
+++ b/solr/core/src/java/org/apache/solr/request/SimpleFacets.java
@@ -47,8 +47,6 @@ import org.apache.lucene.index.MultiTerms;
 import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
-import org.apache.lucene.search.BooleanClause.Occur;
-import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.FilterCollector;
@@ -87,6 +85,7 @@ import org.apache.solr.search.Grouping;
 import org.apache.solr.search.Insanity;
 import org.apache.solr.search.QParser;
 import org.apache.solr.search.QueryParsing;
+import org.apache.solr.search.QueryUtils;
 import org.apache.solr.search.SolrIndexSearcher;
 import org.apache.solr.search.SyntaxError;
 import org.apache.solr.search.facet.FacetDebugInfo;
@@ -337,10 +336,7 @@ public class SimpleFacets {
 
     AllGroupsCollector collector = new AllGroupsCollector<>(new TermGroupSelector(groupField));
     Filter mainQueryFilter = docSet.getTopFilter(); // This returns a filter that only matches documents matching with q param and fq params
-    Query filteredFacetQuery = new BooleanQuery.Builder()
-        .add(facetQuery, Occur.MUST)
-        .add(mainQueryFilter, Occur.FILTER)
-        .build();
+    Query filteredFacetQuery = QueryUtils.combineQueryAndFilter(facetQuery, mainQueryFilter);
     searcher.search(filteredFacetQuery, collector);
     return collector.getGroupCount();
   }

--- a/solr/core/src/java/org/apache/solr/search/DocSetUtil.java
+++ b/solr/core/src/java/org/apache/solr/search/DocSetUtil.java
@@ -28,8 +28,6 @@ import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
-import org.apache.lucene.search.BooleanClause;
-import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.LeafCollector;
@@ -120,11 +118,7 @@ public class DocSetUtil {
   public static DocSet createDocSet(SolrIndexSearcher searcher, Query query, DocSet filter) throws IOException {
 
     if (filter != null) {
-        Filter luceneFilter = filter.getTopFilter();
-        query = new BooleanQuery.Builder()
-            .add(query, BooleanClause.Occur.MUST)
-            .add(luceneFilter, BooleanClause.Occur.FILTER)
-            .build();
+      query = QueryUtils.combineQueryAndFilter(query, filter.getTopFilter());
     }
 
     if (query instanceof TermQuery) {

--- a/solr/core/src/java/org/apache/solr/search/Grouping.java
+++ b/solr/core/src/java/org/apache/solr/search/Grouping.java
@@ -438,8 +438,7 @@ public class Grouping {
       collector = timeLimitingCollector;
     }
     try {
-      Query q = QueryUtils.combineQueryAndFilter(query, luceneFilter);
-      searcher.search(q, collector);
+      searcher.search(QueryUtils.combineQueryAndFilter(query, luceneFilter), collector);
     } catch (TimeLimitingCollector.TimeExceededException | ExitableDirectoryReader.ExitingReaderException x) {
       log.warn( "Query: " + query + "; " + x.getMessage() );
       qr.setPartialResults(true);

--- a/solr/core/src/java/org/apache/solr/search/QueryUtils.java
+++ b/solr/core/src/java/org/apache/solr/search/QueryUtils.java
@@ -151,7 +151,7 @@ public class QueryUtils {
    * If neither are null then we combine with a BooleanQuery.
    */
   public static Query combineQueryAndFilter(Query scoreQuery, Query filterQuery) {
-    if (scoreQuery == null) {
+    if (scoreQuery == null || scoreQuery instanceof MatchAllDocsQuery) {
       if (filterQuery == null) {
         return new MatchAllDocsQuery(); // default if nothing -- match everything
       } else {

--- a/solr/core/src/java/org/apache/solr/search/QueryUtils.java
+++ b/solr/core/src/java/org/apache/solr/search/QueryUtils.java
@@ -151,6 +151,7 @@ public class QueryUtils {
    * If neither are null then we combine with a BooleanQuery.
    */
   public static Query combineQueryAndFilter(Query scoreQuery, Query filterQuery) {
+    // check for *:* is simple and avoids needless BooleanQuery wrapper even though BQ.rewrite optimizes this away
     if (scoreQuery == null || scoreQuery instanceof MatchAllDocsQuery) {
       if (filterQuery == null) {
         return new MatchAllDocsQuery(); // default if nothing -- match everything
@@ -158,7 +159,7 @@ public class QueryUtils {
         return new ConstantScoreQuery(filterQuery);
       }
     } else {
-      if (filterQuery == null) {
+      if (filterQuery == null || filterQuery instanceof MatchAllDocsQuery) {
         return scoreQuery;
       } else {
         return new BooleanQuery.Builder()

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -1656,7 +1656,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
 
     ProcessedFilter pf = getProcessedFilter(cmd.getFilter(), cmd.getFilterList());
     Query query = QueryUtils.makeQueryable(cmd.getQuery());
-    query = QueryUtils.combineQueryAndFilter(query, pf.filter);
+    final Query query = QueryUtils.combineQueryAndFilter(QueryUtils.makeQueryable(cmd.getQuery()), pf.filter);
 
     // handle zero case...
     if (lastDocRequested <= 0) {

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -1548,10 +1548,8 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
 
     boolean needScores = (cmd.getFlags() & GET_SCORES) != 0;
 
-    Query query = QueryUtils.makeQueryable(cmd.getQuery());
-
     ProcessedFilter pf = getProcessedFilter(cmd.getFilter(), cmd.getFilterList());
-    query = QueryUtils.combineQueryAndFilter(query, pf.filter);
+    final Query query = QueryUtils.combineQueryAndFilter(QueryUtils.makeQueryable(cmd.getQuery()), pf.filter);
 
     // handle zero case...
     if (lastDocRequested <= 0) {
@@ -1655,7 +1653,6 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     int maxDoc = maxDoc();
 
     ProcessedFilter pf = getProcessedFilter(cmd.getFilter(), cmd.getFilterList());
-    Query query = QueryUtils.makeQueryable(cmd.getQuery());
     final Query query = QueryUtils.combineQueryAndFilter(QueryUtils.makeQueryable(cmd.getQuery()), pf.filter);
 
     // handle zero case...


### PR DESCRIPTION
 and check query==MatchAllDocsQuery (minor & cheap optimization)

I more thoroughly examined opportunities to use this new function and found them all.  One or two in some spatial code I left for various reasons (e.g. deprecated code).

Note that BooleanQuery.rewrite has an optimization that looks for a MatchAllDocsQuery paired with filters, thus this check here would ultimately not change the fully rewritten query that gets executed.  But, it's such a cheap/easy check and BooleanQuery is a rather heavy wrapper (it's rewrite is extensive).   

CC @cpoerschke 