### PR TITLE
SOLR-14554: Let Solr use WAND algorithm when scores are requested

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -175,6 +175,8 @@ Optimizations
 
 * SOLR-14552: Add BlockMax-WAND support to ReRank queries (Tomás Fernández Löbbe)
 
+* SOLR-14554: Add BlockMax-WAND support for queries where the score is requested (Tomás Fernández Löbbe)
+
 Bug Fixes
 ---------------------
 * SOLR-13264: IndexSizeTrigger aboveOp / belowOp properties not in valid properties.

--- a/solr/core/src/java/org/apache/solr/search/MaxScoreCollector.java
+++ b/solr/core/src/java/org/apache/solr/search/MaxScoreCollector.java
@@ -48,6 +48,10 @@ public class MaxScoreCollector extends SimpleCollector {
   @Override
   public void collect(int doc) throws IOException {
     collectedAnyHits = true;
-    maxScore = Math.max(scorer.score(), maxScore);
+    float docScore = scorer.score();
+    if (Float.compare(docScore, maxScore) > 0) {
+      maxScore = docScore;
+      scorer.setMinCompetitiveScore(Math.nextUp(maxScore));
+    }
   }
 }

--- a/solr/core/src/test/org/apache/solr/search/MaxScoreCollectorTest.java
+++ b/solr/core/src/test/org/apache/solr/search/MaxScoreCollectorTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.search;
+
+import java.io.IOException;
+
+import org.apache.lucene.search.Scorable;
+import org.apache.solr.SolrTestCase;
+
+public class MaxScoreCollectorTest extends SolrTestCase {
+  
+  public void test() throws IOException {
+    MaxScoreCollector collector = new MaxScoreCollector();
+    DummyScorer scorer = new DummyScorer();
+    collector.setScorer(scorer);
+    assertEquals(Float.NaN, collector.getMaxScore(), 0f);
+    assertEquals(0f, scorer.minCompetitiveScore, 0f);
+    
+    collector.collect(0);
+    assertEquals(Float.MIN_VALUE, collector.getMaxScore(), 0f);
+    assertEquals(0f, scorer.minCompetitiveScore, 0f);
+    
+    scorer.nextScore = 1f;
+    collector.collect(0);
+    assertEquals(1f, collector.getMaxScore(), 0f);
+    assertEquals(Math.nextUp(1f), scorer.minCompetitiveScore, 0f);
+
+    scorer.nextScore = 0f;
+    collector.collect(0);
+    assertEquals(1f, collector.getMaxScore(), 0f);
+    assertEquals(Math.nextUp(1f), scorer.minCompetitiveScore, 0f);
+    
+    scorer.nextScore = -1f;
+    collector.collect(0);
+    assertEquals(1f, collector.getMaxScore(), 0f);
+    assertEquals(Math.nextUp(1f), scorer.minCompetitiveScore, 0f);
+    
+    scorer.nextScore = Float.MAX_VALUE;
+    collector.collect(0);
+    assertEquals(Float.MAX_VALUE, collector.getMaxScore(), 0f);
+    assertEquals(Float.POSITIVE_INFINITY, scorer.minCompetitiveScore, 0f);
+    
+    scorer.nextScore = Float.POSITIVE_INFINITY;
+    collector.collect(0);
+    assertEquals(Float.POSITIVE_INFINITY, collector.getMaxScore(), 0f);
+    assertEquals(Float.POSITIVE_INFINITY, scorer.minCompetitiveScore, 0f);
+    
+    
+    scorer.nextScore = Float.NaN;
+    collector.collect(0);
+    assertEquals(Float.NaN, collector.getMaxScore(), 0f);
+    assertEquals(Float.NaN, scorer.minCompetitiveScore, 0f);
+  }
+  
+  private final static class DummyScorer extends Scorable {
+    
+    float nextScore = 0f;
+    float minCompetitiveScore = 0f;
+    
+    @Override
+    public float score() throws IOException {
+      return nextScore;
+    }
+
+    @Override
+    public int docID() {
+      return 0;
+    }
+    
+    @Override
+    public void setMinCompetitiveScore(float minScore) throws IOException {
+      this.minCompetitiveScore = minScore;
+    }
+    
+  }
+
+}

--- a/solr/core/src/test/org/apache/solr/search/SolrIndexSearcherTest.java
+++ b/solr/core/src/test/org/apache/solr/search/SolrIndexSearcherTest.java
@@ -31,7 +31,7 @@ import org.junit.BeforeClass;
 
 public class SolrIndexSearcherTest extends SolrTestCaseJ4 {
 
-  private final static int NUM_DOCS = 20;
+  private final static int NUM_DOCS = 200;
 
   @BeforeClass
   public static void setUpClass() throws Exception {
@@ -42,8 +42,8 @@ public class SolrIndexSearcherTest extends SolrTestCaseJ4 {
           "field2_s", String.valueOf(i % 2),
           "field3_i_dvo", String.valueOf(i),
           "field4_t", numbersTo(i)));
-      assertU(commit()); //commit inside the loop to get multiple segments
     }
+    assertU(commit());
   }
   
   private static String numbersTo(int i) {
@@ -199,7 +199,7 @@ public class SolrIndexSearcherTest extends SolrTestCaseJ4 {
     
     h.getCore().withSearcher(searcher -> {
       QueryCommand cmd = createBasicQueryCommand(1, 1, "field4_t", "0");
-      Query filterQuery = new TermQuery(new Term("field4_t", "19"));
+      Query filterQuery = new TermQuery(new Term("field4_t", Integer.toString(NUM_DOCS - 1)));
       cmd.setFilterList(filterQuery);
       assertNull(searcher.getProcessedFilter(null, cmd.getFilterList()).postFilter);
       assertMatchesEqual(1, searcher, cmd);
@@ -240,7 +240,7 @@ public class SolrIndexSearcherTest extends SolrTestCaseJ4 {
     h.getCore().withSearcher(searcher -> {
       QueryCommand cmd = createBasicQueryCommand(1, 1, "field4_t", "0");
       // Use ScoreMode.COMPLETE for the PostFilter
-      MockPostFilter filterQuery = new MockPostFilter(100, 101, ScoreMode.COMPLETE);
+      MockPostFilter filterQuery = new MockPostFilter(NUM_DOCS * 10, 101, ScoreMode.COMPLETE);
       cmd.setFilterList(filterQuery);
       assertNotNull(searcher.getProcessedFilter(null, cmd.getFilterList()).postFilter);
       assertMatchesEqual(NUM_DOCS, searcher, cmd);


### PR DESCRIPTION
MaxScoreCollector now sets the minCompetitiveScore to the number of the current highest score, which allow MultiCollector to skip docs if the main query collector can.