### PR TITLE
SOLR-14706: Fix support for default autoscaling policy

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -11,8 +11,8 @@ Consult the LUCENE_CHANGES.txt file for additional, low level, changes in this r
 Bug Fixes
 ---------------------
 
-* SOLR-14665: Revert SOLR-12845 adding of default autoscaling cluster policy, due to performance
- issues. (Ishan Chattopadhyaya, Houston Putman, ab)
+* SOLR-14665, SOLR-14706: Revert SOLR-12845 adding of default autoscaling cluster policy, due to performance
+ issues. (Ishan Chattopadhyaya, Houston Putman, Gus Heck, ab)
 
 * SOLR-14671: Parsing dynamic ZK config sometimes cause NumberFormatException (janhoy)
 

--- a/solr/core/src/java/org/apache/solr/cloud/autoscaling/sim/SimNodeStateProvider.java
+++ b/solr/core/src/java/org/apache/solr/cloud/autoscaling/sim/SimNodeStateProvider.java
@@ -19,6 +19,7 @@ package org.apache.solr.cloud.autoscaling.sim;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;

--- a/solr/core/src/java/org/apache/solr/cloud/autoscaling/sim/SimNodeStateProvider.java
+++ b/solr/core/src/java/org/apache/solr/cloud/autoscaling/sim/SimNodeStateProvider.java
@@ -234,6 +234,11 @@ public class SimNodeStateProvider implements NodeStateProvider {
     return nodeValues;
   }
 
+  /** Get all values for a selected node. */
+  public Map<String, Object> simGetNodeValues(String node) {
+    return nodeValues.getOrDefault(node, Collections.emptyMap());
+  }
+
   private void saveRoles() {
     final Map<String, Set<String>> roles = new HashMap<>();
     nodeValues.forEach((n, values) -> {
@@ -320,7 +325,10 @@ public class SimNodeStateProvider implements NodeStateProvider {
     if (values == null) {
       return result;
     }
-    result.putAll(values.entrySet().stream().filter(e -> tags.contains(e.getKey())).collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue())));
+    result.putAll(values.entrySet().stream()
+            .filter(e -> tags.contains(e.getKey()))
+            .filter(e -> e.getValue() != null)
+            .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue())));
     return result;
   }
 

--- a/solr/core/src/java/org/apache/solr/cloud/autoscaling/sim/SimScenario.java
+++ b/solr/core/src/java/org/apache/solr/cloud/autoscaling/sim/SimScenario.java
@@ -814,7 +814,9 @@ public class SimScenario implements AutoCloseable {
         values.put(key, val);
       }
       for (String node : nodes) {
-        scenario.cluster.getSimNodeStateProvider().simSetNodeValues(node, values);
+        Map<String, Object> newValues = new HashMap<>(scenario.cluster.getSimNodeStateProvider().simGetNodeValues(node));
+        newValues.putAll(values);
+        scenario.cluster.getSimNodeStateProvider().simSetNodeValues(node, newValues);
       }
     }
   }

--- a/solr/solr-ref-guide/src/solr-upgrade-notes.adoc
+++ b/solr/solr-ref-guide/src/solr-upgrade-notes.adoc
@@ -36,22 +36,27 @@ If you are upgrading from 7.x, see the section <<Upgrading from 7.x Releases>> b
 
 === Solr 8.6.1 (Upgrading from 8.6.0 only)
 
+See the https://cwiki.apache.org/confluence/display/SOLR/ReleaseNote861[8.6.1 Release Notes^]
+for an overview of the fixes included in Solr 8.6.1.
+
+When upgrading to 8.6.1 users should be aware of the following major changes from 8.6.0.
+
 *Autoscaling*
 
 * As mentioned in the 8.6 upgrade notes, a default autoscaling policy was provided starting in 8.6.0.
 This default autoscaling policy resulted in increasingly slow collection creation calls in large clusters (50+ collections).
 +
 In 8.6.1 the default autoscaling policy has been removed, and clouds will not use autoscaling unless a policy has explicitly been created.
