### PR TITLE
LUCENE-9354: Sync French stop words with latest version from Snowball.

### DIFF
--- a/gradle/generation/snowball.gradle
+++ b/gradle/generation/snowball.gradle
@@ -31,7 +31,7 @@ configure(project(":lucene:analysis:common")) {
     // git commit hash of source code https://github.com/snowballstem/snowball/
     snowballStemmerCommit = "53739a805cfa6c77ff8496dc711dc1c106d987c1"
     // git commit hash of stopwords https://github.com/snowballstem/snowball-website
-    snowballWebsiteCommit = "ff891e74f08e7315523ee3c0cad55bb1b7831b9d"
+    snowballWebsiteCommit = "5a8cf2451d108217585d8e32d744f8b8fd20c711"
     // git commit hash of test data https://github.com/snowballstem/snowball-data
     snowballDataCommit    = "9145f8732ec952c8a3d1066be251da198a8bc792"
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -93,6 +93,9 @@ Improvements
   Nepali, Serbian, and Tamil. New stoplist: Indonesian. Adds gradle 'snowball'
   task to regenerate and ease future upgrades. (Robert Muir, Dawid Weiss)
 
+* LUCENE-9354: Improvements to snowball french stopwords list, so that it is less
+  aggressive. (Philippe Ouellet)
+
 * LUCENE-9114: Improve ValueSourceScorer's Default Cost Implementation (Atri Sharma, David Smiley)
 
 * LUCENE-9074: Introduce Slice Executor For Dynamic Runtime Execution Of Slices (Atri Sharma)

--- a/lucene/analysis/common/src/resources/org/apache/lucene/analysis/snowball/french_stop.txt
+++ b/lucene/analysis/common/src/resources/org/apache/lucene/analysis/snowball/french_stop.txt
@@ -183,3 +183,4 @@ quelle         |  which
 quelles        |  which
 sans           |  without
 soi            |  oneself
+

--- a/lucene/analysis/common/src/resources/org/apache/lucene/analysis/snowball/french_stop.txt
+++ b/lucene/analysis/common/src/resources/org/apache/lucene/analysis/snowball/french_stop.txt
@@ -51,7 +51,7 @@ qui            |  who
 sa             |  his, her (fem)
 se             |  oneself
 ses            |  his (pl)
-son            |  his, her (masc)
+ | son            |  his, her (masc). Omitted because it is homonym of "sound"
 sur            |  on
 ta             |  thy (fem)
 te             |  thee
@@ -79,15 +79,15 @@ t              |  t'
 y              |  there
 
                | forms of être (not including the infinitive):
-été
+ | été - Omitted because it is homonym of "summer"
 étée
 étées
-étés
+ | étés - Omitted because it is homonym of "summers"
 étant
 suis
 es
-est
-sommes
+ | est - Omitted because it is homonym of "east"
+ | sommes - Omitted because it is homonym of "sums"
 êtes
 sont
 serai
@@ -118,7 +118,7 @@ soyez
 soient
 fusse
 fusses
-fût
+ | fût - Omitted because it is homonym of "tap", like in "beer on tap"
 fussions
 fussiez
 fussent
@@ -130,13 +130,13 @@ eue
 eues
 eus
 ai
-as
+ | as - Omitted because it is homonym of "ace"
 avons
 avez
 ont
 aurai
-auras
-aura
+ | auras - Omitted because it is also the name of a kind of wind
+ | aura - Omitted because it is also the name of a kind of wind and homonym of "aura"
 aurons
 aurez
 auront
@@ -147,7 +147,7 @@ auriez
 auraient
 avais
 avait
-avions
+ | avions - Omitted because it is homonym of "planes"
 aviez
 avaient
 eut
@@ -183,4 +183,3 @@ quelle         |  which
 quelles        |  which
 sans           |  without
 soi            |  oneself
-


### PR DESCRIPTION
This new version removed some French homonyms from the list


# Description

Sync French stop words with latest version from Snowball.

This new version removed some French homonyms from the list

# Tests

None, I am a French native speaker and reviewed the stop words myself.

# Checklist


- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [ ] I have run `ant precommit` and the appropriate test suite.
- [ ] I have added tests for my changes.
- [x] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
