### PR TITLE
SOLR-14582 - Broken test needs fix

### DIFF
--- a/solr/core/src/test/org/apache/solr/core/TestConfig.java
+++ b/solr/core/src/test/org/apache/solr/core/TestConfig.java
@@ -163,6 +163,7 @@ public class TestConfig extends SolrTestCaseJ4 {
 
   // If defaults change, add test methods to cover each version
   @Test
+  @AwaitsFix(bugUrl = "https://issues.apache.org/jira/browse/SOLR-14582")
   public void testDefaults() throws Exception {
 
     int numDefaultsTested = 0;


### PR DESCRIPTION
Seems this is likely just an oversight in testing, not a real problem, so Adding AwaitsFix to allow builds to stop failing.