### PR TITLE
Bugfix for FuzzyQuery false negative when prefix length == search term length

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/search/TestFuzzyQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestFuzzyQuery.java
@@ -225,6 +225,39 @@ public class TestFuzzyQuery extends LuceneTestCase {
     directory.close();
   }
   
+  public void testPrefixLengthEqualStringLength() throws Exception {
+    Directory directory = newDirectory();
+    RandomIndexWriter writer = new RandomIndexWriter(random(), directory);
+    addDoc("b*a", writer);
+    addDoc("b*ab", writer);
+    addDoc("b*abc", writer);
+    addDoc("b*abcd", writer);
+    IndexReader reader = writer.getReader();
+    IndexSearcher searcher = newSearcher(reader);
+    writer.close();
+
+    int maxEdits = 0;
+    int prefixLength = 3;
+    FuzzyQuery query = new FuzzyQuery(new Term("field", "b*a"), maxEdits, prefixLength);
+    ScoreDoc[] hits = searcher.search(query, 1000).scoreDocs;
+    assertEquals(1, hits.length);
+    
+    
+    maxEdits = 1;
+    prefixLength = 3;
+    query = new FuzzyQuery(new Term("field", "b*a"), maxEdits, prefixLength);
+    hits = searcher.search(query, 1000).scoreDocs;
+    assertEquals(2, hits.length);
+
+    maxEdits = 2;
+    query = new FuzzyQuery(new Term("field", "b*a"), maxEdits, prefixLength);
+    hits = searcher.search(query, 1000).scoreDocs;
+    assertEquals(3, hits.length);
+
+    reader.close();
+    directory.close();
+  }
+  
   public void test2() throws Exception {
     Directory directory = newDirectory();
     RandomIndexWriter writer = new RandomIndexWriter(random(), directory, new MockAnalyzer(random(), MockTokenizer.KEYWORD, false));


### PR DESCRIPTION
Fix for Jira issue 9365 where search for `abc` doesn't match doc `abcd` if prefixlength = 3 and edit distance =1.
The fix is to rewrite the FuzzyQuery as a specialised form of Automaton query when prefix length == search string length.