-If your cloud has been upgraded to 8.6.0 and you wish to fix this performance degredations, upgrade to 8.6.1 and remove the default cluster policy via the following command.
+If your cloud is running 8.6.0 and **not using an explicit autoscaling policy**, upgrade to 8.6.1 and remove the default cluster policy and preferences via the following command.
 Replace `localhost:8983` with your Solr endpoint.
 +
 ```
-curl -X POST -H 'Content-type:application/json'  -d '{set-cluster-policy : []}' http://localhost:8983/api/cluster/autoscaling
+curl -X POST -H 'Content-type:application/json'  -d '{set-cluster-policy : [], set-cluster-preferences : []}' http://localhost:8983/api/cluster/autoscaling
 ```
 +
 For more details on autoscaling policies, see the section <<solrcloud-autoscaling-overview.adoc#cluster-policy,Cluster Policy>>.
 +
-This information is only relevant for users upgrading from 8.6.0. If upgrading from an earlier version, this warning can be ignored.
+This information is only relevant for users upgrading from 8.6.0. If upgrading from an earlier version to 8.6.1+, this warning can be ignored.
 
 === Solr 8.6
 

--- a/solr/solr-ref-guide/src/solr-upgrade-notes.adoc
+++ b/solr/solr-ref-guide/src/solr-upgrade-notes.adoc
@@ -42,7 +42,12 @@ If you are upgrading from 7.x, see the section <<Upgrading from 7.x Releases>> b
 This default autoscaling policy resulted in increasingly slow collection creation calls in large clusters (50+ collections).
 +
 In 8.6.1 the default autoscaling policy has been removed, and clouds will not use autoscaling unless a policy has explicitly been created.
-In order to fix the performance degradations introduced in 8.6.0, merely upgrade to 8.6.1.
+In order to fix the performance degradations introduced in 8.6.0, upgrade to 8.6.1 and remove the default cluster policy via the following command.
+Replace `localhost:8983` with your Solr endpoint.
++
+```
+curl -X POST -H 'Content-type:application/json'  -d '{set-cluster-policy : []}' http://localhost:8983/api/cluster/autoscaling
+```
 +
 For more details on autoscaling policies, see the section <<solrcloud-autoscaling-overview.adoc#cluster-policy,Cluster Policy>>.
 

--- a/solr/solr-ref-guide/src/solr-upgrade-notes.adoc
+++ b/solr/solr-ref-guide/src/solr-upgrade-notes.adoc
@@ -34,7 +34,7 @@ Detailed steps for upgrading a Solr cluster are in the section <<upgrading-a-sol
 
 If you are upgrading from 7.x, see the section <<Upgrading from 7.x Releases>> below.
 
-=== Solr 8.6.1
+=== Solr 8.6.1 (Upgrading from 8.6.0 only)
 
 *Autoscaling*
 
@@ -42,7 +42,7 @@ If you are upgrading from 7.x, see the section <<Upgrading from 7.x Releases>> b
 This default autoscaling policy resulted in increasingly slow collection creation calls in large clusters (50+ collections).
 +
 In 8.6.1 the default autoscaling policy has been removed, and clouds will not use autoscaling unless a policy has explicitly been created.
-In order to fix the performance degradations introduced in 8.6.0, upgrade to 8.6.1 and remove the default cluster policy via the following command.
+If your cloud has been upgraded to 8.6.0 and you wish to fix this performance degredations, upgrade to 8.6.1 and remove the default cluster policy via the following command.
 Replace `localhost:8983` with your Solr endpoint.
 +
 ```
@@ -50,6 +50,8 @@ curl -X POST -H 'Content-type:application/json'  -d '{set-cluster-policy : []}' 
 ```
 +
 For more details on autoscaling policies, see the section <<solrcloud-autoscaling-overview.adoc#cluster-policy,Cluster Policy>>.
++
+This information is only relevant for users upgrading from 8.6.0. If upgrading from an earlier version, this warning can be ignored.
 
 === Solr 8.6
 
@@ -77,7 +79,9 @@ More information about this new feature is available in the section <<common-que
 
 *Autoscaling*
 
