### PR TITLE
SOLR-14577: Return BAD REQUEST when field is missing in terms QP

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -245,6 +245,9 @@ Bug Fixes
 
 * SOLR-14516: NPE in JsonTextWriter (noble)
 
+* SOLR-14577: Return 400 BAD REQUEST when field is missing on a Terms query parser request
+  (Tomás Fernández Löbbe)
+
 Other Changes
 ---------------------
 * SOLR-14197: SolrResourceLoader: marked many methods as deprecated, and in some cases rerouted exiting logic to avoid

--- a/solr/core/src/java/org/apache/solr/search/TermsQParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/search/TermsQParserPlugin.java
@@ -123,6 +123,9 @@ public class TermsQParserPlugin extends QParserPlugin {
       @Override
       public Query parse() throws SyntaxError {
         String fname = localParams.get(QueryParsing.F);
+        if (fname == null || fname.isEmpty()) {
+          throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, "Missing field to query");
+        }
         FieldType ft = req.getSchema().getFieldType(fname);
         String separator = localParams.get(SEPARATOR, ",");
         String qstr = localParams.get(QueryParsing.V);//never null

--- a/solr/core/src/test/org/apache/solr/search/TestTermsQParserPlugin.java
+++ b/solr/core/src/test/org/apache/solr/search/TestTermsQParserPlugin.java
@@ -18,6 +18,7 @@
 package org.apache.solr.search;
 
 import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -70,6 +71,11 @@ public class TestTermsQParserPlugin extends SolrTestCaseJ4 {
         "//result/doc[4]/str[@name='id'][.='6']",
         "//result/doc[5]/str[@name='id'][.='7']"
     );
+  }
+  
+  @Test
+  public void testMissingField() {
+    assertQEx("Expecting bad request", "Missing field to query", req("q", "{!terms}childrens|scifi"), SolrException.ErrorCode.BAD_REQUEST);
   }
 
   class TermsParams {


### PR DESCRIPTION
It will currently throw a NPE, resulting in a server error.