### PR TITLE
SOLR-10059: Workaround for re-appended query params

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/RequestHandlerBase.java
+++ b/solr/core/src/java/org/apache/solr/handler/RequestHandlerBase.java
@@ -193,7 +193,12 @@ public abstract class RequestHandlerBase implements SolrRequestHandler, SolrInfo
     Timer.Context timer = requestTimes.time();
     try {
       if(pluginInfo != null && pluginInfo.attributes.containsKey(USEPARAM)) req.getContext().put(USEPARAM,pluginInfo.attributes.get(USEPARAM));
-      SolrPluginUtils.setDefaults(this, req, defaults, appends, invariants);
+      if (req.getParams().getBool(ShardParams.IS_SHARD, false)
+        && req.getParams().getBool(ShardParams.SHARDS + ".handler.skipAppend", false)) {
+        SolrPluginUtils.setDefaults(this, req, defaults, null, invariants);
+      } else {
+        SolrPluginUtils.setDefaults(this, req, defaults, appends, invariants);
+      }
       req.getContext().remove(USEPARAM);
       rsp.setHttpCaching(httpCaching);
       handleRequestBody( req, rsp );


### PR DESCRIPTION
# Description

This is a small yet simple fix for [SOLR-10059](https://issues.apache.org/jira/browse/SOLR-10059) to remove the re-appending of query params in the `SearchHandler` `appends` section on shards in a distributed request.

# Solution

The patch skips re-appending on the shards (`isShard=true`) if the parameter `shards.handler.skipAppends=true`. The latter defaults to `false`. 

The fix is built against the `branch_7x` branch. I'll also check for `master` branch.

# Checklist

Please review the following and check all that apply:

- [ ] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have developed this patch against the `master` branch.
- [ ] I have run `ant precommit` and the appropriate test suite.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
