### PR TITLE
Revert "Bugfix for FuzzyQuery false negative (#1493)"

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/FuzzyQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FuzzyQuery.java
@@ -20,7 +20,6 @@ package org.apache.lucene.search;
 import java.io.IOException;
 import java.util.Objects;
 
-import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.SingleTermsEnum;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.Terms;
@@ -100,22 +99,9 @@ public class FuzzyQuery extends MultiTermQuery {
     this.prefixLength = prefixLength;
     this.transpositions = transpositions;
     this.maxExpansions = maxExpansions;
-    if (term.text().length() == prefixLength) {
-      setRewriteAsRegExpQuery();
-    } else {
-      setRewriteMethod(new MultiTermQuery.TopTermsBlendedFreqScoringRewrite(maxExpansions));
-    }
+    setRewriteMethod(new MultiTermQuery.TopTermsBlendedFreqScoringRewrite(maxExpansions));
   }
   
-  private void setRewriteAsRegExpQuery() {
-    setRewriteMethod(new RewriteMethod() {
-      @Override
-      public Query rewrite(IndexReader reader, MultiTermQuery query) throws IOException {
-        return new RegexpQuery(new Term(term.field(), term.text() + ".{0," + maxEdits + "}"));
-      }
-    });
-  }
-
   /**
    * Calls {@link #FuzzyQuery(Term, int, int, int, boolean) 
    * FuzzyQuery(term, maxEdits, prefixLength, defaultMaxExpansions, defaultTranspositions)}.
@@ -180,8 +166,6 @@ public class FuzzyQuery extends MultiTermQuery {
       }
     }
   }
-  
-  
 
   @Override
   protected TermsEnum getTermsEnum(Terms terms, AttributeSource atts) throws IOException {

--- a/lucene/core/src/test/org/apache/lucene/search/TestFuzzyQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestFuzzyQuery.java
@@ -72,33 +72,7 @@ public class TestFuzzyQuery extends LuceneTestCase {
     reader.close();
     directory.close();
   }
-  
-  public void testPrefixLengthEqualStringLength() throws Exception {
-    Directory directory = newDirectory();
-    RandomIndexWriter writer = new RandomIndexWriter(random(), directory);
-    addDoc("bbab", writer);
-    addDoc("bbabc", writer);
-    addDoc("bbabcd", writer);
-    IndexReader reader = writer.getReader();
-    IndexSearcher searcher = newSearcher(reader);
-    writer.close();
 
-    int maxEdits = 1;
-    int prefixLength = 3;
-    FuzzyQuery query = new FuzzyQuery(new Term("field", "bba"), maxEdits, prefixLength);
-    ScoreDoc[] hits = searcher.search(query, 1000).scoreDocs;
-    assertEquals(1, hits.length);
-
-    maxEdits = 2;
-    query = new FuzzyQuery(new Term("field", "bba"), maxEdits, prefixLength);
-    hits = searcher.search(query, 1000).scoreDocs;
-    assertEquals(2, hits.length);
-
-    
-    reader.close();
-    directory.close();
-  }
-  
   public void testFuzziness() throws Exception {
     Directory directory = newDirectory();
     RandomIndexWriter writer = new RandomIndexWriter(random(), directory);


### PR DESCRIPTION
This reverts commit 28e47549c8ba1a7c17ffe7d9e791e88983ef46c2.
The use of RegExpQuery as a fallback has to consider that the search string may contain characters which are illegal regex syntax and need escaping.

Will rethink the approach.