### PR TITLE
LUCENE-9483: Disable per-thread caching of buffers for decompression of stored fields.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/compressing/CompressingStoredFieldsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/compressing/CompressingStoredFieldsReader.java
@@ -405,8 +405,17 @@ public final class CompressingStoredFieldsReader extends StoredFieldsReader {
     // the start pointer at which you can read the compressed documents
     private long startPointer;
 
-    private final BytesRef spare = new BytesRef();
-    private final BytesRef bytes = new BytesRef();
+    private final BytesRef spare;
+    private final BytesRef bytes;
+
+    BlockState() {
+      if (merging) {
+        spare = new BytesRef();
+        bytes = new BytesRef();
+      } else {
+        spare = bytes = null;
+      }
+    }
 
     boolean contains(int docID) {
       return docID >= docBase && docID < docBase + chunkDocs;
@@ -535,6 +544,13 @@ public final class CompressingStoredFieldsReader extends StoredFieldsReader {
       final int length = offsets[index+1] - offset;
       final int totalLength = offsets[chunkDocs];
       final int numStoredFields = this.numStoredFields[index];
+
+      final BytesRef bytes;
+      if (merging) {
+        bytes = this.bytes;
+      } else {
+        bytes = new BytesRef();
+      }
 
       final DataInput documentInput;
       if (length == 0) {


### PR DESCRIPTION
These buffers can use lots of memory when the number of segments,
threads or both is high.
