### PR TITLE
LUCENE-9453 Add sync around volatile write

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterFlushControl.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterFlushControl.java
@@ -324,12 +324,12 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
     }
   }
 
-  private void checkoutAndBlock(DocumentsWriterPerThread perThread) {
+  private synchronized void checkoutAndBlock(DocumentsWriterPerThread perThread) {
     assert perThreadPool.isRegistered(perThread);
     assert perThread.isHeldByCurrentThread();
     assert perThread.isFlushPending() : "can not block non-pending threadstate";
     assert fullFlush : "can not block if fullFlush == false";
-    numPending--;
+    numPending--; // write access synced
     blockedFlushes.add(perThread);
     boolean checkedOut = perThreadPool.checkout(perThread);
     assert checkedOut;

--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterFlushControl.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterFlushControl.java
@@ -324,7 +324,11 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
     }
   }
 
-  private synchronized void checkoutAndBlock(DocumentsWriterPerThread perThread) {
+  /**
+   * To be called only by the owner of this object's monitor lock
+   */
+  private void checkoutAndBlock(DocumentsWriterPerThread perThread) {
+    assert Thread.holdsLock(this);
     assert perThreadPool.isRegistered(perThread);
     assert perThread.isHeldByCurrentThread();
     assert perThread.isFlushPending() : "can not block non-pending threadstate";


### PR DESCRIPTION
checkoutAndBlock is not synchronized, but has a non-atomic write to numPending. Meanwhile, all of the other writes to numPending are in sync methods.

In this case it turns out to be ok because all of the code paths calling this method are already sync:

`synchronized doAfterDocument -> checkout -> checkoutAndBlock`
`checkoutLargestNonPendingWriter -> synchronized(this) -> checkout -> checkoutAndBlock`

If we make synchronized checkoutAndBlock that protects us against future changes, shouldn't cause any performance impact since the code paths will already be going through a sync block, and will make an IntelliJ warning go away.

Found via IntelliJ warnings. 

https://issues.apache.org/jira/browse/LUCENE-9453

