### PR TITLE
LUCENE-8050 Ignore fields having no doc values when merging PerFieldDVFormat

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldDocValuesFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/perfield/PerFieldDocValuesFormat.java
@@ -135,6 +135,9 @@ public abstract class PerFieldDocValuesFormat extends DocValuesFormat {
 
       // Group each consumer by the fields it handles
       for (FieldInfo fi : mergeState.mergeFieldInfos) {
+        if (fi.getDocValuesType() == DocValuesType.NONE) {
+          continue;
+        }
         // merge should ignore current format for the fields being merged
         DocValuesConsumer consumer = getInstance(fi, true);
         Collection<String> fieldsForConsumer = consumersToField.get(consumer);

--- a/lucene/core/src/test/org/apache/lucene/codecs/perfield/TestPerFieldDocValuesFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/perfield/TestPerFieldDocValuesFormat.java
@@ -36,6 +36,7 @@ import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.BaseDocValuesFormatTestCase;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.DirectoryReader;
@@ -65,7 +66,7 @@ public class TestPerFieldDocValuesFormat extends BaseDocValuesFormatTestCase {
   
   @Override
   public void setUp() throws Exception {
-    codec = new RandomCodec(new Random(random().nextLong()), Collections.<String>emptySet());
+    codec = new RandomCodec(new Random(random().nextLong()), Collections.emptySet());
     super.setUp();
   }
   
@@ -186,6 +187,43 @@ public class TestPerFieldDocValuesFormat extends BaseDocValuesFormatTestCase {
     assertEquals(1, dvf2.nbMergeCalls);
     assertEquals(Collections.singletonList("dv3"), dvf2.fieldNames);
 
+    directory.close();
+  }
+
+  public void testDocValuesMergeWithIndexedFields() throws IOException {
+    MergeRecordingDocValueFormatWrapper docValuesFormat = new MergeRecordingDocValueFormatWrapper(TestUtil.getDefaultDocValuesFormat());
+
+    IndexWriterConfig iwc = new IndexWriterConfig();
+    iwc.setCodec(new AssertingCodec() {
+      @Override
+      public DocValuesFormat getDocValuesFormatForField(String field) {
+        return docValuesFormat;
+      }
+    });
+
+    Directory directory = newDirectory();
+
+    IndexWriter iwriter = new IndexWriter(directory, iwc);
+
+    Document doc = new Document();
+    doc.add(new NumericDocValuesField("dv1", 5));
+    doc.add(new TextField("normalField", "not a doc value", Field.Store.NO));
+    iwriter.addDocument(doc);
+    iwriter.commit();
+
+    doc = new Document();
+    doc.add(new TextField("anotherField", "again no doc values here", Field.Store.NO));
+    doc.add(new TextField("normalField", "my document without doc values", Field.Store.NO));
+    iwriter.addDocument(doc);
+    iwriter.commit();
+
+
+    iwriter.forceMerge(1, true);
+    iwriter.close();
+
+    // "normalField" and "anotherField" are ignored when merging doc values.
+    assertEquals(1, docValuesFormat.nbMergeCalls);
+    assertEquals(Collections.singletonList("dv1"), docValuesFormat.fieldNames);
     directory.close();
   }
 


### PR DESCRIPTION
# Description

PerFieldDocValuesFormat delegates the merge to the actual field DVF's merge. Great, but unfortunately it will call getDocValuesFormatForField on all fields (in FieldInfos) even those that have no DocValues (DocValuesType.NONE)

# Solution

Skip FieldInfo when getDocValuesType() == DocValuesType.NONE

# Tests

Test added using doc values in one segment and indexed fields in the other, we asses that the fields not having doc values are skipped while merging.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [] I have run `ant precommit` and the appropriate test suite.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
