### PR TITLE
Found that asciidoctor 1.5.6.2 cause build-site to fail on long anchors

### DIFF
--- a/solr/solr-ref-guide/README.adoc
+++ b/solr/solr-ref-guide/README.adoc
@@ -21,13 +21,11 @@ This is the source for the Solr Reference Guide.
 Raw content is stored in Asciidoc (`.adoc`) formatted files in the `src/` directory.
 
 == Prerequisites for Building
-These files are processed with AsciiDoctor in 2 different ways:
+These files are processed with AsciiDoctor.
 
-* HTML version, using Jekyll:
+* HTML is generated using Jekyll with these key dependencies:
 ** `Ruby` (v2.3 or higher)
 ** The following gems must be installed:
-*** `asciidoctor`:v2.0.10 or higher.
-Use `gem install asciidoctor` to install.
 *** `jekyll`: v3.5, not v4.x.
 Use `gem install jekyll --force --version 3.5.0` to force install of v3.5.0.
 *** `jekyll-asciidoc`: v2.1 or higher; latest version (3.0.0) is fine.
@@ -38,6 +36,12 @@ Use `gem install slim` to install.
 Use `gem install tilt` to install.
 *** `concurrent-ruby`: v1.0 or higher; latest version (1.1.5) is fine.
 Use `gem install concurrent-ruby` to install.
+
+NOTE: The above should install the correct version of the asciidoctor gem implicitly on a new system, but will not upgrade an existing version.
+If you experience problems building that seem unrelated to your changes, check that asciidoctor is at least v2.0.10 or higher.
+This is usually only a problem if you have previously built the ref guide prior to October 2019 or used asciidoctor for some other reason.
+`gem info asciidoctor` will show you what version(s) you have installed.
+
 
 == Building the Guide
 For details on building the ref guide, see `ant -p`.

--- a/solr/solr-ref-guide/README.adoc
+++ b/solr/solr-ref-guide/README.adoc
@@ -26,6 +26,8 @@ These files are processed with AsciiDoctor in 2 different ways:
 * HTML version, using Jekyll:
 ** `Ruby` (v2.3 or higher)
 ** The following gems must be installed:
+*** `asciidoctor`:v2.0.10 or higher.
+Use `gem install asciidoctor` to install.
 *** `jekyll`: v3.5, not v4.x.
 Use `gem install jekyll --force --version 3.5.0` to force install of v3.5.0.
 *** `jekyll-asciidoc`: v2.1 or higher; latest version (3.0.0) is fine.
@@ -36,7 +38,6 @@ Use `gem install slim` to install.
 Use `gem install tilt` to install.
 *** `concurrent-ruby`: v1.0 or higher; latest version (1.1.5) is fine.
 Use `gem install concurrent-ruby` to install.
-
 
 == Building the Guide
 For details on building the ref guide, see `ant -p`.


### PR DESCRIPTION
Documenting need to have ascii doctor version up to date. 