### PR TITLE
LUCENE-9443: UnifiedHighlighter shouldn't close reader

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -196,6 +196,13 @@ Other
 ---------------------
 (No changes)
 
+======================= Lucene 8.6.1 =======================
+
+Bug Fixes
+---------------------
+* LUCENE-9443: The UnifiedHighlighter was closing the underlying reader when there were multiple term-vector fields.
+  This was a regression in 8.6.0.  (David Smiley, Chris Beer)
+
 ======================= Lucene 8.6.0 =======================
 
 API Changes

--- a/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/UnifiedHighlighter.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/UnifiedHighlighter.java
@@ -644,7 +644,7 @@ public class UnifiedHighlighter {
 
       batchDocIdx += fieldValsByDoc.size();
     }
-    IOUtils.close(indexReaderWithTermVecCache);
+    IOUtils.close(indexReaderWithTermVecCache); // FYI won't close underlying reader
     assert docIdIter.docID() == DocIdSetIterator.NO_MORE_DOCS
         || docIdIter.nextDoc() == DocIdSetIterator.NO_MORE_DOCS;
 
@@ -1087,8 +1087,7 @@ public class UnifiedHighlighter {
           .toArray(LeafReader[]::new);
       return new BaseCompositeReader<IndexReader>(leafReaders) {
         @Override
-        protected void doClose() throws IOException {
-          reader.close();
+        protected void doClose() { // don't close the underlying reader
         }
 
         @Override

--- a/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/TestUnifiedHighlighterTermVec.java
+++ b/lucene/highlighter/src/test/org/apache/lucene/search/uhighlight/TestUnifiedHighlighterTermVec.java
@@ -120,6 +120,7 @@ public class TestUnifiedHighlighterTermVec extends LuceneTestCase {
       assertArrayEquals(expectedSnippetsByDoc, fieldToSnippets.get(field));
     }
 
+    ir.document(0); // ensure this works because the ir hasn't been closed
     ir.close();
   }
 


### PR DESCRIPTION
A regression from 8.6.  Don't close the underlying IndexReader.

https://issues.apache.org/jira/browse/LUCENE-9443

Instead of reverting the commit, there's something to be said for closing the wrapped reader since, after all, it's something you're supposed to close.  Since this is a wrapped reader created by the UH, it's easy to make its doClose do nothing.  Furthermore I tweaked a test that would fail prior to this change.  I checked precommit to ensure there is still no warning.