### PR TITLE
Improve how Asserting* classes handle singleton doc values.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -196,6 +196,8 @@ Improvements
 * LUCENE-9446: In BooleanQuery rewrite, always remove MatchAllDocsQuery filter clauses
   when possible. (Julie Tibshirani)
 
+* LUCENE-9501: Improve how Asserting* test classes handle singleton doc values.
+
 Optimizations
 ---------------------
 

--- a/lucene/test-framework/src/java/org/apache/lucene/codecs/asserting/AssertingDocValuesFormat.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/codecs/asserting/AssertingDocValuesFormat.java
@@ -274,7 +274,7 @@ public class AssertingDocValuesFormat extends DocValuesFormat {
       assert field.getDocValuesType() == DocValuesType.SORTED_NUMERIC;
       SortedNumericDocValues values = in.getSortedNumeric(field);
       assert values != null;
-      return new AssertingLeafReader.AssertingSortedNumericDocValues(values, maxDoc);
+      return AssertingLeafReader.AssertingSortedNumericDocValues.create(values, maxDoc);
     }
     
     @Override
@@ -285,7 +285,7 @@ public class AssertingDocValuesFormat extends DocValuesFormat {
       assert field.getDocValuesType() == DocValuesType.SORTED_SET;
       SortedSetDocValues values = in.getSortedSet(field);
       assert values != null;
-      return new AssertingLeafReader.AssertingSortedSetDocValues(values, maxDoc);
+      return AssertingLeafReader.AssertingSortedSetDocValues.create(values, maxDoc);
     }
     
     @Override

--- a/lucene/test-framework/src/java/org/apache/lucene/index/AssertingLeafReader.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/index/AssertingLeafReader.java
@@ -827,7 +827,7 @@ public class AssertingLeafReader extends FilterLeafReader {
       return result;
     }
   }
-  
+
   /** Wraps a SortedNumericDocValues but with additional asserts */
   public static class AssertingSortedNumericDocValues extends SortedNumericDocValues {
     private final Thread creationThread = Thread.currentThread();
@@ -836,10 +836,20 @@ public class AssertingLeafReader extends FilterLeafReader {
     private int lastDocID = -1;
     private int valueUpto;
     private boolean exists;
-    
-    public AssertingSortedNumericDocValues(SortedNumericDocValues in, int maxDoc) {
+
+    private AssertingSortedNumericDocValues(SortedNumericDocValues in, int maxDoc) {
       this.in = in;
       this.maxDoc = maxDoc;
+    }
+
+    public static SortedNumericDocValues create(SortedNumericDocValues in, int maxDoc) {
+      NumericDocValues singleDocValues = DocValues.unwrapSingleton(in);
+      if (singleDocValues == null) {
+        return new AssertingSortedNumericDocValues(in, maxDoc);
+      } else {
+        NumericDocValues assertingDocValues = new AssertingNumericDocValues(singleDocValues, maxDoc);
+        return DocValues.singleton(assertingDocValues);
+      }
     }
 
     @Override
@@ -924,11 +934,21 @@ public class AssertingLeafReader extends FilterLeafReader {
     private long lastOrd = NO_MORE_ORDS;
     private boolean exists;
     
-    public AssertingSortedSetDocValues(SortedSetDocValues in, int maxDoc) {
+    private AssertingSortedSetDocValues(SortedSetDocValues in, int maxDoc) {
       this.in = in;
       this.maxDoc = maxDoc;
       this.valueCount = in.getValueCount();
       assert valueCount >= 0;
+    }
+
+    public static SortedSetDocValues create(SortedSetDocValues in, int maxDoc) {
+      SortedDocValues singleDocValues = DocValues.unwrapSingleton(in);
+      if (singleDocValues == null) {
+        return new AssertingSortedSetDocValues(in, maxDoc);
+      } else {
+        SortedDocValues assertingDocValues = new AssertingSortedDocValues(singleDocValues, maxDoc);
+        return DocValues.singleton(assertingDocValues);
+      }
     }
 
     @Override
@@ -1233,12 +1253,12 @@ public class AssertingLeafReader extends FilterLeafReader {
   
   @Override
   public SortedNumericDocValues getSortedNumericDocValues(String field) throws IOException {
-    SortedNumericDocValues dv = super.getSortedNumericDocValues(field);
     FieldInfo fi = getFieldInfos().fieldInfo(field);
+    SortedNumericDocValues dv = super.getSortedNumericDocValues(field);
     if (dv != null) {
       assert fi != null;
       assert fi.getDocValuesType() == DocValuesType.SORTED_NUMERIC;
-      return new AssertingSortedNumericDocValues(dv, maxDoc());
+      return AssertingSortedNumericDocValues.create(dv, maxDoc());
     } else {
       assert fi == null || fi.getDocValuesType() != DocValuesType.SORTED_NUMERIC;
       return null;


### PR DESCRIPTION
Some queries use DocValues.unwrapSingleton to execute different logic for
single-valued doc values. When tests use AssertingCodec or AssertingLeafReader,
unwrapSingleton will never unwrap the doc values, as they don't have the
expected class. So some queries have code paths that are never exercised with
these asserting wrappers.

This change makes sure to preserve the expected classes when creating asserting
doc values.