### PR TITLE
LUCENE-8962: Ensure we don't include fully deleted segments in a commit

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergePolicy.java
@@ -254,8 +254,10 @@ public abstract class MergePolicy {
     }
 
     /** Called by {@link IndexWriter} after the merge is done and all readers have been closed.
-     * @param success true iff the merge finished successfully ie. was committed */
-    public void mergeFinished(boolean success) throws IOException {
+     * @param success true iff the merge finished successfully ie. was committed
+     * @param segmentDropped true iff the merged segment was dropped since it was fully deleted
+     */
+    public void mergeFinished(boolean success, boolean segmentDropped) throws IOException {
       mergeCompleted.complete(success);
       // https://issues.apache.org/jira/browse/LUCENE-9408
       // if (mergeCompleted.complete(success) == false) {

--- a/lucene/core/src/test/org/apache/lucene/index/TestDemoParallelLeafReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDemoParallelLeafReader.java
@@ -538,7 +538,7 @@ public class TestDemoParallelLeafReader extends LuceneTestCase {
         }
 
         @Override
-        public void mergeFinished(boolean success) throws IOException {
+        public void mergeFinished(boolean success, boolean segmentDropped) throws IOException {
           Throwable th = null;
           for (ParallelLeafReader r : parallelReaders) {
             try {

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
@@ -4181,7 +4181,7 @@ public class TestIndexWriter extends LuceneTestCase {
             SetOnce<Boolean> onlyFinishOnce = new SetOnce<>();
             return new MergePolicy.OneMerge(merge.segments) {
               @Override
-              public void mergeFinished(boolean success) {
+              public void mergeFinished(boolean success, boolean segmentDropped) {
                 onlyFinishOnce.set(true);
               }
             };

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMergePolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMergePolicy.java
@@ -396,10 +396,12 @@ public class TestIndexWriterMergePolicy extends LuceneTestCase {
             waitForMerge.await();
             writer.updateDocument(new Term("id", "2"), d2);
             writer.flush();
-            waitForUpdate.countDown();
           } catch (Exception e) {
             throw new AssertionError(e);
+          } finally {
+            waitForUpdate.countDown();
           }
+
         });
         t.start();
         writer.commit();

--- a/lucene/core/src/test/org/apache/lucene/index/TestMergePolicy.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestMergePolicy.java
@@ -43,7 +43,7 @@ public class TestMergePolicy extends LuceneTestCase {
       Thread t = new Thread(() -> {
         try {
           for (MergePolicy.OneMerge m : ms.merges) {
-            m.mergeFinished(true);
+            m.mergeFinished(true, false);
           }
         } catch (IOException e) {
           throw new AssertionError(e);
@@ -66,7 +66,7 @@ public class TestMergePolicy extends LuceneTestCase {
       }
       Thread t = new Thread(() -> {
         try {
-          ms.merges.get(0).mergeFinished(true);
+          ms.merges.get(0).mergeFinished(true, false);
         } catch (IOException e) {
           throw new AssertionError(e);
         }
@@ -89,7 +89,7 @@ public class TestMergePolicy extends LuceneTestCase {
       Thread t = new Thread(() -> {
         while (stop.get() == false) {
           try {
-            ms.merges.get(i.getAndIncrement()).mergeFinished(true);
+            ms.merges.get(i.getAndIncrement()).mergeFinished(true, false);
             Thread.sleep(1);
           } catch (IOException | InterruptedException e) {
             throw new AssertionError(e);
@@ -115,8 +115,8 @@ public class TestMergePolicy extends LuceneTestCase {
     try (Directory dir = newDirectory()) {
       MergePolicy.MergeSpecification spec = createRandomMergeSpecification(dir, 1);
       MergePolicy.OneMerge oneMerge = spec.merges.get(0);
-      oneMerge.mergeFinished(true);
-      expectThrows(IllegalStateException.class, () -> oneMerge.mergeFinished(false));
+      oneMerge.mergeFinished(true, false);
+      expectThrows(IllegalStateException.class, () -> oneMerge.mergeFinished(false, false));
     }
   }
 


### PR DESCRIPTION
IW might drop segments that are merged into a fully deleted segment on the floor
and deletes the newly created files right away. We should not include these segments
in a commit since we can't guarantee valid ref-counts on these files.