### PR TITLE
Run tests last to fail fast on missing license and doc issues

### DIFF
--- a/dev-tools/scripts/buildAndPushRelease.py
+++ b/dev-tools/scripts/buildAndPushRelease.py
@@ -108,8 +108,8 @@ def prepare(root, version, gpgKeyID, gpgPassword):
   print('  Check DOAP files')
   checkDOAPfiles(version)
 
-  print('  ant -Dtests.badapples=false clean test validate documentation-lint')
-  run('ant -Dtests.badapples=false clean test validate documentation-lint')
+  print('  ant -Dtests.badapples=false clean validate documentation-lint test')
+  run('ant -Dtests.badapples=false clean validate documentation-lint test')
 
   open('rev.txt', mode='wb').write(rev.encode('UTF-8'))
   


### PR DESCRIPTION
This would have saved me many hours of waiting for tests to finish in order to realize that my java-version is not working with jlint as well as an existing RAT issue on the release branch. I think there is no harm in running tests last.