### PR TITLE
LUCENE-9393: FunctionScoreQuery turns TOP_DOCS to COMPLETE in inner weights

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -200,6 +200,8 @@ Improvements
 
 * LUCENE-9359: SegmentInfos#readCommit now always returns a
   CorruptIndexException if the content of the file is invalid. (Adrien Grand)
+  
+* LUCENE-9393: FunctionScoreQuery turns TOP_DOCS to COMPLETE in inner weights
 
 Optimizations
 ---------------------

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/FunctionScoreQuery.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/FunctionScoreQuery.java
@@ -105,7 +105,13 @@ public final class FunctionScoreQuery extends Query {
 
   @Override
   public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
-    Weight inner = in.createWeight(searcher, scoreMode.needsScores() && source.needsScores() ? scoreMode : ScoreMode.COMPLETE_NO_SCORES, 1f);
+    ScoreMode sm = scoreMode;
+    if (scoreMode.needsScores() && source.needsScores() && scoreMode == ScoreMode.TOP_SCORES) {
+      sm = ScoreMode.COMPLETE;
+    } else if (!scoreMode.needsScores() || !source.needsScores()) {
+      sm = ScoreMode.COMPLETE_NO_SCORES;
+    }
+    Weight inner = in.createWeight(searcher, sm, 1f);
     if (scoreMode.needsScores() == false)
       return inner;
     return new FunctionScoreWeight(this, inner, source.rewrite(searcher), boost);

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/FunctionScoreQuery.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/FunctionScoreQuery.java
@@ -105,10 +105,10 @@ public final class FunctionScoreQuery extends Query {
 
   @Override
   public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
-    ScoreMode sm = scoreMode;
-    if (scoreMode.needsScores() && source.needsScores() && scoreMode == ScoreMode.TOP_SCORES) {
+    ScoreMode sm;
+    if (scoreMode.needsScores() && source.needsScores()) {
       sm = ScoreMode.COMPLETE;
-    } else if (!scoreMode.needsScores() || !source.needsScores()) {
+    } else {
       sm = ScoreMode.COMPLETE_NO_SCORES;
     }
     Weight inner = in.createWeight(searcher, sm, 1f);


### PR DESCRIPTION
FunctionScoreQuery can't really use WAND algorithm even if TOP_DOCS score mode is requested. This commit makes the inner weight created use COMPLETE in this case.