### PR TITLE
SOLR-13184: Added some input validation in ValueSourceParser

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/ValueSourceParser.java
+++ b/solr/core/src/java/org/apache/solr/search/ValueSourceParser.java
@@ -340,6 +340,10 @@ public abstract class ValueSourceParser implements NamedListInitializedPlugin {
       public ValueSource parse(FunctionQParser fp) throws SyntaxError {
         String f0 = fp.parseArg();
         String qf = fp.parseArg();
+        if (qf == null) {
+          throw new SolrException(SolrException.ErrorCode.BAD_REQUEST,
+                                  "Invalid linkField detected in '" + fp.qstr + "'");
+        }
         return new JoinDocFreqValueSource( f0, qf );
       }
     });

--- a/solr/core/src/test/org/apache/solr/search/function/TestFunctionQuery.java
+++ b/solr/core/src/test/org/apache/solr/search/function/TestFunctionQuery.java
@@ -845,6 +845,13 @@ public class TestFunctionQuery extends SolrTestCaseJ4 {
                100,10,  25,5,  0,0,   1,1);
     singleTest(fieldAsFunc, "log(\0)",  1,0); 
   }
+  
+  @Test
+  public void testQFieldValidation() {
+    Exception e = expectThrows(SolrException.class, () -> h.query(req("q", "{!frange l=10 u=100}joindf(genre:comedy,$x)")));
+    assertEquals(SolrException.ErrorCode.BAD_REQUEST.code, ((SolrException)e).code());
+    assertEquals("Invalid linkField detected in 'joindf(genre:comedy,$x)'", e.getMessage());
+  }
 
   @Test
   public void testBooleanFunctions() throws Exception {


### PR DESCRIPTION
<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

The joindf parser inside ValueSourceParser did not check for null qfield values before calling JoinDocFreqValueSource(), however JoinDocFreqValueSource() expects qfield to be non-null

# Solution

Perform a simple null check in the ValueSourceParser for qfield

# Tests

Added TestFunctionQuery.testQFieldValidation() which test a query with a joindf function with an invalid input

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title. **(Existing issue)**
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
