### PR TITLE
LUCENE-9350: Don't hold references to large automata on FuzzyQuery

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/FuzzyAutomatonBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FuzzyAutomatonBuilder.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.search;
+
+import org.apache.lucene.util.UnicodeUtil;
+import org.apache.lucene.util.automaton.CompiledAutomaton;
+import org.apache.lucene.util.automaton.LevenshteinAutomata;
+import org.apache.lucene.util.automaton.TooComplexToDeterminizeException;
+
+/**
+ * Builds a set of CompiledAutomaton for fuzzy matching on a given term,
+ * with specified maximum edit distance, fixed prefix and whether or not
+ * to allow transpositions.
+ */
+class FuzzyAutomatonBuilder {
+
+  private final String term;
+  private final int maxEdits;
+  private final LevenshteinAutomata levBuilder;
+  private final String prefix;
+  private final int termLength;
+
+  FuzzyAutomatonBuilder(String term, int maxEdits, int prefixLength, boolean transpositions) {
+    if (maxEdits < 0 || maxEdits > LevenshteinAutomata.MAXIMUM_SUPPORTED_DISTANCE) {
+      throw new IllegalArgumentException("max edits must be 0.." + LevenshteinAutomata.MAXIMUM_SUPPORTED_DISTANCE + ", inclusive; got: " + maxEdits);
+    }
+    if (prefixLength < 0) {
+      throw new IllegalArgumentException("prefixLength cannot be less than 0");
+    }
+    this.term = term;
+    this.maxEdits = maxEdits;
+    int[] codePoints = stringToUTF32(term);
+    this.termLength = codePoints.length;
+    prefixLength = Math.min(prefixLength, codePoints.length);
+    int[] suffix = new int[codePoints.length - prefixLength];
+    System.arraycopy(codePoints, prefixLength, suffix, 0, suffix.length);
+    this.levBuilder = new LevenshteinAutomata(suffix, Character.MAX_CODE_POINT, transpositions);
+    this.prefix = UnicodeUtil.newString(codePoints, 0, prefixLength);
+  }
+
+  CompiledAutomaton[] buildAutomatonSet() {
+    CompiledAutomaton[] compiled = new CompiledAutomaton[maxEdits + 1];
+    for (int i = 0; i <= maxEdits; i++) {
+      try {
+        compiled[i] = new CompiledAutomaton(levBuilder.toAutomaton(i, prefix), true, false);
+      }
+      catch (TooComplexToDeterminizeException e) {
+        throw new FuzzyTermsEnum.FuzzyTermsException(term, e);
+      }
+    }
+    return compiled;
+  }
+
+  CompiledAutomaton buildMaxEditAutomaton() {
+    try {
+      return new CompiledAutomaton(levBuilder.toAutomaton(maxEdits, prefix), true, false);
+    } catch (TooComplexToDeterminizeException e) {
+      throw new FuzzyTermsEnum.FuzzyTermsException(term, e);
+    }
+  }
+
+  int getTermLength() {
+    return this.termLength;
+  }
+
+  private static int[] stringToUTF32(String text) {
+    int[] termText = new int[text.codePointCount(0, text.length())];
+    for (int cp, i = 0, j = 0; i < text.length(); i += Character.charCount(cp)) {
+      termText[j++] = cp = text.codePointAt(i);
+    }
+    return termText;
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/search/FuzzyQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FuzzyQuery.java
@@ -18,14 +18,13 @@ package org.apache.lucene.search;
 
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.apache.lucene.index.SingleTermsEnum;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
-import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.AttributeSource;
-import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.automaton.CompiledAutomaton;
 import org.apache.lucene.util.automaton.LevenshteinAutomata;
 
@@ -53,9 +52,7 @@ import org.apache.lucene.util.automaton.LevenshteinAutomata;
  * not match an indexed term "ab", and FuzzyQuery on term "a" with maxEdits=2 will not
  * match an indexed term "abc".
  */
-public class FuzzyQuery extends MultiTermQuery implements Accountable {
-
-  private static final long BASE_RAM_BYTES = RamUsageEstimator.shallowSizeOfInstance(AutomatonQuery.class);
+public class FuzzyQuery extends MultiTermQuery {
   
   public final static int defaultMaxEdits = LevenshteinAutomata.MAXIMUM_SUPPORTED_DISTANCE;
   public final static int defaultPrefixLength = 0;
@@ -67,10 +64,6 @@ public class FuzzyQuery extends MultiTermQuery implements Accountable {
   private final boolean transpositions;
   private final int prefixLength;
   private final Term term;
-  private final int termLength;
-  private final CompiledAutomaton[] automata;
-
-  private final long ramBytesUsed;
   
   /**
    * Create a new FuzzyQuery that will match terms with an edit distance 
@@ -106,22 +99,7 @@ public class FuzzyQuery extends MultiTermQuery implements Accountable {
     this.prefixLength = prefixLength;
     this.transpositions = transpositions;
     this.maxExpansions = maxExpansions;
-    int[] codePoints = FuzzyTermsEnum.stringToUTF32(term.text());
-    this.termLength = codePoints.length;
-    this.automata = FuzzyTermsEnum.buildAutomata(term.text(), codePoints, prefixLength, transpositions, maxEdits);
     setRewriteMethod(new MultiTermQuery.TopTermsBlendedFreqScoringRewrite(maxExpansions));
-    this.ramBytesUsed = calculateRamBytesUsed(term, this.automata);
-  }
-
-  private static long calculateRamBytesUsed(Term term, CompiledAutomaton[] automata) {
-    long bytes = BASE_RAM_BYTES + term.ramBytesUsed();
-    for (CompiledAutomaton a : automata) {
-      bytes += a.ramBytesUsed();
-    }
-    bytes += 4 * Integer.BYTES;
-    bytes += Long.BYTES;
-    bytes += 1;
-    return bytes;
   }
   
   /**
@@ -173,8 +151,9 @@ public class FuzzyQuery extends MultiTermQuery implements Accountable {
   /**
    * Returns the compiled automata used to match terms
    */
-  public CompiledAutomaton[] getAutomata() {
-    return automata;
+  public CompiledAutomaton getAutomata() {
+    FuzzyAutomatonBuilder builder = new FuzzyAutomatonBuilder(term.text(), maxEdits, prefixLength, transpositions);
+    return builder.buildMaxEditAutomaton();
   }
 
   @Override
@@ -183,7 +162,7 @@ public class FuzzyQuery extends MultiTermQuery implements Accountable {
       if (maxEdits == 0 || prefixLength >= term.text().length()) {
         visitor.consumeTerms(this, term);
       } else {
-        automata[automata.length - 1].visit(visitor, this, field);
+        visitor.consumeTermsMatching(this, term.field(), () -> getAutomata().runAutomaton);
       }
     }
   }
@@ -193,7 +172,7 @@ public class FuzzyQuery extends MultiTermQuery implements Accountable {
     if (maxEdits == 0 || prefixLength >= term.text().length()) {  // can only match if it's exact
       return new SingleTermsEnum(terms.iterator(), term.bytes());
     }
-    return new FuzzyTermsEnum(terms, atts, getTerm(), termLength, maxEdits, automata);
+    return new FuzzyTermsEnum(terms, atts, getTerm(), maxEdits, prefixLength, transpositions);
   }
 
   /**
@@ -237,22 +216,9 @@ public class FuzzyQuery extends MultiTermQuery implements Accountable {
     if (getClass() != obj.getClass())
       return false;
     FuzzyQuery other = (FuzzyQuery) obj;
-    // Note that we don't need to compare termLength or automata because they
-    // are entirely determined by the other fields
-    if (maxEdits != other.maxEdits)
-      return false;
-    if (prefixLength != other.prefixLength)
-      return false;
-    if (maxExpansions != other.maxExpansions)
-      return false;
-    if (transpositions != other.transpositions)
-      return false;
-    if (term == null) {
-      if (other.term != null)
-        return false;
-    } else if (!term.equals(other.term))
-      return false;
-    return true;
+    return Objects.equals(maxEdits, other.maxEdits) && Objects.equals(prefixLength, other.prefixLength)
+        && Objects.equals(maxExpansions, other.maxExpansions) && Objects.equals(transpositions, other.transpositions)
+        && Objects.equals(term, other.term);
   }
 
   /**
@@ -274,8 +240,4 @@ public class FuzzyQuery extends MultiTermQuery implements Accountable {
     }
   }
 
-  @Override
-  public long ramBytesUsed() {
-    return ramBytesUsed;
-  }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/MultiTermQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiTermQuery.java
@@ -286,9 +286,9 @@ public abstract class MultiTermQuery extends Query {
    *  (should instead return {@link TermsEnum#EMPTY} if no
    *  terms match).  The TermsEnum must already be
    *  positioned to the first matching term.
-   * The given {@link AttributeSource} is passed by the {@link RewriteMethod} to
-   * provide attributes, the rewrite method uses to inform about e.g. maximum competitive boosts.
-   * This is currently only used by {@link TopTermsRewrite}
+   *  The given {@link AttributeSource} is passed by the {@link RewriteMethod} to
+   *  share information between segments, for example {@link TopTermsRewrite} uses
+   *  it to share maximum competitive boosts
    */
   protected abstract TermsEnum getTermsEnum(Terms terms, AttributeSource atts) throws IOException;
 


### PR DESCRIPTION
LUCENE-9068 moved fuzzy automata construction into FuzzyQuery itself.  However,
this has the nasty side-effect of blowing up query caches that expect queries to be 
fairly small.  This commit restores the previous behaviour of caching the large automata
on an AttributeSource shared between segments, while making the construction a
bit clearer by factoring it out into a package-private `FuzzyAutomatonBuilder`.