### PR TITLE
Backport LUCENE-9350 to branch_8_5

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -7,7 +7,10 @@ http://s.apache.org/luceneversions
 
 Bug Fixes
 ---------------------
-(No changes)
+
+* LUCENE-9350: Partial reversion of LUCENE-9068; holding levenshtein automata on FuzzyQuery can end
+  up blowing up query caches which use query objects as cache keys, so building the automata is
+  now delayed to search time again.  (Alan Woodward, Mike Drob)
 
 ======================= Lucene 8.5.1 =======================
 

--- a/lucene/core/src/java/org/apache/lucene/search/FuzzyAutomatonBuilder.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FuzzyAutomatonBuilder.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.search;
+
+import org.apache.lucene.util.UnicodeUtil;
+import org.apache.lucene.util.automaton.CompiledAutomaton;
+import org.apache.lucene.util.automaton.LevenshteinAutomata;
+import org.apache.lucene.util.automaton.TooComplexToDeterminizeException;
+
+/**
+ * Builds a set of CompiledAutomaton for fuzzy matching on a given term,
+ * with specified maximum edit distance, fixed prefix and whether or not
+ * to allow transpositions.
+ */
+class FuzzyAutomatonBuilder {
+
+  private final String term;
+  private final int maxEdits;
+  private final LevenshteinAutomata levBuilder;
+  private final String prefix;
+  private final int termLength;
+
+  FuzzyAutomatonBuilder(String term, int maxEdits, int prefixLength, boolean transpositions) {
+    if (maxEdits < 0 || maxEdits > LevenshteinAutomata.MAXIMUM_SUPPORTED_DISTANCE) {
+      throw new IllegalArgumentException("max edits must be 0.." + LevenshteinAutomata.MAXIMUM_SUPPORTED_DISTANCE + ", inclusive; got: " + maxEdits);
+    }
+    if (prefixLength < 0) {
+      throw new IllegalArgumentException("prefixLength cannot be less than 0");
+    }
+    this.term = term;
+    this.maxEdits = maxEdits;
+    int[] codePoints = stringToUTF32(term);
+    this.termLength = codePoints.length;
+    prefixLength = Math.min(prefixLength, codePoints.length);
+    int[] suffix = new int[codePoints.length - prefixLength];
+    System.arraycopy(codePoints, prefixLength, suffix, 0, suffix.length);
+    this.levBuilder = new LevenshteinAutomata(suffix, Character.MAX_CODE_POINT, transpositions);
+    this.prefix = UnicodeUtil.newString(codePoints, 0, prefixLength);
+  }
+
+  CompiledAutomaton[] buildAutomatonSet() {
+    CompiledAutomaton[] compiled = new CompiledAutomaton[maxEdits + 1];
+    for (int i = 0; i <= maxEdits; i++) {
+      try {
+        compiled[i] = new CompiledAutomaton(levBuilder.toAutomaton(i, prefix), true, false);
+      }
+      catch (TooComplexToDeterminizeException e) {
+        throw new FuzzyTermsEnum.FuzzyTermsException(term, e);
+      }
+    }
+    return compiled;
+  }
+
+  CompiledAutomaton buildMaxEditAutomaton() {
+    try {
+      return new CompiledAutomaton(levBuilder.toAutomaton(maxEdits, prefix), true, false);
+    } catch (TooComplexToDeterminizeException e) {
+      throw new FuzzyTermsEnum.FuzzyTermsException(term, e);
+    }
+  }
+
+  int getTermLength() {
+    return this.termLength;
+  }
+
+  private static int[] stringToUTF32(String text) {
+    int[] termText = new int[text.codePointCount(0, text.length())];
+    for (int cp, i = 0, j = 0; i < text.length(); i += Character.charCount(cp)) {
+      termText[j++] = cp = text.codePointAt(i);
+    }
+    return termText;
+  }
+}

--- a/lucene/core/src/java/org/apache/lucene/search/FuzzyQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FuzzyQuery.java
@@ -18,14 +18,13 @@ package org.apache.lucene.search;
 
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.apache.lucene.index.SingleTermsEnum;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
-import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.AttributeSource;
-import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.automaton.CompiledAutomaton;
 import org.apache.lucene.util.automaton.LevenshteinAutomata;
 
@@ -53,9 +52,7 @@ import org.apache.lucene.util.automaton.LevenshteinAutomata;
  * not match an indexed term "ab", and FuzzyQuery on term "a" with maxEdits=2 will not
  * match an indexed term "abc".
  */