-* Solr now includes a default autoscaling policy.
+* **NOTE: The default autoscaling policy has been removed as of 8.6.1**
++
+Solr now includes a default autoscaling policy.
 This policy can be overridden with your custom rules or by specifying an empty policy to replace the default.
 +
 For details of the default policy, see the section <<solrcloud-autoscaling-overview.adoc#cluster-policy,Cluster Policy>>.

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/cloud/autoscaling/Clause.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/cloud/autoscaling/Clause.java
@@ -118,7 +118,7 @@ public class Clause implements MapWriter, Comparable<Clause> {
     Optional<String> globalTagName = m.keySet().stream().filter(Policy.GLOBAL_ONLY_TAGS::contains).findFirst();
     if (globalTagName.isPresent()) {
       globalTag = parse(globalTagName.get(), m);
-      if (m.size() > 2) {
+      if (m.size() > 3) {
         throw new RuntimeException("Only one extra tag supported for the tag " + globalTagName.get() + " in " + toJSONString(m));
       }
       tag = parse(m.keySet().stream()
@@ -686,7 +686,7 @@ public class Clause implements MapWriter, Comparable<Clause> {
       for (Row r : session.matrix) {
         computedValueEvaluator.node = r.node;
         SealedClause sealedClause = getSealedClause(computedValueEvaluator);
-        if (!sealedClause.getGlobalTag().isPass(r)) {
+        if (r.isLive() && !sealedClause.getGlobalTag().isPass(r)) {
           ctx.resetAndAddViolation(r.node, null, new Violation(sealedClause, null, null, r.node, r.getVal(sealedClause.globalTag.name),
               sealedClause.globalTag.delta(r.getVal(globalTag.name)), r.node));
           addViolatingReplicasForGroup(sealedClause.globalTag, computedValueEvaluator, ctx, Type.CORES.tagName, r.node, ctx.currentViolation, session.matrix);

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/cloud/autoscaling/Clause.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/cloud/autoscaling/Clause.java
@@ -117,8 +117,11 @@ public class Clause implements MapWriter, Comparable<Clause> {
     strict = Boolean.parseBoolean(String.valueOf(m.getOrDefault("strict", "true")));
     Optional<String> globalTagName = m.keySet().stream().filter(Policy.GLOBAL_ONLY_TAGS::contains).findFirst();
     if (globalTagName.isPresent()) {
-      if (m.size() > 3) {
-        throw new RuntimeException("Only two extra tags supported for the tag " + globalTagName.get() + " in " + toJSONString(m));
+      if (m.size() > 2) {
+        // 3 keys are allowed only if one of them is 'strict'
+        if (!m.containsKey("strict") || m.size() > 3) {
+          throw new RuntimeException("Only, 'strict' and one extra tag supported for the tag " + globalTagName.get() + " in " + toJSONString(m));
+        }
       }
       globalTag = parse(globalTagName.get(), m);
       tag = parse(m.keySet().stream()

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/cloud/autoscaling/Clause.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/cloud/autoscaling/Clause.java
@@ -117,10 +117,10 @@ public class Clause implements MapWriter, Comparable<Clause> {
     strict = Boolean.parseBoolean(String.valueOf(m.getOrDefault("strict", "true")));
     Optional<String> globalTagName = m.keySet().stream().filter(Policy.GLOBAL_ONLY_TAGS::contains).findFirst();
     if (globalTagName.isPresent()) {
-      globalTag = parse(globalTagName.get(), m);
       if (m.size() > 3) {
-        throw new RuntimeException("Only one extra tag supported for the tag " + globalTagName.get() + " in " + toJSONString(m));
+        throw new RuntimeException("Only two extra tags supported for the tag " + globalTagName.get() + " in " + toJSONString(m));
       }
+      globalTag = parse(globalTagName.get(), m);
       tag = parse(m.keySet().stream()
           .filter(s -> (!globalTagName.get().equals(s) && !IGNORE_TAGS.contains(s)))
           .findFirst().get(), m);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-14706

This is to introduce backwards compatibility for the default autoscaling policy that was removed in 8.6.1 (and 8.7).

The upgrade notes now include the steps to remove the default autoscaling policy via the autoscaling API.

I have tested the following upgrade patterns, and am happy with the results. I'll do more tests if y'all think it is necessary.

8.6.0 -> 8.6.1 RC1 (fail)
8.6.0 -> this patch (success)
8.6.0 -> 8.6.1 RCI -> this patch (success)

I will also be porting this with a few documentation tweaks to 8x