### PR TITLE
LUCENE-9447: Increase block sizes for stored fields.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -189,6 +189,9 @@ Optimizations
 * LUCENE-9395: ConstantValuesSource now shares a single DoubleValues
   instance across all segments (Tony Xu)
 
+* LUCENE-9447: Stored fields are getting more space-efficient through an
+  increase of the block size they use for compression. (Adrien Grand)
+
 Bug Fixes
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/compressing/CompressingStoredFieldsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/compressing/CompressingStoredFieldsReader.java
@@ -373,8 +373,17 @@ public final class CompressingStoredFieldsReader extends StoredFieldsReader {
     // the start pointer at which you can read the compressed documents
     private long startPointer;
 
-    private final BytesRef spare = new BytesRef();
-    private final BytesRef bytes = new BytesRef();
+    private final BytesRef spare;
+    private final BytesRef bytes;
+
+    BlockState() {
+      if (merging) {
+        spare = new BytesRef();
+        bytes = new BytesRef();
+      } else {
+        spare = bytes = null;
+      }
+    }
 
     boolean contains(int docID) {
       return docID >= docBase && docID < docBase + chunkDocs;
@@ -503,6 +512,13 @@ public final class CompressingStoredFieldsReader extends StoredFieldsReader {
       final int length = offsets[index+1] - offset;
       final int totalLength = offsets[chunkDocs];
       final int numStoredFields = this.numStoredFields[index];
+
+      final BytesRef bytes;
+      if (merging) {
+        bytes = this.bytes;
+      } else {
+        bytes = new BytesRef();
+      }
 
       final DataInput documentInput;
       if (length == 0) {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene50/Lucene50StoredFieldsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene50/Lucene50StoredFieldsFormat.java
@@ -148,9 +148,9 @@ public final class Lucene50StoredFieldsFormat extends StoredFieldsFormat {
   StoredFieldsFormat impl(Mode mode) {
     switch (mode) {
       case BEST_SPEED: 
-        return new CompressingStoredFieldsFormat("Lucene50StoredFieldsFastData", CompressionMode.FAST, 1 << 14, 128, 10);
+        return new CompressingStoredFieldsFormat("Lucene50StoredFieldsFastData", CompressionMode.FAST, 64 * 1024, 128, 10);
       case BEST_COMPRESSION: 
-        return new CompressingStoredFieldsFormat("Lucene50StoredFieldsHighData", CompressionMode.HIGH_COMPRESSION, 61440, 512, 10);
+        return new CompressingStoredFieldsFormat("Lucene50StoredFieldsHighData", CompressionMode.HIGH_COMPRESSION, 256 * 1024, 512, 10);
       default: throw new AssertionError();
     }
   }


### PR DESCRIPTION
BEST_SPEED and BEST_COMPRESSION keep the same compression algorithms but
increase their respective block sizes from 16kB and 60kB to 64kB and
256kB.

I disabled the per-thread caching of buffers, which could likely become
memory hogs with these greater block sizes.