### PR TITLE
Rename TestDirectoryFactory to DirectoryFactoriesTest

### DIFF
--- a/solr/core/src/test/org/apache/solr/core/DirectoryFactoriesTest.java
+++ b/solr/core/src/test/org/apache/solr/core/DirectoryFactoriesTest.java
@@ -35,7 +35,7 @@ import java.util.List;
  * TODO: test more methods besides exists(String)
  * </p>
  */
-public class TestDirectoryFactory extends SolrTestCaseJ4 {
+public class DirectoryFactoriesTest extends SolrTestCaseJ4 {
 
   // TODO: what do we need to setup to be able to test HdfsDirectoryFactory?
   public static final List<Class<? extends DirectoryFactory>> ALL_CLASSES


### PR DESCRIPTION
As part of https://issues.apache.org/jira/browse/LUCENE-8626 I noticed that we have both
* https://github.com/apache/lucene-solr/blob/releases/lucene-solr/8.6.1/solr/core/src/test/org/apache/solr/core/DirectoryFactoryTest.java and
* https://github.com/apache/lucene-solr/blob/releases/lucene-solr/8.6.1/solr/core/src/test/org/apache/solr/core/TestDirectoryFactory.java which is mildly confusing.

Something like "DirectoryFactoriesTest" more accurately describes what the "TestDirectoryFactory" test does.