### PR TITLE
SOLR-13184: Added a null check in FunctionQParser.parseArg()

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/FunctionQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/FunctionQParser.java
@@ -203,6 +203,9 @@ public class FunctionQParser extends QParser {
         sp.pos++;
         String param = sp.getId();
         val = getParam(param);
+        if (val == null) {
+          throw new SyntaxError("Missing param $" + param + " while parsing '" + sp.val + "'");
+        }
         break;
       case '\'':
       case '"':

--- a/solr/core/src/test/org/apache/solr/search/QueryParsingTest.java
+++ b/solr/core/src/test/org/apache/solr/search/QueryParsingTest.java
@@ -135,5 +135,10 @@ public class QueryParsingTest extends SolrTestCaseJ4 {
     exception = expectThrows(SolrException.class, () -> h.query(req("q", "*:*", "stats", "true", "stats.field", "{!bleh}")));
     assertEquals(SolrException.ErrorCode.BAD_REQUEST.code, exception.code());
     assertEquals("invalid query parser 'bleh' for query '{!bleh}'", exception.getMessage());
+    
+    // with invalid field
+    exception = expectThrows(SolrException.class, () -> h.query(req("q", "{!frange l=10 u=100}joindf(genre:comedy,$x)")));
+    assertEquals(SolrException.ErrorCode.BAD_REQUEST.code, exception.code());
+    assertEquals("Missing param $x while parsing 'joindf(genre:comedy,$x)'", exception.getCause().getMessage());
   }
 }


### PR DESCRIPTION
<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

FunctionQParser.parseArg() did not throw an error when it failed to properly deference a parameter. This would cause a NPE later in JoinDocFreqValueSource.hashCode() where qfield is expected to be non-null.

# Solution

Added a check in FunctionQParser.parseArg() for null parameters

# Tests

Added an extra test in QueryParsingTest.testGetQParser() to check for NPEs resulting from invalid inputs

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title. **(Existing issue)**
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
