### PR TITLE
Move DWPT private deletes out of FrozenBufferedUpdates

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/BufferedUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/BufferedUpdates.java
@@ -17,9 +17,7 @@
 package org.apache.lucene.index;
 
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 

--- a/lucene/core/src/java/org/apache/lucene/index/BufferedUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/BufferedUpdates.java
@@ -55,11 +55,6 @@ class BufferedUpdates implements Accountable {
      OBJ_HEADER + INT. */
   final static int BYTES_PER_DEL_TERM = 9*RamUsageEstimator.NUM_BYTES_OBJECT_REF + 7*RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + 10*Integer.BYTES;
 
-  /* Rough logic: del docIDs are List<Integer>.  Say list
-     allocates ~2X size (2*POINTER).  Integer is OBJ_HEADER
-     + int */
-  final static int BYTES_PER_DEL_DOCID = 2*RamUsageEstimator.NUM_BYTES_OBJECT_REF + RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + Integer.BYTES;
-
   /* Rough logic: HashMap has an array[Entry] w/ varying
      load factor (say 2 * POINTER).  Entry is object w/
      Query key, Integer val, int hash, Entry next
@@ -71,7 +66,6 @@ class BufferedUpdates implements Accountable {
 
   final Map<Term,Integer> deleteTerms = new HashMap<>(); // TODO cut this over to FieldUpdatesBuffer
   final Map<Query,Integer> deleteQueries = new HashMap<>();
-  final List<Integer> deleteDocIDs = new ArrayList<>();
 
   final Map<String, FieldUpdatesBuffer> fieldUpdates = new HashMap<>();
   
@@ -96,7 +90,7 @@ class BufferedUpdates implements Accountable {
   public String toString() {
     if (VERBOSE_DELETES) {
       return "gen=" + gen + " numTerms=" + numTermDeletes + ", deleteTerms=" + deleteTerms
-        + ", deleteQueries=" + deleteQueries + ", deleteDocIDs=" + deleteDocIDs + ", fieldUpdates=" + fieldUpdates
+        + ", deleteQueries=" + deleteQueries + ", fieldUpdates=" + fieldUpdates
         + ", bytesUsed=" + bytesUsed;
     } else {
       String s = "gen=" + gen;
@@ -105,9 +99,6 @@ class BufferedUpdates implements Accountable {
       }
       if (deleteQueries.size() != 0) {
         s += " " + deleteQueries.size() + " deleted queries";
-      }
-      if (deleteDocIDs.size() != 0) {
-        s += " " + deleteDocIDs.size() + " deleted docIDs";
       }
       if (numFieldUpdates.get() != 0) {
         s += " " + numFieldUpdates.get() + " field updates";
@@ -126,11 +117,6 @@ class BufferedUpdates implements Accountable {
     if (current == null) {
       bytesUsed.addAndGet(BYTES_PER_DEL_QUERY);
     }
-  }
-
-  public void addDocID(int docID) {
-    deleteDocIDs.add(Integer.valueOf(docID));
-    bytesUsed.addAndGet(BYTES_PER_DEL_DOCID);
   }
 
   public void addTerm(Term term, int docIDUpto) {
@@ -185,7 +171,6 @@ class BufferedUpdates implements Accountable {
   void clear() {
     deleteTerms.clear();
     deleteQueries.clear();
-    deleteDocIDs.clear();
     numTermDeletes.set(0);
     numFieldUpdates.set(0);
     fieldUpdates.clear();
@@ -195,16 +180,11 @@ class BufferedUpdates implements Accountable {
   }
   
   boolean any() {
-    return deleteTerms.size() > 0 || deleteDocIDs.size() > 0 || deleteQueries.size() > 0 || numFieldUpdates.get() > 0;
+    return deleteTerms.size() > 0 || deleteQueries.size() > 0 || numFieldUpdates.get() > 0;
   }
 
   @Override
   public long ramBytesUsed() {
     return bytesUsed.get() + fieldUpdatesBytesUsed.get() + termsBytesUsed.get();
-  }
-
-  void clearDeletedDocIds() {
-    bytesUsed.addAndGet(-deleteDocIDs.size() * BufferedUpdates.BYTES_PER_DEL_DOCID);
-    deleteDocIDs.clear();
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/FrozenBufferedUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FrozenBufferedUpdates.java
@@ -87,8 +87,7 @@ final class FrozenBufferedUpdates {
   public FrozenBufferedUpdates(InfoStream infoStream, BufferedUpdates updates, SegmentCommitInfo privateSegment) {
     this.infoStream = infoStream;
     this.privateSegment = privateSegment;
-    assert updates.deleteDocIDs.isEmpty();
-    assert privateSegment == null || updates.deleteTerms.isEmpty() : "segment private packet should only have del queries"; 
+    assert privateSegment == null || updates.deleteTerms.isEmpty() : "segment private packet should only have del queries";
     Term termsArray[] = updates.deleteTerms.keySet().toArray(new Term[updates.deleteTerms.size()]);
     ArrayUtil.timSort(termsArray);
     PrefixCodedTerms.Builder builder = new PrefixCodedTerms.Builder();
@@ -859,5 +858,4 @@ final class FrozenBufferedUpdates {
       return postingsEnum = termsEnum.postings(postingsEnum, PostingsEnum.NONE);
     }
   }
-
 }

--- a/lucene/core/src/test/org/apache/lucene/index/TestBufferedUpdates.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestBufferedUpdates.java
@@ -28,11 +28,6 @@ public class TestBufferedUpdates extends LuceneTestCase {
     BufferedUpdates bu = new BufferedUpdates("seg1");
     assertEquals(bu.ramBytesUsed(), 0L);
     assertFalse(bu.any());
-    int docIds = atLeast(1);
-    for (int i = 0; i < docIds; i++) {
-      bu.addDocID(random().nextInt(100));
-    }
-
     int queries = atLeast(1);
     for (int i = 0; i < queries; i++) {
       final int docIDUpto = random().nextBoolean() ? Integer.MAX_VALUE : random().nextInt();
@@ -50,11 +45,6 @@ public class TestBufferedUpdates extends LuceneTestCase {
 
     long totalUsed = bu.ramBytesUsed();
     assertTrue(totalUsed > 0);
-
-    bu.clearDeletedDocIds();
-    assertTrue("only docIds are cleaned, buffer shouldn't be empty", bu.any());
-    assertTrue("docIds are cleaned, ram in used should decrease", totalUsed > bu.ramBytesUsed());
-    totalUsed = bu.ramBytesUsed();
 
     bu.clearDeleteTerms();
     assertTrue("only terms and docIds are cleaned, the queries are still in memory", bu.any());


### PR DESCRIPTION
This change moves the deletes tracked by FrozenBufferedUpdates that
are private to the DWPT and never used in a global context out of
FrozenBufferedUpdates.