### PR TITLE
Use FileSystem.newInstance instead of get in HDFSBackupRepository

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/backup/repository/HdfsBackupRepository.java
+++ b/solr/core/src/java/org/apache/solr/core/backup/repository/HdfsBackupRepository.java
@@ -98,7 +98,7 @@ public class HdfsBackupRepository implements BackupRepository {
     }
 
     try {
-      this.fileSystem = FileSystem.get(this.baseHdfsPath.toUri(), this.hdfsConfig);
+      this.fileSystem = FileSystem.newInstance(this.baseHdfsPath.toUri(), this.hdfsConfig);
     } catch (IOException e) {
       throw new SolrException(ErrorCode.SERVER_ERROR, e);
     }


### PR DESCRIPTION
FileSystem.get can cause FileSystem closed exceptions, especially with S3. Using FileSystem.newInstance should help that case.