### PR TITLE
SOLR-14751: Zookeeper Admin screen not working for old ZK versions

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -180,6 +180,8 @@ Bug Fixes
 
 * SOLR-14748: Fix incorrect auth/SSL startup logging (Jason Gerlowski)
 
+* SOLR-14751: Zookeeper Admin screen not working for old ZK versions (janhoy)
+
 Other Changes
 ---------------------
 

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/SolrZkClient.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/SolrZkClient.java
@@ -761,6 +761,9 @@ public class SolrZkClient implements Closeable {
         return "";
       }
       return new String(data, StandardCharsets.UTF_8);
+    } catch (NoNodeException nne) {
+      log.debug("Zookeeper does not have the /zookeeper/config znode, assuming old ZK version");
+      return "";
     } catch (KeeperException|InterruptedException ex) {
       throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "Failed to get config from zookeeper", ex);
     }


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/SOLR-14751

Solution is to treat `NoNodeException` not as an unrecoverable exception, but as expected for older ZK versions and return empty string.

A workaround for 8.6.x is to do a

    bin/solr zkroot /zookeeper/config

Then the Admin UI in 8.6 will start working with old ZK.