-public class FuzzyQuery extends MultiTermQuery implements Accountable {
-
-  private static final long BASE_RAM_BYTES = RamUsageEstimator.shallowSizeOfInstance(AutomatonQuery.class);
+public class FuzzyQuery extends MultiTermQuery {
   
   public final static int defaultMaxEdits = LevenshteinAutomata.MAXIMUM_SUPPORTED_DISTANCE;
   public final static int defaultPrefixLength = 0;
@@ -67,10 +64,6 @@ public class FuzzyQuery extends MultiTermQuery implements Accountable {
   private final boolean transpositions;
   private final int prefixLength;
   private final Term term;
-  private final int termLength;
-  private final CompiledAutomaton[] automata;
-
-  private final long ramBytesUsed;
   
   /**
    * Create a new FuzzyQuery that will match terms with an edit distance 
@@ -106,22 +99,7 @@ public class FuzzyQuery extends MultiTermQuery implements Accountable {
     this.prefixLength = prefixLength;
     this.transpositions = transpositions;
     this.maxExpansions = maxExpansions;
-    int[] codePoints = FuzzyTermsEnum.stringToUTF32(term.text());
-    this.termLength = codePoints.length;
-    this.automata = FuzzyTermsEnum.buildAutomata(term.text(), codePoints, prefixLength, transpositions, maxEdits);
     setRewriteMethod(new MultiTermQuery.TopTermsBlendedFreqScoringRewrite(maxExpansions));
-    this.ramBytesUsed = calculateRamBytesUsed(term, this.automata);
-  }
-
-  private static long calculateRamBytesUsed(Term term, CompiledAutomaton[] automata) {
-    long bytes = BASE_RAM_BYTES + term.ramBytesUsed();
-    for (CompiledAutomaton a : automata) {
-      bytes += a.ramBytesUsed();
-    }
-    bytes += 4 * Integer.BYTES;
-    bytes += Long.BYTES;
-    bytes += 1;
-    return bytes;
   }
   
   /**
@@ -173,8 +151,9 @@ public class FuzzyQuery extends MultiTermQuery implements Accountable {
   /**
    * Returns the compiled automata used to match terms
    */
-  public CompiledAutomaton[] getAutomata() {
-    return automata;
+  public CompiledAutomaton getAutomata() {
+    FuzzyAutomatonBuilder builder = new FuzzyAutomatonBuilder(term.text(), maxEdits, prefixLength, transpositions);
+    return builder.buildMaxEditAutomaton();
   }
 
   @Override
@@ -183,7 +162,7 @@ public class FuzzyQuery extends MultiTermQuery implements Accountable {
       if (maxEdits == 0 || prefixLength >= term.text().length()) {
         visitor.consumeTerms(this, term);
       } else {
-        automata[automata.length - 1].visit(visitor, this, field);
+        visitor.consumeTermsMatching(this, term.field(), getAutomata().runAutomaton);
       }
     }
   }
@@ -193,7 +172,7 @@ public class FuzzyQuery extends MultiTermQuery implements Accountable {
     if (maxEdits == 0 || prefixLength >= term.text().length()) {  // can only match if it's exact
       return new SingleTermsEnum(terms.iterator(), term.bytes());
     }
-    return new FuzzyTermsEnum(terms, atts, getTerm(), termLength, maxEdits, automata);
+    return new FuzzyTermsEnum(terms, atts, getTerm(), maxEdits, prefixLength, transpositions);
   }
 
   /**
@@ -237,22 +216,9 @@ public class FuzzyQuery extends MultiTermQuery implements Accountable {
     if (getClass() != obj.getClass())
       return false;
     FuzzyQuery other = (FuzzyQuery) obj;
-    // Note that we don't need to compare termLength or automata because they
-    // are entirely determined by the other fields
-    if (maxEdits != other.maxEdits)
-      return false;
-    if (prefixLength != other.prefixLength)
-      return false;
-    if (maxExpansions != other.maxExpansions)
-      return false;
-    if (transpositions != other.transpositions)
-      return false;
-    if (term == null) {
-      if (other.term != null)
-        return false;
-    } else if (!term.equals(other.term))
-      return false;
-    return true;
+    return Objects.equals(maxEdits, other.maxEdits) && Objects.equals(prefixLength, other.prefixLength)
+        && Objects.equals(maxExpansions, other.maxExpansions) && Objects.equals(transpositions, other.transpositions)
+        && Objects.equals(term, other.term);
   }
   
   /**
@@ -282,8 +248,4 @@ public class FuzzyQuery extends MultiTermQuery implements Accountable {
     }
   }
 
-  @Override
-  public long ramBytesUsed() {
-    return ramBytesUsed;
-  }
 }

--- a/lucene/core/src/java/org/apache/lucene/search/MultiTermQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiTermQuery.java
@@ -286,9 +286,9 @@ public abstract class MultiTermQuery extends Query {
    *  (should instead return {@link TermsEnum#EMPTY} if no
    *  terms match).  The TermsEnum must already be
    *  positioned to the first matching term.
-   * The given {@link AttributeSource} is passed by the {@link RewriteMethod} to
-   * provide attributes, the rewrite method uses to inform about e.g. maximum competitive boosts.
-   * This is currently only used by {@link TopTermsRewrite}
+   *  The given {@link AttributeSource} is passed by the {@link RewriteMethod} to
+   *  share information between segments, for example {@link TopTermsRewrite} uses
+   *  it to share maximum competitive boosts
    */
   protected abstract TermsEnum getTermsEnum(Terms terms, AttributeSource atts) throws IOException;
 

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -215,7 +215,7 @@ public class QueryComponent extends SearchComponent
           rb.setFilters( filters );
         }
       }
-    } catch (SyntaxError | FuzzyTermsEnum.FuzzyTermsException e) {
+    } catch (SyntaxError e) {
       throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, e);
     }
 
