### PR TITLE
SOLR Move "userfiles" stuff from SolrPaths to CoreContainer.

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -353,6 +353,13 @@ public class CoreContainer {
         log.info("Allowing use of paths: {}", cfg.getAllowPaths());
       }
     }
+
+    Path userFilesPath = getUserFilesPath(); // TODO make configurable on cfg?
+    try {
+      Files.createDirectories(userFilesPath); // does nothing if already exists
+    } catch (Exception e) {
+      log.warn("Unable to create [{}].  Features requiring this directory may fail.", userFilesPath, e);
+    }
   }
 
   @SuppressWarnings({"unchecked"})
@@ -1969,6 +1976,16 @@ public class CoreContainer {
   //TODO return Path
   public String getSolrHome() {
     return solrHome.toString();
+  }
+
+  /**
+   * A path where Solr users can retrieve arbitrary files from.  Absolute.
+   * <p>
+   * This directory is generally created by each node on startup.  Files located in this directory can then be
+   * manipulated using select Solr features (e.g. streaming expressions).
+   */
+  public Path getUserFilesPath() {
+    return solrHome.resolve("userfiles");
   }
 
   public boolean isZooKeeperAware() {

--- a/solr/core/src/java/org/apache/solr/core/SolrPaths.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrPaths.java
@@ -39,13 +39,6 @@ import org.slf4j.LoggerFactory;
 public final class SolrPaths {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  /**
-   * Solr allows users to store arbitrary files in a special directory located directly under SOLR_HOME.
-   * <p>
-   * This directory is generally created by each node on startup.  Files located in this directory can then be
-   * manipulated using select Solr features (e.g. streaming expressions).
-   */
-  public static final String USER_FILES_DIRECTORY = "userfiles";
   private static final Set<String> loggedOnce = new ConcurrentSkipListSet<>();
 
   private SolrPaths() {} // don't create this
@@ -92,26 +85,6 @@ public final class SolrPaths {
       logOnceInfo("home_default", "solr home defaulted to '" + home + "' (could not find system property or JNDI)");
     }
     return Paths.get(home).toAbsolutePath().normalize();
-  }
-
-  public static void ensureUserFilesDataDir(Path solrHome) {
-    final Path userFilesPath = getUserFilesPath(solrHome);
-    final File userFilesDirectory = new File(userFilesPath.toString());
-    if (!userFilesDirectory.exists()) {
-      try {
-        final boolean created = userFilesDirectory.mkdir();
-        if (!created) {
-          log.warn("Unable to create [{}] directory in SOLR_HOME [{}].  Features requiring this directory may fail.", USER_FILES_DIRECTORY, solrHome);
-        }
-      } catch (Exception e) {
-        log.warn("Unable to create [{}] directory in SOLR_HOME [{}].  Features requiring this directory may fail.",
-            USER_FILES_DIRECTORY, solrHome, e);
-      }
-    }
-  }
-
-  public static Path getUserFilesPath(Path solrHome) {
-    return Paths.get(solrHome.toAbsolutePath().toString(), USER_FILES_DIRECTORY).toAbsolutePath();
   }
 
   /**

--- a/solr/core/src/java/org/apache/solr/servlet/SolrDispatchFilter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/SolrDispatchFilter.java
@@ -182,7 +182,6 @@ public class SolrDispatchFilter extends BaseSolrFilter {
       String solrHome = (String) config.getServletContext().getAttribute(SOLRHOME_ATTRIBUTE);
       final Path solrHomePath = solrHome == null ? SolrPaths.locateSolrHome() : Paths.get(solrHome);
       coresInit = createCoreContainer(solrHomePath, extraProperties);
-      SolrPaths.ensureUserFilesDataDir(solrHomePath);
       this.httpClient = coresInit.getUpdateShardHandler().getDefaultHttpClient();
       setupJvmMetrics(coresInit);
       if (log.isDebugEnabled()) {


### PR DESCRIPTION
Convert String and File paths to Path API.

CoreContainer seems to me the proper place for the node to expose key directories at a node level.  It's already doing this.  It looked a bit clumsy to me to have the String constant and extra methods elsewhere for userfiles.  And I'd rather not see SolrDispatchFilter touched whatsoever for this feature, even if it was one line.

Once I moved that, and declared as type Path, I couldn't un-see all the code that did heavy back & forth conversion between String paths and File paths.  Not only is String terrible because it's untyped, but Path is the modern replacement, not File.  I wish we could do forbiddenAPI on File but there's lots of old code.  This userfiles code was only added last year though.

I experimented with using Files.walkTree in findReadableFiles() but backed off because I already extended my scope very far and I'd rather eventually see all of the Files streamed instead of needing to materialize _all_ of them into a list. Also, findReadableFiles is pretty clear and wasn't any clearer when I played with a Files.walkTree considering all the rules, particularly ignoring files that aren't readable.  I wonder how intentional that is... maybe it actually _should_ be an error instead of silently ignoring those files.

@gerlowskija 