### PR TITLE
LUCENE-9390: JapaneseTokenizer discards token that is all punctuation characters only

### DIFF
--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/JapaneseTokenizer.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/JapaneseTokenizer.java
@@ -1855,7 +1855,7 @@ public final class JapaneseTokenizer extends Tokenizer {
           }
           backCount += unigramTokenCount;
 
-        } else if (!discardPunctuation || length == 0 || !isPunctuation(fragment[offset])) {
+        } else if (!discardPunctuation || length == 0 || !isAllCharPunctuation(fragment, offset, length)) {
           pending.add(new Token(backID,
                                 fragment,
                                 offset,
@@ -1916,5 +1916,16 @@ public final class JapaneseTokenizer extends Tokenizer {
       default:
         return false;
     }
+  }
+
+  private static boolean isAllCharPunctuation(char[] ch, int offset, int length) {
+    boolean flag = true;
+    for (int i = offset; i < offset + length; i++) {
+      if (!isPunctuation(ch[i])) {
+        flag = false;
+        break;
+      }
+    }
+    return flag;
   }
 }

--- a/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/TestJapaneseTokenizer.java
+++ b/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/TestJapaneseTokenizer.java
@@ -918,4 +918,35 @@ public class
     assertAnalyzesTo(extendedModeAnalyzerNoCompound, "株式会社とアカデミア",
         new String[]{"株式", "会社", "と", "ア", "カ", "デ", "ミ", "ア"});
   }
+
+  public void testDiscardPunctuationStartingPunctuationToken1() throws Exception {
+    assertAnalyzesTo(analyzerNoPunct, "（株）巴商会",
+        new String[] { "（株）", "巴商会" },
+        new int[] { 0, 3 },
+        new int[] { 3, 6 }
+    );
+  }
+
+  public void testDiscardPunctuationStartingPunctuationToken2() throws Exception {
+    assertAnalyzesTo(extendedModeAnalyzerNoPunct, "（株）巴商会",
+        new String[] { "（株）", "巴商会" },
+        new int[] { 0, 3 },
+        new int[] { 3, 6 }
+    );
+  }
+
+  public void testDiscardPunctuationStartingPunctuationToken3() throws Exception {
+    assertAnalyzesTo(analyzerNoPunct, "（）巴商会",
+        new String[] { "巴商会" },
+        new int[] { 2 },
+        new int[] { 5 }
+    );
+  }
+  public void testDiscardPunctuationStartingPunctuationToken4() throws Exception {
+    assertAnalyzesTo(analyzerNoPunct, "−−巴商会",
+        new String[] { "巴商会" },
+        new int[] { 2 },
+        new int[] { 5 }
+    );
+  }
 }


### PR DESCRIPTION
# Description

Check and omit token that has all punctuation characters when discard punctuation flag is true.
Currently, JapaneseTokenizer discards token that has punctuation at first character only.

# Solution

Add isAllPunctuation method for testing token.

# Tests

Ensure to discard if token is all punctuation characters.
And not discard if token that start punctuation character and has non-punctuation character.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
