### PR TITLE
LUCENE-9332 validate source patterns using gradle

### DIFF
--- a/gradle/validation/validate-source-patterns.gradle
+++ b/gradle/validation/validate-source-patterns.gradle
@@ -1,3 +1,5 @@
+import org.gradle.plugins.ide.eclipse.model.Output
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -25,19 +27,222 @@ configure(rootProject) {
     checkSourceDeps
   }
 
-  dependencies {
-    checkSourceDeps "org.codehaus.groovy:groovy-all:2.4.17"
-    checkSourceDeps "org.apache.rat:apache-rat:${scriptDepVersions['apache-rat']}"
+  task("validateSourcePatterns2", type: ValidateSourcePatternTask) {
+    group = 'Verification'
+    description = 'Validate Source Patterns'
+  }
+}
+
+class ValidateSourcePatternTask extends DefaultTask {
+  @Input
+  fileExtensions = [
+    'java', 'jflex', 'py', 'pl', 'g4', 'jj', 'html', 'js',
+    'css', 'xml', 'xsl', 'vm', 'sh', 'cmd', 'bat', 'policy',
+    'properties', 'mdtext', 'groovy',
+    'template', 'adoc', 'json',
+  ]
+
+  @InputFiles
+  inputFileSet = project.fileTree(project.rootDir) {
+    fileExtensions.each { extension ->
+      include 'lucene/**/*.' + extension
+      include 'solr/**/*.' + extension
+      include 'dev-tools/**/*.' + extension
+      include '*.' + extension
+    }
+
+    // TODO: For now we don't scan txt files, so we check licenses in top-level folders separately:
+    include '*.txt'
+    include '*/*.txt'
+
+    exclude '**/build/**'
+    exclude '**/dist/**'
+    exclude 'lucene/benchmark/work/**'
+    exclude 'lucene/benchmark/temp/**'
+    exclude '**/CheckLoggingConfiguration.java'
+    exclude 'lucene/tools/src/groovy/check-source-patterns.groovy' // ourselves :-)
+    exclude 'solr/core/src/test/org/apache/hadoop/**'
   }
 
-  task validateSourcePatterns() {
-    doFirst {
-      ant.taskdef(
-          name: "groovy",
-          classname: "org.codehaus.groovy.ant.Groovy",
-          classpath: configurations.checkSourceDeps.asPath)
+  @Input
+  int baseDirLen = project.rootDir.toString().length() + 1
 
-      ant.groovy(src: project(":lucene").file("tools/src/groovy/check-source-patterns.groovy"))
+  @OutputFile
+  File violationReport = project.file("${project.buildDir}/vsp/source-pattern-report.txt")
+
+  def reportViolation(File f, String name) {
+    def filename = f.toString().substring(baseDirLen).replace(File.separatorChar, (char)'/')
+    violationReport << "${name}: ${filename}"
+  }
+
+//    def licenseMatcher = Defaults.createDefaultMatcher();
+  def lineSplitter = ~$/[\r\n]+/$
+  def isLicense = { matcher, ratDocument ->
+    licenseMatcher.reset()
+    return lineSplitter.split(matcher.group(1)).any{ licenseMatcher.match(ratDocument, it) }
+  }
+
+  def checkLicenseHeaderPrecedes = { File f, String description, contentPattern, commentPattern, text, ratDocument ->
+    def contentMatcher = contentPattern.matcher(text)
+    if (contentMatcher.find()) {
+      def contentStartPos = contentMatcher.start()
+      def commentMatcher = commentPattern.matcher(text)
+      while (commentMatcher.find()) {
+        if (isLicense(commentMatcher, ratDocument)) {
+          if (commentMatcher.start() < contentStartPos) {
+            break // This file is all good, so break loop: license header precedes 'description' definition
+          } else {
+            reportViolation(f, "${description} declaration precedes license header")
+          }
+        }
+      }
+    }
+  }
+
+  def checkMockitoAssume(File f, String text) {
+    if (text.contains("mockito") && !text.contains("assumeWorkingMockito()")) {
+      reportViolation(f, 'File uses Mockito but has no assumeWorkingMockito() call')
+    }
+  }
+
+  def singleLineSplitter = ~$/\r?\n/$
+  def sourceHeaderPattern = ~$/\[source\b.*/$
+  def blockBoundaryPattern = ~$/----\s*/$
+  def blockTitlePattern = ~$/\..*/$
+  def unescapedSymbolPattern = ~$/(?<=[^\\]|^)([-=]>|<[-=])/$ // SOLR-10883
+
+  def checkForUnescapedSymbolSubstitutions(File f, String text) {
+    def inCodeBlock = false
+    def underSourceHeader = false
+    def lineNumber = 0
+
+    singleLineSplitter.split(text).each {
+      ++lineNumber
+      if (underSourceHeader) { // This line is either a single source line, or the boundary of a code block
+        inCodeBlock = blockBoundaryPattern.matcher(it).matches()
+        if ( ! blockTitlePattern.matcher(it).matches()) {
+          underSourceHeader = false
+        }
+      } else {
+        if (inCodeBlock) {
+          inCodeBlock = ! blockBoundaryPattern.matcher(it).matches()
+        } else {
+          underSourceHeader = sourceHeaderPattern.matcher(it).lookingAt()
+          if ( ! underSourceHeader) {
+            def unescapedSymbolMatcher = unescapedSymbolPattern.matcher(it)
+            if (unescapedSymbolMatcher.find()) {
+              reportViolation(f, "Unescaped symbol '${unescapedSymbolMatcher.group(1)}' on line # ${lineNumber}")
+            }
+          }
+        }
+      }
+    }
+  }
+
+  @TaskAction
+  def validateSourcePatterns() {
+    def invalidPatterns = [
+      (~$/@author\b/$) : '@author javadoc tag',
+      (~$/(?i)\bno(n|)commit\b/$) : 'nocommit',
+      (~$/\bTOOD:/$) : 'TOOD instead TODO',
+      (~$/\t/$) : 'tabs instead spaces',
+      (~$/\Q/**\E((?:\s)|(?:\*))*\Q{@inheritDoc}\E((?:\s)|(?:\*))*\Q*/\E/$) : '{@inheritDoc} on its own is unnecessary',
+      (~$/\$$(?:LastChanged)?Date\b/$) : 'svn keyword',
+      (~$/\$$(?:(?:LastChanged)?Revision|Rev)\b/$) : 'svn keyword',
+      (~$/\$$(?:LastChangedBy|Author)\b/$) : 'svn keyword',
+      (~$/\$$(?:Head)?URL\b/$) : 'svn keyword',
+      (~$/\$$Id\b/$) : 'svn keyword',
+      (~$/\$$Header\b/$) : 'svn keyword',
+      (~$/\$$Source\b/$) : 'svn keyword',
+      (~$/^\uFEFF/$) : 'UTF-8 byte order mark',
+      (~$/import java\.lang\.\w+;/$) : 'java.lang import is unnecessary'
+    ]
+
+    // Python and others merrily use var declarations, this is a problem _only_ in Java at least for 8x where we're forbidding var declarations
+    def invalidJavaOnlyPatterns = [
+      (~$/\n\s*var\s+.*=.*<>.*/$) : 'Diamond operators should not be used with var',
+      (~$/\n\s*var\s+/$) : 'var is not allowed in until we stop development on the 8x code line'
+    ]
+
+    def javadocsPattern = ~$/(?sm)^\Q/**\E(.*?)\Q*/\E/$
+    def javaCommentPattern = ~$/(?sm)^\Q/*\E(.*?)\Q*/\E/$
+    def xmlCommentPattern = ~$/(?sm)\Q<!--\E(.*?)\Q-->\E/$
+    def validLoggerPattern = ~$/(?s)\b(private\s|static\s|final\s){3}+\s*Logger\s+\p{javaJavaIdentifierStart}+\s+=\s+\QLoggerFactory.getLogger(MethodHandles.lookup().lookupClass());\E/$
+    def validLoggerNamePattern = ~$/(?s)\b(private\s|static\s|final\s){3}+\s*Logger\s+log+\s+=\s+\QLoggerFactory.getLogger(MethodHandles.lookup().lookupClass());\E/$
+    def packagePattern = ~$/(?m)^\s*package\s+org\.apache.*;/$
+    def xmlTagPattern = ~$/(?m)\s*<[a-zA-Z].*/$
+    def extendsLuceneTestCasePattern = ~$/public.*?class.*?extends.*?LuceneTestCase[^\n]*?\n/$
+    def validSPINameJavadocTag = ~$/(?s)\s*\*\s*@lucene\.spi\s+\{@value #NAME\}/$
+
+    violationReport.newWriter().withWriter {
+      // Truncate the report file
+    }
+
+    inputFileSet.each { f ->
+      logger.debug("Scanning file: ${f}")
+      def text = f.getText('UTF-8')
+      invalidPatterns.each { pattern,name ->
+        if (pattern.matcher(text).find()) {
+          reportViolation(f, name)
+        }
+      }
+      def javadocsMatcher = javadocsPattern.matcher(text)
+//      def ratDocument = new org.apache.rat.document.impl.FileDocument(f);
+      while (javadocsMatcher.find()) {
+//        if (isLicense(javadocsMatcher, ratDocument)) {
+//          reportViolation(f, String.format(Locale.ENGLISH, 'javadoc-style license header [%s]',
+//                  ratDocument.getMetaData().value(MetaData.RAT_URL_LICENSE_FAMILY_NAME)));
+//        }
+      }
+      if (f.name.endsWith('.java')) {
+        if (text.contains('org.slf4j.LoggerFactory')) {
+          if (!validLoggerPattern.matcher(text).find()) {
+            reportViolation(f, 'invalid logging pattern [not private static final, uses static class name]')
+          }
+          if (!validLoggerNamePattern.matcher(text).find()) {
+            reportViolation(f, 'invalid logger name [log, uses static class name, not specialized logger]')
+          }
+        }
+        // make sure that SPI names of all tokenizers/charfilters/tokenfilters are documented
+        if (!f.name.contains("Test") && !f.name.contains("Mock") && !text.contains("abstract class") &&
+                f.name != "TokenizerFactory.java" && f.name != "CharFilterFactory.java" && f.name != "TokenFilterFactory.java" &&
+                (f.name.contains("TokenizerFactory") && text.contains("extends TokenizerFactory") ||
+                        f.name.contains("CharFilterFactory") && text.contains("extends CharFilterFactory") ||
+                        f.name.contains("FilterFactory") && text.contains("extends TokenFilterFactory"))) {
+          if (!validSPINameJavadocTag.matcher(text).find()) {
+            reportViolation(f, 'invalid spi name documentation')
+          }
+        }
+//        checkLicenseHeaderPrecedes(f, 'package', packagePattern, javaCommentPattern, text, ratDocument);
+        if (f.name.contains("Test")) {
+          checkMockitoAssume(f, text)
+        }
+
+        if (f.path.substring(baseDirLen).contains("solr/")
+                && f.name != "SolrTestCase.java"
+                && f.name != "TestXmlQParser.java") {
+          if (extendsLuceneTestCasePattern.matcher(text).find()) {
+            reportViolation(f, "Solr test cases should extend SolrTestCase rather than LuceneTestCase")
+          }
+        }
+        invalidJavaOnlyPatterns.each { pattern,name ->
+          if (pattern.matcher(text).find()) {
+            reportViolation(f, name)
+          }
+        }
+      }
+      if (f.name.endsWith('.xml') || f.name.endsWith('.xml.template')) {
+//        checkLicenseHeaderPrecedes(f, '<tag>', xmlTagPattern, xmlCommentPattern, text, ratDocument);
+      }
+      if (f.name.endsWith('.adoc')) {
+        checkForUnescapedSymbolSubstitutions(f, text)
+      }
+    }
+
+    def violations = violationReport.readLines()
+    if (violations) {
+      throw new GradleException("Found " + violations.size() + " violations(s):\n" +
+              violations.collect{ msg -> "  - ${msg}" }.join("\n"))
     }
   }
 }


### PR DESCRIPTION
If we have a gradle task with declared InputFiles and OutputFile then Gradle can figure out when the check is still up to date and when it needs to be rerun. Most of this is just a straight copy from the groovy script. This can take up to 20s off of precommit.

TODO:
* Figure out how to enable the ratDocument part of this, it was failing on imports for me.
* Split into modules so that we don't run the whole task each time
* Possibly split by file types?

The rat part is the main thing that I need help with, I haven't been able to figure out the right incantation of dependency declarations and build script declarations and whatever else we need to make it in scope. Any pointers appreciated.
