### PR TITLE
SOLR-14619 avoid SolrIndexSearcher.getDocSet(q)

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/SpellCheckComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SpellCheckComponent.java
@@ -243,6 +243,7 @@ public class SpellCheckComponent extends SearchComponent implements SolrCoreAwar
           if (maxResultsFilterQueryString != null) {
             // Get the default Lucene query parser
             QParser parser = QParser.getParser(maxResultsFilterQueryString, rb.req);
+            // typically this should be cached for good perf
             DocSet s = searcher.getDocSet(parser.getQuery());
             maxResultsByFilters = s.size();
           } else {

--- a/solr/core/src/java/org/apache/solr/handler/component/TermsComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/TermsComponent.java
@@ -625,8 +625,7 @@ public class TermsComponent extends SearchComponent {
 
       if (fieldType.isPointField()) {
         for (String term : splitTerms) {
-          Query q = fieldType.getFieldQuery(null, sf, term);
-          int count = indexSearcher.getDocSet(q).size();
+          int count = indexSearcher.count(fieldType.getFieldQuery(null, sf, term));
           termsMap.add(term, count);
         }
       } else {

--- a/solr/core/src/java/org/apache/solr/search/BitDocSet.java
+++ b/solr/core/src/java/org/apache/solr/search/BitDocSet.java
@@ -242,7 +242,7 @@ public class BitDocSet extends DocSet {
     // TODO: if cardinality isn't cached, do a quick measure of sparseness
     // and return null from bits() if too sparse.
 
-    return new Filter() {
+    return new DocSetTopFilter() {
       final FixedBitSet bs = bits;
 
       @Override

--- a/solr/core/src/java/org/apache/solr/search/DocSet.java
+++ b/solr/core/src/java/org/apache/solr/search/DocSet.java
@@ -109,9 +109,7 @@ public abstract class DocSet implements Accountable, Cloneable /* extends Collec
   }
 
   /**
-   * Returns a Filter for use in Lucene search methods, assuming this DocSet
-   * was generated from the top-level MultiReader that the Lucene search
-   * methods will be invoked with.
+   * Returns a Query that matches the documents in this set.  It implements {@link DocSetProducer}.
    */
   public abstract Filter getTopFilter();
 
@@ -137,4 +135,11 @@ public abstract class DocSet implements Accountable, Cloneable /* extends Collec
   // internal only
   protected abstract FixedBitSet getFixedBitSetClone();
 
+  // internal only
+  abstract class DocSetTopFilter extends Filter implements DocSetProducer {
+    @Override
+    public final DocSet createDocSet(SolrIndexSearcher searcher) {
+      return DocSet.this;
+    }
+  }
 }

--- a/solr/core/src/java/org/apache/solr/search/SortedIntDocSet.java
+++ b/solr/core/src/java/org/apache/solr/search/SortedIntDocSet.java
@@ -673,7 +673,7 @@ public class SortedIntDocSet extends DocSet {
 
   @Override
   public Filter getTopFilter() {
-    return new Filter() {
+    return new DocSetTopFilter() {
       int lastEndIdx = 0;
 
       @Override

--- a/solr/core/src/java/org/apache/solr/search/join/GraphQuery.java
+++ b/solr/core/src/java/org/apache/solr/search/join/GraphQuery.java
@@ -248,7 +248,7 @@ public class GraphQuery extends Query {
       BooleanQuery.Builder leafNodeQuery = new BooleanQuery.Builder();
       Query edgeQuery = collectSchemaField.hasDocValues() ? new DocValuesFieldExistsQuery(field) : new WildcardQuery(new Term(field, "*"));
       leafNodeQuery.add(edgeQuery, Occur.MUST_NOT);
-      DocSet leafNodes = fromSearcher.getDocSet(leafNodeQuery.build());
+      DocSet leafNodes = fromSearcher.getDocSet(leafNodeQuery.build()); // caches
       return leafNodes;
     }
     

--- a/solr/core/src/java/org/apache/solr/util/SolrPluginUtils.java
+++ b/solr/core/src/java/org/apache/solr/util/SolrPluginUtils.java
@@ -189,6 +189,7 @@ public class SolrPluginUtils {
    * SolrIndexSearch.numDocs(Query,Query) freaks out if the filtering
    * query is null, so we use this workarround.
    */
+  @Deprecated // low-value method; poor implementation
   public static int numDocs(SolrIndexSearcher s, Query q, Query f)
     throws IOException {
 


### PR DESCRIPTION
There are places where we get a DocSet from a query when we don't need to.
Also, improved DocSet.getTopFilter to implement DocSetProducer so as to avoid possible re-construction of the DocSet.
Deprecated SolrPluginUtils.numDocs. Nobody calls it.
Maybe @yonik or @mkhludnev might be interested in code reviewing?
