### PR TITLE
LUCENE-9402: Let MultiCollector handle minCompetitiveScore

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -216,6 +216,8 @@ Improvements
 
 * LUCENE-9396: Improved truncation detection for points. (Adrien Grand, Robert Muir)
 
+* LUCENE-9402: Let MultiCollector handle minCompetitiveScore (Tomás Fernández Löbbe, Adrien Grand)
+
 Optimizations
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/search/MultiCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiCollector.java
@@ -160,8 +160,9 @@ public class MultiCollector implements Collector {
       if (skipNonCompetitiveScores) {
         for (int i = 0; i < collectors.length; ++i) {
           final LeafCollector c = collectors[i];
-          assert c != null;
-          c.setScorer(new MinCompetitiveScoreAwareScorable(scorer,  i,  minScores));
+          if (c != null) {
+            c.setScorer(new MinCompetitiveScoreAwareScorable(scorer,  i,  minScores));
+          }
         }
       } else {
         scorer = new FilterScorable(scorer) {
@@ -175,8 +176,9 @@ public class MultiCollector implements Collector {
         };
         for (int i = 0; i < collectors.length; ++i) {
           final LeafCollector c = collectors[i];
-          assert c != null;
-          c.setScorer(scorer);
+          if (c != null) {
+            c.setScorer(scorer);
+          }
         }
       }
     }


### PR DESCRIPTION
Here is an idea to make MultiCollector be able to handle `minCompetitiveScore`. Looking at this comment in the code:
```
            // Ignore calls to setMinCompetitiveScore so that if we wrap two
            // collectors and one of them wants to skip low-scoring hits, then
            // the other collector still sees all hits. We could try to reconcile
            // min scores and take the maximum min score across collectors, but
            // this is very unlikely to be helpful in practice.
```
This implementation tries to make it so that all collectors can see all the hits and only allow skipping if all collectors set a min competitive score. The value passed to the inner scorer is the minimum among all collectors (instead of the maximum as the comment suggests).