### PR TITLE
LUCENE-9405: Ensure IndexWriter only closes merge readers once.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -266,6 +266,9 @@ Bug Fixes
 * LUCENE-9362: Fix equality check in ExpressionValueSource#rewrite. This fixes rewriting of inner value sources.
   (Dmitry Emets)
 
+* LUCENE-9405: IndexWriter incorrectly calls closeMergeReaders twice when the merged segment is 100% deleted.
+  (Simon Willnauer, Mike Mccandless, Mike Sokolov)
+
 Other
 ---------------------
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -267,7 +267,7 @@ Bug Fixes
   (Dmitry Emets)
 
 * LUCENE-9405: IndexWriter incorrectly calls closeMergeReaders twice when the merged segment is 100% deleted.
-  (Simon Willnauer, Mike Mccandless, Mike Sokolov)
+  (Michael Froh, Simon Willnauer, Mike Mccandless, Mike Sokolov)
 
 Other
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -4483,6 +4483,7 @@ public class IndexWriter implements Closeable, TwoPhaseCommit, Accountable,
         // Merge would produce a 0-doc segment, so we do nothing except commit the merge to remove all the 0-doc segments that we "merged":
         assert merge.info.info.maxDoc() == 0;
         commitMerge(merge, mergeState);
+        success = true;
         return 0;
       }
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
@@ -4167,4 +4167,38 @@ public class TestIndexWriter extends LuceneTestCase {
       }
     }
   }
+
+  public void testMergeZeroDocsMergeIsClosedOnce() throws IOException {
+    LogDocMergePolicy keepAllSegments = new LogDocMergePolicy() {
+      @Override
+      public boolean keepFullyDeletedSegment(IOSupplier<CodecReader> readerIOSupplier) {
+        return true;
+      }
+    };
+    try (Directory dir = newDirectory()) {
+      try (IndexWriter writer = new IndexWriter(dir,
+          new IndexWriterConfig().setMergePolicy(new OneMergeWrappingMergePolicy(keepAllSegments, merge -> {
+            SetOnce<Boolean> onlyFinishOnce = new SetOnce<>();
+            return new MergePolicy.OneMerge(merge.segments) {
+              @Override
+              public void mergeFinished() {
+                onlyFinishOnce.set(true);
+              }
+            };
+          })))) {
+          Document doc = new Document();
+          doc.add(new StringField("id", "1", Field.Store.NO));
+          writer.addDocument(doc);
+          writer.flush();
+          writer.addDocument(doc);
+          writer.flush();
+          writer.deleteDocuments(new Term("id", "1"));
+          writer.flush();
+          assertEquals(2, writer.getSegmentCount());
+          assertEquals(0, writer.getDocStats().numDocs);
+          assertEquals(2, writer.getDocStats().maxDoc);
+          writer.forceMerge(1);
+      }
+    }
+  }
 }


### PR DESCRIPTION
IndexWriter incorrectly calls closeMergeReaders twice when the
merged segment is 100% deleted ie. would produce a fully deleted
segment.