### PR TITLE
SOLR-14690: QueryResultKey.[nc_]minExactCount

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/QueryResultKey.java
+++ b/solr/core/src/java/org/apache/solr/search/QueryResultKey.java
@@ -37,7 +37,7 @@ public final class QueryResultKey implements Accountable {
   final SortField[] sfields;
   final List<Query> filters;
   final int nc_flags;  // non-comparable flags... ignored by hashCode and equals
-  final int minExactCount;
+  final int nc_minExactCount;  // non-comparable value... ignored by hashCode and equals
 
   private final int hc;  // cached hashCode
   private final long ramBytesUsed; // cached
@@ -48,12 +48,12 @@ public final class QueryResultKey implements Accountable {
     this(query, filters, sort, nc_flags, Integer.MAX_VALUE);
   }
 
-  public QueryResultKey(Query query, List<Query> filters, Sort sort, int nc_flags, int minExactCount) {
+  public QueryResultKey(Query query, List<Query> filters, Sort sort, int nc_flags, int nc_minExactCount) {
     this.query = query;
     this.sort = sort;
     this.filters = filters;
     this.nc_flags = nc_flags;
-    this.minExactCount = minExactCount;
+    this.nc_minExactCount = nc_minExactCount;
 
     int h = query.hashCode();
 
@@ -70,7 +70,6 @@ public final class QueryResultKey implements Accountable {
       h = h*29 + sf.hashCode();
       ramSfields += BASE_SF_RAM_BYTES_USED + RamUsageEstimator.sizeOfObject(sf.getField());
     }
-    h = h*31 + minExactCount;
 
     hc = h;
 
@@ -102,7 +101,6 @@ public final class QueryResultKey implements Accountable {
     if (this.sfields.length != other.sfields.length) return false;
     if (!this.query.equals(other.query)) return false;
     if (!unorderedCompare(this.filters, other.filters)) return false;
-    if (this.minExactCount != other.minExactCount) return false;
 
     for (int i=0; i<sfields.length; i++) {
       SortField sf1 = this.sfields[i];

--- a/solr/core/src/test/org/apache/solr/core/QueryResultKeyTest.java
+++ b/solr/core/src/test/org/apache/solr/core/QueryResultKeyTest.java
@@ -142,9 +142,9 @@ public class QueryResultKeyTest extends SolrTestCaseJ4 {
     final Query base = new FlatHashTermQuery("base");
     assertKeyEquals(new QueryResultKey(base, buildFiltersFromNumbers(nums), null, 0, 10),
         new QueryResultKey(base, buildFiltersFromNumbers(nums), null, 0, 10));
-    assertKeyNotEquals(new QueryResultKey(base, buildFiltersFromNumbers(nums), null, 0, 10),
+    assertKeyEquals(new QueryResultKey(base, buildFiltersFromNumbers(nums), null, 0, 10),
         new QueryResultKey(base, buildFiltersFromNumbers(nums), null, 0, 20));
-    assertKeyNotEquals(new QueryResultKey(base, buildFiltersFromNumbers(nums), null, 0, 10),
+    assertKeyEquals(new QueryResultKey(base, buildFiltersFromNumbers(nums), null, 0, 10),
         new QueryResultKey(base, buildFiltersFromNumbers(nums), null, 0));//Integer.MAX_VALUE
     assertKeyEquals(new QueryResultKey(base, buildFiltersFromNumbers(nums), null, 0, Integer.MAX_VALUE),
         new QueryResultKey(base, buildFiltersFromNumbers(nums), null, 0));

--- a/solr/core/src/test/org/apache/solr/search/SolrIndexSearcherTest.java
+++ b/solr/core/src/test/org/apache/solr/search/SolrIndexSearcherTest.java
@@ -144,6 +144,10 @@ public class SolrIndexSearcherTest extends SolrTestCaseJ4 {
       cmd.clearFlags(SolrIndexSearcher.NO_CHECK_QCACHE | SolrIndexSearcher.NO_SET_QCACHE);
       searcher.search(new QueryResult(), cmd);
       assertMatchesGreaterThan(NUM_DOCS, searcher, cmd);
+      while (0 < cmd.getMinExactCount()) {
+        cmd.setMinExactCount(cmd.getMinExactCount() - 1);
+        assertMatchesGreaterThan(NUM_DOCS, searcher, cmd);
+      }
       return null;
     });
   }
@@ -154,6 +158,11 @@ public class SolrIndexSearcherTest extends SolrTestCaseJ4 {
       cmd.clearFlags(SolrIndexSearcher.NO_CHECK_QCACHE | SolrIndexSearcher.NO_SET_QCACHE);
       searcher.search(new QueryResult(), cmd);
       assertMatchesEqual(NUM_DOCS, searcher, cmd);
+      // caching does confer exact count benefits on subsequent requests with lower min exact hits
+      while (0 < cmd.getMinExactCount()) {
+        cmd.setMinExactCount(cmd.getMinExactCount() - 1);
+        assertMatchesEqual(NUM_DOCS, searcher, cmd);
+      }
       return null;
     });
   }


### PR DESCRIPTION
Allow with-minExactCount searches to use query cache entries from without-minExactCount searches.

https://issues.apache.org/jira/browse/SOLR-14690