### PR TITLE
LUCENE-9374: Add checkBrokenLinks gradle task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,7 @@ apply from: file('gradle/validation/ecj-lint.gradle')
 apply from: file('gradle/validation/gradlew-scripts-tweaked.gradle')
 apply from: file('gradle/validation/missing-docs-check.gradle')
 apply from: file('gradle/validation/validate-log-calls.gradle')
+apply from: file('gradle/validation/documentation-lint.gradle')
 
 // Source or data regeneration tasks
 apply from: file('gradle/generation/jflex.gradle')
@@ -134,4 +135,3 @@ apply from: file('gradle/ant-compat/forbidden-api-rules-in-sync.gradle')
 apply from: file('gradle/documentation/documentation.gradle')
 apply from: file('gradle/documentation/changes-to-html.gradle')
 apply from: file('gradle/render-javadoc.gradle')
-apply from: file('gradle/validation/documentation-lint.gradle')  // should be placed here; needs to be evaluated after documentation.gradle

--- a/build.gradle
+++ b/build.gradle
@@ -134,3 +134,4 @@ apply from: file('gradle/ant-compat/forbidden-api-rules-in-sync.gradle')
 apply from: file('gradle/documentation/documentation.gradle')
 apply from: file('gradle/documentation/changes-to-html.gradle')
 apply from: file('gradle/render-javadoc.gradle')
+apply from: file('gradle/validation/documentation-lint.gradle')  // should be placed here; needs to be evaluated after documentation.gradle

--- a/build.gradle
+++ b/build.gradle
@@ -115,7 +115,7 @@ apply from: file('gradle/validation/ecj-lint.gradle')
 apply from: file('gradle/validation/gradlew-scripts-tweaked.gradle')
 apply from: file('gradle/validation/missing-docs-check.gradle')
 apply from: file('gradle/validation/validate-log-calls.gradle')
-apply from: file('gradle/validation/documentation-lint.gradle')
+apply from: file('gradle/validation/check-broken-links.gradle')
 
 // Source or data regeneration tasks
 apply from: file('gradle/generation/jflex.gradle')

