### PR TITLE
SOLR-14413: allow timeAllowed and cursorMark parameters

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -358,11 +358,6 @@ public class QueryComponent extends SearchComponent
 
     // -1 as flag if not set.
     long timeAllowed = params.getLong(CommonParams.TIME_ALLOWED, -1L);
-    if (null != rb.getCursorMark() && 0 < timeAllowed) {
-      // fundamentally incompatible
-      throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, "Can not search using both " +
-                              CursorMarkParams.CURSOR_MARK_PARAM + " and " + CommonParams.TIME_ALLOWED);
-    }
 
     QueryCommand cmd = rb.createQueryCommand();
     cmd.setTimeAllowed(timeAllowed);

--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -34,6 +34,7 @@ import org.apache.solr.cloud.ZkController;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.CommonParams;
+import org.apache.solr.common.params.CursorMarkParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.ShardParams;
 import org.apache.solr.common.util.NamedList;
@@ -379,6 +380,13 @@ public class SearchHandler extends RequestHandlerBase implements SolrCoreAware, 
         log.warn("Query: {}; ", req.getParamString(), ex);
         if( rb.rsp.getResponse() == null) {
           rb.rsp.addResponse(new SolrDocumentList());
+
+          // If a cursorMark was passed, and we didn't progress, set
+          // the nextCursorMark to the same position
+          String cursorStr = rb.req.getParams().get(CursorMarkParams.CURSOR_MARK_PARAM);
+          if (null != cursorStr) {
+            rb.rsp.add(CursorMarkParams.CURSOR_MARK_NEXT, cursorStr);
+          }
         }
         if(rb.isDebug()) {
           NamedList debug = new NamedList();

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-deeppaging.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-deeppaging.xml
@@ -30,12 +30,21 @@
 
   <xi:include href="solrconfig.snippet.randomindexconfig.xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
 
+  <searchComponent name="delayingSearchComponent"
+                   class="org.apache.solr.search.DelayingSearchComponent"/>
+
+  <requestHandler name="/select" class="solr.SearchHandler">
+    <arr name="first-components">
+      <str>delayingSearchComponent</str>
+    </arr>
+  </requestHandler>
+
   <updateHandler class="solr.DirectUpdateHandler2">
     <updateLog>
       <str name="dir">${solr.ulog.dir:}</str>
     </updateLog>
   </updateHandler>
-  
+
   <!-- deep paging better play nice with caching -->
   <query>
     <!-- no wautowarming, it screws up our ability to sanity check cache stats in tests -->

--- a/solr/core/src/test/org/apache/solr/cloud/DistribCursorPagingTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/DistribCursorPagingTest.java
@@ -132,13 +132,6 @@ public class DistribCursorPagingTest extends AbstractFullDistribZkTestBase {
                       CURSOR_MARK_PARAM, CURSOR_MARK_START),
                ErrorCode.BAD_REQUEST, "_docid_");
 
