### PR TITLE
SOLR-11208: Usage SynchronousQueue in Executors prevent large scale operations

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/OverseerCollectionMessageHandler.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/OverseerCollectionMessageHandler.java
@@ -28,7 +28,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -170,8 +170,10 @@ public class OverseerCollectionMessageHandler implements OverseerMessageHandler,
   // This is used for handling mutual exclusion of the tasks.
 
   final private LockTree lockTree = new LockTree();
-  ExecutorService tpe = new ExecutorUtil.MDCAwareThreadPoolExecutor(5, 10, 0L, TimeUnit.MILLISECONDS,
-      new SynchronousQueue<>(),
+  // With an unbounded queue such as LinkedBlockingQueue, maximumPoolSize is not used and corePoolSize is the max number
+  // of threads (see ThreadPoolExecutor class Javadoc)
+  ExecutorService tpe = new ExecutorUtil.MDCAwareThreadPoolExecutor(10, 10, 0L, TimeUnit.MILLISECONDS,
+      new LinkedBlockingQueue<>(),
       new SolrNamedThreadFactory("OverseerCollectionMessageHandlerThreadFactory"));
 
   protected static final Random RANDOM;


### PR DESCRIPTION
In `OverseerCollectionMessageHandler` replace the `SynchronousQueue` by a `LinkedBlockingQueue` for handing more jobs to the executor service than there are threads.

Given this is an old Jira, the issue is real, the OP suggested that easy fix almost 3 years ago and nobody implemented it, there might be something I missed here, so will not push that code before somebody reviews it.