--- a/gradle/validation/check-broken-links.gradle
+++ b/gradle/validation/check-broken-links.gradle
@@ -17,23 +17,21 @@
 
 configure(rootProject) {
 
-  task documentationLint {
+  task checkBrokenLinks {
     group 'Verification'
-    description 'Verify all documentation'
+    description 'Check broken links in the entire documentation'
 
     dependsOn ':lucene:checkBrokenLinks'
     dependsOn ':solr:checkBrokenLinks'
   }
-}
 
+}
 configure(subprojects.findAll { it.path in [':lucene', ':solr'] }) {
 
   project.afterEvaluate {
     task checkBrokenLinks(type: CheckBrokenLinksTask) {
       docsDir = project.docroot
-      dependsOn subprojects.collect { prj ->
-        prj.tasks.matching { it.name == 'renderSiteJavadoc' }
-      }
+      dependsOn 'documentation'
     }
 
     // TODO: uncomment this line after fixing all broken links.

--- a/gradle/validation/check-broken-links.gradle
+++ b/gradle/validation/check-broken-links.gradle
@@ -37,8 +37,11 @@ configure(subprojects.findAll { it.path in [':lucene', ':solr'] }) {
 
 class CheckBrokenLinksTask extends DefaultTask {
 
+  // wraps input directory location in DirectoryProperty so as to lazily evaluate 'docroot' property
+  // (see gradle/documentation/documentation.gradle)
   @InputDirectory
-  final Provider<File> docsDir = project.providers.provider { project.docroot }
+  final DirectoryProperty docsDir = project.objects.directoryProperty()
+    .fileProvider(project.providers.provider { project.docroot })
 
   @InputFile
   File script = project.rootProject.file("dev-tools/scripts/checkJavadocLinks.py")
@@ -56,7 +59,7 @@ class CheckBrokenLinksTask extends DefaultTask {
         args = [
           "-B",
           script.absolutePath,
-          docsDir.get().absolutePath
+          docsDir.get().getAsFile()
         ]
       }
     }

--- a/gradle/validation/check-broken-links.gradle
+++ b/gradle/validation/check-broken-links.gradle
@@ -37,10 +37,10 @@ configure(subprojects.findAll { it.path in [':lucene', ':solr'] }) {
 
 class CheckBrokenLinksTask extends DefaultTask {
 
-  @Input
+  @InputDirectory
   Provider<File> docsDir = project.providers.provider { project.docroot }
 
-  @Input
+  @InputFile
   File script = project.rootProject.file("dev-tools/scripts/checkJavadocLinks.py")
 
   @TaskAction

--- a/gradle/validation/check-broken-links.gradle
+++ b/gradle/validation/check-broken-links.gradle
@@ -40,6 +40,9 @@ class CheckBrokenLinksTask extends DefaultTask {
   @Input
   Provider<File> docsDir = project.providers.provider { project.docroot }
 
+  @Input
+  File script = project.rootProject.file("dev-tools/scripts/checkJavadocLinks.py")
+
   @TaskAction
   def check() {
     def outputFile = project.file("${getTemporaryDir()}/check-broken-links-output.txt")
@@ -52,7 +55,7 @@ class CheckBrokenLinksTask extends DefaultTask {
         errorOutput = output
         args = [
           "-B",
-          project.rootProject.file("dev-tools/scripts/checkJavadocLinks.py").absolutePath,
+          script.absolutePath,
           docsDir.get().absolutePath
         ]
       }

--- a/gradle/validation/check-broken-links.gradle
+++ b/gradle/validation/check-broken-links.gradle
@@ -38,7 +38,7 @@ configure(subprojects.findAll { it.path in [':lucene', ':solr'] }) {
 class CheckBrokenLinksTask extends DefaultTask {
 
   @InputDirectory
-  Provider<File> docsDir = project.providers.provider { project.docroot }
+  final Provider<File> docsDir = project.providers.provider { project.docroot }
 
   @InputFile
   File script = project.rootProject.file("dev-tools/scripts/checkJavadocLinks.py")

--- a/gradle/validation/check-broken-links.gradle
+++ b/gradle/validation/check-broken-links.gradle
@@ -28,22 +28,17 @@ configure(rootProject) {
 }
 configure(subprojects.findAll { it.path in [':lucene', ':solr'] }) {
 
-  project.afterEvaluate {
-    task checkBrokenLinks(type: CheckBrokenLinksTask) {
-      docsDir = project.docroot
-      dependsOn 'documentation'
-    }
+  task checkBrokenLinks(type: CheckBrokenLinksTask, 'dependsOn': 'documentation')
 
-    // TODO: uncomment this line after fixing all broken links.
-    // (we can't fix the cross-project links until ant build is disabled.)
-    // check.dependsOn checkBrokenLinks
-  }
-
+  // TODO: uncomment this line after fixing all broken links.
+  // (we can't fix the cross-project links until ant build is disabled.)
+  // check.dependsOn checkBrokenLinks
 }
 
 class CheckBrokenLinksTask extends DefaultTask {
+
   @Input
-  File docsDir
+  Provider<File> docsDir = project.providers.provider { project.docroot }
 
   @TaskAction
   def check() {
@@ -58,7 +53,7 @@ class CheckBrokenLinksTask extends DefaultTask {
         args = [
           "-B",
           project.rootProject.file("dev-tools/scripts/checkJavadocLinks.py").absolutePath,
-          docsDir.absolutePath
+          docsDir.get().absolutePath
         ]
       }
     }

--- a/gradle/validation/documentation-lint.gradle
+++ b/gradle/validation/documentation-lint.gradle
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+configure(rootProject) {
+
+  task documentationLint {
+    group 'Verification'
+    description 'Verify all documentation'
+
+    dependsOn 'documentation'
+    dependsOn subprojects.collect { prj ->
+      prj.tasks.matching { task -> task.name == 'checkBrokenLinks'}
+    }
+  }
+
+  // TODO: uncomment this line after fixing all broken links.
+  // (we can't fix the cross-project links until ant build is disabled.)
+  // check.dependsOn documentationLint
+}
+
+configure(subprojects.findAll { it.path in [':lucene', ':solr'] }) {
+  task checkBrokenLinks(type: CheckBrokenLinksTask)
+}
+
+class CheckBrokenLinksTask extends DefaultTask {
+  @Input
+  File docsDir = project.docroot
+
+  @TaskAction
+  def check() {
+    def outputFile = project.file("${getTemporaryDir()}/check-broken-links-output.txt")
+    def result
+    outputFile.withOutputStream { output ->
+      result = project.exec {
+        executable "python3"
+        ignoreExitValue = true
+        standardOutput = output
+        errorOutput = output
+        args = [
+          "-B",
+          project.rootProject.file("dev-tools/scripts/checkJavadocLinks.py").absolutePath,
+          docsDir.absolutePath
+        ]
+      }
+    }
+
+    if (result.getExitValue() != 0) {
+      throw new GradleException("Broken links check failed. Command output at: ${outputFile}")
+    }
+  }
+}

--- a/gradle/validation/documentation-lint.gradle
+++ b/gradle/validation/documentation-lint.gradle
@@ -21,24 +21,31 @@ configure(rootProject) {
     group 'Verification'
     description 'Verify all documentation'
 
-    dependsOn 'documentation'
-    dependsOn subprojects.collect { prj ->
-      prj.tasks.matching { task -> task.name == 'checkBrokenLinks'}
-    }
+    dependsOn ':lucene:checkBrokenLinks'
+    dependsOn ':solr:checkBrokenLinks'
   }
-
-  // TODO: uncomment this line after fixing all broken links.
-  // (we can't fix the cross-project links until ant build is disabled.)
-  // check.dependsOn documentationLint
 }
 
 configure(subprojects.findAll { it.path in [':lucene', ':solr'] }) {
-  task checkBrokenLinks(type: CheckBrokenLinksTask)
+
+  project.afterEvaluate {
+    task checkBrokenLinks(type: CheckBrokenLinksTask) {
+      docsDir = project.docroot
+      dependsOn subprojects.collect { prj ->
+        prj.tasks.matching { it.name == 'renderSiteJavadoc' }
+      }
+    }
+
+    // TODO: uncomment this line after fixing all broken links.
+    // (we can't fix the cross-project links until ant build is disabled.)
+    // check.dependsOn checkBrokenLinks
+  }
+
 }
 
 class CheckBrokenLinksTask extends DefaultTask {
   @Input
-  File docsDir = project.docroot
+  File docsDir
 
   @TaskAction
   def check() {


### PR DESCRIPTION
## Description

~This adds `documentationLint` task to gradle build.~ This adds `checkBrokenLinks` task to gradle build. The task is a placeholder for `:lucene:checkBrokenLinks` and `:solr:checkBrokenLinks` that detect broken or invalid links in docs under `_project_/build/documentation`. 
For now, both check tasks fail as there are broken links in the javadocs.

See also https://issues.apache.org/jira/browse/LUCENE-9374

## Gradle command

```
./gradlew checkBrokenLinks
```

or 

```
./gradlew :lucene:checkBrokenLinks
./gradlew :solr:checkBrokenLinks
```

## Note

- I added `documentationLint` task that wraps `checkBrokenLinks` to align semantics with `documentation` task, but it can be removed if not needed.
- `documentation-lint.gradle` could be placed under `gradle/documentation` ?