### PR TITLE
SOLR-15185: Rewrite Hash query

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -88,6 +88,9 @@ when told to. The admin UI now tells it to. (Nazerke Seidan, David Smiley)
 * SOLR-15100: Make the ConfigSetService pluggable/configurable via <string name="configSetService" /> in solr.xml
  (baisui)
 
+* SOLR-15185: Various optimizations to the {!hash} QParser, typically used by the parallel()
+  streaming expression.  The hash algorithm changed.  (David Smiley)
+
 Other Changes
 ----------------------
 * SOLR-14656: Autoscaling framework removed (Ishan Chattopadhyaya, noble, Ilan Ginzburg)

--- a/solr/core/src/test/org/apache/solr/search/TestHashQParserPlugin.java
+++ b/solr/core/src/test/org/apache/solr/search/TestHashQParserPlugin.java
@@ -71,7 +71,7 @@ public class TestHashQParserPlugin extends SolrTestCaseJ4 {
     params = new ModifiableSolrParams();
     params.add("q", "*:*");
     params.add("fq", "{!hash worker=0 workers=2 cost="+getCost(random())+"}");
-    params.add("partitionKeys", "a_i,a_s,a_i,a_s,a_i");
+    params.add("partitionKeys", "nonexistent");
     params.add("wt", "xml");
     ModifiableSolrParams finalParams = params;
     expectThrows(SolrException.class, () -> h.query(req(finalParams)));


### PR DESCRIPTION
* Simpler
* Don't use Filter (to be removed)
* Do use TwoPhaseIterator, not PostFilter
* Don't pre-compute matching docs (wasteful)
* Support more fields, and more field types
* Faster hash on Strings (avoid Char conversion)
* Stronger hash when using multiple fields

----
@joel-bernstein, I set out to remove the use of Filter in `{!hash}` (because https://issues.apache.org/jira/browse/SOLR-12336 ) and then I saw a bunch of things that I felt could be improved.  Apparently I had nothing better to do this weekend 😄   j/k     WDYT?
