### PR TITLE
SOLR-14623: Minor Improvements to SolrCloud tests

### DIFF
--- a/solr/core/src/java/org/apache/solr/client/solrj/embedded/JettySolrRunner.java
+++ b/solr/core/src/java/org/apache/solr/client/solrj/embedded/JettySolrRunner.java
@@ -124,6 +124,7 @@ public class JettySolrRunner {
   private String host;
 
   private volatile boolean started = false;
+  private volatile String nodeName;
 
   public static class DebugFilter implements Filter {
     private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -443,10 +444,7 @@ public class JettySolrRunner {
   }
 
   public String getNodeName() {
-    if (getCoreContainer() == null) {
-      return null;
-    }
-    return getCoreContainer().getZkController().getNodeName();
+    return nodeName;
   }
 
   public boolean isRunning() {
@@ -532,6 +530,10 @@ public class JettySolrRunner {
 
     } finally {
       started  = true;
+      if (getCoreContainer() != null && getCoreContainer().isZooKeeperAware()) {
+        this.nodeName = getCoreContainer().getZkController().getNodeName();
+      }
+
       if (prevContext != null)  {
         MDC.setContextMap(prevContext);
       } else {

--- a/solr/core/src/test/org/apache/solr/cloud/TestWaitForStateWithJettyShutdowns.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestWaitForStateWithJettyShutdowns.java
@@ -101,7 +101,7 @@ public class TestWaitForStateWithJettyShutdowns extends SolrTestCaseJ4 {
           try {
             cluster.getSolrClient().waitForState(col_name, 180, TimeUnit.SECONDS,
                                                  new LatchCountingPredicateWrapper(latch,
-                                                                                   clusterShape(1, 0)));
+                                                                                   clusterShape(1, 1)));
           } catch (Exception e) {
             log.error("background thread got exception", e);
             throw new RuntimeException(e);

--- a/solr/core/src/test/org/apache/solr/cloud/UnloadDistributedZkTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/UnloadDistributedZkTest.java
@@ -256,6 +256,8 @@ public class UnloadDistributedZkTest extends BasicDistributedZkTest {
     // ensure there is a leader
     zkStateReader.getLeaderRetry("unloadcollection", "shard1", 15000);
 
+    waitForRecoveriesToFinish("unloadcollection", zkStateReader, false);
+
     try (HttpSolrClient addClient = getHttpSolrClient(jettys.get(1).getBaseUrl() + "/unloadcollection_shard1_replica2", 30000, 90000)) {
 
       // add a few docs while the leader is down

--- a/solr/core/src/test/org/apache/solr/cloud/api/collections/TestCollectionsAPIViaSolrCloudCluster.java
+++ b/solr/core/src/test/org/apache/solr/cloud/api/collections/TestCollectionsAPIViaSolrCloudCluster.java
@@ -205,8 +205,6 @@ public class TestCollectionsAPIViaSolrCloudCluster extends SolrCloudTestCase {
 
     // delete the collection
     CollectionAdminRequest.deleteCollection(collectionName).process(client);
-    AbstractDistribZkTestBase.waitForCollectionToDisappear
-        (collectionName, client.getZkStateReader(), true, 330);
   }
 
   @Test

--- a/solr/core/src/test/org/apache/solr/search/TestRecovery.java
+++ b/solr/core/src/test/org/apache/solr/search/TestRecovery.java
@@ -89,6 +89,8 @@ public class TestRecovery extends SolrTestCaseJ4 {
   @After
   public void afterTest() {
     TestInjection.reset(); // do after every test, don't wait for AfterClass
+    UpdateLog.testing_logReplayHook = null;
+    UpdateLog.testing_logReplayFinishHook = null;
     if (savedFactory == null) {
       System.clearProperty("solr.directoryFactory");
     } else {


### PR DESCRIPTION
Here are some of the changes herein:
1. MiniSolrCloudCluster: Changing the polling to waitForState (based on watch/latch)
2. Improve waiting for Jetty stop, wait until node is not in liveNodes (JettySolrRunner)
3. TestCloudConsistency: Explicitly pick the jetty hosting shard1's leader
4. TestWaitForStateWithJettyShutdowns: Wait until replica becomes active
5. TestCollectionsAPIViaSolrCloudCluster: Don't wait for the collection to be deleted fully at the end
6. TestRecovery: Unset the UpdateLog hooks