-    // using cursor w/ timeAllowed
-    assertFail(params("q", "*:*", 
-                      "sort", "id desc", 
-                      CommonParams.TIME_ALLOWED, "1000",
-                      CURSOR_MARK_PARAM, CURSOR_MARK_START),
-               ErrorCode.BAD_REQUEST, CommonParams.TIME_ALLOWED);
-
     // using cursor w/ grouping
     assertFail(params("q", "*:*", 
                       "sort", "id desc", 

--- a/solr/solr-ref-guide/src/common-query-parameters.adoc
+++ b/solr/solr-ref-guide/src/common-query-parameters.adoc
@@ -206,7 +206,7 @@ The default value of this parameter is blank, which causes no extra "explain inf
 
 == timeAllowed Parameter
 
-This parameter specifies the amount of time, in milliseconds, allowed for a search to complete. If this time expires before the search is complete, any partial results will be returned, but values such as `numFound`, <<faceting.adoc#faceting,facet>> counts, and result <<the-stats-component.adoc#the-stats-component,stats>> may not be accurate for the entire result set. In case of expiration, if `omitHeader` isn't set to `true` the response header contains a special flag called `partialResults`.
+This parameter specifies the amount of time, in milliseconds, allowed for a search to complete. If this time expires before the search is complete, any partial results will be returned, but values such as `numFound`, <<faceting.adoc#faceting,facet>> counts, and result <<the-stats-component.adoc#the-stats-component,stats>> may not be accurate for the entire result set. In case of expiration, if `omitHeader` isn't set to `true` the response header contains a special flag called `partialResults`. When using `timeAllowed` in combination with <<pagination-of-results.adoc#using-cursors,`cursorMark`>>, and the `partialResults` flag is present, some matching documents may have been skipped in the result set. Additionally, if  the `partialResults` flag is present, `cursorMark` can match `nextCursorMark` even if there may be more results
 
 [source,json]
 ----
@@ -252,7 +252,7 @@ The default value of this parameter is `false`.
 
 This parameter may be set to either `true` or `false`.
 
-If set to `true`, this parameter excludes the header from the returned results. The header contains information about the request, such as the time it took to complete. The default value for this parameter is `false`.
+If set to `true`, this parameter excludes the header from the returned results. The header contains information about the request, such as the time it took to complete. The default value for this parameter is `false`. When using parameters such as <<common-query-parameters.adoc#timeallowed-parameter,`timeAllowed`>>, and <<solrcloud-query-routing-and-read-tolerance.adoc#shards-tolerant-parameter,`shards.tolerant`>>, which can lead to partial results, it is advisable to keep the keep the header, so that the `partialResults` flag can be checked, and values such as `numFound`, `nextCursorMark`, <<faceting.adoc#faceting,Facet>> counts, and result <<the-stats-component.adoc#the-stats-component,Stats>> can be interpreted in the context of partial results.
 
 == wt Parameter
 

--- a/solr/solr-ref-guide/src/pagination-of-results.adoc
+++ b/solr/solr-ref-guide/src/pagination-of-results.adoc
@@ -97,6 +97,7 @@ There are a few important constraints to be aware of when using `cursorMark` par
 
 . `cursorMark` and `start` are mutually exclusive parameters.
 * Your requests must either not include a `start` parameter, or it must be specified with a value of "```0```".
+. When using the <<common-query-parameters.adoc#timeallowed-parameter,`timeAllowed` request param>>, partial results may be returned.  If time expires before the search is complete - as indicated when the `responseHeader` includes `"partialResults": true`, some matching documents may have been skipped. Additionally, if `cursorMark` matches `nextCursorMark`, you cannot be sure that there are no more results. In these situation, consider increasing `timeAllowed` and reissuing the query.  When the `responseHeader` no longer includes `"partialResults": true` and `cursorMark` matches `nextCursorMark`, there are no more results.
 . `sort` clauses must include the uniqueKey field (either `asc` or `desc`).
 * If `id` is your uniqueKey field, then sort parameters like `id asc` and `name asc, id desc` would both work fine, but `name asc` by itself would not
 . Sorts including <<working-with-dates.adoc#working-with-dates,Date Math>> based functions that involve calculations relative to `NOW` will cause confusing results, since every document will get a new sort value on every subsequent request. This can easily result in cursors that never end, and constantly return the same documents over and over – even if the documents are never updated.


### PR DESCRIPTION
# Description

[SOLR-14413](https://issues.apache.org/jira/browse/SOLR-14413): allow timeAllowed and cursorMark parameters.

Ever since cursorMarks were introduced in SOLR-5463 in 2014, cursorMark and timeAllowed parameters were not allowed in combination ("Can not search using both cursorMark and timeAllowed"), from [QueryComponent.java](https://github.com/apache/lucene-solr/blob/03363f413f2134594b012175deb3f10ec9384400/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java#L358):
```java
 if (null != rb.getCursorMark() && 0 < timeAllowed) {
  // fundamentally incompatible
  throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, "Can not search using both " + CursorMarkParams.CURSOR_MARK_PARAM + " and " + CommonParams.TIME_ALLOWED);
}

```
While theoretically impure to use them in combination, it is often desirable to support cursormarks-style deep paging and attempt to protect Solr nodes from runaway queries using timeAllowed, in the hopes that most of the time, the query completes in the allotted time, and there is no conflict.

 
However if the query takes too long, it may be preferable to end the query and protect the Solr node and provide the user with a somewhat inaccurate sorted list. As noted in SOLR-6930, SOLR-5986 and others, timeAllowed is frequently used to prevent runaway load.  In fact, cursorMark and shards.tolerant are allowed in combination, so any argument in favor of purity would be a bit muddied in my opinion.

 

This was discussed once in the mailing list that I can find: https://mail-archives.apache.org/mod_mbox/lucene-solr-user/201506.mbox/%3C5591740B.4080807@elyograg.org%3E It did not look like there was strong support for preventing the combination.

 

I have tested cursorMark and timeAllowed combination together, and even when partial results are returned because the timeAllowed is exceeded, the cursorMark response value is still valid and reasonable.

# Solution

Remove the parameter check and assume that the implementer submitting the query accepts the tradeoff between accurate sorting, and timebounded queries.

# Tests

I removed the corresponding tests that checked the parameter combination - I didn't see any further insight in those tests as to why the combination wasn't allowed, so I assume they were just providing coverage of that check.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [x] I have added tests for my changes.
- [x] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
