### PR TITLE
LUCENE-9423: Handle exception in NIOFSDirectory#openInput

### DIFF
--- a/lucene/core/src/test/org/apache/lucene/store/TestNIOFSDirectory.java
+++ b/lucene/core/src/test/org/apache/lucene/store/TestNIOFSDirectory.java
@@ -18,7 +18,17 @@ package org.apache.lucene.store;
 
 
 import java.io.IOException;
+import java.net.URI;
+import java.nio.channels.FileChannel;
+import java.nio.file.FileSystem;
+import java.nio.file.OpenOption;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
+import java.util.Set;
+
+import org.apache.lucene.mockfile.FilterFileChannel;
+import org.apache.lucene.mockfile.FilterPath;
+import org.apache.lucene.mockfile.LeakFS;
 
 /**
  * Tests NIOFSDirectory
@@ -28,5 +38,30 @@ public class TestNIOFSDirectory extends BaseDirectoryTestCase {
   @Override
   protected Directory getDirectory(Path path) throws IOException {
     return new NIOFSDirectory(path);
+  }
+
+  public void testHandleExceptionInConstructor() throws Exception {
+    Path path = createTempDir().toRealPath();
+    final LeakFS leakFS = new LeakFS(path.getFileSystem()) {
+      @Override
+      public FileChannel newFileChannel(Path path, Set<? extends OpenOption> options,
+                                        FileAttribute<?>... attrs) throws IOException {
+        return new FilterFileChannel(super.newFileChannel(path, options, attrs)) {
+          @Override
+          public long size() throws IOException {
+            throw new IOException("simulated");
+          }
+        };
+      }
+    };
+    FileSystem fs = leakFS.getFileSystem(URI.create("file:///"));
+    Path wrapped = new FilterPath(path, fs);
+    try (Directory dir = new NIOFSDirectory(wrapped)) {
+      try (IndexOutput out = dir.createOutput("test.bin", IOContext.DEFAULT)) {
+        out.writeString("hello");
+      }
+      final IOException error = expectThrows(IOException.class, () -> dir.openInput("test.bin", IOContext.DEFAULT));
+      assertEquals("simulated", error.getMessage());
+    }
   }
 }


### PR DESCRIPTION
If we fail to get the size of a file in the constructor of NIOFSIndexInput, then we will leak a FileChannel opened in NIOFSDirectory#openInput.