### PR TITLE
LUCENE-9328: Add PooledDocValuesReader

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/PooledDocValuesReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/PooledDocValuesReader.java
@@ -58,7 +58,7 @@ public class PooledDocValuesReader extends FilterLeafReader {
   private final LeafReaderContext pooledContext;
   private final Predicate<String> fieldFilter;
 
-  private int currentDoc;
+  private int currentDoc = -1;
 
   /**
    * Creates a new PooledDocValuesReader, wrapping an existing reader context
@@ -211,6 +211,7 @@ public class PooledDocValuesReader extends FilterLeafReader {
 
     final NumericDocValues in;
     boolean positioned = false;
+    int realDoc = -1;
 
     private PooledNumeric(NumericDocValues in) {
       this.in = in;
@@ -218,7 +219,10 @@ public class PooledDocValuesReader extends FilterLeafReader {
 
     @Override
     public void advanceReal(int target) throws IOException {
-      positioned = in.advanceExact(target);
+      if (target > realDoc) {
+        realDoc = in.advance(target);
+      }
+      positioned = realDoc == target;
     }
 
     @Override
@@ -249,7 +253,7 @@ public class PooledDocValuesReader extends FilterLeafReader {
       if (target != currentDoc) {
         throw new IllegalStateException("Pooled docvalues can only be advanced to their controlling doc " + target);
       }
-      return currentDoc;
+      return realDoc;
     }
 
     @Override
@@ -262,6 +266,7 @@ public class PooledDocValuesReader extends FilterLeafReader {
 
     final SortedNumericDocValues in;
     boolean positioned;
+    int realDoc = -1;
     long[] values = new long[1];
 
     private PooledSortedNumeric(SortedNumericDocValues in) {
@@ -270,7 +275,10 @@ public class PooledDocValuesReader extends FilterLeafReader {
 
     @Override
     public void advanceReal(int target) throws IOException {
-      positioned = in.advanceExact(target);
+      if (target > realDoc) {
+        realDoc = in.advance(target);
+      }
+      positioned = realDoc == target;
       if (positioned) {
         int c = in.docValueCount();
         values = ArrayUtil.grow(values, c);
@@ -321,7 +329,7 @@ public class PooledDocValuesReader extends FilterLeafReader {
             throw new IllegalStateException("Pooled docvalues can only be advanced to their controlling doc " + target);
           }
           currentValue = 0;
-          return currentDoc;
+          return realDoc;
         }
 
         @Override
@@ -336,6 +344,7 @@ public class PooledDocValuesReader extends FilterLeafReader {
 
     final BinaryDocValues in;
     boolean positioned = false;
+    int realDoc = -1;
 
     private PooledBinary(BinaryDocValues in) {
       this.in = in;
@@ -348,7 +357,10 @@ public class PooledDocValuesReader extends FilterLeafReader {
 
     @Override
     public void advanceReal(int target) throws IOException {
-      positioned = in.advanceExact(target);
+      if (target > realDoc) {
+        realDoc = in.advance(target);
+      }
+      positioned = realDoc == target;
     }
 
     @Override
@@ -374,7 +386,7 @@ public class PooledDocValuesReader extends FilterLeafReader {
       if (target != currentDoc) {
         throw new IllegalStateException("Pooled docvalues can only be advanced to their controlling doc " + target);
       }
-      return currentDoc;
+      return realDoc;
     }
 
     @Override
@@ -387,6 +399,7 @@ public class PooledDocValuesReader extends FilterLeafReader {
 
     final SortedDocValues in;
     boolean positioned = false;
+    int realDoc = -1;
 
     private PooledSorted(SortedDocValues in) {
       this.in = in;
@@ -409,7 +422,10 @@ public class PooledDocValuesReader extends FilterLeafReader {
 
     @Override
     public void advanceReal(int target) throws IOException {
-      positioned = in.advanceExact(target);
+      if (target > realDoc) {
+        realDoc = in.advance(target);
+      }
+      positioned = realDoc == target;
     }
 
     @Override
@@ -435,7 +451,7 @@ public class PooledDocValuesReader extends FilterLeafReader {
       if (target != currentDoc) {
         throw new IllegalStateException("Pooled docvalues can only be advanced to their controlling doc " + target);
       }
-      return currentDoc;
+      return realDoc;
     }
 
     @Override
@@ -448,6 +464,7 @@ public class PooledDocValuesReader extends FilterLeafReader {
 
     final SortedSetDocValues in;
     boolean positioned = false;
+    int realDoc = -1;
     long[] ords = new long[1];
 
     private PooledSortedSet(SortedSetDocValues in) {
@@ -456,7 +473,10 @@ public class PooledDocValuesReader extends FilterLeafReader {
 
     @Override
     public void advanceReal(int target) throws IOException {
-      positioned = in.advanceExact(target);
+      if (target > realDoc) {
+        realDoc = in.advance(target);
+      }
+      positioned = realDoc == target;
       if (positioned) {
         int c = 0;
         long ord;
@@ -515,7 +535,7 @@ public class PooledDocValuesReader extends FilterLeafReader {
             throw new IllegalStateException("Pooled docvalues can only be advanced to their controlling doc " + target);
           }
           current = 0;
-          return currentDoc;
+          return realDoc;
         }
 
         @Override

--- a/lucene/core/src/java/org/apache/lucene/index/PooledDocValuesReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/PooledDocValuesReader.java
@@ -1,0 +1,528 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.index;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Predicate;
+
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.BytesRef;
+
+/**
+ * A LeafReader implementation that will cache docvalues iterators, so that multiple
+ * calls to {@link #getNumericDocValues(String)}, etc, for the same field will only
+ * pull a single underlying iterator.
+ *
+ * The underlying iterators should be advanced by calling {@link #advanceAll(int)}.
+ * Iterators returned from the {@code getXXXDocValues} methods will only allow
+ * advancing by calling {@code advance(target)} or {@code advanceExact(target)} to
+ * the doc passed to {@link #advanceAll(int)}.  Calling {@code nextDoc()}, or
+ * advancing to a different document will throw an exception.
+ *
+ * Useful for e.g. grouping code that maintains multiple
+ * {@link org.apache.lucene.search.FieldComparator} instances for a common
+ * sort field.
+ *
+ * Consumers that use a reader context to pass references to this reader should
+ * call {@link #getPooledContext()} rather than {@link #getContext()}, to ensure
+ * that {@code docBase} and {@code ord} values from the wrapped reader context
+ * are preserved.
+ *
+ * If you only want to pool certain fields (for example, if you are using an
+ * expression with several variables, only one of which is referenced multiple
+ * times) then you can pass a field filter predicate to the constructor which
+ * will select which fields to pool.  Pooling has an overhead, particularly
+ * for {@link SortedSetDocValues} and {@link SortedNumericDocValues} which need
+ * to read all values for a document up-front.
+ */
+public class PooledDocValuesReader extends FilterLeafReader {
+
+  private final Map<String, PooledIterator> pooledValues = new HashMap<>();
+  private final LeafReaderContext pooledContext;
+  private final Predicate<String> fieldFilter;
+
+  private int currentDoc;
+
+  /**
+   * Creates a new PooledDocValuesReader, wrapping an existing reader context
+   * and pooling all docvalues
+   */
+  public PooledDocValuesReader(LeafReaderContext in) {
+    this(in, field -> true);
+  }
+
+  /**
+   * Creates a new PooledDocValuesReader, wrapping an existing reader context and
+   * pooling docvalues from fields that match the fieldFilter predicate
+   */
+  public PooledDocValuesReader(LeafReaderContext in, Predicate<String> fieldFilter) {
+    super(in.reader());
+    this.fieldFilter = fieldFilter;
+    this.pooledContext = new LeafReaderContext(in.parent, this, in.ordInParent, in.docBaseInParent, in.ord, in.docBase);
+  }
+
+  /**
+   * The reader context for this reader.
+   *
+   * Preserves the docBase and ord from the wrapped reader context - prefer this
+   * to calling {@link #getContext()}
+   */
+  public LeafReaderContext getPooledContext() {
+    return pooledContext;
+  }
+
+  /**
+   * Advances all pooled doc values iterators to the given target doc
+   */
+  public void advanceAll(int target) throws IOException {
+    this.currentDoc = target;
+    for (PooledIterator it : pooledValues.values()) {
+      it.advanceReal(target);
+    }
+  }
+
+  @Override
+  public NumericDocValues getNumericDocValues(String field) throws IOException {
+    if (fieldFilter.test(field) == false) {
+      return super.getNumericDocValues(field);
+    }
+    if (pooledValues.containsKey(field) == false) {
+      NumericDocValues ndv = in.getNumericDocValues(field);
+      if (ndv == null) {
+        return null;
+      }
+      pooledValues.put(field, new PooledNumeric(ndv));
+    }
+    PooledIterator it = pooledValues.get(field);
+    if (it instanceof PooledNumeric == false) {
+      return null;
+    }
+    return (NumericDocValues) it;
+  }
+
+  @Override
+  public SortedNumericDocValues getSortedNumericDocValues(String field) throws IOException {
+    if (fieldFilter.test(field) == false) {
+      return super.getSortedNumericDocValues(field);
+    }
+    if (pooledValues.containsKey(field) == false) {
+      SortedNumericDocValues sndv = in.getSortedNumericDocValues(field);
+      if (sndv == null) {
+        return null;
+      }
+      pooledValues.put(field, new PooledSortedNumeric(sndv));
+    }
+    PooledIterator it = pooledValues.get(field);
+    if (it instanceof PooledSortedNumeric == false) {
+      return null;
+    }
+    return ((PooledSortedNumeric)it).getIterator();
+  }
+
+  @Override
+  public BinaryDocValues getBinaryDocValues(String field) throws IOException {
+    if (fieldFilter.test(field) == false) {
+      return super.getBinaryDocValues(field);
+    }
+    if (pooledValues.containsKey(field) == false) {
+      BinaryDocValues bdv = in.getBinaryDocValues(field);
+      if (bdv == null) {
+        return null;
+      }
+      pooledValues.put(field, new PooledBinary(bdv));
+    }
+    PooledIterator it = pooledValues.get(field);
+    if (it instanceof PooledBinary == false) {
+      return null;
+    }
+    return (BinaryDocValues) it;
+  }
+
+  @Override
+  public SortedDocValues getSortedDocValues(String field) throws IOException {
+    if (fieldFilter.test(field) == false) {
+      return super.getSortedDocValues(field);
+    }
+    if (pooledValues.containsKey(field) == false) {
+      SortedDocValues sdv = in.getSortedDocValues(field);
+      if (sdv == null) {
+        return null;
+      }
+      pooledValues.put(field, new PooledSorted(sdv));
+    }
+    PooledIterator it = pooledValues.get(field);
+    if (it instanceof PooledSorted == false) {
+      return null;
+    }
+    return (SortedDocValues) it;
+  }
+
+  @Override
+  public SortedSetDocValues getSortedSetDocValues(String field) throws IOException {
+    if (fieldFilter.test(field) == false) {
+      return super.getSortedSetDocValues(field);
+    }
+    if (pooledValues.containsKey(field) == false) {
+      SortedSetDocValues ssdv = in.getSortedSetDocValues(field);
+      if (ssdv == null) {
+        return null;
+      }
+      pooledValues.put(field, new PooledSortedSet(ssdv));
+    }
+    PooledIterator it = pooledValues.get(field);
+    if (it instanceof PooledSortedSet == false) {
+      return null;
+    }
+    return ((PooledSortedSet)it).getIterator();
+  }
+
+  @Override
+  public CacheHelper getCoreCacheHelper() {
+    return in.getCoreCacheHelper();
+  }
+
+  @Override
+  public CacheHelper getReaderCacheHelper() {
+    return in.getReaderCacheHelper();
+  }
+
+  private interface PooledIterator {
+    void advanceReal(int target) throws IOException;
+  }
+
+  private class PooledNumeric extends NumericDocValues implements PooledIterator {
+
+    final NumericDocValues in;
+    boolean positioned = false;
+
+    private PooledNumeric(NumericDocValues in) {
+      this.in = in;
+    }
+
+    @Override
+    public void advanceReal(int target) throws IOException {
+      positioned = in.advanceExact(target);
+    }
+
+    @Override
+    public long longValue() throws IOException {
+      return in.longValue();
+    }
+
+    @Override
+    public boolean advanceExact(int target) throws IOException {
+      if (target != currentDoc) {
+        throw new IllegalStateException("Pooled docvalues can only be advanced to their controlling doc " + target);
+      }
+      return positioned;
+    }
+
+    @Override
+    public int docID() {
+      return in.docID();
+    }
+
+    @Override
+    public int nextDoc() throws IOException {
+      throw new IllegalStateException("Cannot call nextDoc() on pooled docvalues");
+    }
+
+    @Override
+    public int advance(int target) throws IOException {
+      if (target != currentDoc) {
+        throw new IllegalStateException("Pooled docvalues can only be advanced to their controlling doc " + target);
+      }
+      return currentDoc;
+    }
+
+    @Override
+    public long cost() {
+      return in.cost();
+    }
+  }
+
+  private class PooledSortedNumeric implements PooledIterator {
+
+    final SortedNumericDocValues in;
+    boolean positioned;
+    long[] values = new long[1];
+
+    private PooledSortedNumeric(SortedNumericDocValues in) {
+      this.in = in;
+    }
+
+    @Override
+    public void advanceReal(int target) throws IOException {
+      positioned = in.advanceExact(target);
+      if (positioned) {
+        int c = in.docValueCount();
+        values = ArrayUtil.grow(values, c);
+        for (int i = 0; i < c; i++) {
+          values[i] = in.nextValue();
+        }
+      }
+    }
+
+    SortedNumericDocValues getIterator() {
+      return new SortedNumericDocValues() {
+
+        int currentValue;
+
+        @Override
+        public long nextValue() {
+          currentValue++;
+          return values[currentValue - 1];
+        }
+
+        @Override
+        public int docValueCount() {
+          return in.docValueCount();
+        }
+
+        @Override
+        public boolean advanceExact(int target) {
+          if (target != currentDoc) {
+            throw new IllegalStateException("Pooled docvalues can only be advanced to their controlling doc " + target);
+          }
+          currentValue = 0;
+          return positioned;
+        }
+
+        @Override
+        public int docID() {
+          return currentDoc;
+        }
+
+        @Override
+        public int nextDoc() {
+          throw new IllegalStateException("Cannot call nextDoc() on pooled docvalues");
+        }
+
+        @Override
+        public int advance(int target) {
+          if (target != currentDoc) {
+            throw new IllegalStateException("Pooled docvalues can only be advanced to their controlling doc " + target);
+          }
+          currentValue = 0;
+          return currentDoc;
+        }
+
+        @Override
+        public long cost() {
+          return in.cost();
+        }
+      };
+    }
+  }
+
+  private class PooledBinary extends BinaryDocValues implements PooledIterator {
+
+    final BinaryDocValues in;
+    boolean positioned = false;
+
+    private PooledBinary(BinaryDocValues in) {
+      this.in = in;
+    }
+
+    @Override
+    public BytesRef binaryValue() throws IOException {
+      return in.binaryValue();
+    }
+
+    @Override
+    public void advanceReal(int target) throws IOException {
+      positioned = in.advanceExact(target);
+    }
+
+    @Override
+    public boolean advanceExact(int target) throws IOException {
+      if (target != currentDoc) {
+        throw new IllegalStateException("Pooled docvalues can only be advanced to their controlling doc " + target);
+      }
+      return positioned;
+    }
+
+    @Override
+    public int docID() {
+      return in.docID();
+    }
+
+    @Override
+    public int nextDoc() throws IOException {
+      throw new IllegalStateException("Cannot call nextDoc() on pooled docvalues");
+    }
+
+    @Override
+    public int advance(int target) throws IOException {
+      if (target != currentDoc) {
+        throw new IllegalStateException("Pooled docvalues can only be advanced to their controlling doc " + target);
+      }
+      return currentDoc;
+    }
+
+    @Override
+    public long cost() {
+      return in.cost();
+    }
+  }
+
+  private class PooledSorted extends SortedDocValues implements PooledIterator {
+
+    final SortedDocValues in;
+    boolean positioned = false;
+
+    private PooledSorted(SortedDocValues in) {
+      this.in = in;
+    }
+
+    @Override
+    public int ordValue() throws IOException {
+      return in.ordValue();
+    }
+
+    @Override
+    public BytesRef lookupOrd(int ord) throws IOException {
+      return in.lookupOrd(ord);
+    }
+
+    @Override
+    public int getValueCount() {
+      return in.getValueCount();
+    }
+
+    @Override
+    public void advanceReal(int target) throws IOException {
+      positioned = in.advanceExact(target);
+    }
+
+    @Override
+    public boolean advanceExact(int target) throws IOException {
+      if (target != currentDoc) {
+        throw new IllegalStateException("Pooled docvalues can only be advanced to their controlling doc " + target);
+      }
+      return positioned;
+    }
+
+    @Override
+    public int docID() {
+      return in.docID();
+    }
+
+    @Override
+    public int nextDoc() throws IOException {
+      throw new IllegalStateException("Cannot call nextDoc() on pooled docvalues");
+    }
+
+    @Override
+    public int advance(int target) throws IOException {
+      if (target != currentDoc) {
+        throw new IllegalStateException("Pooled docvalues can only be advanced to their controlling doc " + target);
+      }
+      return currentDoc;
+    }
+
+    @Override
+    public long cost() {
+      return in.cost();
+    }
+  }
+
+  private class PooledSortedSet implements PooledIterator {
+
+    final SortedSetDocValues in;
+    boolean positioned = false;
+    long[] ords = new long[1];
+
+    private PooledSortedSet(SortedSetDocValues in) {
+      this.in = in;
+    }
+
+    @Override
+    public void advanceReal(int target) throws IOException {
+      positioned = in.advanceExact(target);
+      if (positioned) {
+        int c = 0;
+        long ord;
+        do {
+          ord = in.nextOrd();
+          ords = ArrayUtil.grow(ords, c + 1);
+          ords[c] = ord;
+          c++;
+        } while (ord != SortedSetDocValues.NO_MORE_ORDS);
+      }
+    }
+
+    SortedSetDocValues getIterator() {
+      return new SortedSetDocValues() {
+
+        int current;
+
+        @Override
+        public long nextOrd() {
+          current++;
+          return ords[current - 1];
+        }
+
+        @Override
+        public BytesRef lookupOrd(long ord) throws IOException {
+          return in.lookupOrd(ord);
+        }
+
+        @Override
+        public long getValueCount() {
+          return in.getValueCount();
+        }
+
+        @Override
+        public boolean advanceExact(int target) {
+          if (target != currentDoc) {
+            throw new IllegalStateException("Pooled docvalues can only be advanced to their controlling doc " + target);
+          }
+          current = 0;
+          return positioned;
+        }
+
+        @Override
+        public int docID() {
+          return in.docID();
+        }
+
+        @Override
+        public int nextDoc() {
+          throw new IllegalStateException("Cannot call nextDoc() on pooled docvalues");
+        }
+
+        @Override
+        public int advance(int target) {
+          if (target != currentDoc) {
+            throw new IllegalStateException("Pooled docvalues can only be advanced to their controlling doc " + target);
+          }
+          current = 0;
+          return currentDoc;
+        }
+
+        @Override
+        public long cost() {
+          return in.cost();
+        }
+      };
+    }
+  }
+}

--- a/lucene/core/src/test/org/apache/lucene/index/TestPooledDocValuesReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestPooledDocValuesReader.java
@@ -45,7 +45,7 @@ public class TestPooledDocValuesReader extends LuceneTestCase {
     int numDocs = atLeast(1000);
     for (int i = 0; i < numDocs; i++) {
       Document doc = new Document();
-      if (rarely() == false) {
+      if (rarely() == false && i > 1) {
         doc.add(new NumericDocValuesField("numeric1", random().nextLong()));
         int count = atLeast(3);
         for (int j = 0; j < count; j++) {
@@ -136,7 +136,7 @@ public class TestPooledDocValuesReader extends LuceneTestCase {
     int numDocs = atLeast(1000);
     for (int i = 0; i < numDocs; i++) {
       Document doc = new Document();
-      if (rarely() == false) {
+      if (rarely() == false && i > 0) {
         int valueCount = atLeast(1);
         for (int j = 0; j < valueCount; j++) {
           doc.add(new SortedNumericDocValuesField("numeric1", random().nextLong()));
@@ -212,7 +212,7 @@ public class TestPooledDocValuesReader extends LuceneTestCase {
     int numDocs = atLeast(1000);
     for (int i = 0; i < numDocs; i++) {
       Document doc = new Document();
-      if (rarely() == false) {
+      if (rarely() == false && i > 0) {
         doc.add(new BinaryDocValuesField("binary1", TestUtil.randomBinaryTerm(random())));
         doc.add(new BinaryDocValuesField("binary2", TestUtil.randomBinaryTerm(random())));
       }
@@ -279,7 +279,7 @@ public class TestPooledDocValuesReader extends LuceneTestCase {
     int numDocs = atLeast(1000);
     for (int i = 0; i < numDocs; i++) {
       Document doc = new Document();
-      if (rarely() == false) {
+      if (rarely() == false && i > 0) {
         doc.add(new SortedDocValuesField("sorted1", TestUtil.randomBinaryTerm(random())));
         doc.add(new SortedDocValuesField("sorted2", TestUtil.randomBinaryTerm(random())));
         int count = atLeast(3);
@@ -371,7 +371,7 @@ public class TestPooledDocValuesReader extends LuceneTestCase {
     int numDocs = atLeast(1000);
     for (int i = 0; i < numDocs; i++) {
       Document doc = new Document();
-      if (rarely() == false) {
+      if (rarely() == false && i > 0) {
         int valueCount = atLeast(1);
         for (int j = 0; j < valueCount; j++) {
           doc.add(new SortedSetDocValuesField("sorted1", TestUtil.randomBinaryTerm(random())));

--- a/lucene/core/src/test/org/apache/lucene/index/TestPooledDocValuesReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestPooledDocValuesReader.java
@@ -1,0 +1,446 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.index;
+
+import java.io.IOException;
+
+import org.apache.lucene.analysis.MockAnalyzer;
+import org.apache.lucene.document.BinaryDocValuesField;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.document.SortedSetDocValuesField;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.SortedNumericSelector;
+import org.apache.lucene.search.SortedSetSelector;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.LuceneTestCase;
+import org.apache.lucene.util.TestUtil;
+
+public class TestPooledDocValuesReader extends LuceneTestCase {
+
+  public void testNumeric() throws IOException {
+
+    Directory dir = newDirectory();
+    RandomIndexWriter w =  new RandomIndexWriter(random(), dir,
+        newIndexWriterConfig(new MockAnalyzer(random())).setMergePolicy(newLogMergePolicy()));
+
+    int numDocs = atLeast(1000);
+    for (int i = 0; i < numDocs; i++) {
+      Document doc = new Document();
+      if (rarely() == false) {
+        doc.add(new NumericDocValuesField("numeric1", random().nextLong()));
+        int count = atLeast(3);
+        for (int j = 0; j < count; j++) {
+          doc.add(new SortedNumericDocValuesField("multinumeric1", random().nextLong()));
+        }
+      }
+      doc.add(new NumericDocValuesField("numeric2", i));
+      w.addDocument(doc);
+    }
+
+    IndexReader r = w.getReader();
+
+    for (LeafReaderContext c : r.leaves()) {
+      PooledDocValuesReader pool = new PooledDocValuesReader(c, f -> f.endsWith("numeric1"));
+      LeafReaderContext pooledContext = pool.getPooledContext();
+      assertEquals(pooledContext.docBase, c.docBase);
+      assertEquals(pooledContext.ord, c.ord);
+
+      NumericDocValues control = c.reader().getNumericDocValues("numeric1");
+      NumericDocValues pooled1 = pooledContext.reader().getNumericDocValues("numeric1");
+      NumericDocValues pooled2 = pooledContext.reader().getNumericDocValues("numeric1");
+      NumericDocValues secondary = pooledContext.reader().getNumericDocValues("numeric2");
+      NumericDocValues multi1 = SortedNumericSelector.wrap(
+          pooledContext.reader().getSortedNumericDocValues("multinumeric1"),
+          SortedNumericSelector.Type.MAX, SortField.Type.LONG);
+      NumericDocValues multi2 = SortedNumericSelector.wrap(
+          pooledContext.reader().getSortedNumericDocValues("multinumeric1"),
+          SortedNumericSelector.Type.MAX, SortField.Type.LONG);
+      NumericDocValues multicontrol = SortedNumericSelector.wrap(
+          c.reader().getSortedNumericDocValues("multinumeric1"),
+          SortedNumericSelector.Type.MAX, SortField.Type.LONG);
+
+      assertSame(pooled1, pooled2);
+      assertNull(pooledContext.reader().getNumericDocValues("numeric3"));
+      assertNull(pooledContext.reader().getSortedSetDocValues("numeric1"));
+
+      secondary.nextDoc();  // shouldn't throw an exception because unpooled
+
+      for (int i = 0; i < c.reader().maxDoc(); i++) {
+        if (rarely()) {
+          continue; // skip a value
+        }
+        final int doc = i;
+        pool.advanceAll(i);
+        boolean present = control.advanceExact(i);
+        if (present) {
+          assertEquals(i, pooled1.advance(i));
+          assertEquals(i, pooled2.advance(i));
+          assertEquals(control.longValue(), pooled1.longValue());
+          assertEquals(control.longValue(), pooled2.longValue());
+        }
+        else {
+          assertFalse(pooled1.advanceExact(i));
+          assertFalse(pooled2.advanceExact(i));
+        }
+        expectThrows(IllegalStateException.class, () -> pooled1.advanceExact(doc + 1));
+        expectThrows(IllegalStateException.class, () -> pooled1.advance(doc + 1));
+        expectThrows(IllegalStateException.class, pooled1::nextDoc);
+        present = multicontrol.advanceExact(i);
+        if (present) {
+          assertEquals(i, multi1.advance(i));
+          assertEquals(i, multi2.advance(i));
+          assertEquals(multicontrol.longValue(), multi1.longValue());
+          assertEquals(multicontrol.longValue(), multi2.longValue());
+        }
+        else {
+          assertFalse(multi1.advanceExact(i));
+          assertFalse(multi2.advanceExact(i));
+        }
+        expectThrows(IllegalStateException.class, () -> multi1.advanceExact(doc + 1));
+        expectThrows(IllegalStateException.class, () -> multi1.advance(doc + 1));
+        expectThrows(IllegalStateException.class, multi1::nextDoc);
+      }
+    }
+
+    r.close();
+    w.close();
+    dir.close();
+
+  }
+
+  public void testSortedNumeric() throws IOException {
+
+    Directory dir = newDirectory();
+    RandomIndexWriter w =  new RandomIndexWriter(random(), dir,
+        newIndexWriterConfig(new MockAnalyzer(random())).setMergePolicy(newLogMergePolicy()));
+
+    int numDocs = atLeast(1000);
+    for (int i = 0; i < numDocs; i++) {
+      Document doc = new Document();
+      if (rarely() == false) {
+        int valueCount = atLeast(1);
+        for (int j = 0; j < valueCount; j++) {
+          doc.add(new SortedNumericDocValuesField("numeric1", random().nextLong()));
+        }
+      }
+      doc.add(new SortedNumericDocValuesField("numeric2", i));
+      doc.add(new SortedNumericDocValuesField("numeric2", i + 1));
+      w.addDocument(doc);
+    }
+
+    IndexReader r = w.getReader();
+
+    for (LeafReaderContext c : r.leaves()) {
+      PooledDocValuesReader pool = new PooledDocValuesReader(c, "numeric1"::equals);
+      LeafReaderContext pooledContext = pool.getPooledContext();
+      assertEquals(pooledContext.docBase, c.docBase);
+      assertEquals(pooledContext.ord, c.ord);
+
+      SortedNumericDocValues control = c.reader().getSortedNumericDocValues("numeric1");
+      SortedNumericDocValues pooled1 = pooledContext.reader().getSortedNumericDocValues("numeric1");
+      SortedNumericDocValues pooled2 = pooledContext.reader().getSortedNumericDocValues("numeric1");
+      SortedNumericDocValues unpooled = pooledContext.reader().getSortedNumericDocValues("numeric2");
+
+      assertNull(pooledContext.reader().getSortedNumericDocValues("numeric3"));
+      assertNull(pooledContext.reader().getBinaryDocValues("numeric1"));
+      unpooled.nextDoc(); // shouldn't throw an exception because unpooled
+
+      for (int i = 0; i < c.reader().maxDoc(); i++) {
+        if (rarely()) {
+          continue; // skip a value
+        }
+        final int doc = i;
+        pool.advanceAll(i);
+        boolean present = control.advanceExact(i);
+        if (present) {
+          assertEquals(i, pooled1.advance(i));
+          assertEquals(i, pooled2.advance(i));
+          assertEquals(control.docValueCount(), pooled1.docValueCount());
+          assertEquals(control.docValueCount(), pooled2.docValueCount());
+          long[] values = new long[control.docValueCount()];
+          for (int j = 0; j < control.docValueCount(); j++) {
+            values[j] = control.nextValue();
+            assertEquals(values[j], pooled1.nextValue());
+          }
+          for (int j = 0; j < values.length; j++) {
+            assertEquals(values[j], pooled2.nextValue());
+          }
+          expectThrows(IllegalStateException.class, () -> pooled1.advanceExact(doc + 1));
+          expectThrows(IllegalStateException.class, () -> pooled1.advance(doc + 1));
+          expectThrows(IllegalStateException.class, pooled1::nextDoc);
+        }
+        else {
+          assertFalse(pooled1.advanceExact(i));
+          assertFalse(pooled2.advanceExact(i));
+          expectThrows(IllegalStateException.class, () -> pooled1.advance(doc + 1));
+          expectThrows(IllegalStateException.class, () -> pooled1.advanceExact(doc + 1));
+          expectThrows(IllegalStateException.class, pooled1::nextDoc);
+        }
+      }
+    }
+
+    r.close();
+    w.close();
+    dir.close();
+  }
+
+  public void testBinary() throws IOException {
+
+    Directory dir = newDirectory();
+    RandomIndexWriter w =  new RandomIndexWriter(random(), dir,
+        newIndexWriterConfig(new MockAnalyzer(random())).setMergePolicy(newLogMergePolicy()));
+
+    int numDocs = atLeast(1000);
+    for (int i = 0; i < numDocs; i++) {
+      Document doc = new Document();
+      if (rarely() == false) {
+        doc.add(new BinaryDocValuesField("binary1", TestUtil.randomBinaryTerm(random())));
+        doc.add(new BinaryDocValuesField("binary2", TestUtil.randomBinaryTerm(random())));
+      }
+      w.addDocument(doc);
+    }
+
+    IndexReader r = w.getReader();
+
+    for (LeafReaderContext c : r.leaves()) {
+      PooledDocValuesReader pool = new PooledDocValuesReader(c, "binary1"::equals);
+      LeafReaderContext pooledContext = pool.getPooledContext();
+      assertEquals(pooledContext.docBase, c.docBase);
+      assertEquals(pooledContext.ord, c.ord);
+
+      BinaryDocValues control = c.reader().getBinaryDocValues("binary1");
+      BinaryDocValues pooled1 = pooledContext.reader().getBinaryDocValues("binary1");
+      BinaryDocValues pooled2 = pooledContext.reader().getBinaryDocValues("binary1");
+      BinaryDocValues unpooled = pooledContext.reader().getBinaryDocValues("binary2");
+
+      assertSame(pooled1, pooled2);
+      assertNull(pooledContext.reader().getNumericDocValues("binary1"));
+      assertNull(pooledContext.reader().getBinaryDocValues("binary3"));
+
+      unpooled.nextDoc();   // shouldn't throw an exception because unpooled
+
+      for (int i = 0; i < c.reader().maxDoc(); i++) {
+        if (rarely()) {
+          continue; // skip a value
+        }
+        final int doc = i;
+        pool.advanceAll(i);
+        boolean present = control.advanceExact(i);
+        if (present) {
+          assertEquals(i, pooled1.advance(i));
+          assertEquals(i, pooled2.advance(i));
+          assertEquals(control.binaryValue(), pooled1.binaryValue());
+          assertEquals(control.binaryValue(), pooled2.binaryValue());
+          expectThrows(IllegalStateException.class, () -> pooled1.advanceExact(doc + 1));
+          expectThrows(IllegalStateException.class, () -> pooled1.advance(doc + 1));
+          expectThrows(IllegalStateException.class, pooled1::nextDoc);
+        }
+        else {
+          assertFalse(pooled1.advanceExact(i));
+          assertFalse(pooled2.advanceExact(i));
+          expectThrows(IllegalStateException.class, () -> pooled1.advance(doc + 1));
+          expectThrows(IllegalStateException.class, () -> pooled1.advanceExact(doc + 1));
+          expectThrows(IllegalStateException.class, pooled1::nextDoc);
+        }
+      }
+    }
+
+    r.close();
+    w.close();
+    dir.close();
+
+  }
+
+  public void testSorted() throws IOException {
+
+    Directory dir = newDirectory();
+    RandomIndexWriter w =  new RandomIndexWriter(random(), dir,
+        newIndexWriterConfig(new MockAnalyzer(random())).setMergePolicy(newLogMergePolicy()));
+
+    int numDocs = atLeast(1000);
+    for (int i = 0; i < numDocs; i++) {
+      Document doc = new Document();
+      if (rarely() == false) {
+        doc.add(new SortedDocValuesField("sorted1", TestUtil.randomBinaryTerm(random())));
+        doc.add(new SortedDocValuesField("sorted2", TestUtil.randomBinaryTerm(random())));
+        int count = atLeast(3);
+        for (int j = 0; j < count; j++) {
+          doc.add(new SortedSetDocValuesField("multisorted1", TestUtil.randomBinaryTerm(random())));
+        }
+      }
+      w.addDocument(doc);
+    }
+
+    IndexReader r = w.getReader();
+
+    for (LeafReaderContext c : r.leaves()) {
+      PooledDocValuesReader pool = new PooledDocValuesReader(c, f -> f.endsWith("sorted1"));
+      LeafReaderContext pooledContext = pool.getPooledContext();
+      assertEquals(pooledContext.docBase, c.docBase);
+      assertEquals(pooledContext.ord, c.ord);
+
+      SortedDocValues control = c.reader().getSortedDocValues("sorted1");
+      SortedDocValues pooled1 = pooledContext.reader().getSortedDocValues("sorted1");
+      SortedDocValues pooled2 = pooledContext.reader().getSortedDocValues("sorted1");
+      SortedDocValues unpooled = pooledContext.reader().getSortedDocValues("sorted2");
+      SortedDocValues multicontrol = SortedSetSelector.wrap(
+          c.reader().getSortedSetDocValues("multisorted1"), SortedSetSelector.Type.MIDDLE_MAX);
+      SortedDocValues multi1 = SortedSetSelector.wrap(
+          pooledContext.reader().getSortedSetDocValues("multisorted1"), SortedSetSelector.Type.MIDDLE_MAX);
+      SortedDocValues multi2 = SortedSetSelector.wrap(
+          pooledContext.reader().getSortedSetDocValues("multisorted1"), SortedSetSelector.Type.MIDDLE_MAX);
+
+      assertSame(pooled1, pooled2);
+      assertNull(pooledContext.reader().getBinaryDocValues("sorted3"));
+      assertNull(pooledContext.reader().getNumericDocValues("sorted1"));
+      assertEquals(control.getValueCount(), pooled1.getValueCount());
+
+      unpooled.nextDoc(); // shouldn't throw an exception because unpooled
+
+      for (int i = 0; i < c.reader().maxDoc(); i++) {
+        if (rarely()) {
+          continue; // skip a value
+        }
+        final int doc = i;
+        pool.advanceAll(i);
+        boolean present = control.advanceExact(i);
+        if (present) {
+          assertEquals(i, pooled1.advance(i));
+          assertEquals(i, pooled2.advance(i));
+          assertEquals(control.binaryValue(), pooled1.binaryValue());
+          assertEquals(control.binaryValue(), pooled2.binaryValue());
+          assertEquals(control.ordValue(), pooled1.ordValue());
+          assertEquals(control.ordValue(), pooled2.ordValue());
+        } else {
+          assertFalse(pooled1.advanceExact(i));
+          assertFalse(pooled2.advanceExact(i));
+        }
+        expectThrows(IllegalStateException.class, () -> pooled1.advance(doc + 1));
+        expectThrows(IllegalStateException.class, () -> pooled1.advanceExact(doc + 1));
+        expectThrows(IllegalStateException.class, pooled1::nextDoc);
+        present = multicontrol.advanceExact(i);
+        if (present) {
+          assertEquals(i, multi1.advance(i));
+          assertEquals(i, multi2.advance(i));
+          assertEquals(multicontrol.binaryValue(), multi1.binaryValue());
+          assertEquals(multicontrol.binaryValue(), multi2.binaryValue());
+          assertEquals(multicontrol.ordValue(), multi1.ordValue());
+          assertEquals(multicontrol.ordValue(), multi2.ordValue());
+        }
+        else {
+          assertFalse(multi1.advanceExact(i));
+          assertFalse(multi2.advanceExact(i));
+        }
+        expectThrows(IllegalStateException.class, () -> multi1.advance(doc + 1));
+        expectThrows(IllegalStateException.class, () -> multi1.advanceExact(doc + 1));
+        expectThrows(IllegalStateException.class, multi1::nextDoc);
+      }
+    }
+
+    r.close();
+    w.close();
+    dir.close();
+
+  }
+
+  public void testSortedSet() throws IOException {
+
+    Directory dir = newDirectory();
+    RandomIndexWriter w =  new RandomIndexWriter(random(), dir,
+        newIndexWriterConfig(new MockAnalyzer(random())).setMergePolicy(newLogMergePolicy()));
+
+    int numDocs = atLeast(1000);
+    for (int i = 0; i < numDocs; i++) {
+      Document doc = new Document();
+      if (rarely() == false) {
+        int valueCount = atLeast(1);
+        for (int j = 0; j < valueCount; j++) {
+          doc.add(new SortedSetDocValuesField("sorted1", TestUtil.randomBinaryTerm(random())));
+          doc.add(new SortedSetDocValuesField("sorted2", TestUtil.randomBinaryTerm(random())));
+        }
+      }
+      w.addDocument(doc);
+    }
+
+    IndexReader r = w.getReader();
+
+    for (LeafReaderContext c : r.leaves()) {
+      PooledDocValuesReader pool = new PooledDocValuesReader(c, "sorted1"::equals);
+      LeafReaderContext pooledContext = pool.getPooledContext();
+      assertEquals(pooledContext.docBase, c.docBase);
+      assertEquals(pooledContext.ord, c.ord);
+
+      SortedSetDocValues control = c.reader().getSortedSetDocValues("sorted1");
+      SortedSetDocValues pooled1 = pooledContext.reader().getSortedSetDocValues("sorted1");
+      SortedSetDocValues pooled2 = pooledContext.reader().getSortedSetDocValues("sorted1");
+
+      assertEquals(control.getValueCount(), pooled1.getValueCount());
+      assertEquals(control.getValueCount(), pooled2.getValueCount());
+
+      assertNull(pooledContext.reader().getNumericDocValues("sorted1"));
+      assertNull(pooledContext.reader().getSortedSetDocValues("sorted3"));
+
+      SortedSetDocValues unpooled = pooledContext.reader().getSortedSetDocValues("sorted2");
+      unpooled.nextDoc(); // shouldn't throw an exception because it's unpooled
+
+      for (int i = 0; i < c.reader().maxDoc(); i++) {
+        if (rarely()) {
+          continue; // skip a value
+        }
+        final int doc = i;
+        pool.advanceAll(i);
+        boolean present = control.advanceExact(i);
+        if (present) {
+          assertEquals(i, pooled1.advance(i));
+          assertEquals(i, pooled2.advance(i));
+          long[] values = new long[4];
+          int count = 0;
+          for (long ord = control.nextOrd(); ord != SortedSetDocValues.NO_MORE_ORDS; ord = control.nextOrd()) {
+            values = ArrayUtil.grow(values, count + 1);
+            values[count] = ord;
+            count++;
+            assertEquals(ord, pooled1.nextOrd());
+          }
+          for (int j = 0; j < count; j++) {
+            assertEquals(values[j], pooled2.nextOrd());
+          }
+          expectThrows(IllegalStateException.class, () -> pooled1.advanceExact(doc + 1));
+          expectThrows(IllegalStateException.class, () -> pooled1.advance(doc + 1));
+          expectThrows(IllegalStateException.class, pooled1::nextDoc);
+        }
+        else {
+          assertFalse(pooled1.advanceExact(i));
+          assertFalse(pooled2.advanceExact(i));
+          expectThrows(IllegalStateException.class, () -> pooled1.advance(doc + 1));
+          expectThrows(IllegalStateException.class, () -> pooled1.advanceExact(doc + 1));
+          expectThrows(IllegalStateException.class, pooled1::nextDoc);
+        }
+      }
+    }
+
+    r.close();
+    w.close();
+    dir.close();
+
+  }
+
+}

--- a/lucene/grouping/src/java/org/apache/lucene/search/grouping/SecondPassGroupingCollector.java
+++ b/lucene/grouping/src/java/org/apache/lucene/search/grouping/SecondPassGroupingCollector.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Objects;
 
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.PooledDocValuesReader;
 import org.apache.lucene.search.Scorable;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.SimpleCollector;
@@ -42,6 +43,7 @@ public class SecondPassGroupingCollector<T> extends SimpleCollector {
 
   protected int totalHitCount;
   protected int totalGroupedHitCount;
+  protected PooledDocValuesReader pooledReader;
 
   /**
    * Create a new SecondPassGroupingCollector
@@ -88,12 +90,14 @@ public class SecondPassGroupingCollector<T> extends SimpleCollector {
       return;
     totalGroupedHitCount++;
     T value = groupSelector.currentValue();
+    pooledReader.advanceAll(doc);
     groupReducer.collect(value, doc);
   }
 
   @Override
   protected void doSetNextReader(LeafReaderContext readerContext) throws IOException {
-    groupReducer.setNextReader(readerContext);
+    pooledReader = new PooledDocValuesReader(readerContext);
+    groupReducer.setNextReader(pooledReader.getPooledContext());
     groupSelector.setNextReader(readerContext);
   }
 


### PR DESCRIPTION
This commit adds a PooledDocValuesReader that shares doc values
iterators among several consumers, and adds it to grouping second-pass
collectors.