### PR TITLE
LUCENE-9482: Fix deletion count error message

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentInfos.java
@@ -376,7 +376,7 @@ public final class SegmentInfos implements Cloneable, Iterable<SegmentCommitInfo
           throw new CorruptIndexException("invalid deletion count: " + softDelCount + " vs maxDoc=" + info.maxDoc(), input);
         }
         if (softDelCount + delCount > info.maxDoc()) {
-          throw new CorruptIndexException("invalid deletion count: " + softDelCount + delCount + " vs maxDoc=" + info.maxDoc(), input);
+          throw new CorruptIndexException("invalid deletion count: " + (softDelCount + delCount) + " vs maxDoc=" + info.maxDoc(), input);
         }
         final byte[] sciId;
         if (format > VERSION_74) {


### PR DESCRIPTION
`throw new CorruptIndexException("invalid deletion count: " + softDelCount + delCount + " vs maxDoc=" + info.maxDoc(), input);`
It needs to be changed to:
`throw new CorruptIndexException("invalid deletion count: " + (softDelCount + delCount) + " vs maxDoc=" + info.maxDoc(), input);`

The value of "softDelCount + delCount" must be calculated first.