### PR TITLE
SOLR-12823: fix test failures

### DIFF
--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/CloudHttp2SolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/CloudHttp2SolrClientTest.java
@@ -777,7 +777,6 @@ public class CloudHttp2SolrClientTest extends SolrCloudTestCase {
   public ExpectedException exception = ExpectedException.none();
 
   @Test
-  @AwaitsFix(bugUrl = "https://issues.apache.org/jira/browse/SOLR-12823")
   public void testWrongZkChrootTest() throws IOException {
 
     exception.expect(SolrException.class);

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/CloudSolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/CloudSolrClientTest.java
@@ -761,7 +761,6 @@ public class CloudSolrClientTest extends SolrCloudTestCase {
   public ExpectedException exception = ExpectedException.none();
 
   @Test
-  @AwaitsFix(bugUrl = "https://issues.apache.org/jira/browse/SOLR-12823")
   public void testWrongZkChrootTest() throws IOException {
     try (CloudSolrClient client = getCloudSolrClient(cluster.getZkServer().getZkAddress() + "/xyz/foo")) {
       client.setZkClientTimeout(1000 * 60);

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/TestCloudSolrClientConnections.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/TestCloudSolrClientConnections.java
@@ -31,7 +31,6 @@ import org.junit.Test;
 public class TestCloudSolrClientConnections extends SolrTestCaseJ4 {
 
   @Test
-  @AwaitsFix(bugUrl = "https://issues.apache.org/jira/browse/SOLR-12823")
   public void testCloudClientCanConnectAfterClusterComesUp() throws Exception {
 
     // Start by creating a cluster with no jetties
@@ -59,7 +58,6 @@ public class TestCloudSolrClientConnections extends SolrTestCaseJ4 {
   }
 
   @Test
-  @AwaitsFix(bugUrl = "https://issues.apache.org/jira/browse/SOLR-12823")
   public void testCloudClientUploads() throws Exception {
 
     Path configPath = getFile("solrj").toPath().resolve("solr/configsets/configset-2/conf");


### PR DESCRIPTION
# Description

Fix test failures in CloudHttp2SolrClientTest CloudSolrClientTest TestCloudSolrClientConnections due to previous SOLR-12823 commit.

# Solution

ZkStateReader returns a specific SolrException when expected nodes in the cluster created during cluster initialization do not exist.

# Tests

Fixes the tests mentioned above.

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [X] I have developed this patch against the `master` branch.
- [X] I have run `ant precommit` and the appropriate test suite.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
