### PR TITLE
SOLR-14582: Expose IWC.setMaxCommitMergeWaitMillis in Solr's index config

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -125,6 +125,9 @@ New Features
 
 * SOLR-14604: Add the ability to uninstall a package from with the Package CLI. (MarcusSorealheis)
 
+* SOLR-14582: Expose IWC.setMaxCommitMergeWaitMillis in Solr's index config. This is an expert config option that can be
+  set when using a custom MergePolicy (doesn't have any effect on the default MP) (Tomás Fernández Löbbe)
+
 Improvements
 ---------------------
 

--- a/solr/core/src/java/org/apache/solr/update/SolrIndexConfig.java
+++ b/solr/core/src/java/org/apache/solr/update/SolrIndexConfig.java
@@ -68,6 +68,13 @@ public class SolrIndexConfig implements MapSerializable {
 
   public final double ramBufferSizeMB;
   public final int ramPerThreadHardLimitMB;
+  /**
+   * When using a custom merge policy that allows triggering synchronous merges on commit
+   * (see {@link MergePolicy#findFullFlushMerges(org.apache.lucene.index.MergeTrigger, org.apache.lucene.index.SegmentInfos, org.apache.lucene.index.MergePolicy.MergeContext)}),
+   * a timeout (in seconds) can be set for those merges to finish. Use {@code <maxCommitMergeWaitSeconds>10</maxCommitMergeWaitSeconds>} in the {@code <indexConfig>} section.
+   * See {@link IndexWriterConfig#setMaxCommitMergeWaitSeconds(long)}.
+   */
+  public final int maxCommitMergeWaitSeconds;
 
   public final int writeLockTimeout;
   public final String lockType;
@@ -87,6 +94,7 @@ public class SolrIndexConfig implements MapSerializable {
     maxBufferedDocs = -1;
     ramBufferSizeMB = 100;
     ramPerThreadHardLimitMB = -1;
+    maxCommitMergeWaitSeconds = -1;
     writeLockTimeout = -1;
     lockType = DirectoryFactory.LOCK_TYPE_NATIVE;
     mergePolicyFactoryInfo = null;
@@ -129,8 +137,9 @@ public class SolrIndexConfig implements MapSerializable {
         true);
 
     useCompoundFile = solrConfig.getBool(prefix+"/useCompoundFile", def.useCompoundFile);
-    maxBufferedDocs=solrConfig.getInt(prefix+"/maxBufferedDocs",def.maxBufferedDocs);
+    maxBufferedDocs = solrConfig.getInt(prefix+"/maxBufferedDocs", def.maxBufferedDocs);
     ramBufferSizeMB = solrConfig.getDouble(prefix+"/ramBufferSizeMB", def.ramBufferSizeMB);
+    maxCommitMergeWaitSeconds = solrConfig.getInt(prefix+"/maxCommitMergeWaitSeconds", def.maxCommitMergeWaitSeconds);
 
     // how do we validate the value??
     ramPerThreadHardLimitMB = solrConfig.getInt(prefix+"/ramPerThreadHardLimitMB", def.ramPerThreadHardLimitMB);
@@ -185,6 +194,7 @@ public class SolrIndexConfig implements MapSerializable {
         "maxBufferedDocs", maxBufferedDocs,
         "ramBufferSizeMB", ramBufferSizeMB,
         "ramPerThreadHardLimitMB", ramPerThreadHardLimitMB,
+        "maxCommitMergeWaitSeconds", maxCommitMergeWaitSeconds,
         "writeLockTimeout", writeLockTimeout,
         "lockType", lockType,
         "infoStreamEnabled", infoStream != InfoStream.NO_OUTPUT);
@@ -229,6 +239,10 @@ public class SolrIndexConfig implements MapSerializable {
 
     if (ramPerThreadHardLimitMB != -1) {
       iwc.setRAMPerThreadHardLimitMB(ramPerThreadHardLimitMB);
+    }
+    
+    if (maxCommitMergeWaitSeconds > 0) {
+      iwc.setMaxCommitMergeWaitSeconds(maxCommitMergeWaitSeconds);
     }
 
     iwc.setSimilarity(schema.getSimilarity());

--- a/solr/core/src/java/org/apache/solr/update/SolrIndexConfig.java
+++ b/solr/core/src/java/org/apache/solr/update/SolrIndexConfig.java
@@ -72,7 +72,7 @@ public class SolrIndexConfig implements MapSerializable {
    * <p>
    * When using a custom merge policy that allows triggering synchronous merges on commit
    * (see {@link MergePolicy#findFullFlushMerges(org.apache.lucene.index.MergeTrigger, org.apache.lucene.index.SegmentInfos, org.apache.lucene.index.MergePolicy.MergeContext)}),
-   * a timeout (in milliseconds) can be set for those merges to finish. Use {@code <maxCommitMergeWait>1000</maxCommitMergeWait>} in the {@code <indexConfig>} section.
+   * a timeout (in milliseconds) can be set for those merges to finish. Use {@code <maxCommitMergeWaitTime>1000</maxCommitMergeWaitTime>} in the {@code <indexConfig>} section.
    * See {@link IndexWriterConfig#setMaxCommitMergeWaitMillis(long)}.
    * </p>
    * <p>
@@ -145,7 +145,7 @@ public class SolrIndexConfig implements MapSerializable {
     useCompoundFile = solrConfig.getBool(prefix+"/useCompoundFile", def.useCompoundFile);
     maxBufferedDocs = solrConfig.getInt(prefix+"/maxBufferedDocs", def.maxBufferedDocs);
     ramBufferSizeMB = solrConfig.getDouble(prefix+"/ramBufferSizeMB", def.ramBufferSizeMB);
-    maxCommitMergeWaitMillis = solrConfig.getInt(prefix+"/maxCommitMergeWait", def.maxCommitMergeWaitMillis);
+    maxCommitMergeWaitMillis = solrConfig.getInt(prefix+"/maxCommitMergeWaitTime", def.maxCommitMergeWaitMillis);
 
     // how do we validate the value??
     ramPerThreadHardLimitMB = solrConfig.getInt(prefix+"/ramPerThreadHardLimitMB", def.ramPerThreadHardLimitMB);
@@ -200,7 +200,7 @@ public class SolrIndexConfig implements MapSerializable {
         "maxBufferedDocs", maxBufferedDocs,
         "ramBufferSizeMB", ramBufferSizeMB,
         "ramPerThreadHardLimitMB", ramPerThreadHardLimitMB,
-        "maxCommitMergeWait", maxCommitMergeWaitMillis,
+        "maxCommitMergeWaitTime", maxCommitMergeWaitMillis,
         "writeLockTimeout", writeLockTimeout,
         "lockType", lockType,
         "infoStreamEnabled", infoStream != InfoStream.NO_OUTPUT);

--- a/solr/core/src/java/org/apache/solr/update/SolrIndexConfig.java
+++ b/solr/core/src/java/org/apache/solr/update/SolrIndexConfig.java
@@ -69,12 +69,18 @@ public class SolrIndexConfig implements MapSerializable {
   public final double ramBufferSizeMB;
   public final int ramPerThreadHardLimitMB;
   /**
+   * <p>
    * When using a custom merge policy that allows triggering synchronous merges on commit
    * (see {@link MergePolicy#findFullFlushMerges(org.apache.lucene.index.MergeTrigger, org.apache.lucene.index.SegmentInfos, org.apache.lucene.index.MergePolicy.MergeContext)}),
-   * a timeout (in seconds) can be set for those merges to finish. Use {@code <maxCommitMergeWaitSeconds>10</maxCommitMergeWaitSeconds>} in the {@code <indexConfig>} section.
-   * See {@link IndexWriterConfig#setMaxCommitMergeWaitSeconds(long)}.
+   * a timeout (in milliseconds) can be set for those merges to finish. Use {@code <maxCommitMergeWait>1000</maxCommitMergeWait>} in the {@code <indexConfig>} section.
+   * See {@link IndexWriterConfig#setMaxCommitMergeWaitMillis(long)}.
+   * </p>
+   * <p>
+   * Note that as of Solr 8.6, no {@code MergePolicy} shipped with Lucene/Solr make use of
+   * {@code MergePolicy.findFullFlushMerges}, which means this setting has no effect unless a custom {@code MergePolicy} is used.
+   * </p> 
    */
-  public final int maxCommitMergeWaitSeconds;
+  public final int maxCommitMergeWaitMillis;
 
   public final int writeLockTimeout;
   public final String lockType;
@@ -94,7 +100,7 @@ public class SolrIndexConfig implements MapSerializable {
     maxBufferedDocs = -1;
     ramBufferSizeMB = 100;
     ramPerThreadHardLimitMB = -1;
-    maxCommitMergeWaitSeconds = -1;
+    maxCommitMergeWaitMillis = -1;
     writeLockTimeout = -1;
     lockType = DirectoryFactory.LOCK_TYPE_NATIVE;
     mergePolicyFactoryInfo = null;
@@ -139,7 +145,7 @@ public class SolrIndexConfig implements MapSerializable {
     useCompoundFile = solrConfig.getBool(prefix+"/useCompoundFile", def.useCompoundFile);
     maxBufferedDocs = solrConfig.getInt(prefix+"/maxBufferedDocs", def.maxBufferedDocs);
     ramBufferSizeMB = solrConfig.getDouble(prefix+"/ramBufferSizeMB", def.ramBufferSizeMB);
-    maxCommitMergeWaitSeconds = solrConfig.getInt(prefix+"/maxCommitMergeWaitSeconds", def.maxCommitMergeWaitSeconds);
+    maxCommitMergeWaitMillis = solrConfig.getInt(prefix+"/maxCommitMergeWait", def.maxCommitMergeWaitMillis);
 
     // how do we validate the value??
     ramPerThreadHardLimitMB = solrConfig.getInt(prefix+"/ramPerThreadHardLimitMB", def.ramPerThreadHardLimitMB);
@@ -194,7 +200,7 @@ public class SolrIndexConfig implements MapSerializable {
         "maxBufferedDocs", maxBufferedDocs,
         "ramBufferSizeMB", ramBufferSizeMB,
         "ramPerThreadHardLimitMB", ramPerThreadHardLimitMB,
-        "maxCommitMergeWaitSeconds", maxCommitMergeWaitSeconds,
+        "maxCommitMergeWait", maxCommitMergeWaitMillis,
         "writeLockTimeout", writeLockTimeout,
         "lockType", lockType,
         "infoStreamEnabled", infoStream != InfoStream.NO_OUTPUT);
@@ -241,8 +247,8 @@ public class SolrIndexConfig implements MapSerializable {
       iwc.setRAMPerThreadHardLimitMB(ramPerThreadHardLimitMB);
     }
     
-    if (maxCommitMergeWaitSeconds > 0) {
-      iwc.setMaxCommitMergeWaitSeconds(maxCommitMergeWaitSeconds);
+    if (maxCommitMergeWaitMillis > 0) {
+      iwc.setMaxCommitMergeWaitMillis(maxCommitMergeWaitMillis);
     }
 
     iwc.setSimilarity(schema.getSimilarity());

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig.snippet.randomindexconfig.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig.snippet.randomindexconfig.xml
@@ -32,7 +32,7 @@ A solrconfig.xml snippet containing indexConfig settings for randomized testing.
 
   <maxBufferedDocs>${solr.tests.maxBufferedDocs}</maxBufferedDocs>
   <ramBufferSizeMB>${solr.tests.ramBufferSizeMB}</ramBufferSizeMB>
-  <maxCommitMergeWait>${solr.tests.maxCommitMergeWait:-1}</maxCommitMergeWait>
+  <maxCommitMergeWaitTime>${solr.tests.maxCommitMergeWaitTime:-1}</maxCommitMergeWaitTime>
   <ramPerThreadHardLimitMB>${solr.tests.ramPerThreadHardLimitMB}</ramPerThreadHardLimitMB>
 
   <mergeScheduler class="${solr.tests.mergeScheduler}" />

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig.snippet.randomindexconfig.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig.snippet.randomindexconfig.xml
@@ -32,6 +32,7 @@ A solrconfig.xml snippet containing indexConfig settings for randomized testing.
 
   <maxBufferedDocs>${solr.tests.maxBufferedDocs}</maxBufferedDocs>
   <ramBufferSizeMB>${solr.tests.ramBufferSizeMB}</ramBufferSizeMB>
+  <maxCommitMergeWaitSeconds>${solr.tests.maxCommitMergeWaitSeconds:-1}</maxCommitMergeWaitSeconds>
   <ramPerThreadHardLimitMB>${solr.tests.ramPerThreadHardLimitMB}</ramPerThreadHardLimitMB>
 
   <mergeScheduler class="${solr.tests.mergeScheduler}" />

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig.snippet.randomindexconfig.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig.snippet.randomindexconfig.xml
@@ -32,7 +32,7 @@ A solrconfig.xml snippet containing indexConfig settings for randomized testing.
 
   <maxBufferedDocs>${solr.tests.maxBufferedDocs}</maxBufferedDocs>
   <ramBufferSizeMB>${solr.tests.ramBufferSizeMB}</ramBufferSizeMB>
-  <maxCommitMergeWaitSeconds>${solr.tests.maxCommitMergeWaitSeconds:-1}</maxCommitMergeWaitSeconds>
+  <maxCommitMergeWait>${solr.tests.maxCommitMergeWait:-1}</maxCommitMergeWait>
   <ramPerThreadHardLimitMB>${solr.tests.ramPerThreadHardLimitMB}</ramPerThreadHardLimitMB>
 
   <mergeScheduler class="${solr.tests.mergeScheduler}" />

--- a/solr/core/src/test/org/apache/solr/update/SolrIndexConfigTest.java
+++ b/solr/core/src/test/org/apache/solr/update/SolrIndexConfigTest.java
@@ -178,7 +178,7 @@ public class SolrIndexConfigTest extends SolrTestCaseJ4 {
 
     ++mSizeExpected; assertTrue(m.get("ramBufferSizeMB") instanceof Double);
     
-    ++mSizeExpected; assertTrue(m.get("maxCommitMergeWaitSeconds") instanceof Integer);
+    ++mSizeExpected; assertTrue(m.get("maxCommitMergeWait") instanceof Integer);
 
     ++mSizeExpected; assertTrue(m.get("ramPerThreadHardLimitMB") instanceof Integer);
 
@@ -213,13 +213,13 @@ public class SolrIndexConfigTest extends SolrTestCaseJ4 {
   
   public void testMaxCommitMergeWaitSeconds() throws Exception {
     SolrConfig sc = new SolrConfig(TEST_PATH().resolve("collection1"), "solrconfig-test-misc.xml");
-    assertEquals(-1, sc.indexConfig.maxCommitMergeWaitSeconds);
-    assertEquals(IndexWriterConfig.DEFAULT_MAX_COMMIT_MERGE_WAIT_SECONDS, sc.indexConfig.toIndexWriterConfig(h.getCore()).getMaxCommitMergeWaitSeconds());
-    System.setProperty("solr.tests.maxCommitMergeWaitSeconds", "10");
+    assertEquals(-1, sc.indexConfig.maxCommitMergeWaitMillis);
+    assertEquals(IndexWriterConfig.DEFAULT_MAX_COMMIT_MERGE_WAIT_MILLIS, sc.indexConfig.toIndexWriterConfig(h.getCore()).getMaxCommitMergeWaitMillis());
+    System.setProperty("solr.tests.maxCommitMergeWait", "10");
     sc = new SolrConfig(TEST_PATH().resolve("collection1"), "solrconfig-test-misc.xml");
-    assertEquals(10, sc.indexConfig.maxCommitMergeWaitSeconds);
-    assertEquals(10, sc.indexConfig.toIndexWriterConfig(h.getCore()).getMaxCommitMergeWaitSeconds());
-    System.clearProperty("solr.tests.maxCommitMergeWaitSeconds");
+    assertEquals(10, sc.indexConfig.maxCommitMergeWaitMillis);
+    assertEquals(10, sc.indexConfig.toIndexWriterConfig(h.getCore()).getMaxCommitMergeWaitMillis());
+    System.clearProperty("solr.tests.maxCommitMergeWait");
     
   }
 }

--- a/solr/core/src/test/org/apache/solr/update/SolrIndexConfigTest.java
+++ b/solr/core/src/test/org/apache/solr/update/SolrIndexConfigTest.java
@@ -177,6 +177,8 @@ public class SolrIndexConfigTest extends SolrTestCaseJ4 {
     ++mSizeExpected; assertTrue(m.get("maxBufferedDocs") instanceof Integer);
 
     ++mSizeExpected; assertTrue(m.get("ramBufferSizeMB") instanceof Double);
+    
+    ++mSizeExpected; assertTrue(m.get("maxCommitMergeWaitSeconds") instanceof Integer);
 
     ++mSizeExpected; assertTrue(m.get("ramPerThreadHardLimitMB") instanceof Integer);
 
@@ -207,5 +209,17 @@ public class SolrIndexConfigTest extends SolrTestCaseJ4 {
     ++mSizeExpected; assertNotNull(m.get("metrics"));
 
     assertEquals(mSizeExpected, m.size());
+  }
+  
+  public void testMaxCommitMergeWaitSeconds() throws Exception {
+    SolrConfig sc = new SolrConfig(TEST_PATH().resolve("collection1"), "solrconfig-test-misc.xml");
+    assertEquals(-1, sc.indexConfig.maxCommitMergeWaitSeconds);
+    assertEquals(IndexWriterConfig.DEFAULT_MAX_COMMIT_MERGE_WAIT_SECONDS, sc.indexConfig.toIndexWriterConfig(h.getCore()).getMaxCommitMergeWaitSeconds());
+    System.setProperty("solr.tests.maxCommitMergeWaitSeconds", "10");
+    sc = new SolrConfig(TEST_PATH().resolve("collection1"), "solrconfig-test-misc.xml");
+    assertEquals(10, sc.indexConfig.maxCommitMergeWaitSeconds);
+    assertEquals(10, sc.indexConfig.toIndexWriterConfig(h.getCore()).getMaxCommitMergeWaitSeconds());
+    System.clearProperty("solr.tests.maxCommitMergeWaitSeconds");
+    
   }
 }

--- a/solr/core/src/test/org/apache/solr/update/SolrIndexConfigTest.java
+++ b/solr/core/src/test/org/apache/solr/update/SolrIndexConfigTest.java
@@ -36,6 +36,7 @@ import org.apache.solr.core.TestMergePolicyConfig;
 import org.apache.solr.index.SortingMergePolicy;
 import org.apache.solr.schema.IndexSchema;
 import org.apache.solr.schema.IndexSchemaFactory;
+import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -56,6 +57,12 @@ public class SolrIndexConfigTest extends SolrTestCaseJ4 {
   @BeforeClass
   public static void beforeClass() throws Exception {
     initCore(solrConfigFileName,schemaFileName);
+  }
+  
+  @After
+  public void tearDown() throws Exception {
+    System.clearProperty("solr.tests.maxCommitMergeWait");
+    super.tearDown();
   }
   
   private final Path instanceDir = TEST_PATH().resolve("collection1");
@@ -178,7 +185,7 @@ public class SolrIndexConfigTest extends SolrTestCaseJ4 {
 
     ++mSizeExpected; assertTrue(m.get("ramBufferSizeMB") instanceof Double);
     
-    ++mSizeExpected; assertTrue(m.get("maxCommitMergeWait") instanceof Integer);
+    ++mSizeExpected; assertTrue(m.get("maxCommitMergeWaitTime") instanceof Integer);
 
     ++mSizeExpected; assertTrue(m.get("ramPerThreadHardLimitMB") instanceof Integer);
 
@@ -211,15 +218,13 @@ public class SolrIndexConfigTest extends SolrTestCaseJ4 {
     assertEquals(mSizeExpected, m.size());
   }
   
-  public void testMaxCommitMergeWaitSeconds() throws Exception {
+  public void testMaxCommitMergeWaitTime() throws Exception {
     SolrConfig sc = new SolrConfig(TEST_PATH().resolve("collection1"), "solrconfig-test-misc.xml");
     assertEquals(-1, sc.indexConfig.maxCommitMergeWaitMillis);
     assertEquals(IndexWriterConfig.DEFAULT_MAX_COMMIT_MERGE_WAIT_MILLIS, sc.indexConfig.toIndexWriterConfig(h.getCore()).getMaxCommitMergeWaitMillis());
-    System.setProperty("solr.tests.maxCommitMergeWait", "10");
+    System.setProperty("solr.tests.maxCommitMergeWaitTime", "10");
     sc = new SolrConfig(TEST_PATH().resolve("collection1"), "solrconfig-test-misc.xml");
     assertEquals(10, sc.indexConfig.maxCommitMergeWaitMillis);
     assertEquals(10, sc.indexConfig.toIndexWriterConfig(h.getCore()).getMaxCommitMergeWaitMillis());
-    System.clearProperty("solr.tests.maxCommitMergeWait");
-    
   }
 }


### PR DESCRIPTION
LUCENE-8962 added the ability to merge segments synchronously on commit. This isn't done by default and the default MergePolicy won't do it, but custom merge policies can take advantage of this. Solr allows plugging in custom merge policies, so if someone wants to make use of this feature they could, however, they need to set IndexWriterConfig.maxCommitMergeWaitSeconds to something greater than 0.
Since this is an expert feature, I plan to document it only in javadoc and not the ref guide.