### PR TITLE
SOLR-14351: commitScheduler was missing MDC logging

### DIFF
--- a/solr/core/src/java/org/apache/solr/update/CommitTracker.java
+++ b/solr/core/src/java/org/apache/solr/update/CommitTracker.java
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.core.SolrCore;
+import org.apache.solr.logging.MDCLoggingContext;
 import org.apache.solr.request.LocalSolrQueryRequest;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.common.util.SolrNamedThreadFactory;
@@ -57,8 +58,10 @@ public final class CommitTracker implements Runnable {
   private int docsUpperBound;
   private long timeUpperBound;
   private long tLogFileSizeUpperBound;
-  
-  private final ScheduledExecutorService scheduler = 
+
+  // note: can't use ExecutorsUtil because it doesn't have a *scheduled* ExecutorService.
+  //  Not a big deal but it means we must take care of MDC logging here.
+  private final ScheduledExecutorService scheduler =
       Executors.newScheduledThreadPool(1, new SolrNamedThreadFactory("commitScheduler"));
   private ScheduledFuture pending;
   
@@ -248,9 +251,8 @@ public final class CommitTracker implements Runnable {
       pending = null;  // allow a new commit to be scheduled
     }
 
-    SolrQueryRequest req = new LocalSolrQueryRequest(core,
-        new ModifiableSolrParams());
-    try {
+    MDCLoggingContext.setCore(core);
+    try (SolrQueryRequest req = new LocalSolrQueryRequest(core, new ModifiableSolrParams())) {
       CommitUpdateCommand command = new CommitUpdateCommand(req, false);
       command.openSearcher = openSearcher;
       command.waitSearcher = WAIT_SEARCHER;
@@ -271,9 +273,9 @@ public final class CommitTracker implements Runnable {
     } catch (Exception e) {
       SolrException.log(log, "auto commit error...", e);
     } finally {
-      // log.info("###done committing");
-      req.close();
+      MDCLoggingContext.clear();
     }
+    // log.info("###done committing");
   }
   
   // to facilitate testing: blocks if called during commit


### PR DESCRIPTION
Adding this to https://issues.apache.org/jira/browse/SOLR-14351 even though it's not a perfect fit.

As an aside, I've seen MDC missing logs from searcher warming QuerySenderListener.  There's another JIRA issue for that one indirectly fixed via stacking SolrRequestInfo.