### PR TITLE
SOLR-14677: Always close DIH EntityProcessor/DataSource

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -176,6 +176,8 @@ Bug Fixes
 * SOLR-14657: Improve error handling in IndexReader realted metrics that were causing scary ERROR logging
   if metrics were requested while Solr was in the process of closing/re-opening a new IndexReader. (hossman)
 
+* SOLR-14677: Improve DIH termination logic to close all DataSources, EntityProcessors (Jason Gerlowski)
+
 Other Changes
 ---------------------
 

--- a/solr/contrib/dataimporthandler/src/java/org/apache/solr/handler/dataimport/DataSource.java
+++ b/solr/contrib/dataimporthandler/src/java/org/apache/solr/handler/dataimport/DataSource.java
@@ -16,6 +16,7 @@
  */
 package org.apache.solr.handler.dataimport;
 
+import java.io.Closeable;
 import java.util.Properties;
 
 /**
@@ -35,7 +36,7 @@ import java.util.Properties;
  *
  * @since solr 1.3
  */
-public abstract class DataSource<T> {
+public abstract class DataSource<T> implements Closeable {
 
   /**
    * Initializes the DataSource with the <code>Context</code> and

--- a/solr/contrib/dataimporthandler/src/java/org/apache/solr/handler/dataimport/DocBuilder.java
+++ b/solr/contrib/dataimporthandler/src/java/org/apache/solr/handler/dataimport/DocBuilder.java
@@ -18,6 +18,7 @@ package org.apache.solr.handler.dataimport;
 
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrInputDocument;
+import org.apache.solr.common.util.IOUtils;
 import org.apache.solr.core.SolrCore;
 import org.apache.solr.handler.dataimport.config.ConfigNameConstants;
 import org.apache.solr.handler.dataimport.config.DIHConfiguration;
@@ -272,24 +273,38 @@ public class DocBuilder {
     } catch(Exception e)
     {
       throw new RuntimeException(e);
-    } finally
-    {
-      if (writer != null) {
-        writer.close();
+    } finally {
+      // Cannot use IOUtils.closeQuietly since DIH relies on exceptions bubbling out of writer.close() to indicate
+      // success/failure of the run.
+      RuntimeException raisedDuringClose = null;
+      try {
+        if (writer != null) {
+          writer.close();
+        }
+      } catch (RuntimeException e) {
+        log.warn("Exception encountered while closing DIHWriter " + writer +
+                "; temporarily suppressing to ensure other DocBuilder elements are closed", e);
+        raisedDuringClose = e;
       }
+
       if (epwList != null) {
         closeEntityProcessorWrappers(epwList);
       }
       if(reqParams.isDebug()) {
         reqParams.getDebugInfo().debugVerboseOutput = getDebugLogger().output;
       }
+
+      if (raisedDuringClose != null) {
+        throw raisedDuringClose;
+      }
     }
   }
   private void closeEntityProcessorWrappers(List<EntityProcessorWrapper> epwList) {
     for(EntityProcessorWrapper epw : epwList) {
-      epw.close();
-      if(epw.getDatasource()!=null) {
-        epw.getDatasource().close();
+      IOUtils.closeQuietly(epw);
+
+      if(epw.getDatasource() != null) {
+        IOUtils.closeQuietly(epw.getDatasource());
       }
       closeEntityProcessorWrappers(epw.getChildren());
     }

--- a/solr/contrib/dataimporthandler/src/java/org/apache/solr/handler/dataimport/DocBuilder.java
+++ b/solr/contrib/dataimporthandler/src/java/org/apache/solr/handler/dataimport/DocBuilder.java
@@ -282,8 +282,9 @@ public class DocBuilder {
           writer.close();
         }
       } catch (RuntimeException e) {
-        log.warn("Exception encountered while closing DIHWriter " + writer +
-                "; temporarily suppressing to ensure other DocBuilder elements are closed", e);
+        if (log.isWarnEnabled()) {
+          log.warn("Exception encountered while closing DIHWriter " + writer + "; temporarily suppressing to ensure other DocBuilder elements are closed", e); // logOk
+        }
         raisedDuringClose = e;
       }
 

--- a/solr/contrib/dataimporthandler/src/java/org/apache/solr/handler/dataimport/EntityProcessor.java
+++ b/solr/contrib/dataimporthandler/src/java/org/apache/solr/handler/dataimport/EntityProcessor.java
@@ -16,6 +16,7 @@
  */
 package org.apache.solr.handler.dataimport;
 
+import java.io.Closeable;
 import java.util.Map;
 
 /**
@@ -36,7 +37,7 @@ import java.util.Map;
  *
  * @since solr 1.3
  */
-public abstract class EntityProcessor {
+public abstract class EntityProcessor implements Closeable {
 
   /**
    * This method is called when it starts processing an entity. When it comes


### PR DESCRIPTION
# Description

Prior to this commit, the wrapup logic at the end of
DocBuilder.execute() closed out a series of DIH objects, but did so
in a way that an exception closing any of them resulted in the remainder
staying open.  This is especially problematic since Writer.close()
throws exceptions that DIH uses to determine the success/failure of the
run.

In practice this caused network errors sending DIH data to other Solr
nodes to result in leaked JDBC connections.

# Solution

This PR changes DocBuilder's termination logic to handle exceptions
more gracefully, ensuring that errors closing a DIHWriter (for example)
don't prevent the closure of entity-processor and DataSource objects.

# Tests

None

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