@@ -1484,7 +1484,12 @@ public class QueryComponent extends SearchComponent
     SolrQueryResponse rsp = rb.rsp;
 
     SolrIndexSearcher searcher = req.getSearcher();
-    searcher.search(result, cmd);
+
+    try {
+      searcher.search(result, cmd);
+    } catch (FuzzyTermsEnum.FuzzyTermsException e) {
+      throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, e);
+    }
     rb.setResult(result);
 
     ResultContext ctx = new BasicResultContext(rb);

--- a/solr/core/src/test/org/apache/solr/search/FuzzySearchTest.java
+++ b/solr/core/src/test/org/apache/solr/search/FuzzySearchTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.search;
+
+import java.io.IOException;
+
+import org.apache.lucene.util.LuceneTestCase;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.impl.BaseHttpSolrClient;
+import org.apache.solr.client.solrj.impl.CloudSolrClient;
+import org.apache.solr.client.solrj.request.CollectionAdminRequest;
+import org.apache.solr.cloud.SolrCloudTestCase;
+import org.apache.solr.common.SolrInputDocument;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+@LuceneTestCase.Slow
+public class FuzzySearchTest extends SolrCloudTestCase {
+  private final static String COLLECTION = "c1";
+  private CloudSolrClient client;
+
+  @BeforeClass
+  public static void setupCluster() throws Exception {
+    configureCluster(1).addConfig(COLLECTION, configset("cloud-minimal")).configure();
+  }
+
+  @Before
+  public void setupCollection() throws Exception {
+    client = cluster.getSolrClient();
+    client.setDefaultCollection(COLLECTION);
+
+    CollectionAdminRequest.createCollection(COLLECTION, 1, 1).process(client);
+    cluster.waitForActiveCollection(COLLECTION, 1, 1);
+  }
+
+  @Test
+  public void testTooComplex() throws IOException, SolrServerException {
+    SolrInputDocument doc = new SolrInputDocument();
+
+    doc.setField("id", "1");
+    doc.setField("text", "foo");
+    client.add(doc);
+    client.commit(); // Must have index files written, but the contents don't matter
+
+    SolrQuery query = new SolrQuery("text:headquarters\\(在日米海軍横須賀基地司令部庁舎\\/旧横須賀鎮守府会議所・横須賀海軍艦船部\\)~");
+
+    BaseHttpSolrClient.RemoteSolrException e = expectThrows(BaseHttpSolrClient.RemoteSolrException.class, () -> client.query(query));
+    assertTrue("Should be client error, not server error", e.code() >= 400 && e.code() < 500);
+  }
+}


### PR DESCRIPTION
It may be worthwhile to review this by individual commits instead of all at once. I do not intend to squash these when committing.

I'm most concerned about whether the changes in commit 3363df7 are sufficient - they are enough for API and compilation, but it's not clear if I needed to update some implementations of QueryVisitor to tie all of this together.