### PR TITLE
LUCENE-9409: Check file lengths before creating slices.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/blocktree/BlockTreeTermsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/blocktree/BlockTreeTermsWriter.java
@@ -1035,14 +1035,14 @@ public final class BlockTreeTermsWriter extends FieldsConsumer {
 
     boolean success = false;
     try {
-      metaOut.writeVInt(fields.size());
-      for (ByteBuffersDataOutput fieldMeta : fields) {
-        fieldMeta.copyTo(metaOut);
-      }
       CodecUtil.writeFooter(indexOut);
       metaOut.writeLong(indexOut.getFilePointer());
       CodecUtil.writeFooter(termsOut);
       metaOut.writeLong(termsOut.getFilePointer());
+      metaOut.writeVInt(fields.size());
+      for (ByteBuffersDataOutput fieldMeta : fields) {
+        fieldMeta.copyTo(metaOut);
+      }
       CodecUtil.writeFooter(metaOut);
       success = true;
     } finally {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene86/Lucene86PointsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene86/Lucene86PointsReader.java
@@ -72,7 +72,6 @@ public class Lucene86PointsReader extends PointsReader implements Closeable {
           readState.segmentInfo.getId(),
           readState.segmentSuffix);
 
-      long indexLength = -1, dataLength = -1;
       try (ChecksumIndexInput metaIn = readState.directory.openChecksumInput(metaFileName, readState.context)) {
         Throwable priorE = null;
         try {
@@ -82,6 +81,11 @@ public class Lucene86PointsReader extends PointsReader implements Closeable {
               Lucene86PointsFormat.VERSION_CURRENT,
               readState.segmentInfo.getId(),
               readState.segmentSuffix);
+
+          final long indexLength = metaIn.readLong();
+          CodecUtil.retrieveChecksum(indexIn, indexLength);
+          final long dataLength = metaIn.readLong();
+          CodecUtil.retrieveChecksum(dataIn, dataLength);
 
           while (true) {
             int fieldNumber = metaIn.readInt();
@@ -93,18 +97,12 @@ public class Lucene86PointsReader extends PointsReader implements Closeable {
             BKDReader reader = new BKDReader(metaIn, indexIn, dataIn);
             readers.put(fieldNumber, reader);
           }
-          indexLength = metaIn.readLong();
-          dataLength = metaIn.readLong();
         } catch (Throwable t) {
           priorE = t;
         } finally {
           CodecUtil.checkFooter(metaIn, priorE);
         }
       }
-      // At this point, checksums of the meta file have been validated so we
-      // know that indexLength and dataLength are very likely correct.
-      CodecUtil.retrieveChecksum(indexIn, indexLength);
-      CodecUtil.retrieveChecksum(dataIn, dataLength);
       success = true;
     } finally {
       if (success == false) {

--- a/lucene/test-framework/src/java/org/apache/lucene/index/RandomCodec.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/index/RandomCodec.java
@@ -132,9 +132,9 @@ public class RandomCodec extends AssertingCodec {
                   });
 
                 // We could have 0 points on merge since all docs with dimensional fields may be deleted:
-                Runnable finalizer = writer.finish(metaOut, indexOut, dataOut);
+                Runnable finalizer = writer.finish(tempMetaOut, indexOut, dataOut);
                 if (finalizer != null) {
-                  metaOut.writeInt(fieldInfo.number);
+                  tempMetaOut.writeInt(fieldInfo.number);
                   finalizer.run();
                 }
               }


### PR DESCRIPTION
This changes terms and points to check the length of the index/data
files before creating slices in these files. A side-effect of this is
that we can no longer verify checksums of the meta file before checking
the length of other files, but this shouldn't be a problem. On the other
hand it helps make sure that we would return a clear exception in case
of truncation instead of a confusing OutOfBoundsException that isn't
clear whether it's due to index corruption or a bug in Lucene.
