### PR TITLE
SOLR-14767 : fix long field parsing from string

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -251,6 +251,9 @@ Bug Fixes
 * SOLR-14850: Fix ExactStatsCache NullPointerException when shards.tolerant=true.
   (Eugene Tenkaev via ab)
 
+* SOLR-14767: Fix NumberFormatException when integer/long field value is specified as floating number
+  (Apoorv Bhawsar, Munendra S N)
+
 Other Changes
 ---------------------
 

--- a/solr/core/src/java/org/apache/solr/schema/IntPointField.java
+++ b/solr/core/src/java/org/apache/solr/schema/IntPointField.java
@@ -51,8 +51,7 @@ public class IntPointField extends PointField implements IntValueFieldType {
     try {
       if (val instanceof CharSequence) return Integer.parseInt( val.toString());
     } catch (NumberFormatException e) {
-      Float v = Float.parseFloat(val.toString());
-      return v.intValue();
+      return (int)Float.parseFloat(val.toString());
     }
     return super.toNativeType(val);
   }
@@ -153,7 +152,7 @@ public class IntPointField extends PointField implements IntValueFieldType {
       try {
         intValue = Integer.parseInt(value.toString());
       } catch (NumberFormatException e) {
-        intValue = (int) Double.parseDouble(value.toString());
+        intValue = (int) Float.parseFloat(value.toString());
       }
     }
     return new IntPoint(field.getName(), intValue);

--- a/solr/core/src/java/org/apache/solr/schema/IntPointField.java
+++ b/solr/core/src/java/org/apache/solr/schema/IntPointField.java
@@ -146,7 +146,16 @@ public class IntPointField extends PointField implements IntValueFieldType {
 
   @Override
   public IndexableField createField(SchemaField field, Object value) {
-    int intValue = (value instanceof Number) ? ((Number) value).intValue() : Integer.parseInt(value.toString());
+    int intValue;
+    if (value instanceof Number) {
+      intValue = ((Number) value).intValue();
+    } else {
+      try {
+        intValue = Integer.parseInt(value.toString());
+      } catch (NumberFormatException e) {
+        intValue = (int) Double.parseDouble(value.toString());
+      }
+    }
     return new IntPoint(field.getName(), intValue);
   }
 

--- a/solr/core/src/java/org/apache/solr/schema/LongPointField.java
+++ b/solr/core/src/java/org/apache/solr/schema/LongPointField.java
@@ -151,7 +151,16 @@ public class LongPointField extends PointField implements LongValueFieldType {
 
   @Override
   public IndexableField createField(SchemaField field, Object value) {
-    long longValue = (value instanceof Number) ? ((Number) value).longValue() : Long.parseLong(value.toString());
+    long longValue;
+    if (value instanceof Number) {
+      longValue = ((Number) value).longValue();
+    } else {
+      try {
+        longValue = Long.parseLong(value.toString());
+      } catch (NumberFormatException e) {
+        longValue = (long) Double.parseDouble(value.toString());
+      }
+    }
     return new LongPoint(field.getName(), longValue);
   }
 

--- a/solr/core/src/java/org/apache/solr/schema/LongPointField.java
+++ b/solr/core/src/java/org/apache/solr/schema/LongPointField.java
@@ -50,8 +50,7 @@ public class LongPointField extends PointField implements LongValueFieldType {
     try {
       if (val instanceof CharSequence) return Long.parseLong(val.toString());
     } catch (NumberFormatException e) {
-      Double v = Double.parseDouble(val.toString());
-      return v.longValue();
+      return (long)Double.parseDouble(val.toString());
     }
     return super.toNativeType(val);
   }

--- a/solr/core/src/java/org/apache/solr/schema/TrieField.java
+++ b/solr/core/src/java/org/apache/solr/schema/TrieField.java
@@ -553,9 +553,16 @@ public class TrieField extends NumericFieldType {
 
     switch (type) {
       case INTEGER:
-        int i = (value instanceof Number)
-          ? ((Number)value).intValue()
-          : Integer.parseInt(value.toString());
+        int i;
+        if (value instanceof Number) {
+          i = ((Number) value).intValue();
+        } else {
+          try {
+            i = Integer.parseInt(value.toString());
+          } catch (NumberFormatException e) {
+            i = (int) Float.parseFloat(value.toString());
+          }
+        }
         f = new LegacyIntField(field.getName(), i, ft);
         break;
       case FLOAT:
@@ -565,9 +572,16 @@ public class TrieField extends NumericFieldType {
         f = new LegacyFloatField(field.getName(), fl, ft);
         break;
       case LONG:
-        long l = (value instanceof Number)
-          ? ((Number)value).longValue()
-          : Long.parseLong(value.toString());
+        long l;
+        if (value instanceof Number) {
+          l = ((Number) value).longValue();
+        } else {
+          try {
+            l = Long.parseLong(value.toString());
+          } catch (NumberFormatException e) {
+            l = (long) Double.parseDouble(value.toString());
+          }
+        }
         f = new LegacyLongField(field.getName(), l, ft);
         break;
       case DOUBLE:

--- a/solr/core/src/test/org/apache/solr/update/TestUpdate.java
+++ b/solr/core/src/test/org/apache/solr/update/TestUpdate.java
@@ -239,15 +239,13 @@ public class TestUpdate extends SolrTestCaseJ4 {
   }
 
   @Test // SOLR-14767
-  public void testStringUpdateOnLongAndIntFields() throws IOException {
-    SolrInputDocument doc = new SolrInputDocument();
-    //values such as 2.3 should be parsed and not return failure
-    doc.addField("id", "1");
-    doc.addField("int_i", "42.0");
-    doc.addField("long_l", "42.2");
+  public void testStringUpdateOnLongAndIntFields() throws Exception {
+    clearIndex();
 
-    AddUpdateCommand cmd = new AddUpdateCommand(req());
-    cmd.solrDoc = doc;
-      h.getCore().getUpdateHandler().addDoc(cmd);
+    addAndGetVersion(sdoc("id","1", "val_is", "42.0", "val_is", 12, "val_i", "12.1", "val_l",
+        "42.0", "val_ll", "12.1", "val_ll", "32"), null);
+    assertJQ(req("qt","/get", "id","1", "fl","id,val*")
+        ,"=={'doc':{'id':'1', 'val_i':12, 'val_is':[42,12], 'val_l':42, 'val_ll':[12,32]}}"
+    );
   }
 }

--- a/solr/core/src/test/org/apache/solr/update/TestUpdate.java
+++ b/solr/core/src/test/org/apache/solr/update/TestUpdate.java
@@ -238,4 +238,16 @@ public class TestUpdate extends SolrTestCaseJ4 {
     fail();
   }
 
+  @Test // SOLR-14767
+  public void testStringUpdateOnLongAndIntFields() throws IOException {
+    SolrInputDocument doc = new SolrInputDocument();
+    //values such as 2.3 should be parsed and not return failure
+    doc.addField("id", "1");
+    doc.addField("int_i", "42.0");
+    doc.addField("long_l", "42.2");
+
+    AddUpdateCommand cmd = new AddUpdateCommand(req());
+    cmd.solrDoc = doc;
+      h.getCore().getUpdateHandler().addDoc(cmd);
+  }
 }


### PR DESCRIPTION
<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

Int and Long fields when passed as a string should consider all possible value formats and not throw NumberFormatException

# Solution

Use Double.parse as a fallback when it fails

# Tests

added a test to index with values as `42.2` which should not cause NumberFormatException

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
