### PR TITLE
SOLR-14546: add a Bug Fixes section for Solr 9.0.0 in CHANGES.txt

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -79,6 +79,8 @@ Other Changes
 * SOLR-12823: Remove /clusterstate.json support, including support for collections created with stateFormat=1,
   as well as support for Collection API MIGRATESTATEFORMAT action and support for the legacyCloud flag (Ilan Ginzburg).
 
+Bug Fixes
+---------------------
 * SOLR-14546: Fix for a relatively hard to hit issue in OverseerTaskProcessor that could lead to out of order execution
   of Collection API tasks competing for a lock (Ilan Ginzburg).
 


### PR DESCRIPTION
# Description

Add a "Bug Fixes" section in the Solr 9.0.0 section in CHANGES.txt and move the fix to SOLR-14546 into it.

# Solution

Text edit.

