### PR TITLE
SOLR-14524: Harden MultiThreadedOCPTest testFillWorkQueue()

### DIFF
--- a/solr/core/src/test/org/apache/solr/cloud/MultiThreadedOCPTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/MultiThreadedOCPTest.java
@@ -118,7 +118,7 @@ public class MultiThreadedOCPTest extends AbstractFullDistribZkTestBase {
   /**
    * Verifies the status of an async task submitted to the Overseer Collection queue.
    * @return <code>null</code> if the task has not completed, the completion timestamp if the task has completed
-   * (see {@link org.apache.solr.cloud.api.collections.OverseerCollectionMessageHandler#mockOperation}).
+   * (see mockOperation() in {@link org.apache.solr.cloud.api.collections.OverseerCollectionMessageHandler}).
    */
   private Long checkTaskHasCompleted(SolrClient client, int requestId) throws IOException, SolrServerException {
     return (Long) getStatusResponse(Integer.toString(requestId), client).getResponse().get("MOCK_FINISHED");


### PR DESCRIPTION

# Description

Make MultiThreadedOCPTest.testFillWorkQueue() less vulnerable to timing issues when test or overseer code are being slowed down by external factors (load, GC etc).

# Solution

A combination of verifying preconditions (to fail with a meaningful messages helping pinpoint issues for future test hardening), longer task execution time (that **does not delay** total test runtime) and do light synchronization between test steps and Overseeer processing progress. 

# Tests

This _is_ a test.

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [X] I have developed this patch against the `master` branch.
- [X] I have run `ant precommit` and the appropriate test suite.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
