### PR TITLE
LUCENE-9378: Disable compression on binary values whose length is less than 32.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -218,6 +218,10 @@ Optimizations
 * LUCENE-9087: Build always trees with full leaves and lower the default value for maxPointsPerLeafNode to 512.
   (Ignacio Vera)
 
+* LUCENE-9378: Disabled compression on short binary values, as compression
+  incurred significant slowdowns on highly compressible inputs.
+  (Adrien Grand, Mike Sokolov)
+
 Bug Fixes
 ---------------------
 * LUCENE-9259: Fix wrong NGramFilterFactory argument name for preserveOriginal option (Paul Pazderski)

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene80/Lucene80DocValuesFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene80/Lucene80DocValuesFormat.java
@@ -151,8 +151,9 @@ public final class Lucene80DocValuesFormat extends DocValuesFormat {
   static final String META_CODEC = "Lucene80DocValuesMetadata";
   static final String META_EXTENSION = "dvm";
   static final int VERSION_START = 0;
-  static final int VERSION_BIN_COMPRESSED = 1;  
-  static final int VERSION_CURRENT = VERSION_BIN_COMPRESSED;
+  static final int VERSION_BIN_COMPRESSED = 1;
+  static final int VERSION_BIN_LEN_COMPRESSED = 2;
+  static final int VERSION_CURRENT = VERSION_BIN_LEN_COMPRESSED;
 
   // indicates docvalues type
   static final byte NUMERIC = 0;

--- a/lucene/core/src/java/org/apache/lucene/util/compress/LZ4.java
+++ b/lucene/core/src/java/org/apache/lucene/util/compress/LZ4.java
@@ -209,6 +209,36 @@ public final class LZ4 {
   }
 
   /**
+   * Hash table implementation that doesn't compress the input at all.
+   */
+  public static final class NoCompressionHashTable extends HashTable {
+
+    /** Sole constructor */
+    public NoCompressionHashTable() {}
+
+    @Override
+    void reset(byte[] b, int off, int len) {
+      // no-op
+    }
+
+    @Override
+    int get(int off) {
+      return -1;
+    }
+
+    @Override
+    int previous(int off) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    boolean assertReset() {
+      return true;
+    }
+
+  }
+
+  /**
    * Simple lossy {@link HashTable} that only stores the last ocurrence for
    * each hash on {@code 2^14} bytes of memory.
    */

--- a/lucene/core/src/test/org/apache/lucene/util/compress/TestNoLZ4.java
+++ b/lucene/core/src/test/org/apache/lucene/util/compress/TestNoLZ4.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.util.compress;
+
+import org.apache.lucene.util.compress.LZ4.HashTable;
+
+public class TestNoLZ4 extends LZ4TestCase {
+
+  @Override
+  protected HashTable newHashTable() {
+    LZ4.HashTable hashTable = new LZ4.NoCompressionHashTable();
+    return new AssertingHashTable(hashTable);
+  }
+
+}


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/LUCENE-9378

This commit disables compression on short binary values, and also
switches from "fast" compression to "high" compression for long values.
The reasoning is that "high" compression tends to insert fewer, longer
back references, which makes decompression slightly faster.
