### PR TITLE
Ensure we only rollback IW once

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -1097,7 +1097,6 @@ public class IndexWriter implements Closeable, TwoPhaseCommit, Accountable,
         flush(true, true);
         waitForMerges();
         commitInternal(config.getMergePolicy());
-        rollbackInternal(); // ie close, since we just committed
       } catch (Throwable t) {
         // Be certain to close the index on any exception
         try {
@@ -1107,6 +1106,7 @@ public class IndexWriter implements Closeable, TwoPhaseCommit, Accountable,
         }
         throw t;
       }
+      rollbackInternal(); // if we got that far lets rollback and close
     }
   }
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterExceptions.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterExceptions.java
@@ -2023,4 +2023,44 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
 
     dir.close();
   }
+
+
+  public void testOnlyRollbackOnceOnException() throws IOException {
+    AtomicBoolean once = new AtomicBoolean(false);
+    InfoStream stream = new InfoStream() {
+      @Override
+      public void message(String component, String message) {
+        if ("TP".equals(component) && "rollback before checkpoint".equals(message)) {
+          if (once.compareAndSet(false, true)) {
+            throw new RuntimeException("boom");
+          } else {
+            throw new AssertionError("has been rolled back twice");
+          }
+
+        }
+      }
+
+      @Override
+      public boolean isEnabled(String component) {
+        return "TP".equals(component);
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+    try (Directory dir = newDirectory()) {
+      try (IndexWriter writer = new IndexWriter(dir, newIndexWriterConfig().setInfoStream(stream)){
+        @Override
+        protected boolean isEnableTestPoints() {
+          return true;
+        }
+      }) {
+      }
+    } catch (RuntimeException x) {
+      assertEquals("boom", x.getMessage());
+      assertEquals("has suppressed exceptions: " + Arrays.toString(x.getSuppressed()), 0, x.getSuppressed().length);
+      assertNull(x.getCause());
+    }
+  }
 }

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterExceptions.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterExceptions.java
@@ -2057,10 +2057,10 @@ public class TestIndexWriterExceptions extends LuceneTestCase {
         }
       }) {
       }
-    } catch (RuntimeException x) {
-      assertEquals("boom", x.getMessage());
-      assertEquals("has suppressed exceptions: " + Arrays.toString(x.getSuppressed()), 0, x.getSuppressed().length);
-      assertNull(x.getCause());
+    } catch (RuntimeException e) {
+      assertEquals("boom", e.getMessage());
+      assertEquals("has suppressed exceptions: " + Arrays.toString(e.getSuppressed()), 0, e.getSuppressed().length);
+      assertNull(e.getCause());
     }
   }
 }


### PR DESCRIPTION
Today we might rollback IW more than once if we hit an exception during
the rollback code when we shutdown. This change moves the rollback code outside
of the try block to ensure we always roll back but never roll back twice.