### PR TITLE
RegExp - add case insensitive matching option

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/RegexpQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/RegexpQuery.java
@@ -96,14 +96,14 @@ public class RegexpQuery extends AutomatonQuery {
    * Constructs a query for terms matching <code>term</code>.
    * 
    * @param term regular expression.
-   * @param maxDeterminizedStates maximum number of states that compiling the
    * @param syntax_flags optional RegExp syntax features from {@link RegExp}
    *  automaton for the regexp can result in.  Set higher to allow more complex
    *  queries and lower to prevent memory exhaustion.
    * @param match_flags boolean 'or' of match behavior options such as case insensitivity
+   * @param maxDeterminizedStates maximum number of states that compiling the
    */
-  public RegexpQuery(Term term,  int maxDeterminizedStates, int syntax_flags, int match_flags) {
-    this(term, defaultProvider, maxDeterminizedStates, syntax_flags, match_flags);
+  public RegexpQuery(Term term, int syntax_flags, int match_flags, int maxDeterminizedStates) {
+    this(term, syntax_flags, match_flags, defaultProvider, maxDeterminizedStates);
   }
   
   /**
@@ -118,7 +118,7 @@ public class RegexpQuery extends AutomatonQuery {
    */
   public RegexpQuery(Term term, int syntax_flags, AutomatonProvider provider,
       int maxDeterminizedStates) {
-    this(term, provider, maxDeterminizedStates, syntax_flags, 0);
+    this(term, syntax_flags, 0, provider, maxDeterminizedStates);
   }
   
   /**
@@ -126,14 +126,14 @@ public class RegexpQuery extends AutomatonQuery {
    * 
    * @param term regular expression.
    * @param syntax_flags optional RegExp features from {@link RegExp}
+   * @param match_flags boolean 'or' of match behavior options such as case insensitivity
    * @param provider custom AutomatonProvider for named automata
    * @param maxDeterminizedStates maximum number of states that compiling the
    *  automaton for the regexp can result in.  Set higher to allow more complex
    *  queries and lower to prevent memory exhaustion.
-   * @param match_flags boolean 'or' of match behavior options such as case insensitivity
    */
-  public RegexpQuery(Term term, AutomatonProvider provider,
-      int maxDeterminizedStates, int syntax_flags, int match_flags) {
+  public RegexpQuery(Term term, int syntax_flags, int match_flags, AutomatonProvider provider,
+      int maxDeterminizedStates) {
     super(term,
           new RegExp(term.text(), syntax_flags, match_flags).toAutomaton(
                        provider, maxDeterminizedStates), maxDeterminizedStates);

--- a/lucene/core/src/java/org/apache/lucene/search/RegexpQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/RegexpQuery.java
@@ -82,20 +82,20 @@ public class RegexpQuery extends AutomatonQuery {
   /**
    * Constructs a query for terms matching <code>term</code>.
    * 
+   * @param flags optional RegExp syntax features from {@link RegExp}
+   * @param match_flags boolean 'or' of match behavior options such as case insensitivity
    * @param term regular expression.
-   * @param flags optional RegExp features from {@link RegExp}
-   * @param caseSensitive set to false for case insensitive matching of ASCII characters 
    */
-  public RegexpQuery(Term term, int flags, boolean caseSensitive) {
+  public RegexpQuery(int flags, int match_flags, Term term) {
     this(term, flags, defaultProvider,
-      Operations.DEFAULT_MAX_DETERMINIZED_STATES, caseSensitive);
+      Operations.DEFAULT_MAX_DETERMINIZED_STATES, match_flags);
   }
   
   /**
    * Constructs a query for terms matching <code>term</code>.
    * 
    * @param term regular expression.
-   * @param flags optional RegExp features from {@link RegExp}
+   * @param flags optional RegExp syntax features from {@link RegExp}
    * @param maxDeterminizedStates maximum number of states that compiling the
    *  automaton for the regexp can result in.  Set higher to allow more complex
    *  queries and lower to prevent memory exhaustion.
@@ -108,14 +108,14 @@ public class RegexpQuery extends AutomatonQuery {
    * Constructs a query for terms matching <code>term</code>.
    * 
    * @param term regular expression.
-   * @param flags optional RegExp features from {@link RegExp}
+   * @param flags optional RegExp syntax features from {@link RegExp}
    * @param maxDeterminizedStates maximum number of states that compiling the
    *  automaton for the regexp can result in.  Set higher to allow more complex
    *  queries and lower to prevent memory exhaustion.
-   * @param caseSensitive set to false for case insensitive matching of ASCII characters 
+   * @param match_flags boolean 'or' of match behavior options such as case insensitivity
    */
-  public RegexpQuery(Term term, int flags, int maxDeterminizedStates, boolean caseSensitive) {
-    this(term, flags, defaultProvider, maxDeterminizedStates, caseSensitive);
+  public RegexpQuery(Term term, int flags, int maxDeterminizedStates, int match_flags) {
+    this(term, flags, defaultProvider, maxDeterminizedStates, match_flags);
   }
   
   /**
@@ -130,7 +130,7 @@ public class RegexpQuery extends AutomatonQuery {
    */
   public RegexpQuery(Term term, int flags, AutomatonProvider provider,
       int maxDeterminizedStates) {
-    this(term, flags, provider, maxDeterminizedStates, true);
+    this(term, flags, provider, maxDeterminizedStates, 0);
   }
   
   /**
@@ -142,12 +142,12 @@ public class RegexpQuery extends AutomatonQuery {
    * @param maxDeterminizedStates maximum number of states that compiling the
    *  automaton for the regexp can result in.  Set higher to allow more complex
    *  queries and lower to prevent memory exhaustion.
-   * @param caseSensitive set to false for case insensitive matching of ASCII characters 
+   * @param match_flags boolean 'or' of match behavior options such as case insensitivity
    */
   public RegexpQuery(Term term, int flags, AutomatonProvider provider,
-      int maxDeterminizedStates, boolean caseSensitive) {
+      int maxDeterminizedStates, int match_flags) {
     super(term,
-          new RegExp(term.text(), flags, caseSensitive).toAutomaton(
+          new RegExp(term.text(), flags, match_flags).toAutomaton(
                        provider, maxDeterminizedStates), maxDeterminizedStates);
   }
 

--- a/lucene/core/src/java/org/apache/lucene/search/RegexpQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/RegexpQuery.java
@@ -82,18 +82,6 @@ public class RegexpQuery extends AutomatonQuery {
   /**
    * Constructs a query for terms matching <code>term</code>.
    * 
-   * @param flags optional RegExp syntax features from {@link RegExp}
-   * @param match_flags boolean 'or' of match behavior options such as case insensitivity
-   * @param term regular expression.
-   */
-  public RegexpQuery(int flags, int match_flags, Term term) {
-    this(term, flags, defaultProvider,
-      Operations.DEFAULT_MAX_DETERMINIZED_STATES, match_flags);
-  }
-  
-  /**
-   * Constructs a query for terms matching <code>term</code>.
-   * 
    * @param term regular expression.
    * @param flags optional RegExp syntax features from {@link RegExp}
    * @param maxDeterminizedStates maximum number of states that compiling the
@@ -108,46 +96,46 @@ public class RegexpQuery extends AutomatonQuery {
    * Constructs a query for terms matching <code>term</code>.
    * 
    * @param term regular expression.
-   * @param flags optional RegExp syntax features from {@link RegExp}
    * @param maxDeterminizedStates maximum number of states that compiling the
+   * @param syntax_flags optional RegExp syntax features from {@link RegExp}
    *  automaton for the regexp can result in.  Set higher to allow more complex
    *  queries and lower to prevent memory exhaustion.
    * @param match_flags boolean 'or' of match behavior options such as case insensitivity
    */
-  public RegexpQuery(Term term, int flags, int maxDeterminizedStates, int match_flags) {
-    this(term, flags, defaultProvider, maxDeterminizedStates, match_flags);
+  public RegexpQuery(Term term,  int maxDeterminizedStates, int syntax_flags, int match_flags) {
+    this(term, defaultProvider, maxDeterminizedStates, syntax_flags, match_flags);
   }
   
   /**
    * Constructs a query for terms matching <code>term</code>.
    * 
    * @param term regular expression.
-   * @param flags optional RegExp features from {@link RegExp}
+   * @param syntax_flags optional RegExp features from {@link RegExp}
    * @param provider custom AutomatonProvider for named automata
    * @param maxDeterminizedStates maximum number of states that compiling the
    *  automaton for the regexp can result in.  Set higher to allow more complex
    *  queries and lower to prevent memory exhaustion.
    */
-  public RegexpQuery(Term term, int flags, AutomatonProvider provider,
+  public RegexpQuery(Term term, int syntax_flags, AutomatonProvider provider,
       int maxDeterminizedStates) {
-    this(term, flags, provider, maxDeterminizedStates, 0);
+    this(term, provider, maxDeterminizedStates, syntax_flags, 0);
   }
   
   /**
    * Constructs a query for terms matching <code>term</code>.
    * 
    * @param term regular expression.
-   * @param flags optional RegExp features from {@link RegExp}
+   * @param syntax_flags optional RegExp features from {@link RegExp}
    * @param provider custom AutomatonProvider for named automata
    * @param maxDeterminizedStates maximum number of states that compiling the
    *  automaton for the regexp can result in.  Set higher to allow more complex
    *  queries and lower to prevent memory exhaustion.
    * @param match_flags boolean 'or' of match behavior options such as case insensitivity
    */
-  public RegexpQuery(Term term, int flags, AutomatonProvider provider,
-      int maxDeterminizedStates, int match_flags) {
+  public RegexpQuery(Term term, AutomatonProvider provider,
+      int maxDeterminizedStates, int syntax_flags, int match_flags) {
     super(term,
-          new RegExp(term.text(), flags, match_flags).toAutomaton(
+          new RegExp(term.text(), syntax_flags, match_flags).toAutomaton(
                        provider, maxDeterminizedStates), maxDeterminizedStates);
   }
 

--- a/lucene/core/src/java/org/apache/lucene/search/RegexpQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/RegexpQuery.java
@@ -70,19 +70,6 @@ public class RegexpQuery extends AutomatonQuery {
   
   /**
    * Constructs a query for terms matching <code>term</code>.
-   * <p>
-   * By default, all regular expression features are enabled.
-   * </p>
-   * 
-   * @param term regular expression.
-   * @param caseSensitive set to false for case insensitive matching 
-   */
-  public RegexpQuery(Term term, boolean caseSensitive) {
-    this(term, RegExp.ALL, caseSensitive);
-  }  
-  
-  /**
-   * Constructs a query for terms matching <code>term</code>.
    * 
    * @param term regular expression.
    * @param flags optional RegExp features from {@link RegExp}
@@ -97,7 +84,7 @@ public class RegexpQuery extends AutomatonQuery {
    * 
    * @param term regular expression.
    * @param flags optional RegExp features from {@link RegExp}
-   * @param caseSensitive set to false for case insensitive matching 
+   * @param caseSensitive set to false for case insensitive matching of ASCII characters 
    */
   public RegexpQuery(Term term, int flags, boolean caseSensitive) {
     this(term, flags, defaultProvider,
@@ -125,7 +112,7 @@ public class RegexpQuery extends AutomatonQuery {
    * @param maxDeterminizedStates maximum number of states that compiling the
    *  automaton for the regexp can result in.  Set higher to allow more complex
    *  queries and lower to prevent memory exhaustion.
-   * @param caseSensitive set to false for case insensitive matching 
+   * @param caseSensitive set to false for case insensitive matching of ASCII characters 
    */
   public RegexpQuery(Term term, int flags, int maxDeterminizedStates, boolean caseSensitive) {
     this(term, flags, defaultProvider, maxDeterminizedStates, caseSensitive);
@@ -155,7 +142,7 @@ public class RegexpQuery extends AutomatonQuery {
    * @param maxDeterminizedStates maximum number of states that compiling the
    *  automaton for the regexp can result in.  Set higher to allow more complex
    *  queries and lower to prevent memory exhaustion.
-   * @param caseSensitive set to false for case insensitive matching 
+   * @param caseSensitive set to false for case insensitive matching of ASCII characters 
    */
   public RegexpQuery(Term term, int flags, AutomatonProvider provider,
       int maxDeterminizedStates, boolean caseSensitive) {

--- a/lucene/core/src/java/org/apache/lucene/search/RegexpQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/RegexpQuery.java
@@ -70,6 +70,19 @@ public class RegexpQuery extends AutomatonQuery {
   
   /**
    * Constructs a query for terms matching <code>term</code>.
+   * <p>
+   * By default, all regular expression features are enabled.
+   * </p>
+   * 
+   * @param term regular expression.
+   * @param caseSensitive set to false for case insensitive matching 
+   */
+  public RegexpQuery(Term term, boolean caseSensitive) {
+    this(term, RegExp.ALL, caseSensitive);
+  }  
+  
+  /**
+   * Constructs a query for terms matching <code>term</code>.
    * 
    * @param term regular expression.
    * @param flags optional RegExp features from {@link RegExp}
@@ -79,6 +92,18 @@ public class RegexpQuery extends AutomatonQuery {
       Operations.DEFAULT_MAX_DETERMINIZED_STATES);
   }
 
+  /**
+   * Constructs a query for terms matching <code>term</code>.
+   * 
+   * @param term regular expression.
+   * @param flags optional RegExp features from {@link RegExp}
+   * @param caseSensitive set to false for case insensitive matching 
+   */
+  public RegexpQuery(Term term, int flags, boolean caseSensitive) {
+    this(term, flags, defaultProvider,
+      Operations.DEFAULT_MAX_DETERMINIZED_STATES, caseSensitive);
+  }
+  
   /**
    * Constructs a query for terms matching <code>term</code>.
    * 
@@ -97,6 +122,20 @@ public class RegexpQuery extends AutomatonQuery {
    * 
    * @param term regular expression.
    * @param flags optional RegExp features from {@link RegExp}
+   * @param maxDeterminizedStates maximum number of states that compiling the
+   *  automaton for the regexp can result in.  Set higher to allow more complex
+   *  queries and lower to prevent memory exhaustion.
+   * @param caseSensitive set to false for case insensitive matching 
+   */
+  public RegexpQuery(Term term, int flags, int maxDeterminizedStates, boolean caseSensitive) {
+    this(term, flags, defaultProvider, maxDeterminizedStates, caseSensitive);
+  }
+  
+  /**
+   * Constructs a query for terms matching <code>term</code>.
+   * 
+   * @param term regular expression.
+   * @param flags optional RegExp features from {@link RegExp}
    * @param provider custom AutomatonProvider for named automata
    * @param maxDeterminizedStates maximum number of states that compiling the
    *  automaton for the regexp can result in.  Set higher to allow more complex
@@ -104,8 +143,24 @@ public class RegexpQuery extends AutomatonQuery {
    */
   public RegexpQuery(Term term, int flags, AutomatonProvider provider,
       int maxDeterminizedStates) {
+    this(term, flags, provider, maxDeterminizedStates, true);
+  }
+  
+  /**
+   * Constructs a query for terms matching <code>term</code>.
+   * 
+   * @param term regular expression.
+   * @param flags optional RegExp features from {@link RegExp}
+   * @param provider custom AutomatonProvider for named automata
+   * @param maxDeterminizedStates maximum number of states that compiling the
+   *  automaton for the regexp can result in.  Set higher to allow more complex
+   *  queries and lower to prevent memory exhaustion.
+   * @param caseSensitive set to false for case insensitive matching 
+   */
+  public RegexpQuery(Term term, int flags, AutomatonProvider provider,
+      int maxDeterminizedStates, boolean caseSensitive) {
     super(term,
-          new RegExp(term.text(), flags).toAutomaton(
+          new RegExp(term.text(), flags, caseSensitive).toAutomaton(
                        provider, maxDeterminizedStates), maxDeterminizedStates);
   }
 

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
@@ -448,12 +448,12 @@ public class RegExp {
    */
   public static final int NONE = 0x0000;
   
-  //-----  Non-syntax flags ( > 0xff )  ------
+  //-----  Matching flags ( > 0xff )  ------
   
   /**
    * Allows case insensitive matching of ASCII characters.
    */
-  static final int ASCII_CASE_INSENSITIVE = 0x0100;    
+  public static final int ASCII_CASE_INSENSITIVE = 0x0100;    
 
   //Immutable parsed state
   /**
@@ -508,7 +508,7 @@ public class RegExp {
    *              regular expression
    */
   public RegExp(String s, int syntax_flags) throws IllegalArgumentException {
-    this(s, syntax_flags, true);
+    this(s, syntax_flags, 0);
   }
   /**
    * Constructs new <code>RegExp</code> from a string.
@@ -516,20 +516,19 @@ public class RegExp {
    * @param s regexp string
    * @param syntax_flags boolean 'or' of optional syntax constructs to be
    *          enabled
-   * @param caseSensitive case sensitive matching of ASCII characters
+   * @param match_flags boolean 'or' of match behavior options such as case insensitivity
    * @exception IllegalArgumentException if an error occurred while parsing the
    *              regular expression
    */
-  public RegExp(String s, int syntax_flags, boolean caseSensitive) throws IllegalArgumentException {    
-    originalString = s;
-    // Trim any bits unrelated to syntax flags
+  public RegExp(String s, int syntax_flags, int match_flags) throws IllegalArgumentException {    
+    // (for BWC reasons we don't validate invalid bits, just trim instead)
     syntax_flags  = syntax_flags & 0xff;
-    if (caseSensitive) {
-      flags = syntax_flags;
-    } else {      
-      // Add in the case-insensitive setting
-      flags = syntax_flags | ASCII_CASE_INSENSITIVE;
+    
+    if (match_flags > 0 && match_flags <= ALL) {
+      throw new IllegalArgumentException("Illegal match flag");
     }
+    flags = syntax_flags | match_flags;
+    originalString = s;
     RegExp e;
     if (s.length() == 0) e = makeString(flags, "");
     else {

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
@@ -405,6 +405,7 @@ public class RegExp {
     REGEXP_PRE_CLASS
   }
   
+  //-----  Syntax flags ( <= 0xff )  ------
   /**
    * Syntax flag, enables intersection (<code>&amp;</code>).
    */
@@ -437,27 +438,22 @@ public class RegExp {
   public static final int INTERVAL = 0x0020;
   
   /**
-   * Allows case insensitive matching.
-   */
-  public static final int UNICODE_CASE_INSENSITIVE = 0x0040;  
-  
-  /**
    * Syntax flag, enables all optional regexp syntax
    * but preserves default setting of case sensitive matching. 
    */
-  public static final int ALL = 0xffff ^ UNICODE_CASE_INSENSITIVE ;
-  
-  
-  /**
-   * Syntax flag, enables all optional regexp syntax
-   * and allows case insensitive matching. 
-   */
-  public static final int ALL_AND_CASE_INSENSITIVE = 0xffff;
-  
+  public static final int ALL = 0xff;
+      
   /**
    * Syntax flag, enables no optional regexp syntax.
    */
   public static final int NONE = 0x0000;
+  
+  //-----  Non-syntax flags ( > 0xff )  ------
+  
+  /**
+   * Allows case insensitive matching.
+   */
+  public static final int UNICODE_CASE_INSENSITIVE = 0x0100;    
 
   //Immutable parsed state
   /**
@@ -503,6 +499,19 @@ public class RegExp {
   }
   
   /**
+   * Constructs new <code>RegExp</code> from a string. Same as
+   * <code>RegExp(s, ALL)</code>.
+   * 
+   * @param s regexp string
+   * @param caseSensitive case sensitive matching
+   * @exception IllegalArgumentException if an error occurred while parsing the
+   *              regular expression
+   */
+  public RegExp(String s, boolean caseSensitive) throws IllegalArgumentException {
+    this(s, ALL, caseSensitive);
+  }  
+  
+  /**
    * Constructs new <code>RegExp</code> from a string.
    * 
    * @param s regexp string
@@ -512,8 +521,28 @@ public class RegExp {
    *              regular expression
    */
   public RegExp(String s, int syntax_flags) throws IllegalArgumentException {
+    this(s, syntax_flags, true);
+  }
+  /**
+   * Constructs new <code>RegExp</code> from a string.
+   * 
+   * @param s regexp string
+   * @param syntax_flags boolean 'or' of optional syntax constructs to be
+   *          enabled
+   * @param caseSensitive case sensitive matching
+   * @exception IllegalArgumentException if an error occurred while parsing the
+   *              regular expression
+   */
+  public RegExp(String s, int syntax_flags, boolean caseSensitive) throws IllegalArgumentException {    
     originalString = s;
-    flags = syntax_flags;
+    // Trim any bits unrelated to syntax flags
+    syntax_flags  = syntax_flags & 0xff;
+    if (caseSensitive) {
+      flags = syntax_flags;
+    } else {      
+      // Add in the case-insensitive setting
+      flags = syntax_flags  | UNICODE_CASE_INSENSITIVE;
+    }
     RegExp e;
     if (s.length() == 0) e = makeString(flags, "");
     else {

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
@@ -521,8 +521,9 @@ public class RegExp {
    *              regular expression
    */
   public RegExp(String s, int syntax_flags, int match_flags) throws IllegalArgumentException {    
-    // (for BWC reasons we don't validate invalid bits, just trim instead)
-    syntax_flags  = syntax_flags & 0xff;
+    if (syntax_flags >  ALL) {
+      throw new IllegalArgumentException("Illegal syntax flag");
+    }
     
     if (match_flags > 0 && match_flags <= ALL) {
       throw new IllegalArgumentException("Illegal match flag");

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
@@ -439,13 +439,20 @@ public class RegExp {
   /**
    * Allows case insensitive matching.
    */
-  public static final int CASE_INSENSITIVE = 0x0040;  
+  public static final int UNICODE_CASE_INSENSITIVE = 0x0040;  
   
   /**
    * Syntax flag, enables all optional regexp syntax
    * but preserves default setting of case sensitive matching. 
    */
-  public static final int ALL = 0xffff ^ CASE_INSENSITIVE ;
+  public static final int ALL = 0xffff ^ UNICODE_CASE_INSENSITIVE ;
+  
+  
+  /**
+   * Syntax flag, enables all optional regexp syntax
+   * and allows case insensitive matching. 
+   */
+  public static final int ALL_AND_CASE_INSENSITIVE = 0xffff;
   
   /**
    * Syntax flag, enables no optional regexp syntax.
@@ -709,7 +716,7 @@ public class RegExp {
         a = MinimizationOperations.minimize(a, maxDeterminizedStates);
         break;
       case REGEXP_CHAR:
-        if (check(CASE_INSENSITIVE)) {
+        if (check(UNICODE_CASE_INSENSITIVE)) {
           a = toCaseInsensitiveChar(c, maxDeterminizedStates);
         } else {
           a = Automata.makeChar(c);          
@@ -725,7 +732,7 @@ public class RegExp {
         a = Automata.makeEmpty();
         break;
       case REGEXP_STRING:
-        if (check(CASE_INSENSITIVE)) {
+        if (check(UNICODE_CASE_INSENSITIVE)) {
           a = toCaseInsensitiveString(maxDeterminizedStates);
         } else {
           a = Automata.makeString(s);

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
@@ -453,7 +453,7 @@ public class RegExp {
   /**
    * Allows case insensitive matching.
    */
-  public static final int UNICODE_CASE_INSENSITIVE = 0x0100;    
+  static final int UNICODE_CASE_INSENSITIVE = 0x0100;    
 
   //Immutable parsed state
   /**

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/RegExp.java
@@ -438,8 +438,7 @@ public class RegExp {
   public static final int INTERVAL = 0x0020;
   
   /**
-   * Syntax flag, enables all optional regexp syntax
-   * but preserves default setting of case sensitive matching. 
+   * Syntax flag, enables all optional regexp syntax.
    */
   public static final int ALL = 0xff;
       

--- a/lucene/core/src/test/org/apache/lucene/search/TestRegexpQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestRegexpQuery.java
@@ -74,8 +74,8 @@ public class TestRegexpQuery extends LuceneTestCase {
   }
   
   private long caseInsensitiveRegexQueryNrHits(String regex) throws IOException {
-    RegexpQuery query = new RegexpQuery( RegExp.ALL, RegExp.ASCII_CASE_INSENSITIVE,         
-        newTerm(regex));
+    RegexpQuery query = new RegexpQuery(newTerm(regex), Operations.DEFAULT_MAX_DETERMINIZED_STATES, 
+        RegExp.ALL, RegExp.ASCII_CASE_INSENSITIVE);
     return searcher.count(query);
   }  
   

--- a/lucene/core/src/test/org/apache/lucene/search/TestRegexpQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestRegexpQuery.java
@@ -73,6 +73,11 @@ public class TestRegexpQuery extends LuceneTestCase {
     return searcher.count(query);
   }
   
+  private long caseInsensitiveRegexQueryNrHits(String regex) throws IOException {
+    RegexpQuery query = new RegexpQuery(newTerm(regex), false);
+    return searcher.count(query);
+  }  
+  
   public void testRegex1() throws IOException {
     assertEquals(1, regexQueryNrHits("q.[aeiou]c.*"));
   }
@@ -123,6 +128,11 @@ public class TestRegexpQuery extends LuceneTestCase {
         }
     );
     assertTrue(expected.getMessage().contains("invalid character class"));         
+  }  
+  
+  public void testCaseInsensitive() throws IOException {
+    assertEquals(0, regexQueryNrHits("Quick"));
+    assertEquals(1, caseInsensitiveRegexQueryNrHits("Quick"));
   }  
   
   public void testRegexComplement() throws IOException {

--- a/lucene/core/src/test/org/apache/lucene/search/TestRegexpQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestRegexpQuery.java
@@ -74,7 +74,8 @@ public class TestRegexpQuery extends LuceneTestCase {
   }
   
   private long caseInsensitiveRegexQueryNrHits(String regex) throws IOException {
-    RegexpQuery query = new RegexpQuery(newTerm(regex), RegExp.ALL, false);
+    RegexpQuery query = new RegexpQuery( RegExp.ALL, RegExp.ASCII_CASE_INSENSITIVE,         
+        newTerm(regex));
     return searcher.count(query);
   }  
   

--- a/lucene/core/src/test/org/apache/lucene/search/TestRegexpQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestRegexpQuery.java
@@ -74,8 +74,8 @@ public class TestRegexpQuery extends LuceneTestCase {
   }
   
   private long caseInsensitiveRegexQueryNrHits(String regex) throws IOException {
-    RegexpQuery query = new RegexpQuery(newTerm(regex), Operations.DEFAULT_MAX_DETERMINIZED_STATES, 
-        RegExp.ALL, RegExp.ASCII_CASE_INSENSITIVE);
+    RegexpQuery query = new RegexpQuery(newTerm(regex), RegExp.ALL, RegExp.ASCII_CASE_INSENSITIVE,
+        Operations.DEFAULT_MAX_DETERMINIZED_STATES);
     return searcher.count(query);
   }  
   

--- a/lucene/core/src/test/org/apache/lucene/search/TestRegexpQuery.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestRegexpQuery.java
@@ -74,7 +74,7 @@ public class TestRegexpQuery extends LuceneTestCase {
   }
   
   private long caseInsensitiveRegexQueryNrHits(String regex) throws IOException {
-    RegexpQuery query = new RegexpQuery(newTerm(regex), false);
+    RegexpQuery query = new RegexpQuery(newTerm(regex), RegExp.ALL, false);
     return searcher.count(query);
   }  
   

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestRegExp.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestRegExp.java
@@ -244,7 +244,8 @@ public class TestRegExp extends LuceneTestCase {
     Matcher matcher = pattern.matcher(docValue);
     assertTrue("Java regex " + regexPattern + " did not match doc value " + docValue, matcher.matches());
 
-    RegExp regex =  new RegExp(regexPattern, RegExp.ALL, caseSensitiveQuery);
+    int matchFlags = caseSensitiveQuery ? 0 : RegExp.ASCII_CASE_INSENSITIVE;
+    RegExp regex =  new RegExp(regexPattern, RegExp.ALL, matchFlags);
     Automaton automaton = regex.toAutomaton();
     ByteRunAutomaton bytesMatcher = new ByteRunAutomaton(automaton);
     BytesRef br = new BytesRef(docValue);

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestRegExp.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestRegExp.java
@@ -244,8 +244,7 @@ public class TestRegExp extends LuceneTestCase {
     Matcher matcher = pattern.matcher(docValue);
     assertTrue("Java regex " + regexPattern + " did not match doc value " + docValue, matcher.matches());
 
-    RegExp regex = caseSensitiveQuery ? new RegExp(regexPattern) : new RegExp(regexPattern,  
-        RegExp.ALL | RegExp.UNICODE_CASE_INSENSITIVE);
+    RegExp regex =  new RegExp(regexPattern, RegExp.ALL, caseSensitiveQuery);
     Automaton automaton = regex.toAutomaton();
     ByteRunAutomaton bytesMatcher = new ByteRunAutomaton(automaton);
     BytesRef br = new BytesRef(docValue);

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestRegExp.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestRegExp.java
@@ -244,7 +244,8 @@ public class TestRegExp extends LuceneTestCase {
     Matcher matcher = pattern.matcher(docValue);
     assertTrue("Java regex " + regexPattern + " did not match doc value " + docValue, matcher.matches());
 
-    RegExp regex = caseSensitiveQuery ? new RegExp(regexPattern) : new RegExp(regexPattern, RegExp.CASE_INSENSITIVE);
+    RegExp regex = caseSensitiveQuery ? new RegExp(regexPattern) : new RegExp(regexPattern,  
+        RegExp.ALL | RegExp.UNICODE_CASE_INSENSITIVE);
     Automaton automaton = regex.toAutomaton();
     ByteRunAutomaton bytesMatcher = new ByteRunAutomaton(automaton);
     BytesRef br = new BytesRef(docValue);


### PR DESCRIPTION
Relates to Jira issue [9386](https://issues.apache.org/jira/projects/LUCENE/issues/LUCENE-9386)

Added a new CASE_INSENSITIVE option to the existing flags.
The RegExp class is a little strange because instances represent either the parser or the parsed objects it nests in a tree. The `flags` field is only relevant to the root parser and was left blank in all parsed nodes. This PR's changes require that the flags int is propagated to all nodes so that they can see if it includes the case insensitive option (all other bits in the flag represent parsing options so there was no need to propagate before).