### PR TITLE
SOLR-14428 minimize memory footprint of fuzzy query

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/MultiTermQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiTermQuery.java
@@ -324,7 +324,7 @@ public abstract class MultiTermQuery extends Query {
    * Sets the rewrite method to be used when executing the
    * query.  You can use one of the four core methods, or
    * implement your own subclass of {@link RewriteMethod}. */
-  public void setRewriteMethod(RewriteMethod method) {
+  public final void setRewriteMethod(RewriteMethod method) {
     rewriteMethod = method;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/search/Query.java
+++ b/lucene/core/src/java/org/apache/lucene/search/Query.java
@@ -126,4 +126,15 @@ public abstract class Query {
   protected final int classHash() {
     return CLASS_NAME_HASH;
   }
+
+  /**
+   * Some Query implementations will compute and store extra fields for execution efficiency. However, when the
+   * resulting Query is used as the key in a cache, it bloats the memory requirements because the extra fields are
+   * not required for equality comparisons. Give Query and Cache objects an opportunity to collaborate and reduce
+   * the memory footprint.
+   * @return a Query that {{@link #equals(Object)}} this query. Can be the same instance or a new instance.
+   */
+  public Query toCacheKey() {
+    return this;
+  }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/Query.java
+++ b/lucene/core/src/java/org/apache/lucene/search/Query.java
@@ -132,7 +132,7 @@ public abstract class Query {
    * resulting Query is used as the key in a cache, it bloats the memory requirements because the extra fields are
    * not required for equality comparisons. Give Query and Cache objects an opportunity to collaborate and reduce
    * the memory footprint.
-   * @return a Query that {{@link #equals(Object)}} this query. Can be the same instance or a new instance.
+   * @return a Query that {@link #equals(Object) equals} this query. Can be the same instance or a new instance.
    */
   public Query toCacheKey() {
     return this;

--- a/solr/core/src/java/org/apache/solr/search/QueryResultKey.java
+++ b/solr/core/src/java/org/apache/solr/search/QueryResultKey.java
@@ -22,10 +22,8 @@ import org.apache.lucene.search.SortField;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.RamUsageEstimator;
 
-import java.util.Iterator;
 import java.util.List;
 import java.util.ArrayList;
-import java.util.ListIterator;
 import java.util.stream.Collectors;
 
 /** A hash key encapsulating a query, a list of filters, and a sort

--- a/solr/core/src/java/org/apache/solr/search/QueryResultKey.java
+++ b/solr/core/src/java/org/apache/solr/search/QueryResultKey.java
@@ -45,7 +45,7 @@ public final class QueryResultKey implements Accountable {
 
 
   public QueryResultKey(Query query, List<Query> filters, Sort sort, int nc_flags) {
-    this.query = query;
+    this.query = query.toCacheKey();
     this.sort = sort;
     this.filters = filters;
     this.nc_flags = nc_flags;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-14428

Make the automata of a fuzzy query mutable so that we don't always have to store them. However, there will be cases when we need to recompute them anyway.

Will add unit tests if this approach makes sense.