### PR TITLE
Fix visibility on member variables in IndexWriter and friends

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriter.java
@@ -30,7 +30,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import java.util.function.ToLongFunction;
 
-import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.DocumentsWriterPerThread.FlushedSegment;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.store.AlreadyClosedException;
@@ -126,7 +125,6 @@ final class DocumentsWriter implements Closeable, Accountable {
   private volatile boolean pendingChangesInCurrentFullFlush;
 
   final DocumentsWriterPerThreadPool perThreadPool;
-  final FlushPolicy flushPolicy;
   final DocumentsWriterFlushControl flushControl;
 
   DocumentsWriter(FlushNotifications flushNotifications, int indexCreatedVersionMajor, AtomicLong pendingNumDocs, boolean enableTestPoints,
@@ -142,7 +140,6 @@ final class DocumentsWriter implements Closeable, Accountable {
           directory, config, infoStream, deleteQueue, infos,
           pendingNumDocs, enableTestPoints);
     });
-    flushPolicy = config.getFlushPolicy();
     this.pendingNumDocs = pendingNumDocs;
     flushControl = new DocumentsWriterFlushControl(this, config);
     this.flushNotifications = flushNotifications;
@@ -151,7 +148,6 @@ final class DocumentsWriter implements Closeable, Accountable {
   long deleteQueries(final Query... queries) throws IOException {
     return applyDeleteOrUpdate(q -> q.addDelete(queries));
   }
-
 
   long deleteTerms(final Term... terms) throws IOException {
     return applyDeleteOrUpdate(q -> q.addDelete(terms));
@@ -406,7 +402,7 @@ final class DocumentsWriter implements Closeable, Accountable {
     return hasEvents;
   }
 
-  long updateDocuments(final Iterable<? extends Iterable<? extends IndexableField>> docs, final Analyzer analyzer,
+  long updateDocuments(final Iterable<? extends Iterable<? extends IndexableField>> docs,
                        final DocumentsWriterDeleteQueue.Node<?> delNode) throws IOException {
     boolean hasEvents = preUpdate();
 
@@ -420,7 +416,7 @@ final class DocumentsWriter implements Closeable, Accountable {
       ensureOpen();
       final int dwptNumDocs = dwpt.getNumDocsInRAM();
       try {
-        seqNo = dwpt.updateDocuments(docs, analyzer, delNode, flushNotifications);
+        seqNo = dwpt.updateDocuments(docs, delNode, flushNotifications);
       } finally {
         if (dwpt.isAborted()) {
           flushControl.doOnAbort(dwpt);

--- a/lucene/core/src/java/org/apache/lucene/index/IndexFileDeleter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexFileDeleter.java
@@ -345,8 +345,8 @@ final class IndexFileDeleter implements Closeable {
   void ensureOpen() throws AlreadyClosedException {
     writer.ensureOpen(false);
     // since we allow 'closing' state, we must still check this, we could be closing because we hit e.g. OOM
-    if (writer.tragedy.get() != null) {
-      throw new AlreadyClosedException("refusing to delete any files: this IndexWriter hit an unrecoverable exception", writer.tragedy.get());
+    if (writer.getTragicException() != null) {
+      throw new AlreadyClosedException("refusing to delete any files: this IndexWriter hit an unrecoverable exception", writer.getTragicException());
     }
   }
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestAddIndexes.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestAddIndexes.java
@@ -1446,7 +1446,7 @@ public class TestAddIndexes extends LuceneTestCase {
     assertEquals(wrappedReader.numDocs(), writer.getDocStats().numDocs);
     assertEquals(maxDoc, writer.getDocStats().maxDoc);
     writer.commit();
-    SegmentCommitInfo commitInfo = writer.listOfSegmentCommitInfos().get(0);
+    SegmentCommitInfo commitInfo = writer.cloneSegmentInfos().info(0);
     assertEquals(maxDoc-wrappedReader.numDocs(), commitInfo.getSoftDelCount());
     writer.close();
     Directory dir3 = newDirectory();

--- a/lucene/core/src/test/org/apache/lucene/index/TestConcurrentMergeScheduler.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestConcurrentMergeScheduler.java
@@ -115,7 +115,7 @@ public class TestConcurrentMergeScheduler extends LuceneTestCase {
           failure.clearDoFail();
           assertTrue(writer.isClosed());
           // Abort should have closed the deleter:
-          assertTrue(writer.deleter.isClosed());
+          assertTrue(writer.isDeleterClosed());
           break outer;
         }
       }

--- a/lucene/core/src/test/org/apache/lucene/index/TestFlushByRamOrCountsPolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestFlushByRamOrCountsPolicy.java
@@ -99,7 +99,7 @@ public class TestFlushByRamOrCountsPolicy extends LuceneTestCase {
         flushPolicy.peakBytesWithoutFlush <= maxRAMBytes);
     assertActiveBytesAfter(flushControl);
     if (flushPolicy.hasMarkedPending) {
-      assertTrue(maxRAMBytes < flushControl.peakActiveBytes);
+      assertTrue(maxRAMBytes < flushControl.getPeakActiveBytes());
     }
     if (ensureNotStalled) {
       assertFalse(docsWriter.flushControl.stallControl.wasStalled());
@@ -194,8 +194,8 @@ public class TestFlushByRamOrCountsPolicy extends LuceneTestCase {
       assertTrue("peak bytes without flush exceeded watermark",
           flushPolicy.peakBytesWithoutFlush <= maxRAMBytes);
       if (flushPolicy.hasMarkedPending) {
-        assertTrue("max: " + maxRAMBytes + " " + flushControl.peakActiveBytes,
-            maxRAMBytes <= flushControl.peakActiveBytes);
+        assertTrue("max: " + maxRAMBytes + " " + flushControl.getPeakActiveBytes(),
+            maxRAMBytes <= flushControl.getPeakActiveBytes());
       }
     }
     assertActiveBytesAfter(flushControl);
@@ -253,7 +253,7 @@ public class TestFlushByRamOrCountsPolicy extends LuceneTestCase {
             "single thread must not block numThreads: " + numThreads[i],
             docsWriter.flushControl.stallControl.hasBlocked());
       }
-      if (docsWriter.flushControl.peakNetBytes > (2.d * iwc.getRAMBufferSizeMB() * 1024.d * 1024.d)) {
+      if (docsWriter.flushControl.getPeakNetBytes() > (2.d * iwc.getRAMBufferSizeMB() * 1024.d * 1024.d)) {
         assertTrue(docsWriter.flushControl.stallControl.wasStalled());
       }
       assertActiveBytesAfter(flushControl);

--- a/lucene/core/src/test/org/apache/lucene/index/TestForceMergeForever.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestForceMergeForever.java
@@ -70,7 +70,7 @@ public class TestForceMergeForever extends LuceneTestCase {
       w.addDocument(docs.nextDoc());
     }
     MergePolicy mp = w.getConfig().getMergePolicy();
-    final int mergeAtOnce = 1+w.listOfSegmentCommitInfos().size();
+    final int mergeAtOnce = 1+w.cloneSegmentInfos().size();
     if (mp instanceof TieredMergePolicy) {
       ((TieredMergePolicy) mp).setMaxMergeAtOnce(mergeAtOnce);
     } else if (mp instanceof LogMergePolicy) {

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
@@ -3448,12 +3448,12 @@ public class TestIndexWriter extends LuceneTestCase {
     d.add(new StringField("id", "doc-1", Field.Store.YES));
     writer.addDocument(d);
     writer.deleteDocuments(new Term("id", "doc-1"));
-    assertEquals(1, writer.listOfSegmentCommitInfos().size());
+    assertEquals(1, writer.cloneSegmentInfos().size());
     writer.flush();
-    assertEquals(1, writer.listOfSegmentCommitInfos().size());
+    assertEquals(1, writer.cloneSegmentInfos().size());
     writer.commit();
     assertFiles(writer);
-    assertEquals(1, writer.listOfSegmentCommitInfos().size());
+    assertEquals(1, writer.cloneSegmentInfos().size());
     IOUtils.close(writer, dir);
   }
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterDelete.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterDelete.java
@@ -923,7 +923,7 @@ public class TestIndexWriterDelete extends LuceneTestCase {
         break;
       }
     }
-    assertTrue(modifier.deleter.isClosed());
+    assertTrue(modifier.isDeleterClosed());
 
     TestIndexWriter.assertNoUnreferencedFiles(dir, "docsWriter.abort() failed to delete unreferenced files");
     dir.close();

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterExceptions.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterExceptions.java
@@ -597,7 +597,7 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
     // only one flush should fail:
     assertFalse(hitError);
     hitError = true;
-    assertTrue(writer.deleter.isClosed());
+    assertTrue(writer.isDeleterClosed());
     assertTrue(writer.isClosed());
     assertFalse(DirectoryReader.indexExists(dir));
 
@@ -1292,7 +1292,7 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
           } catch (RuntimeException e) {
             assertTrue(e.getMessage().startsWith(FailOnTermVectors.EXC_MSG));
             // This is an aborting exception, so writer is closed:
-            assertTrue(w.deleter.isClosed());
+            assertTrue(w.isDeleterClosed());
             assertTrue(w.isClosed());
             dir.close();
             continue iters;

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterExceptions2.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterExceptions2.java
@@ -143,7 +143,7 @@ public class TestIndexWriterExceptions2 extends LuceneTestCase {
             }
           } catch (AlreadyClosedException ace) {
             // OK: writer was closed by abort; we just reopen now:
-            assertTrue(iw.deleter.isClosed());
+            assertTrue(iw.isDeleterClosed());
             assertTrue(allowAlreadyClosed);
             allowAlreadyClosed = false;
             conf = newIndexWriterConfig(analyzer);
@@ -177,7 +177,7 @@ public class TestIndexWriterExceptions2 extends LuceneTestCase {
             }
           } catch (AlreadyClosedException ace) {
             // OK: writer was closed by abort; we just reopen now:
-            assertTrue(iw.deleter.isClosed());
+            assertTrue(iw.isDeleterClosed());
             assertTrue(allowAlreadyClosed);
             allowAlreadyClosed = false;
             conf = newIndexWriterConfig(analyzer);
@@ -215,7 +215,7 @@ public class TestIndexWriterExceptions2 extends LuceneTestCase {
             }
           } catch (AlreadyClosedException ace) {
             // OK: writer was closed by abort; we just reopen now:
-            assertTrue(iw.deleter.isClosed());
+            assertTrue(iw.isDeleterClosed());
             assertTrue(allowAlreadyClosed);
             allowAlreadyClosed = false;
             conf = newIndexWriterConfig(analyzer);

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMaxDocs.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMaxDocs.java
@@ -458,7 +458,7 @@ public class TestIndexWriterMaxDocs extends LuceneTestCase {
     dir2.close();
   }
 
-  public void testTooLargeMaxDocs() throws Exception {
+  public void testTooLargeMaxDocs() {
     expectThrows(IllegalArgumentException.class, () -> {
       IndexWriter.setMaxDocs(Integer.MAX_VALUE);
     });

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterOnDiskFull.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterOnDiskFull.java
@@ -550,7 +550,7 @@ public class TestIndexWriterOnDiskFull extends LuceneTestCase {
     expectThrows(IOException.class, () -> {
       writer.addDocument(doc);
     });
-    assertTrue(writer.deleter.isClosed());
+    assertTrue(writer.isDeleterClosed());
     assertTrue(writer.isClosed());
 
     dir.close();

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterWithThreads.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterWithThreads.java
@@ -180,7 +180,7 @@ public class TestIndexWriterWithThreads extends LuceneTestCase {
         writer.commit();
       } catch (AlreadyClosedException ace) {
         // OK: abort closes the writer
-        assertTrue(writer.deleter.isClosed());
+        assertTrue(writer.isDeleterClosed());
       } finally {
         writer.close();
       }
@@ -317,7 +317,7 @@ public class TestIndexWriterWithThreads extends LuceneTestCase {
         success = true;
       } catch (AlreadyClosedException ace) {
         // OK: abort closes the writer
-        assertTrue(writer.deleter.isClosed());
+        assertTrue(writer.isDeleterClosed());
       } catch (IOException ioe) {
         writer.rollback();
         failure.clearDoFail();
@@ -388,7 +388,7 @@ public class TestIndexWriterWithThreads extends LuceneTestCase {
       writer.close();
     });
 
-    assertTrue(writer.deleter.isClosed());
+    assertTrue(writer.isDeleterClosed());
     dir.close();
   }
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestPerSegmentDeletes.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestPerSegmentDeletes.java
@@ -49,14 +49,14 @@ public class TestPerSegmentDeletes extends LuceneTestCase {
     }
     //System.out.println("commit1");
     writer.commit();
-    assertEquals(1, writer.listOfSegmentCommitInfos().size());
+    assertEquals(1, writer.cloneSegmentInfos().size());
     for (int x = 5; x < 10; x++) {
       writer.addDocument(DocHelper.createDocument(x, "2", 2));
       //System.out.println("numRamDocs(" + x + ")" + writer.numRamDocs());
     }
     //System.out.println("commit2");
     writer.commit();
-    assertEquals(2, writer.listOfSegmentCommitInfos().size());
+    assertEquals(2, writer.cloneSegmentInfos().size());
 
     for (int x = 10; x < 15; x++) {
       writer.addDocument(DocHelper.createDocument(x, "3", 2));
@@ -71,12 +71,12 @@ public class TestPerSegmentDeletes extends LuceneTestCase {
 
     // deletes are now resolved on flush, so there shouldn't be
     // any deletes after flush
-    assertFalse(writer.bufferedUpdatesStream.any());
+    assertFalse(writer.hasChangesInRam());
 
     // get reader flushes pending deletes
     // so there should not be anymore
     IndexReader r1 = writer.getReader();
-    assertFalse(writer.bufferedUpdatesStream.any());
+    assertFalse(writer.hasChangesInRam());
     r1.close();
 
     // delete id:2 from the first segment
@@ -90,7 +90,7 @@ public class TestPerSegmentDeletes extends LuceneTestCase {
     fsmp.length = 2;
     writer.maybeMerge();
 
-    assertEquals(2, writer.listOfSegmentCommitInfos().size());
+    assertEquals(2, writer.cloneSegmentInfos().size());
 
     // id:2 shouldn't exist anymore because
     // it's been applied in the merge and now it's gone

--- a/lucene/core/src/test/org/apache/lucene/index/TestSoftDeletesRetentionMergePolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSoftDeletesRetentionMergePolicy.java
@@ -394,7 +394,7 @@ public class TestSoftDeletesRetentionMergePolicy extends LuceneTestCase {
     // We expect any MP to merge these segments into one segment
     // when calling forceMergeDeletes.
     writer.forceMergeDeletes(true);
-    assertEquals(1, writer.listOfSegmentCommitInfos().size());
+    assertEquals(1, writer.cloneSegmentInfos().size());
     assertEquals(1, writer.getDocStats().numDocs);
     assertEquals(1, writer.getDocStats().maxDoc);
     writer.close();
@@ -417,7 +417,7 @@ public class TestSoftDeletesRetentionMergePolicy extends LuceneTestCase {
       writer.addDocument(d);
     }
     writer.flush();
-    assertEquals(1, writer.listOfSegmentCommitInfos().size());
+    assertEquals(1, writer.cloneSegmentInfos().size());
 
     if (softDelete != null) {
       // the newly created segment should be dropped as it is fully deleted (i.e. only contains deleted docs).
@@ -445,7 +445,7 @@ public class TestSoftDeletesRetentionMergePolicy extends LuceneTestCase {
     IndexReader reader = writer.getReader();
     assertEquals(reader.numDocs(), 1);
     reader.close();
-    assertEquals(1, writer.listOfSegmentCommitInfos().size());
+    assertEquals(1, writer.cloneSegmentInfos().size());
 
     writer.close();
     dir.close();
@@ -604,8 +604,8 @@ public class TestSoftDeletesRetentionMergePolicy extends LuceneTestCase {
       }
     }
     writer.forceMergeDeletes(true);
-    assertEquals(1, writer.listOfSegmentCommitInfos().size());
-    SegmentCommitInfo si = writer.listOfSegmentCommitInfos().get(0);
+    assertEquals(1, writer.cloneSegmentInfos().size());
+    SegmentCommitInfo si = writer.cloneSegmentInfos().info(0);
     assertEquals(0, si.getSoftDelCount()); // hard-delete should supersede the soft-delete
     assertEquals(0, si.getDelCount());
     assertEquals(1, si.info.maxDoc());
@@ -625,8 +625,8 @@ public class TestSoftDeletesRetentionMergePolicy extends LuceneTestCase {
     doUpdate(new Term("id", "0"), writer,
         new NumericDocValuesField("soft_delete", 1), new NumericDocValuesField("other-field", 1));
     sm.maybeRefreshBlocking();
-    assertEquals(1, writer.listOfSegmentCommitInfos().size());
-    SegmentCommitInfo si = writer.listOfSegmentCommitInfos().get(0);
+    assertEquals(1, writer.cloneSegmentInfos().size());
+    SegmentCommitInfo si = writer.cloneSegmentInfos().info(0);
     assertEquals(1, si.getSoftDelCount());
     assertEquals(1, si.info.maxDoc());
     IOUtils.close(sm, writer, dir);

--- a/lucene/core/src/test/org/apache/lucene/index/TestTieredMergePolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestTieredMergePolicy.java
@@ -363,9 +363,9 @@ public class TestTieredMergePolicy extends BaseMergePolicyTestCase {
 
     w.commit(); // want to trigger merge no matter what.
 
-    assertEquals("There should be exactly one very large and one small segment", 2, w.listOfSegmentCommitInfos().size());
-    SegmentCommitInfo info0 = w.listOfSegmentCommitInfos().get(0);
-    SegmentCommitInfo info1 = w.listOfSegmentCommitInfos().get(1);
+    assertEquals("There should be exactly one very large and one small segment", 2, w.cloneSegmentInfos().size());
+    SegmentCommitInfo info0 = w.cloneSegmentInfos().info(0);
+    SegmentCommitInfo info1 = w.cloneSegmentInfos().info(1);
     int largeSegDocCount = Math.max(info0.info.maxDoc(), info1.info.maxDoc());
     int smallSegDocCount = Math.min(info0.info.maxDoc(), info1.info.maxDoc());
     assertEquals("The large segment should have a bunch of docs", largeSegDocCount, remainingDocs);

--- a/lucene/core/src/test/org/apache/lucene/index/TestTragicIndexWriterDeadlock.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestTragicIndexWriterDeadlock.java
@@ -138,7 +138,7 @@ public class TestTragicIndexWriterDeadlock extends LuceneTestCase {
 
     final IndexWriter w = new IndexWriter(dir, iwc) {
       @Override
-      void mergeSuccess(MergePolicy.OneMerge merge) {
+      protected void mergeSuccess(MergePolicy.OneMerge merge) {
         // tragedy strikes!
         throw new OutOfMemoryError();
       }

--- a/lucene/test-framework/src/java/org/apache/lucene/index/BaseIndexFileFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/index/BaseIndexFileFormatTestCase.java
@@ -623,7 +623,7 @@ abstract class BaseIndexFileFormatTestCase extends LuceneTestCase {
         } catch (AlreadyClosedException ace) {
           // OK: writer was closed by abort; we just reopen now:
           dir.setRandomIOExceptionRateOnOpen(0.0); // disable exceptions on openInput until next iteration
-          assertTrue(iw.deleter.isClosed());
+          assertTrue(iw.isDeleterClosed());
           assertTrue(allowAlreadyClosed);
           allowAlreadyClosed = false;
           conf = newIndexWriterConfig(analyzer);
@@ -659,7 +659,7 @@ abstract class BaseIndexFileFormatTestCase extends LuceneTestCase {
           } catch (AlreadyClosedException ace) {
             // OK: writer was closed by abort; we just reopen now:
             dir.setRandomIOExceptionRateOnOpen(0.0); // disable exceptions on openInput until next iteration
-            assertTrue(iw.deleter.isClosed());
+            assertTrue(iw.isDeleterClosed());
             assertTrue(allowAlreadyClosed);
             allowAlreadyClosed = false;
             conf = newIndexWriterConfig(analyzer);


### PR DESCRIPTION
Today it looks like wild wild west inside IndexWriter and some of it's
associated classes. This change makes sure all non-final members have
private visibility, methods that are not used outside of IW today are
made private unless they have been public. This change also removes
some unused or unnecessary members where possible and deleted some dead
code from previous refactoring.