### PR TITLE
LUCENE-9407: change the visibility of the LatLonXQuery classes to public

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/document/LatLonDocValuesBoxQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LatLonDocValuesBoxQuery.java
@@ -34,7 +34,7 @@ import org.apache.lucene.search.TwoPhaseIterator;
 import org.apache.lucene.search.Weight;
 
 /** Distance query for {@link LatLonDocValuesField}. */
-final class LatLonDocValuesBoxQuery extends Query {
+public final class LatLonDocValuesBoxQuery extends Query {
 
   private final String field;
   private final int minLatitude, maxLatitude, minLongitude, maxLongitude;

--- a/lucene/core/src/java/org/apache/lucene/document/LatLonDocValuesDistanceQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LatLonDocValuesDistanceQuery.java
@@ -34,7 +34,7 @@ import org.apache.lucene.search.TwoPhaseIterator;
 import org.apache.lucene.search.Weight;
 
 /** Distance query for {@link LatLonDocValuesField}. */
-final class LatLonDocValuesDistanceQuery extends Query {
+public final class LatLonDocValuesDistanceQuery extends Query {
 
   private final String field;
   private final double latitude, longitude;

--- a/lucene/core/src/java/org/apache/lucene/document/LatLonPointDistanceFeatureQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LatLonPointDistanceFeatureQuery.java
@@ -43,8 +43,21 @@ import org.apache.lucene.util.DocIdSetBuilder;
 import org.apache.lucene.util.NumericUtils;
 import org.apache.lucene.util.SloppyMath;
 
-
-final class LatLonPointDistanceFeatureQuery extends Query {
+/**
+ * This class models a query that scores
+ * documents based on their haversine distance in meters to {@code (originLat, originLon)}:
+ *
+ * {@code score = weight * pivotDistanceMeters / (pivotDistanceMeters + distance)}.
+ *
+ * ie. score is in the {@code [0, weight]} range, is equal to {@code weight} when
+ * the document's value is equal to {@code (originLat, originLon)} and is equal to
+ * {@code weight/2}  when the document's value is distant of
+ * {@code pivotDistanceMeters} from {@code (originLat, originLon)}.
+ *
+ * In case of multi-valued fields, only the closest point to {@code (originLat, originLon)}
+ * will be considered.
+ */
+public final class LatLonPointDistanceFeatureQuery extends Query {
 
   private final String field;
   private final double originLat;

--- a/lucene/core/src/java/org/apache/lucene/document/LatLonPointDistanceQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LatLonPointDistanceQuery.java
@@ -51,13 +51,13 @@ import static org.apache.lucene.geo.GeoEncodingUtils.encodeLongitude;
 /**
  * Distance query for {@link LatLonPoint}.
  */
-final class LatLonPointDistanceQuery extends Query {
+public final class LatLonPointDistanceQuery extends Query {
   final String field;
   final double latitude;
   final double longitude;
   final double radiusMeters;
 
-  public LatLonPointDistanceQuery(String field, double latitude, double longitude, double radiusMeters) {
+  LatLonPointDistanceQuery(String field, double latitude, double longitude, double radiusMeters) {
     if (field == null) {
       throw new IllegalArgumentException("field must not be null");
     }
@@ -326,18 +326,38 @@ final class LatLonPointDistanceQuery extends Query {
     };
   }
 
+  /**
+   * Returns the field name for the query.
+   *
+   * @return the field name for the query
+   */
   public String getField() {
     return field;
   }
 
+  /**
+   * Returns the latitude at the center: must be within standard +/-90 coordinate bounds.
+   *
+   * @return latitude at the center
+   */
   public double getLatitude() {
     return latitude;
   }
 
+  /**
+   * Returns the longitude at the center: must be within standard +/-180 coordinate bounds.
+   *
+   * @return longitude at the center
+   */
   public double getLongitude() {
     return longitude;
   }
 
+  /**
+   * Returns the maximum distance from the center in meters.
+   *
+   * @return the maximum distance from the center in meters.
+   */
   public double getRadiusMeters() {
     return radiusMeters;
   }

--- a/lucene/core/src/java/org/apache/lucene/document/LatLonPointInPolygonQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LatLonPointInPolygonQuery.java
@@ -53,7 +53,7 @@ import static org.apache.lucene.geo.GeoEncodingUtils.encodeLongitude;
  *
  *  @lucene.experimental */
 
-final class LatLonPointInPolygonQuery extends Query {
+public final class LatLonPointInPolygonQuery extends Query {
   final String field;
   final Polygon[] polygons;
 

--- a/lucene/core/src/java/org/apache/lucene/document/LatLonShapeBoundingBoxQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LatLonShapeBoundingBoxQuery.java
@@ -39,7 +39,7 @@ import static org.apache.lucene.geo.GeoEncodingUtils.encodeLongitudeCeil;
  * <p>The field must be indexed using
  * {@link org.apache.lucene.document.LatLonShape#createIndexableFields} added per document.
  **/
-final class LatLonShapeBoundingBoxQuery extends ShapeQuery {
+public final class LatLonShapeBoundingBoxQuery extends ShapeQuery {
   private final Rectangle rectangle;
   private final EncodedRectangle encodedRectangle;
 

--- a/lucene/core/src/java/org/apache/lucene/document/LatLonShapeQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LatLonShapeQuery.java
@@ -33,7 +33,7 @@ import org.apache.lucene.util.NumericUtils;
  * <p>The field must be indexed using {@link LatLonShape#createIndexableFields} added per document.
  *
  **/
-final class LatLonShapeQuery extends ShapeQuery {
+public final class LatLonShapeQuery extends ShapeQuery {
   final private LatLonGeometry[] geometries;
   final private Component2D component2D;
 

--- a/lucene/core/src/java/org/apache/lucene/document/LongDistanceFeatureQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/document/LongDistanceFeatureQuery.java
@@ -38,6 +38,18 @@ import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.DocIdSetBuilder;
 
+/**
+ * This query class scores documents based on their distance to {@code origin}:
+ * {@code score = weight * pivotDistance / (pivotDistance + distance)}.
+ *
+ * ie.: score is in the {@code [0, weight]} range, is equal to {@code weight} when
+ * the document's value is equal to {@code origin} and is equal to
+ * {@code weight/2}  when the document's value is distant of
+ * {@code pivotDistance} from {@code origin}.
+ *
+ * In case of multi-valued fields, only the closest point to {@code origin}
+ * will be considered.
+ */
 final class LongDistanceFeatureQuery extends Query {
 
   private final String field;


### PR DESCRIPTION
LUCENE-9407: change the visibility of the LatLonXQuery classes to public in order to allow using them outside of the org.apache.lucene.document package


# Description

A few years ago the geospatial queries  classes have been refactored to be package-private.
This restriction doesn't allow these classes to be used outside of the org.apache.lucene.document package.

# Solution

Changed the visibility of the LatLonXQuery classes to public so that they can be used outside of the org.apache.lucene.document package (e.g. elasticsearch percolator)

# Tests

No Tests required because no functionality has been changed.


# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for How to Contribute and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers access to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the master branch.
- [x] I have run ant precommit and the appropriate test suite.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the Ref Guide (for Solr changes only).