### PR TITLE
SOLR-14425: Aliases: ZK sync() needs to be synchronous

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -135,6 +135,9 @@ Bug Fixes
 
 * SOLR-14421: New examples in solr.in.cmd in Solr 8.5 don't work as provided (Colvin Cowie via janhoy)
 
+* SOLR-14425: Reading of collection aliases didn't always read the latest state from ZooKeeper (incorrect sync() usage)
+  (David Smiley)
+
 Other Changes
 ---------------------
 * SOLR-14197: SolrResourceLoader: marked many methods as deprecated, and in some cases rerouted exiting logic to avoid

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/ZkStateReader.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/ZkStateReader.java
@@ -2154,7 +2154,7 @@ public class ZkStateReader implements SolrCloseable {
     public boolean update() throws KeeperException, InterruptedException {
       log.debug("Checking ZK for most up to date Aliases {}", ALIASES);
       // Call sync() first to ensure the subsequent read (getData) is up to date.
-      zkClient.getSolrZooKeeper().sync(ALIASES, null, null);
+      zkClient.sync(ALIASES);
       Stat stat = new Stat();
       final byte[] data = zkClient.getData(ALIASES, null, stat, true);
       return setIfNewer(Aliases.fromJSON(data, stat.getVersion()));


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-14425

CC @dragonsinth @tflobbe Does this make sense?

Separately, I'll file an issue to add CuratorFramework to SolrZkClient