### PR TITLE
LUCENE-9492: Fix beasting to accept also task names in form ":project…

### DIFF
--- a/gradle/testing/beasting.gradle
+++ b/gradle/testing/beasting.gradle
@@ -23,7 +23,7 @@
 //       runner duplicated suite names (much like https://github.com/gradle/test-retry-gradle-plugin)
 // TODO: this is a somewhat related issue: https://github.com/gradle/test-retry-gradle-plugin/issues/29
 
-def beastingMode = gradle.startParameter.taskNames.contains("beast");
+def beastingMode = gradle.startParameter.taskNames.any{ name -> name == 'beast' || name.endsWith(':beast') }
 
 allprojects {
   plugins.withType(JavaPlugin) {
@@ -47,7 +47,7 @@ if (beastingMode) {
         group "Verification"
       }
 
-      def dups = Integer.parseInt(resolvedTestOption("tests.dups"))
+      def dups = Integer.parseInt(resolvedTestOption("tests.dups") as String)
       if (dups <= 0) {
         throw new GradleException("Specify -Ptests.dups=[count] for beast task.")
       }


### PR DESCRIPTION
…:beast"; fix bug with default value rejected by Integer.parseInt