### PR TITLE
SOLR-13973: Depricate Tika support in 8.7

### DIFF
--- a/solr/contrib/dataimporthandler-extras/src/java/org/apache/solr/handler/dataimport/TikaEntityProcessor.java
+++ b/solr/contrib/dataimporthandler-extras/src/java/org/apache/solr/handler/dataimport/TikaEntityProcessor.java
@@ -28,6 +28,8 @@ import org.apache.tika.parser.html.IdentityHtmlMapper;
 import org.apache.tika.sax.BodyContentHandler;
 import org.apache.tika.sax.ContentHandlerDecorator;
 import org.apache.tika.sax.XHTMLContentHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
@@ -43,6 +45,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -59,10 +62,12 @@ import static org.apache.solr.handler.dataimport.XPathEntityProcessor.URL;
  * be extracted from a file's metadata, identify
  * the geo field for this information with this attribute:
  * <code>spatialMetadataField</code>
- *
+ * @deprecated since 8.7
  * @since solr 3.1
  */
+@Deprecated
 public class TikaEntityProcessor extends EntityProcessorBase {
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private static Parser EMPTY_PARSER = new EmptyParser();
   private TikaConfig tikaConfig;
   private String format = "text";
@@ -75,6 +80,7 @@ public class TikaEntityProcessor extends EntityProcessorBase {
 
   @Override
   public void init(Context context) {
+    log.warn("Tika support in Solr has been deprecated as of 8.7. See SOLR-13973 for details.");
     super.init(context);
     done = false;
   }

--- a/solr/contrib/langid/src/java/org/apache/solr/update/processor/TikaLanguageIdentifierUpdateProcessor.java
+++ b/solr/contrib/langid/src/java/org/apache/solr/update/processor/TikaLanguageIdentifierUpdateProcessor.java
@@ -34,7 +34,9 @@ import org.slf4j.LoggerFactory;
  * <p>
  * See <a href="http://wiki.apache.org/solr/LanguageDetection">http://wiki.apache.org/solr/LanguageDetection</a>
  * @since 3.5
+ * @deprecated since 8.7
  */
+@Deprecated
 public class TikaLanguageIdentifierUpdateProcessor extends LanguageIdentifierUpdateProcessor {
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());

--- a/solr/contrib/langid/src/java/org/apache/solr/update/processor/TikaLanguageIdentifierUpdateProcessorFactory.java
+++ b/solr/contrib/langid/src/java/org/apache/solr/update/processor/TikaLanguageIdentifierUpdateProcessorFactory.java
@@ -40,7 +40,9 @@ import org.apache.solr.util.plugin.SolrCoreAware;
  * </pre>
  * See <a href="http://wiki.apache.org/solr/LanguageDetection">http://wiki.apache.org/solr/LanguageDetection</a>
  * @since 3.5
+ * @deprecated since 8.7
  */
+@Deprecated
 public class TikaLanguageIdentifierUpdateProcessorFactory extends
         UpdateRequestProcessorFactory implements SolrCoreAware, LangIdParams {
 

--- a/solr/solr-ref-guide/src/solr-upgrade-notes.adoc
+++ b/solr/solr-ref-guide/src/solr-upgrade-notes.adoc
@@ -126,6 +126,10 @@ Work to replace DIH with a community-supported plugin is underway and may be ava
 A community-supported version of this may be available as a plugin in the future.
 For more details, please see https://issues.apache.org/jira/browse/SOLR-14021[SOLR-14021^].
 
+* Tika support in Solr is deprecated and is scheduled to be removed in 9.0.
+A community-supported version of this may be available as a plugin in the future.
+For more details, please see https://issues.apache.org/jira/browse/SOLR-13973[SOLR-13973^].
+
 Users interested in maintaining a feature as a plugin are encouraged to join the https://lucene.apache.org/solr/community.html#mailing-lists-irc[developer mailing list^] to find out more about how to help.
 
 === Solr 8.5

--- a/solr/solr-ref-guide/src/uploading-data-with-solr-cell-using-apache-tika.adoc
+++ b/solr/solr-ref-guide/src/uploading-data-with-solr-cell-using-apache-tika.adoc
@@ -16,6 +16,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+WARNING: Tika support in Solr is deprecated as of 8.7 and maybe be removed in 9.0. See SOLR-13973 for details.
+
 If the documents you need to index are in a binary format, such as Word, Excel, PDFs, etc., Solr includes a request handler which uses http://lucene.apache.org/tika/[Apache Tika] to extract text for indexing to Solr.
 
 Solr uses code from the Tika project to provide a framework for incorporating many different file-format parsers such as http://incubator.apache.org/pdfbox/[Apache PDFBox] and http://poi.apache.org/index.html[Apache POI] into Solr itself.


### PR DESCRIPTION
Tika support in Solr is deprecated and is scheduled to be removed in 9.0.

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

Depricating Tika support in solr verion 8.7

# Solution

Reference guide has been updated and classes have been marked as depricated for tika

# Tests

All tests have been run to confirm to functionality is broken
# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [ ] I have added tests for my changes.
- [x] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
