### PR TITLE
SOLR-13195: added check for missing shards param in SearchHandler

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -239,10 +239,16 @@ public class SearchHandler extends RequestHandlerBase implements SolrCoreAware, 
     CoreContainer cc = req.getCore().getCoreContainer();
     boolean isZkAware = cc.isZooKeeperAware();
     rb.isDistrib = req.getParams().getBool(DISTRIB, isZkAware);
+    // SOLR-13195: For back compatibility, allow distributed search only when the
+    // request has a shards parameter
+    final String shards = req.getParams().get(ShardParams.SHARDS);
+    if (rb.isDistrib && (shards == null) && !isZkAware) {
+      throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, "shards not defined but " +
+                              "required without SolrCloud");
+    }
     if (!rb.isDistrib) {
       // for back compat, a shards param with URLs like localhost:8983/solr will mean that this
       // search is distributed.
-      final String shards = req.getParams().get(ShardParams.SHARDS);
       rb.isDistrib = ((shards != null) && (shards.indexOf('/') > 0));
     }
     


### PR DESCRIPTION
<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

The distributedProcess methods of the search pipeline never checks to see if a request has a shards parameter, eventhough a shards param is required if SOLR is not running with SolrCloud

# Solution

Added code in SearchHandler.getAndPrepShardHandler() to check for a shards param, and throw an exception if it's not defined.

# Tests

Added SearchHandlerTest.testDistribWithoutZk() which covers legacy distributed queries without a shards param

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title. **(Existing issue)**
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
