### PR TITLE
LUCENE-9487: Add a null check on BooleanWeight

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/BooleanWeight.java
+++ b/lucene/core/src/java/org/apache/lucene/search/BooleanWeight.java
@@ -108,6 +108,9 @@ final class BooleanWeight extends Weight {
       // explanations have the same value as the score, we pull a scorer and
       // use it to compute the score.
       Scorer scorer = scorer(context);
+      if (scorer == null) {
+        return Explanation.noMatch("Failure to get scorer", subs);
+      }
       int advanced = scorer.iterator().advance(doc);
       assert advanced == doc;
       return Explanation.match(scorer.score(), "sum of:", subs);


### PR DESCRIPTION
There is no null check for scorer in BooleanWeight.explain()

Signed-off-by: jeng832 <jeng832@gmail.com>
