### PR TITLE
SOLR-11390 Trie* field javadocs to @see *Point

### DIFF
--- a/solr/core/src/java/org/apache/solr/schema/DatePointField.java
+++ b/solr/core/src/java/org/apache/solr/schema/DatePointField.java
@@ -97,7 +97,6 @@ import org.apache.solr.util.DateMathParser;
  * acronym UTC was chosen as a compromise."
  * </blockquote>
  *
- * @see TrieDateField
  * @see PointField
  */
 public class DatePointField extends PointField implements DateValueFieldType {

--- a/solr/core/src/java/org/apache/solr/schema/PointField.java
+++ b/solr/core/src/java/org/apache/solr/schema/PointField.java
@@ -62,7 +62,7 @@ public abstract class PointField extends NumericFieldType {
   /**
    * <p>
    * The Test framework can set this global variable to instruct PointField that
-   * (on init) it should be tollerant of the <code>precisionStep</code> argument used by TrieFields.
+   * (on init) it should be tolerant of the <code>precisionStep</code> argument used by TrieFields.
    * This allows for simple randomization of TrieFields and PointFields w/o extensive duplication
    * of <code>&lt;fieldType/&gt;</code> declarations.
    * </p>

--- a/solr/core/src/java/org/apache/solr/schema/TrieDateField.java
+++ b/solr/core/src/java/org/apache/solr/schema/TrieDateField.java
@@ -82,6 +82,7 @@ import org.apache.solr.util.DateMathParser;
  *
  * @see TrieField
  * @deprecated Trie fields are deprecated as of Solr 7.0
+ * @see DatePointField
  */
 @Deprecated
 public class TrieDateField extends TrieField implements DateValueFieldType {

--- a/solr/core/src/java/org/apache/solr/schema/TrieDoubleField.java
+++ b/solr/core/src/java/org/apache/solr/schema/TrieDoubleField.java
@@ -50,6 +50,7 @@ import org.apache.lucene.util.mutable.MutableValueDouble;
  * @see Double
  * @see <a href="http://java.sun.com/docs/books/jls/third_edition/html/typesValues.html#4.2.3">Java Language Specification, s4.2.3</a>
  * @deprecated Trie fields are deprecated as of Solr 7.0
+ * @see DoublePointField
  */
 @Deprecated
 public class TrieDoubleField extends TrieField implements DoubleValueFieldType {

--- a/solr/core/src/java/org/apache/solr/schema/TrieField.java
+++ b/solr/core/src/java/org/apache/solr/schema/TrieField.java
@@ -81,6 +81,7 @@ import org.slf4j.LoggerFactory;
  * @see org.apache.solr.legacy.LegacyNumericRangeQuery
  * @since solr 1.4
  * @deprecated Trie fields are deprecated as of Solr 7.0
+ * @see PointField
  */
 @Deprecated
 public class TrieField extends NumericFieldType {

--- a/solr/core/src/java/org/apache/solr/schema/TrieFloatField.java
+++ b/solr/core/src/java/org/apache/solr/schema/TrieFloatField.java
@@ -50,6 +50,7 @@ import org.apache.lucene.util.mutable.MutableValueFloat;
  * @see Float
  * @see <a href="http://java.sun.com/docs/books/jls/third_edition/html/typesValues.html#4.2.3">Java Language Specification, s4.2.3</a>
  * @deprecated Trie fields are deprecated as of Solr 7.0
+ * @see FloatPointField
  */
 @Deprecated
 public class TrieFloatField extends TrieField implements FloatValueFieldType {

--- a/solr/core/src/java/org/apache/solr/schema/TrieIntField.java
+++ b/solr/core/src/java/org/apache/solr/schema/TrieIntField.java
@@ -43,6 +43,7 @@ import org.apache.lucene.util.mutable.MutableValueInt;
  * 
  * @see Integer
  * @deprecated Trie fields are deprecated as of Solr 7.0
+ * @see IntPointField
  */
 @Deprecated
 public class TrieIntField extends TrieField implements IntValueFieldType {

--- a/solr/core/src/java/org/apache/solr/schema/TrieLongField.java
+++ b/solr/core/src/java/org/apache/solr/schema/TrieLongField.java
@@ -43,6 +43,7 @@ import org.apache.lucene.util.mutable.MutableValueLong;
  * 
  * @see Long
  * @deprecated Trie fields are deprecated as of Solr 7.0
+ * @see LongPointField
  */
 @Deprecated
 public class TrieLongField extends TrieField implements LongValueFieldType {

--- a/solr/core/src/test/org/apache/solr/schema/WrappedTrieIntField.java
+++ b/solr/core/src/test/org/apache/solr/schema/WrappedTrieIntField.java
@@ -21,6 +21,7 @@ import org.apache.lucene.search.SortField;
 /**
  * Custom field wrapping an int, to test sorting via a custom comparator.
  * @deprecated Trie fields are deprecated as of Solr 7.0
+ * @see WrappedIntPointField
  */
 @Deprecated
 public class WrappedTrieIntField extends TrieIntField {


### PR DESCRIPTION
cc: @cpoerschke I can't tag you as a reviewer for some reason, but this is based on your patch and I added two more changes - fixed spelling and removed back link from DatePoint to TrieDate.