### PR TITLE
Remove some needless toAbsolutePath calls

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -735,11 +735,11 @@ public class CoreContainer {
         true, "totalSpace", SolrInfoBean.Category.CONTAINER.toString(), "fs");
     solrMetricsContext.gauge(() -> dataHome.toFile().getUsableSpace(),
         true, "usableSpace", SolrInfoBean.Category.CONTAINER.toString(), "fs");
-    solrMetricsContext.gauge(() -> dataHome.toAbsolutePath().toString(),
+    solrMetricsContext.gauge(() -> dataHome.toString(),
         true, "path", SolrInfoBean.Category.CONTAINER.toString(), "fs");
     solrMetricsContext.gauge(() -> {
           try {
-            return org.apache.lucene.util.IOUtils.spins(dataHome.toAbsolutePath());
+            return org.apache.lucene.util.IOUtils.spins(dataHome);
           } catch (IOException e) {
             // default to spinning
             return true;
@@ -750,11 +750,11 @@ public class CoreContainer {
         true, "totalSpace", SolrInfoBean.Category.CONTAINER.toString(), "fs", "coreRoot");
     solrMetricsContext.gauge(() -> cfg.getCoreRootDirectory().toFile().getUsableSpace(),
         true, "usableSpace", SolrInfoBean.Category.CONTAINER.toString(), "fs", "coreRoot");
-    solrMetricsContext.gauge(() -> cfg.getCoreRootDirectory().toAbsolutePath().toString(),
+    solrMetricsContext.gauge(() -> cfg.getCoreRootDirectory().toString(),
         true, "path", SolrInfoBean.Category.CONTAINER.toString(), "fs", "coreRoot");
     solrMetricsContext.gauge(() -> {
           try {
-            return org.apache.lucene.util.IOUtils.spins(cfg.getCoreRootDirectory().toAbsolutePath());
+            return org.apache.lucene.util.IOUtils.spins(cfg.getCoreRootDirectory());
           } catch (IOException e) {
             // default to spinning
             return true;

--- a/solr/core/src/java/org/apache/solr/core/CoreDescriptor.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreDescriptor.java
@@ -126,6 +126,7 @@ public class CoreDescriptor {
 
   private final CloudDescriptor cloudDesc;
 
+  /** The absolute path to where the core lives. */
   private final Path instanceDir;
 
   /** The original standard core properties, before substitution */
@@ -175,14 +176,15 @@ public class CoreDescriptor {
   /**
    * Create a new CoreDescriptor.
    * @param name            the CoreDescriptor's name
-   * @param instanceDir     a Path resolving to the instanceDir
+   * @param instanceDir     a Path resolving to the instanceDir. Must be absolute.
    * @param coreProps       a Map of the properties for this core
    * @param containerProperties the properties from the enclosing container.
    * @param zkController    the ZkController in SolrCloud mode, otherwise null.
    */
   public CoreDescriptor(String name, Path instanceDir, Map<String, String> coreProps,
                         Properties containerProperties, ZkController zkController) {
-    this.instanceDir = instanceDir.toAbsolutePath();
+    this.instanceDir = instanceDir;
+    assert instanceDir.isAbsolute();
 
     originalCoreProperties.setProperty(CORE_NAME, name);
 
@@ -257,7 +259,7 @@ public class CoreDescriptor {
         propName = SOLR_CORE_PROP_PREFIX + propName;
       substitutableProperties.setProperty(propName, propValue);
     }
-    substitutableProperties.setProperty("solr.core.instanceDir", instanceDir.toAbsolutePath().toString());
+    substitutableProperties.setProperty("solr.core.instanceDir", instanceDir.toString());
   }
 
   /**

--- a/solr/core/src/java/org/apache/solr/core/SolrPaths.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrPaths.java
@@ -56,10 +56,8 @@ public final class SolrPaths {
    * <li>Look in the current working directory for a solr/ directory</li>
    * </ol>
    * <p>
-   * The return value is normalized.  Normalization essentially means it ends in a trailing slash.
    *
-   * @return A normalized solrhome
-   * @see #normalizeDir(String)
+   * @return the Solr home, absolute and normalized.
    */
   public static Path locateSolrHome() {
 
@@ -91,7 +89,7 @@ public final class SolrPaths {
       home = "solr/";
       logOnceInfo("home_default", "solr home defaulted to '" + home + "' (could not find system property or JNDI)");
     }
-    return Paths.get(home);
+    return Paths.get(home).toAbsolutePath().normalize();
   }
 
   public static void ensureUserFilesDataDir(Path solrHome) {

--- a/solr/core/src/java/org/apache/solr/core/SolrResourceLoader.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrResourceLoader.java
@@ -135,10 +135,10 @@ public class SolrResourceLoader implements ResourceLoader, Closeable {
    */
   public SolrResourceLoader(Path instanceDir, ClassLoader parent) {
     if (instanceDir == null) {
-      this.instanceDir = SolrPaths.locateSolrHome().toAbsolutePath().normalize();
+      this.instanceDir = SolrPaths.locateSolrHome();
       log.debug("new SolrResourceLoader for deduced Solr Home: '{}'", this.instanceDir);
     } else {
-      this.instanceDir = instanceDir.toAbsolutePath().normalize();
+      this.instanceDir = instanceDir;
       log.debug("new SolrResourceLoader for directory: '{}'", this.instanceDir);
     }
 
@@ -338,11 +338,11 @@ public class SolrResourceLoader implements ResourceLoader, Closeable {
   public String resourceLocation(String resource) {
     Path inConfigDir = getInstancePath().resolve("conf").resolve(resource);
     if (Files.exists(inConfigDir) && Files.isReadable(inConfigDir))
-      return inConfigDir.toAbsolutePath().normalize().toString();
+      return inConfigDir.normalize().toString();
 
     Path inInstanceDir = getInstancePath().resolve(resource);
     if (Files.exists(inInstanceDir) && Files.isReadable(inInstanceDir))
-      return inInstanceDir.toAbsolutePath().normalize().toString();
+      return inInstanceDir.normalize().toString();
 
     try (InputStream is = classLoader.getResourceAsStream(resource.replace(File.separatorChar, '/'))) {
       if (is != null)
@@ -673,14 +673,8 @@ public class SolrResourceLoader implements ResourceLoader, Closeable {
   }
 
   /**
-   * Determines the solrhome from the environment.
-   * Tries JNDI (java:comp/env/solr/home) then system property (solr.solr.home);
-   * if both fail, defaults to solr/
-   * @return the instance directory name
-   */
-
-  /**
-   * @return the instance path for this resource loader
+   * The instance path for this resource loader, as passed in from the constructor.
+   * It's absolute when this is for Solr Home or a Solr Core instance dir.
    */
   public Path getInstancePath() {
     return instanceDir;

--- a/solr/core/src/java/org/apache/solr/filestore/DistribPackageStore.java
+++ b/solr/core/src/java/org/apache/solr/filestore/DistribPackageStore.java
@@ -528,7 +528,7 @@ public class DistribPackageStore implements PackageStore {
   }
 
   public static Path getPackageStoreDirPath(Path solrHome) {
-    return Paths.get(solrHome.toAbsolutePath().toString(), PackageStoreAPI.PACKAGESTORE_DIRECTORY).toAbsolutePath();
+    return solrHome.resolve(PackageStoreAPI.PACKAGESTORE_DIRECTORY);
   }
 
   private static String _getMetapath(String path) {

--- a/solr/core/src/test/org/apache/solr/core/DirectoryFactoryTest.java
+++ b/solr/core/src/test/org/apache/solr/core/DirectoryFactoryTest.java
@@ -22,6 +22,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Properties;
 
+import org.apache.lucene.mockfile.FilterPath;
 import org.apache.solr.SolrTestCase;
 import org.apache.solr.common.util.NamedList;
 import org.junit.After;
@@ -37,7 +38,7 @@ public class DirectoryFactoryTest extends SolrTestCase {
 
   @BeforeClass
   public static void setupLoader() throws Exception {
-    solrHome = Paths.get(createTempDir().toAbsolutePath().toString());
+    solrHome = FilterPath.unwrap(createTempDir()); // FilterPath can interfere
     loader = new SolrResourceLoader(solrHome);
   }
 
@@ -114,7 +115,8 @@ public class DirectoryFactoryTest extends SolrTestCase {
   }
 
   private void assertDataHome(String expected, String instanceDir, DirectoryFactory df, CoreContainer cc, String... properties) throws IOException {
-    String dataHome = df.getDataHome(new CoreDescriptor("core_name", Paths.get(instanceDir), cc, properties));
+    String dataHome = df.getDataHome(
+            new CoreDescriptor("core_name", Paths.get(instanceDir).toAbsolutePath(), cc, properties));
     assertEquals(Paths.get(expected).toAbsolutePath(), Paths.get(dataHome).toAbsolutePath());
   }
 

--- a/solr/core/src/test/org/apache/solr/core/ResourceLoaderTest.java
+++ b/solr/core/src/test/org/apache/solr/core/ResourceLoaderTest.java
@@ -203,7 +203,7 @@ public class ResourceLoaderTest extends SolrTestCaseJ4 {
 
   @SuppressWarnings("deprecation")
   public void testLoadDeprecatedFactory() throws Exception {
-    SolrResourceLoader loader = new SolrResourceLoader(Paths.get("solr/collection1"));
+    SolrResourceLoader loader = new SolrResourceLoader(Paths.get("solr/collection1").toAbsolutePath());
     // ensure we get our exception
     loader.newInstance(DeprecatedTokenFilterFactory.class.getName(), TokenFilterFactory.class, null,
         new Class[] { Map.class }, new Object[] { new HashMap<String,String>() });

--- a/solr/core/src/test/org/apache/solr/util/MockCoreContainer.java
+++ b/solr/core/src/test/org/apache/solr/util/MockCoreContainer.java
@@ -27,7 +27,7 @@ import org.apache.solr.core.CoreDescriptor;
 public class MockCoreContainer extends CoreContainer {
   public static class MockCoreDescriptor extends CoreDescriptor {
     public MockCoreDescriptor() {
-      super("mock", Paths.get("path"), Collections.emptyMap(), null, null);
+      super("mock", Paths.get("path").toAbsolutePath(), Collections.emptyMap(), null, null);
     }
   }
   

--- a/solr/test-framework/src/java/org/apache/solr/BaseDistributedSearchTestCase.java
+++ b/solr/test-framework/src/java/org/apache/solr/BaseDistributedSearchTestCase.java
@@ -475,7 +475,7 @@ public abstract class BaseDistributedSearchTestCase extends SolrTestCaseJ4 {
     if (explicitCoreNodeName) {
       props.setProperty("coreNodeName", Integer.toString(nodeCnt.incrementAndGet()));
     }
-    props.setProperty("coreRootDirectory", solrHome.toPath().resolve("cores").toAbsolutePath().toString());
+    props.setProperty("coreRootDirectory", solrHome.toPath().resolve("cores").toString());
 
     JettySolrRunner jetty = new JettySolrRunner(solrHome.getAbsolutePath(), props, JettyConfig.builder()
         .stopAtShutdown(true)

--- a/solr/test-framework/src/java/org/apache/solr/cloud/AbstractDistribZkTestBase.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/AbstractDistribZkTestBase.java
@@ -342,7 +342,7 @@ public abstract class AbstractDistribZkTestBase extends BaseDistributedSearchTes
         "-confname", dstConfigName,
         "-confdir", srcConfigSet,
         "-zkHost", zkAddr,
-        "-configsetsDir", configSetDir.toAbsolutePath().toString(),
+        "-configsetsDir", configSetDir.toString(),
     };
 
     SolrCLI.ConfigSetUploadTool tool = new SolrCLI.ConfigSetUploadTool();

--- a/solr/test-framework/src/java/org/apache/solr/cloud/AbstractFullDistribZkTestBase.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/AbstractFullDistribZkTestBase.java
@@ -701,7 +701,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
     } else if (random().nextBoolean()) {
       props.setProperty("replicaType", Replica.Type.NRT.toString());
     }
-    props.setProperty("coreRootDirectory", solrHome.toPath().resolve("cores").toAbsolutePath().toString());
+    props.setProperty("coreRootDirectory", solrHome.toPath().resolve("cores").toString());
     
     JettySolrRunner jetty = new JettySolrRunner(solrHome.getPath(), props, jettyconfig);
 
@@ -739,7 +739,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
     } else if (random().nextBoolean()) {
       props.setProperty("replicaType", Replica.Type.NRT.toString());
     }
-    props.setProperty("coreRootDirectory", solrHome.toPath().resolve("cores").toAbsolutePath().toString());
+    props.setProperty("coreRootDirectory", solrHome.toPath().resolve("cores").toString());
 
     JettySolrRunner jetty = new JettySolrRunner(solrHome.getPath(), props, jettyconfig, true);
 


### PR DESCRIPTION
Continuation of #1546
Here, we avoid calling toAbsolutePath when not needed because we know it's already absolute.  Look carefully; there's a few other changes.

I liken this to pointless null checks in code when you know the thing isn't null.