### PR TITLE
LUCENE-8962: Allow waiting for all merges in a merge spec

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -2129,12 +2129,12 @@ public class IndexWriter implements Closeable, TwoPhaseCommit, Accountable,
 
   private final void maybeMerge(MergePolicy mergePolicy, MergeTrigger trigger, int maxNumSegments) throws IOException {
     ensureOpen(false);
-    if (updatePendingMerges(mergePolicy, trigger, maxNumSegments)) {
+    if (updatePendingMerges(mergePolicy, trigger, maxNumSegments) != null) {
       mergeScheduler.merge(mergeSource, trigger);
     }
   }
 
-  private synchronized boolean updatePendingMerges(MergePolicy mergePolicy, MergeTrigger trigger, int maxNumSegments)
+  private synchronized MergePolicy.MergeSpecification updatePendingMerges(MergePolicy mergePolicy, MergeTrigger trigger, int maxNumSegments)
     throws IOException {
 
     // In case infoStream was disabled on init, but then enabled at some
@@ -2144,22 +2144,21 @@ public class IndexWriter implements Closeable, TwoPhaseCommit, Accountable,
     assert maxNumSegments == UNBOUNDED_MAX_MERGE_SEGMENTS || maxNumSegments > 0;
     assert trigger != null;
     if (stopMerges) {
-      return false;
+      return null;
     }
 
     // Do not start new merges if disaster struck
     if (tragedy.get() != null) {
-      return false;
+      return null;
     }
-    boolean newMergesFound = false;
+
     final MergePolicy.MergeSpecification spec;
     if (maxNumSegments != UNBOUNDED_MAX_MERGE_SEGMENTS) {
       assert trigger == MergeTrigger.EXPLICIT || trigger == MergeTrigger.MERGE_FINISHED :
       "Expected EXPLICT or MERGE_FINISHED as trigger even with maxNumSegments set but was: " + trigger.name();
 
       spec = mergePolicy.findForcedMerges(segmentInfos, maxNumSegments, Collections.unmodifiableMap(segmentsToMerge), this);
-      newMergesFound = spec != null;
-      if (newMergesFound) {
+      if (spec != null) {
         final int numMerges = spec.merges.size();
         for(int i=0;i<numMerges;i++) {
           final MergePolicy.OneMerge merge = spec.merges.get(i);
@@ -2169,14 +2168,13 @@ public class IndexWriter implements Closeable, TwoPhaseCommit, Accountable,
     } else {
       spec = mergePolicy.findMerges(trigger, segmentInfos, this);
     }
-    newMergesFound = spec != null;
-    if (newMergesFound) {
+    if (spec != null) {
       final int numMerges = spec.merges.size();
       for(int i=0;i<numMerges;i++) {
         registerMerge(spec.merges.get(i));
       }
     }
-    return newMergesFound;
+    return spec;
   }
 
   /** Expert: to be used by a {@link MergePolicy} to avoid
@@ -4289,7 +4287,7 @@ public class IndexWriter implements Closeable, TwoPhaseCommit, Accountable,
   @SuppressWarnings("try")
   private synchronized void closeMergeReaders(MergePolicy.OneMerge merge, boolean suppressExceptions) throws IOException {
     final boolean drop = suppressExceptions == false;
-    try (Closeable finalizer = merge::mergeFinished) {
+    try (Closeable finalizer = () -> merge.mergeFinished(suppressExceptions==false)) {
       IOUtils.applyToAll(merge.readers, sr -> {
         final ReadersAndUpdates rld = getPooledInstance(sr.getOriginalSegmentInfo(), false);
         // We still hold a ref so it should not have been removed:

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -4287,7 +4287,7 @@ public class IndexWriter implements Closeable, TwoPhaseCommit, Accountable,
   @SuppressWarnings("try")
   private synchronized void closeMergeReaders(MergePolicy.OneMerge merge, boolean suppressExceptions) throws IOException {
     final boolean drop = suppressExceptions == false;
-    try (Closeable finalizer = () -> merge.mergeFinished(suppressExceptions==false)) {
+    try (Closeable finalizer = () -> merge.mergeFinished(suppressExceptions == false)) {
       IOUtils.applyToAll(merge.readers, sr -> {
         final ReadersAndUpdates rld = getPooledInstance(sr.getOriginalSegmentInfo(), false);
         // We still hold a ref so it should not have been removed:

--- a/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
@@ -32,7 +32,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BooleanSupplier;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestDemoParallelLeafReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDemoParallelLeafReader.java
@@ -538,7 +538,7 @@ public class TestDemoParallelLeafReader extends LuceneTestCase {
         }
 
         @Override
-        public void mergeFinished() throws IOException {
+        public void mergeFinished(boolean success) throws IOException {
           Throwable th = null;
           for (ParallelLeafReader r : parallelReaders) {
             try {

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
@@ -4181,7 +4181,7 @@ public class TestIndexWriter extends LuceneTestCase {
             SetOnce<Boolean> onlyFinishOnce = new SetOnce<>();
             return new MergePolicy.OneMerge(merge.segments) {
               @Override
-              public void mergeFinished() {
+              public void mergeFinished(boolean success) {
                 onlyFinishOnce.set(true);
               }
             };

--- a/lucene/core/src/test/org/apache/lucene/index/TestMergePolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestMergePolicy.java
@@ -38,7 +38,7 @@ public class TestMergePolicy extends LuceneTestCase {
     try (Directory dir = newDirectory()) {
       MergePolicy.MergeSpecification ms = createRandomMergeSpecification(dir, 1 + random().nextInt(10));
       for (MergePolicy.OneMerge m : ms.merges) {
-        assertFalse(m.isCommitted());
+        assertFalse(m.hasCompletedSuccessfully().isPresent());
       }
       Thread t = new Thread(() -> {
         try {
@@ -52,7 +52,7 @@ public class TestMergePolicy extends LuceneTestCase {
       t.start();
       assertTrue(ms.await(100, TimeUnit.HOURS));
       for (MergePolicy.OneMerge m : ms.merges) {
-        assertTrue(m.isCommitted());
+        assertTrue(m.hasCompletedSuccessfully().get());
       }
       t.join();
     }
@@ -62,7 +62,7 @@ public class TestMergePolicy extends LuceneTestCase {
     try (Directory dir = newDirectory()) {
       MergePolicy.MergeSpecification ms = createRandomMergeSpecification(dir, 3);
       for (MergePolicy.OneMerge m : ms.merges) {
-        assertFalse(m.isCommitted());
+        assertFalse(m.hasCompletedSuccessfully().isPresent());
       }
       Thread t = new Thread(() -> {
         try {
@@ -73,7 +73,7 @@ public class TestMergePolicy extends LuceneTestCase {
       });
       t.start();
       assertFalse(ms.await(10, TimeUnit.MILLISECONDS));
-      assertFalse(ms.merges.get(1).isCommitted());
+      assertFalse(ms.merges.get(1).hasCompletedSuccessfully().isPresent());
       t.join();
     }
   }
@@ -82,7 +82,7 @@ public class TestMergePolicy extends LuceneTestCase {
     try (Directory dir = newDirectory()) {
       MergePolicy.MergeSpecification ms = createRandomMergeSpecification(dir, 10000);
       for (MergePolicy.OneMerge m : ms.merges) {
-        assertFalse(m.isCommitted());
+        assertFalse(m.hasCompletedSuccessfully().isPresent());
       }
       AtomicInteger i = new AtomicInteger(0);
       AtomicBoolean stop = new AtomicBoolean(false);
@@ -102,9 +102,9 @@ public class TestMergePolicy extends LuceneTestCase {
       t.join();
       for (int j = 0; j < ms.merges.size(); j++) {
         if (j < i.get()) {
-          assertTrue(ms.merges.get(j).isCommitted());
+          assertTrue(ms.merges.get(j).hasCompletedSuccessfully().get());
         } else {
-          assertFalse(ms.merges.get(j).isCommitted());
+          assertFalse(ms.merges.get(j).hasCompletedSuccessfully().isPresent());
         }
       }
     }

--- a/lucene/core/src/test/org/apache/lucene/index/TestMergePolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestMergePolicy.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.index;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.LuceneTestCase;
+import org.apache.lucene.util.StringHelper;
+import org.apache.lucene.util.TestUtil;
+import org.apache.lucene.util.Version;
+
+public class TestMergePolicy extends LuceneTestCase {
+
+  public void testWaitForOneMerge() throws IOException, InterruptedException {
+    try (Directory dir = newDirectory()) {
+      MergePolicy.MergeSpecification ms = createRandomMergeSpecification(dir, 1 + random().nextInt(10));
+      for (MergePolicy.OneMerge m : ms.merges) {
+        assertFalse(m.isCommitted());
+      }
+      Thread t = new Thread(() -> {
+        try {
+          for (MergePolicy.OneMerge m : ms.merges) {
+            m.mergeFinished(true);
+          }
+        } catch (IOException e) {
+          throw new AssertionError(e);
+        }
+      });
+      t.start();
+      assertTrue(ms.await(100, TimeUnit.HOURS));
+      for (MergePolicy.OneMerge m : ms.merges) {
+        assertTrue(m.isCommitted());
+      }
+      t.join();
+    }
+  }
+
+  public void testTimeout() throws IOException, InterruptedException {
+    try (Directory dir = newDirectory()) {
+      MergePolicy.MergeSpecification ms = createRandomMergeSpecification(dir, 3);
+      for (MergePolicy.OneMerge m : ms.merges) {
+        assertFalse(m.isCommitted());
+      }
+      Thread t = new Thread(() -> {
+        try {
+          ms.merges.get(0).mergeFinished(true);
+        } catch (IOException e) {
+          throw new AssertionError(e);
+        }
+      });
+      t.start();
+      assertFalse(ms.await(10, TimeUnit.MILLISECONDS));
+      assertFalse(ms.merges.get(1).isCommitted());
+      t.join();
+    }
+  }
+
+  public void testTimeoutLargeNumberOfMerges() throws IOException, InterruptedException {
+    try (Directory dir = newDirectory()) {
+      MergePolicy.MergeSpecification ms = createRandomMergeSpecification(dir, 10000);
+      for (MergePolicy.OneMerge m : ms.merges) {
+        assertFalse(m.isCommitted());
+      }
+      AtomicInteger i = new AtomicInteger(0);
+      AtomicBoolean stop = new AtomicBoolean(false);
+      Thread t = new Thread(() -> {
+        while (stop.get() == false) {
+          try {
+            ms.merges.get(i.getAndIncrement()).mergeFinished(true);
+            Thread.sleep(1);
+          } catch (IOException | InterruptedException e) {
+            throw new AssertionError(e);
+          }
+        }
+      });
+      t.start();
+      assertFalse(ms.await(10, TimeUnit.MILLISECONDS));
+      stop.set(true);
+      t.join();
+      for (int j = 0; j < ms.merges.size(); j++) {
+        if (j < i.get()) {
+          assertTrue(ms.merges.get(j).isCommitted());
+        } else {
+          assertFalse(ms.merges.get(j).isCommitted());
+        }
+      }
+    }
+  }
+
+  public void testFinishTwice() throws IOException {
+    try (Directory dir = newDirectory()) {
+      MergePolicy.MergeSpecification spec = createRandomMergeSpecification(dir, 1);
+      MergePolicy.OneMerge oneMerge = spec.merges.get(0);
+      oneMerge.mergeFinished(true);
+      expectThrows(IllegalStateException.class, () -> oneMerge.mergeFinished(false));
+    }
+  }
+
+  public void testTotalMaxDoc() throws IOException {
+    try (Directory dir = newDirectory()) {
+      MergePolicy.MergeSpecification spec = createRandomMergeSpecification(dir, 1);
+      int docs = 0;
+      MergePolicy.OneMerge oneMerge = spec.merges.get(0);
+      for (SegmentCommitInfo info : oneMerge.segments) {
+        docs += info.info.maxDoc();
+      }
+      assertEquals(docs, oneMerge.totalMaxDoc);
+    }
+  }
+
+  private static MergePolicy.MergeSpecification createRandomMergeSpecification(Directory dir, int numMerges) {
+    MergePolicy.MergeSpecification ms = new MergePolicy.MergeSpecification();
+      for (int ii = 0; ii < numMerges; ++ii) {
+        final SegmentInfo si = new SegmentInfo(
+            dir, // dir
+            Version.LATEST, // version
+            Version.LATEST, // min version
+            TestUtil.randomSimpleString(random()), // name
+            random().nextInt(1000), // maxDoc
+            random().nextBoolean(), // isCompoundFile
+            null, // codec
+            Collections.emptyMap(), // diagnostics
+            TestUtil.randomSimpleString(// id
+                random(),
+                StringHelper.ID_LENGTH,
+                StringHelper.ID_LENGTH).getBytes(StandardCharsets.US_ASCII),
+            Collections.emptyMap(), // attributes
+            null /* indexSort */);
+        final List<SegmentCommitInfo> segments = new LinkedList<SegmentCommitInfo>();
+        segments.add(new SegmentCommitInfo(si, 0, 0, 0, 0, 0, StringHelper.randomId()));
+        ms.add(new MergePolicy.OneMerge(segments));
+      }
+      return ms;
+  }
+}


### PR DESCRIPTION
This change adds infrastructure to allow straight forward waiting
on one or more merges or an entire merge specification. This is
a basis for LUCENE-8962.