### PR TITLE
LUCENE-9321: Fix Javadoc offline link base url for snapshot build

### DIFF
--- a/gradle/documentation/documentation.gradle
+++ b/gradle/documentation/documentation.gradle
@@ -22,16 +22,20 @@ configure(rootProject) {
   ext {
     luceneDocUrl = project.propertyOrDefault('lucene.javadoc.url', {
       if (project.version != project.baseVersion) {
+        // non-release build
         project('lucene').file('build/documentation').toURI().toASCIIString()
       } else {
+        // release build
         "https://lucene.apache.org/core/${urlVersion}"
       }
     }())
 
     solrDocUrl = project.propertyOrDefault('solr.javadoc.url', {
       if (project.version != project.baseVersion) {
+        // non-release build
         project('solr').file('build/documentation').toURI().toASCIIString()
       } else {
+        // release build
         "https://lucene.apache.org/solr/${urlVersion}"
       }
     }())

--- a/gradle/documentation/documentation.gradle
+++ b/gradle/documentation/documentation.gradle
@@ -18,10 +18,24 @@
 configure(rootProject) {
   def urlVersion = project.baseVersion.replace('.', '_')
   def refguideUrlVersion = project.baseVersion.replaceFirst(/^(\d+)\.(\d+).*$/, '$1_$2')
-  
+
   ext {
-    luceneDocUrl = project.propertyOrDefault('lucene.javadoc.url', "https://lucene.apache.org/core/${urlVersion}")
-    solrDocUrl = project.propertyOrDefault('solr.javadoc.url', "https://lucene.apache.org/solr/${urlVersion}")
+    luceneDocUrl = project.propertyOrDefault('lucene.javadoc.url', {
+      if (project.version != project.baseVersion) {
+        project('lucene').file('build/documentation').toURI().toASCIIString()
+      } else {
+        "https://lucene.apache.org/core/${urlVersion}"
+      }
+    }())
+
+    solrDocUrl = project.propertyOrDefault('solr.javadoc.url', {
+      if (project.version != project.baseVersion) {
+        project('solr').file('build/documentation').toURI().toASCIIString()
+      } else {
+        "https://lucene.apache.org/solr/${urlVersion}"
+      }
+    }())
+
     solrRefguideUrl = project.propertyOrDefault('solr.refguide.url', "https://lucene.apache.org/solr/guide/${refguideUrlVersion}")
   }
 

--- a/gradle/documentation/render-javadoc.gradle
+++ b/gradle/documentation/render-javadoc.gradle
@@ -213,23 +213,28 @@ class RenderJavadocTask extends DefaultTask {
     // - find all (enabled) tasks this tasks depends on (with same name), calling findRenderTasksInDependencies()
     // - sort the tasks preferring those whose project name equals 'core', then lexigraphical by path
     // - for each task get output dir to create relative or absolute link
-    findRenderTasksInDependencies()
-      .sort(false, Comparator.comparing{ (it.project.name != 'core') as Boolean }.thenComparing(Comparator.comparing{ it.path }))
-      .each{ otherTask ->
-        def otherProject = otherTask.project
-        // For relative links we compute the actual relative link between projects.
-        def crossLuceneSolr = (otherProject.docroot != project.docroot)
-        if (relativeProjectLinks && !crossLuceneSolr) {
-          def pathTo = otherTask.outputDir.toPath().toAbsolutePath()
-          def pathFrom = outputDir.toPath().toAbsolutePath()
-          def relative = pathFrom.relativize(pathTo).toString().replace(File.separator, '/')
-          opts << [ '-link', relative ]
-        } else {
-          // For absolute links, we determine the target URL by assembling the full URL.
-          def base = otherProject.path.startsWith(":lucene") ? luceneDocUrl : solrDocUrl
-          allOfflineLinks.put("${base}/${otherProject.relativeDocPath}/".toString(), otherTask.outputDir)
+    // NOTE: explicitly exclude solr/test-framework, or attempting to link to lucene-test-framework because if we did javadoc would
+    // attempt to link class refs in in org.apache.lucene, causing broken links. (either broken links to things like "Directory" if
+    // lucene-test-framework was first, or broken links to things like LuceneTestCase if lucene-core was first)
+    if (project.path != ':solr:test-framework') {  //
+      findRenderTasksInDependencies()
+        .sort(false, Comparator.comparing { (it.project.name != 'core') as Boolean }.thenComparing(Comparator.comparing { it.path }))
+        .each { otherTask ->
+          def otherProject = otherTask.project
+          // For relative links we compute the actual relative link between projects.
+          def crossLuceneSolr = (otherProject.docroot != project.docroot)
+          if (relativeProjectLinks && !crossLuceneSolr) {
+            def pathTo = otherTask.outputDir.toPath().toAbsolutePath()
+            def pathFrom = outputDir.toPath().toAbsolutePath()
+            def relative = pathFrom.relativize(pathTo).toString().replace(File.separator, '/')
+            opts << ['-link', relative]
+          } else {
+            // For absolute links, we determine the target URL by assembling the full URL.
+            def base = otherProject.path.startsWith(":lucene") ? luceneDocUrl : solrDocUrl
+            allOfflineLinks.put("${base}/${otherProject.relativeDocPath}/".toString(), otherTask.outputDir)
+          }
         }
-      }
+    }
     
     // Add offline links.
     allOfflineLinks.each { url, dir ->


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/LUCENE-9321

This includes two changes in documentation task.

1. Fix Javadoc offline link base url to make snapshot build pass `checkBrokenLinks`.
2. Explicitly disable cross-project link for `:solr:test-framework`, otherwise broken links are generated due to split package issue.
See: https://github.com/apache/lucene-solr/blob/master/solr/test-framework/build.xml#L59

By applying those changes, `./gradlew :solr:checkBrokenLinks` succeeds on snapshot build.