### PR TITLE
LUCENE-8962: Merge segments on getReader

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/MergeTrigger.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergeTrigger.java
@@ -53,4 +53,8 @@ public enum MergeTrigger {
    * Merge was triggered on commit.
    */
   COMMIT,
+  /**
+   * Merge was triggered on opening NRT readers.
+   */
+  GET_READER,
 }


### PR DESCRIPTION
Add IndexWriter merge-on-refresh feature to selectively merge small segments on getReader, subject to a configurable timeout, to improve search performance by reducing the number of small segments for searching.
