### PR TITLE
LUCENE-9383: benchmark module: Gradle conversion (complete)

### DIFF
--- a/lucene/benchmark/build.gradle
+++ b/lucene/benchmark/build.gradle
@@ -21,43 +21,41 @@ apply plugin: 'java'
 description = 'System for benchmarking Lucene'
 
 dependencies {  
-  compile project(':lucene:core')
+  implementation project(':lucene:core')
 
-  compile project(':lucene:analysis:common')
-  compile project(':lucene:facet')
-  compile project(':lucene:highlighter')
-  compile project(':lucene:queries')
-  compile project(':lucene:spatial-extras')
-  compile project(':lucene:queryparser')
+  implementation project(':lucene:analysis:common')
+  implementation project(':lucene:facet')
+  implementation project(':lucene:highlighter')
+  implementation project(':lucene:queries')
+  implementation project(':lucene:spatial-extras')
+  implementation project(':lucene:queryparser')
 
-  compile "org.apache.commons:commons-compress"
-  compile "com.ibm.icu:icu4j"
-  compile "org.locationtech.spatial4j:spatial4j"
-  compile("net.sourceforge.nekohtml:nekohtml", {
+  implementation "org.apache.commons:commons-compress"
+  implementation "com.ibm.icu:icu4j"
+  implementation "org.locationtech.spatial4j:spatial4j"
+  implementation("net.sourceforge.nekohtml:nekohtml", {
     exclude module: "xml-apis"
   })
 
-  runtime project(':lucene:analysis:icu')
+  runtimeOnly project(':lucene:analysis:icu')
 
-  testCompile project(':lucene:test-framework')
+  testImplementation project(':lucene:test-framework')
 }
 
-ext {
-  tempDir = file("temp")
-  workDir = file("work")
-}
+def tempDir = file("temp")
+def workDir = file("work")
 
 task run(type: JavaExec) {
   description "Run a perf test (optional: -PtaskAlg=conf/your-algorithm-file -PmaxHeapSize=1G)"
   main 'org.apache.lucene.benchmark.byTask.Benchmark'
   classpath sourceSets.main.runtimeClasspath
   // allow these to be specified on the CLI via -PtaskAlg=  for example
-  def taskAlg = project.properties['taskAlg'] ?: 'conf/micro-standard.alg'
+  def taskAlg = propertyOrDefault('taskAlg', 'conf/micro-standard.alg')
   args = [taskAlg]
 
-  maxHeapSize = project.properties['maxHeapSize'] ?: '1G'
+  maxHeapSize = propertyOrDefault('maxHeapSize', '1G')
 
-  String stdOutStr = project.properties['standardOutput']
+  String stdOutStr = propertyOrDefault('standardOutput', null)
   if (stdOutStr != null) {
     standardOutput = new File(stdOutStr).newOutputStream()
   }
@@ -75,66 +73,39 @@ perl -CSD scripts/collation.bm2jira.pl work/collation.benchmark.output.txt
  */
 
 /* Old "shingle" Ant target:
-gradle reuters run -PtaskAlg=conf/shingle.alg -PstandardOutput=work/shingle.benchmark.output.txt
+gradle getReuters run -PtaskAlg=conf/shingle.alg -PstandardOutput=work/shingle.benchmark.output.txt
 perl -CSD scripts/shingle.bm2jira.pl work/shingle.benchmark.output.txt
  */
 
 // The remaining tasks just get / extract / prepare data
 
 task getEnWiki(type: Download) {
-  src "https://home.apache.org/~dsmiley/data/enwiki-20070527-pages-articles.xml.bz2"
-  dest file("$tempDir/${src.file.split('/').last()}")
+  def finalName = "enwiki-20070527-pages-articles.xml"
+  src "https://home.apache.org/~dsmiley/data/" + finalName + ".bz2"
+  dest file("$tempDir/" + finalName + ".bz2")
   overwrite false
   compress false
 
   doLast {
-    ant.bunzip2(src: dest, dest: tempDir) // will chop off .bz2
+    ant.bunzip2(src: dest, dest: tempDir)
   }
+  outputs.file file("$tempDir/$finalName")
 }
 
 task getGeoNames(type: Download) {
   // note: latest data is at: https://download.geonames.org/export/dump/allCountries.zip
   //       and then randomize with: gsort -R -S 1500M file.txt > file_random.txt
   //       and then compress with: bzip2 -9 -k file_random.txt
-  src "https://home.apache.org/~dsmiley/data/geonames_20130921_randomOrder_allCountries.txt.bz2"
-  dest file("$tempDir/${src.file.split('/').last()}")
+  def finalName = "geonames_20130921_randomOrder_allCountries.txt"
+  src "https://home.apache.org/~dsmiley/data/" + finalName + ".bz2"
+  dest file("$tempDir/" + finalName + ".bz2")
   overwrite false
   compress false
 
   doLast {
     ant.bunzip2(src: dest, dest: tempDir) // will chop off .bz2
   }
-}
-
-task getReuters(type: Download) {
-  // note: there is no HTTPS url and we don't care because this is merely test/perf data
-  src "http://www.daviddlewis.com/resources/testcollections/reuters21578/reuters21578.tar.gz"
-  dest file("$tempDir/${src.file.split('/').last()}")
-  overwrite false
-  compress false
-}
-task extractReuters(type: Copy) {
-  dependsOn getReuters
-  from(tarTree(getReuters.dest)) { // can expand a .gz on the fly
-    exclude '*.txt'
-  }
-  into file("$workDir/reuters")
-}
-task reuters(type: JavaExec) {
-  dependsOn extractReuters
-  def input = extractReuters.outputs.files[0]
-  def output = "$workDir/reuters-out"
-  inputs.dir(input)
-  outputs.dir(output)
-  main = 'org.apache.lucene.benchmark.utils.ExtractReuters'
-  classpath = sourceSets.main.runtimeClasspath
-  jvmArgs = ['-Xmx1G']
-  args = [input, output]
-
-  doFirst {
-    file(output).deleteDir()
-    println "Extracting reuters to $output"
-  }
+  outputs.file file("$tempDir/$finalName")
 }
 
 task getTop100kWikiWordFiles(type: Download) {
@@ -143,10 +114,44 @@ task getTop100kWikiWordFiles(type: Download) {
   overwrite false
   compress false
 
+  def finalPath = file("$workDir/top100k-out")
+
   doLast {
-    copy {
+    project.sync {
       from tarTree(dest) // defined above.  Will decompress on the fly
-      into file("$workDir/top100k-out")
+      into finalPath
     }
   }
+  outputs.dir finalPath
+}
+
+task getReuters(type: Download) {
+  // note: there is no HTTPS url and we don't care because this is merely test/perf data
+  src "http://www.daviddlewis.com/resources/testcollections/reuters21578/reuters21578.tar.gz"
+  dest file("$tempDir/${src.file.split('/').last()}")
+  overwrite false
+  compress false
+
+  def untarPath = file("$workDir/reuters")
+  def finalPath = file("$workDir/reuters-out")
+  dependsOn sourceSets.main.runtimeClasspath
+
+  doLast {
+    project.sync {
+      from(tarTree(dest)) { // defined above.  Will decompress on the fly
+        exclude '*.txt'
+      }
+      into untarPath
+    }
+    println "Extracting reuters to $finalPath"
+    finalPath.deleteDir() // necessary
+    // TODO consider porting ExtractReuters to groovy?
+    project.javaexec {
+      main = 'org.apache.lucene.benchmark.utils.ExtractReuters'
+      classpath = sourceSets.main.runtimeClasspath
+      maxHeapSize = '1G'
+      args = [untarPath, finalPath]
+    }
+  }
+  outputs.dir finalPath
 }

--- a/lucene/benchmark/build.gradle
+++ b/lucene/benchmark/build.gradle
@@ -15,27 +15,138 @@
  * limitations under the License.
  */
 
-
-apply plugin: 'java-library'
+apply plugin: 'java'
+// NOT a 'java-library'.  Maybe 'application' but seems too limiting.
 
 description = 'System for benchmarking Lucene'
 
 dependencies {  
-  api project(':lucene:core')
+  compile project(':lucene:core')
 
-  implementation project(':lucene:analysis:common')
-  implementation project(':lucene:facet')
-  implementation project(':lucene:highlighter')
-  implementation project(':lucene:queries')
-  implementation project(':lucene:spatial-extras')
-  implementation project(':lucene:queryparser')
+  compile project(':lucene:analysis:common')
+  compile project(':lucene:facet')
+  compile project(':lucene:highlighter')
+  compile project(':lucene:queries')
+  compile project(':lucene:spatial-extras')
+  compile project(':lucene:queryparser')
 
-  implementation "org.apache.commons:commons-compress"
-  implementation "com.ibm.icu:icu4j"
-  implementation "org.locationtech.spatial4j:spatial4j"
-  implementation("net.sourceforge.nekohtml:nekohtml", {
+  compile "org.apache.commons:commons-compress"
+  compile "com.ibm.icu:icu4j"
+  compile "org.locationtech.spatial4j:spatial4j"
+  compile("net.sourceforge.nekohtml:nekohtml", {
     exclude module: "xml-apis"
   })
 
-  testImplementation project(':lucene:test-framework')
+  runtime project(':lucene:analysis:icu')
+
+  testCompile project(':lucene:test-framework')
+}
+
+ext {
+  tempDir = file("temp")
+  workDir = file("work")
+}
+
+task run(type: JavaExec) {
+  description "Run a perf test (optional: -PtaskAlg=conf/your-algorithm-file -PmaxHeapSize=1G)"
+  main 'org.apache.lucene.benchmark.byTask.Benchmark'
+  classpath sourceSets.main.runtimeClasspath
+  // allow these to be specified on the CLI via -PtaskAlg=  for example
+  def taskAlg = project.properties['taskAlg'] ?: 'conf/micro-standard.alg'
+  args = [taskAlg]
+
+  maxHeapSize = project.properties['maxHeapSize'] ?: '1G'
+
+  String stdOutStr = project.properties['standardOutput']
+  if (stdOutStr != null) {
+    standardOutput = new File(stdOutStr).newOutputStream()
+  }
+
+  debugOptions {
+    enabled = false
+    port = 5005
+    suspend = true
+  }
+}
+
+/* Old "collation" Ant target:
+gradle getTop100kWikiWordFiles run -PtaskAlg=conf/collation.alg -PstandardOutput=work/collation.benchmark.output.txt
+perl -CSD scripts/collation.bm2jira.pl work/collation.benchmark.output.txt
+ */
+
+/* Old "shingle" Ant target:
+gradle reuters run -PtaskAlg=conf/shingle.alg -PstandardOutput=work/shingle.benchmark.output.txt
+perl -CSD scripts/shingle.bm2jira.pl work/shingle.benchmark.output.txt
+ */
+
+// The remaining tasks just get / extract / prepare data
+
+task getEnWiki(type: Download) {
+  src "https://home.apache.org/~dsmiley/data/enwiki-20070527-pages-articles.xml.bz2"
+  dest file("$tempDir/${src.file.split('/').last()}")
+  overwrite false
+  compress false
+
+  doLast {
+    ant.bunzip2(src: dest, dest: tempDir) // will chop off .bz2
+  }
+}
+
+task getGeoNames(type: Download) {
+  // note: latest data is at: https://download.geonames.org/export/dump/allCountries.zip
+  //       and then randomize with: gsort -R -S 1500M file.txt > file_random.txt
+  //       and then compress with: bzip2 -9 -k file_random.txt
+  src "https://home.apache.org/~dsmiley/data/geonames_20130921_randomOrder_allCountries.txt.bz2"
+  dest file("$tempDir/${src.file.split('/').last()}")
+  overwrite false
+  compress false
+
+  doLast {
+    ant.bunzip2(src: dest, dest: tempDir) // will chop off .bz2
+  }
+}
+
+task getReuters(type: Download) {
+  // note: there is no HTTPS url and we don't care because this is merely test/perf data
+  src "http://www.daviddlewis.com/resources/testcollections/reuters21578/reuters21578.tar.gz"
+  dest file("$tempDir/${src.file.split('/').last()}")
+  overwrite false
+  compress false
+}
+task extractReuters(type: Copy) {
+  dependsOn getReuters
+  from(tarTree(getReuters.dest)) { // can expand a .gz on the fly
+    exclude '*.txt'
+  }
+  into file("$workDir/reuters")
+}
+task reuters(type: JavaExec) {
+  dependsOn extractReuters
+  def input = extractReuters.outputs.files[0]
+  def output = "$workDir/reuters-out"
+  inputs.dir(input)
+  outputs.dir(output)
+  main = 'org.apache.lucene.benchmark.utils.ExtractReuters'
+  classpath = sourceSets.main.runtimeClasspath
+  jvmArgs = ['-Xmx1G']
+  args = [input, output]
+
+  doFirst {
+    file(output).deleteDir()
+    println "Extracting reuters to $output"
+  }
+}
+
+task getTop100kWikiWordFiles(type: Download) {
+  src "https://home.apache.org/~rmuir/wikipedia/top.100k.words.de.en.fr.uk.wikipedia.2009-11.tar.bz2"
+  dest file("$tempDir/${src.file.split('/').last()}")
+  overwrite false
+  compress false
+
+  doLast {
+    copy {
+      from tarTree(dest) // defined above.  Will decompress on the fly
+      into file("$workDir/top100k-out")
+    }
+  }
 }

--- a/lucene/benchmark/scripts/collation.bm2jira.pl
+++ b/lucene/benchmark/scripts/collation.bm2jira.pl
@@ -40,17 +40,17 @@ while (<>) {
 }
 
 # Print out platform info
-print "JAVA:\n", `java -version 2>&1`, "\nOS:\n";
-if ($^O =~ /win/i) {
-  print "$^O\n";
-  eval {
-    require Win32;
-    print Win32::GetOSName(), "\n", Win32::GetOSVersion(), "\n";
-  };
-  die "Error loading Win32: $@" if ($@);
-} else {
-  print `uname -a 2>&1`;
-}
+#print "JAVA:\n", `java -version 2>&1`, "\nOS:\n";
+#if ($^O =~ /win/i) {
+#  print "$^O\n";
+#  eval {
+#    require Win32;
+#    print Win32::GetOSName(), "\n", Win32::GetOSVersion(), "\n";
+#  };
+#  die "Error loading Win32: $@" if ($@);
+#} else {
+#  print `uname -a 2>&1`;
+#}
 
 print "\n||Language||java.text||ICU4J||KeywordAnalyzer||ICU4J Improvement||\n";
 


### PR DESCRIPTION
I switched from "java-library" type of Gradle plugin/module to more plainly "java" because this module isn't a library (isn't something depended on by anything), it's closer to an app.  I tried type "application" but I didn't have the same control that the "JavaExec" task gives you.  One consequence of not using "java-library" is that the names of the categories of dependencies are different, and so this appears odd/unusual relative to the other modules.

I did not convert "collation" and "shingle" Ant targets, but I put there the two-line CLI equivalents for both in the form of a comment.  I ram them and they worked... albeit a confusion in one of the perl scripts that thought "darwin" OS was ==~ Windows simply because it contained "win" :-). 

Notice the style of "getEnWiki" and "getGeoNames" and "getTop100kWikiWordFiles":  One task that does all it needs to do by adding a final step in doLast.  Now notice a different style: "reuters" (depending on extractReuters depending on getReuters).  This is more verbose, but admittedly for this case it has to do more.  I'm not well versed enough in Gradle to know which style is preferable.  I lean towards short & concise.  The current state is a nocommit IMO; need to harmonize the approaches.

I did not convert https://www-2.cs.cmu.edu/afs/cs.cmu.edu/project/theo-20/www/data/news20.tar.gz (aka news20) or https://people.csail.mit.edu/u/j/jrennie/public_html/20Newsgroups/20news-18828.tar.gz or https://kdd.ics.uci.edu/databases/20newsgroups/mini_newsgroups.tar.gz (aka mini-news) because I could not find .alg files that used them.