### PR TITLE
SOLR-14675: CloudHttp2SolrClient async request method

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/BaseCloudSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/BaseCloudSolrClient.java
@@ -848,7 +848,7 @@ public abstract class BaseCloudSolrClient extends SolrClient {
    *
    * @return A {@link NamedList} with the response if sync, or a {@link NamedList} containing a single Cancellable object if async
    */
-  NamedList<Object> makeRequest(@SuppressWarnings({"rawtypes"}) SolrRequest request,
+  NamedList<Object> makeRequest(SolrRequest<?> request,
                                 String collection,
                                 AsyncListener<LBSolrClient.Rsp> asyncListener) throws SolrServerException, IOException {
     // the collection parameter of the request overrides that of the parameter to this method
@@ -868,7 +868,7 @@ public abstract class BaseCloudSolrClient extends SolrClient {
    * there's a chance that the request will fail due to cached stale state,
    * which means the state must be refreshed from ZK and retried.
    */
-  protected NamedList<Object> requestWithRetryOnStaleState(@SuppressWarnings({"rawtypes"})SolrRequest request,
+  protected NamedList<Object> requestWithRetryOnStaleState(SolrRequest<?> request,
                                                            int retryCount,
                                                            List<String> inputCollections,
                                                            AsyncListener<LBSolrClient.Rsp> asyncListener) throws SolrServerException, IOException {
@@ -1055,7 +1055,7 @@ public abstract class BaseCloudSolrClient extends SolrClient {
     return resp;
   }
 
-  protected NamedList<Object> sendRequest(@SuppressWarnings({"rawtypes"})SolrRequest request, List<String> inputCollections, AsyncListener<LBSolrClient.Rsp> asyncListener)
+  protected NamedList<Object> sendRequest(SolrRequest<?> request, List<String> inputCollections, AsyncListener<LBSolrClient.Rsp> asyncListener)
       throws SolrServerException, IOException {
     connect();
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/BaseCloudSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/BaseCloudSolrClient.java
@@ -1178,12 +1178,12 @@ public abstract class BaseCloudSolrClient extends SolrClient {
     if (makeAsyncRequest) {
       // Make request asynchronously, wrap Cancellable in a NamedList to match return type of synchronous request
       NamedList<Object> cancellableWrapper = new NamedList<>();
-      Cancellable cancellable = ((LBHttp2SolrClient) getLbClient()).asyncReq(req, asyncListener);
+      Cancellable cancellable = ((LBHttp2SolrClient) lbSolrClient).asyncReq(req, asyncListener);
       cancellableWrapper.add("asyncCancellable", cancellable);
       return cancellableWrapper;
     } else {
       // Make request synchronously
-      LBSolrClient.Rsp rsp = getLbClient().request(req);
+      LBSolrClient.Rsp rsp = lbSolrClient.request(req);
       return rsp.getResponse();
     }
   }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
@@ -130,7 +130,7 @@ public class CloudHttp2SolrClient  extends BaseCloudSolrClient {
    * @throws IOException If there is a low-level I/O error.
    * @throws SolrServerException if there is an error on the server
    */
-  public Cancellable asyncRequest(@SuppressWarnings({"rawtypes"}) SolrRequest request,
+  public Cancellable asyncRequest(SolrRequest<?> request,
                                   String collection,
                                   AsyncListener<NamedList<Object>> asyncListener) throws SolrServerException, IOException {
     NamedList<Object> cancellableWrapper = this.makeRequest(request, collection, new AsyncListener<>() {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
@@ -23,8 +23,13 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.solr.client.solrj.SolrRequest;
+import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.request.UpdateRequest;
+import org.apache.solr.client.solrj.util.AsyncListener;
+import org.apache.solr.client.solrj.util.Cancellable;
 import org.apache.solr.common.SolrException;
+import org.apache.solr.common.util.NamedList;
 
 /**
  * SolrJ client class to communicate with SolrCloud using Http2SolrClient.
@@ -111,6 +116,25 @@ public class CloudHttp2SolrClient  extends BaseCloudSolrClient {
   @Override
   protected boolean wasCommError(Throwable rootCause) {
     return false;
+  }
+
+  /**
+   * Execute an asynchronous request against a Solr server for a given collection
+   *
+   * @param request the request to execute
+   * @param collection the collection to execute the request against
+   * @param asyncListener the request listener, not null (use a no-op listener instead for async requests with no callback)
+   *
+   * @return a {@link Cancellable} allowing you to cancel execution of the async request
+   *
+   * @throws IOException If there is a low-level I/O error.
+   * @throws SolrServerException if there is an error on the server
+   */
+  public Cancellable asyncRequest(@SuppressWarnings({"rawtypes"}) SolrRequest request,
+                                  String collection,
+                                  AsyncListener<LBSolrClient.Rsp> asyncListener) throws SolrServerException, IOException {
+    NamedList<Object> cancellableWrapper = this.makeRequest(request, collection, asyncListener);
+    return (Cancellable) cancellableWrapper.get("asyncCancellable");
   }
 
   /**

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
@@ -132,8 +132,23 @@ public class CloudHttp2SolrClient  extends BaseCloudSolrClient {
    */
   public Cancellable asyncRequest(@SuppressWarnings({"rawtypes"}) SolrRequest request,
                                   String collection,
-                                  AsyncListener<LBSolrClient.Rsp> asyncListener) throws SolrServerException, IOException {
-    NamedList<Object> cancellableWrapper = this.makeRequest(request, collection, asyncListener);
+                                  AsyncListener<NamedList<Object>> asyncListener) throws SolrServerException, IOException {
+    NamedList<Object> cancellableWrapper = this.makeRequest(request, collection, new AsyncListener<>() {
+      @Override
+      public void onStart() {
+        asyncListener.onStart();
+      }
+
+      @Override
+      public void onSuccess(LBSolrClient.Rsp rsp) {
+        asyncListener.onSuccess(rsp.getResponse());
+      }
+
+      @Override
+      public void onFailure(Throwable throwable) {
+        asyncListener.onFailure(throwable);
+      }
+    });
     return (Cancellable) cancellableWrapper.get("asyncCancellable");
   }
 

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/CloudHttp2SolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/CloudHttp2SolrClientTest.java
@@ -1088,9 +1088,9 @@ public class CloudHttp2SolrClientTest extends SolrCloudTestCase {
     CollectionAdminRequest.createCollection(collectionName, "conf", 2, 1).process(cluster.getSolrClient());
     cluster.waitForActiveCollection(collectionName, 2, 2);
 
-    AsyncListener callback = new AsyncListener() {
+    AsyncListener<LBHttp2SolrClient.Rsp> callback = new AsyncListener<>() {
       @Override
-      public void onSuccess(Object o) { asyncCallbackRun = true; }
+      public void onSuccess(LBHttp2SolrClient.Rsp rsp) { asyncCallbackRun = true; }
 
       @Override
       public void onFailure(Throwable throwable) { }


### PR DESCRIPTION
<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

As of now, the [Http2SolrClient](https://github.com/apache/lucene-solr/blob/master/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java) and the [LBHttp2SolrClient](https://github.com/apache/lucene-solr/blob/master/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java) both have support for making async requests, but there isn't a way to use these methods from a [CloudHttp2SolrClient](https://github.com/apache/lucene-solr/blob/master/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java). My change introduces an async request method to the CloudHttp2SolrClient which internally calls the LBHttp2SolrClient's async request method, and returns a Cancellable.

# Solution

I created a new method `CloudHttp2SolrClient#asyncRequest(SolrRequest request, String collection, AsyncListener<NamedList<Object>> asyncListener)` which makes an async request. In BaseCloudSolrClient, I modified `requestWithRetryOnStaleState` and `sendRequest` to take in an AsyncListener parameter, and they check if the listener is null or not to determine whether or not to make an async request. To return a Cancellable in the asyncRequest without changing the return type of the BaseCloudSolrClient request methods, the `BaseCloudSolrClient#makeRequest` method returns a NamedList containing the Cancellable object to be returned by the CloudHttp2SolrClient's asyncRequest method.

# Tests

I have added a test to [CloudHttp2SolrClientTest.java](https://github.com/apache/lucene-solr/blob/master/solr/solrj/src/test/org/apache/solr/client/solrj/impl/CloudHttp2SolrClientTest.java) that confirms that successful async requests result in an `onSuccess()` callback method being run. This test only serves to confirm that async requests properly branch to the `LBHttp2SolrClient.asyncReq()` method; it doesn't check the correctness of the response (i.e. it assumes that `LBHttp2SolrClient.asyncReq()` works correctly).

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
