### PR TITLE
LUCENE-9427: Ensure unified highlighter considers all terms in fuzzy query.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -136,6 +136,9 @@ Bug fixes
 * LUCENE-9365: FuzzyQuery was missing matches when prefix length was equal to the term length
   (Mark Harwood, Mike Drob)
 
+* LUCENE-9427: Fix a regression where the unified highlighter didn't produce
+  highlights on fuzzy queries that correspond to exact matches. (Julie Tibshirani)
+
 Other
 
 * LUCENE-9391: Upgrade HPPC to 0.8.2. (Haoyu Zhai)

--- a/lucene/core/src/java/org/apache/lucene/search/FuzzyQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FuzzyQuery.java
@@ -159,11 +159,7 @@ public class FuzzyQuery extends MultiTermQuery {
   @Override
   public void visit(QueryVisitor visitor) {
     if (visitor.acceptField(field)) {
-      if (maxEdits == 0 || prefixLength >= term.text().length()) {
-        visitor.consumeTerms(this, term);
-      } else {
-        visitor.consumeTermsMatching(this, term.field(), () -> getAutomata().runAutomaton);
-      }
+      visitor.consumeTermsMatching(this, term.field(), () -> getAutomata().runAutomaton);
     }
   }
 

--- a/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/TestUnifiedHighlighterMTQ.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/TestUnifiedHighlighterMTQ.java
@@ -240,7 +240,7 @@ public class TestUnifiedHighlighterMTQ extends LuceneTestCase {
     ir.close();
   }
 
-  public void testOneFuzzy() throws Exception {
+  public void testFuzzy() throws Exception {
     RandomIndexWriter iw = new RandomIndexWriter(random(), dir, indexAnalyzer);
 
     Field body = new Field("body", "", fieldType);
@@ -267,6 +267,15 @@ public class TestUnifiedHighlighterMTQ extends LuceneTestCase {
 
     // with prefix
     query = new FuzzyQuery(new Term("body", "tets"), 1, 2);
+    topDocs = searcher.search(query, 10, Sort.INDEXORDER);
+    assertEquals(2, topDocs.totalHits.value);
+    snippets = highlighter.highlight("body", query, topDocs);
+    assertEquals(2, snippets.length);
+    assertEquals("This is a <b>test</b>.", snippets[0]);
+    assertEquals("<b>Test</b> a one sentence document.", snippets[1]);
+
+    // with zero max edits
+    query = new FuzzyQuery(new Term("body", "test"), 0, 2);
     topDocs = searcher.search(query, 10, Sort.INDEXORDER);
     assertEquals(2, topDocs.totalHits.value);
     snippets = highlighter.highlight("body", query, topDocs);


### PR DESCRIPTION
This fixes a regression where if a fuzzy query corresponds to an exact match
(for example it has maxEdits: 0), then the unified highlighter doesn't produce
highlights for the matching terms.

The proposed fix is to always pass back an automaton when visiting a fuzzy
query. This seems to match the previous behavior before the regression was
introduced.