### PR TITLE
LUCENE-9338: Clean up type safety in SimpleBindings

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -216,6 +216,9 @@ Other
 * LUCENE-9191: Make LineFileDocs's random seeking more efficient, making tests using LineFileDocs faster (Robert Muir,
   Mike McCandless)
 
+* LUCENE-9338: Refactors SimpleBindings to improve type safety and cycle detection (Alan Woodward,
+  Adrien Grand)
+
 ======================= Lucene 8.5.1 =======================
 
 Bug Fixes

--- a/lucene/expressions/src/java/org/apache/lucene/expressions/ExpressionValueSource.java
+++ b/lucene/expressions/src/java/org/apache/lucene/expressions/ExpressionValueSource.java
@@ -31,9 +31,8 @@ import org.apache.lucene.search.IndexSearcher;
 /**
  * A {@link DoubleValuesSource} which evaluates a {@link Expression} given the context of an {@link Bindings}.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 final class ExpressionValueSource extends DoubleValuesSource {
-  final DoubleValuesSource variables[];
+  final DoubleValuesSource[] variables;
   final Expression expression;
   final boolean needsScores;
 
@@ -42,17 +41,13 @@ final class ExpressionValueSource extends DoubleValuesSource {
     this.expression = Objects.requireNonNull(expression);
     variables = new DoubleValuesSource[expression.variables.length];
     boolean needsScores = false;
-    try {
-      for (int i = 0; i < variables.length; i++) {
-        DoubleValuesSource source = bindings.getDoubleValuesSource(expression.variables[i]);
-        if (source == null) {
-          throw new RuntimeException("Internal error. Variable (" + expression.variables[i] + ") does not exist.");
-        }
-        needsScores |= source.needsScores();
-        variables[i] = source;
+    for (int i = 0; i < variables.length; i++) {
+      DoubleValuesSource source = bindings.getDoubleValuesSource(expression.variables[i]);
+      if (source == null) {
+        throw new RuntimeException("Internal error. Variable (" + expression.variables[i] + ") does not exist.");
       }
-    } catch (StackOverflowError e) {
-      throw new IllegalArgumentException("Recursion error: Cycle detected originating in " + this);
+      needsScores |= source.needsScores();
+      variables[i] = source;
     }
     this.needsScores = needsScores;
   }

--- a/lucene/expressions/src/java/org/apache/lucene/expressions/SimpleBindings.java
+++ b/lucene/expressions/src/java/org/apache/lucene/expressions/SimpleBindings.java
@@ -107,8 +107,8 @@ public final class SimpleBindings extends Bindings {
    * @throws IllegalArgumentException if the bindings is inconsistent
    */
   public void validate() {
-    for (String origin : map.keySet()) {
-      map.get(origin).apply(new CycleDetectionBindings(origin));
+    for (Map.Entry<String, Function<Bindings, DoubleValuesSource>> origin : map.entrySet()) {
+      origin.getValue().apply(new CycleDetectionBindings(origin.getKey()));
     }
   }
 

--- a/lucene/expressions/src/test/org/apache/lucene/expressions/TestExpressionValidation.java
+++ b/lucene/expressions/src/test/org/apache/lucene/expressions/TestExpressionValidation.java
@@ -110,4 +110,15 @@ public class TestExpressionValidation extends LuceneTestCase {
     });
     assertTrue(expected.getMessage().contains("Cycle detected"));
   }
+
+  public void testCoRecursion42() throws Exception {
+    SimpleBindings bindings = new SimpleBindings();
+    bindings.add("cycle2", JavascriptCompiler.compile("cycle1"));
+    bindings.add("cycle1", JavascriptCompiler.compile("cycle0"));
+    bindings.add("cycle0", JavascriptCompiler.compile("cycle1"));
+    IllegalArgumentException expected = expectThrows(IllegalArgumentException.class, () -> {
+      bindings.validate();
+    });
+    assertEquals("Recursion error: Cycle detected [cycle2, cycle1, cycle0]->cycle1", expected.getMessage());
+  }
 }

--- a/lucene/expressions/src/test/org/apache/lucene/expressions/TestExpressionValidation.java
+++ b/lucene/expressions/src/test/org/apache/lucene/expressions/TestExpressionValidation.java
@@ -110,15 +110,4 @@ public class TestExpressionValidation extends LuceneTestCase {
     });
     assertTrue(expected.getMessage().contains("Cycle detected"));
   }
-
-  public void testCoRecursion42() throws Exception {
-    SimpleBindings bindings = new SimpleBindings();
-    bindings.add("cycle2", JavascriptCompiler.compile("cycle1"));
-    bindings.add("cycle1", JavascriptCompiler.compile("cycle0"));
-    bindings.add("cycle0", JavascriptCompiler.compile("cycle1"));
-    IllegalArgumentException expected = expectThrows(IllegalArgumentException.class, () -> {
-      bindings.validate();
-    });
-    assertEquals("Recursion error: Cycle detected [cycle2, cycle1, cycle0]->cycle1", expected.getMessage());
-  }
 }


### PR DESCRIPTION
Replaces SimpleBindings' `Map<String, Object>` with a map of 
`Supplier<DoubleValuesSource>` to improve type safety.  Also moves cycle
detection directly into ExpressionValuesSource.