### PR TITLE
SOLR-14510: Remove deprecations added with BlockMax WAND support

### DIFF
--- a/solr/core/src/java/org/apache/solr/response/GeoJSONResponseWriter.java
+++ b/solr/core/src/java/org/apache/solr/response/GeoJSONResponseWriter.java
@@ -294,13 +294,6 @@ class GeoJSONWriter extends JSONWriter {
     }
   }
 
-  @Deprecated
-  @Override
-  public void writeStartDocumentList(String name, 
-      long start, int size, long numFound, Float maxScore) throws IOException {
-    throw new UnsupportedOperationException();
-  }
-  
   @Override
   public void writeStartDocumentList(String name, 
       long start, int size, long numFound, Float maxScore, Boolean numFoundExact) throws IOException

--- a/solr/core/src/java/org/apache/solr/response/JSONResponseWriter.java
+++ b/solr/core/src/java/org/apache/solr/response/JSONResponseWriter.java
@@ -214,13 +214,6 @@ class ArrayOfNameTypeValueJSONWriter extends JSONWriter {
     ifNeededWriteTypeAndValueKey("doc");
     super.writeSolrDocument(name, doc, returnFields, idx);
   }
-
-  @Deprecated
-  @Override
-  public void writeStartDocumentList(String name, long start, int size, long numFound, Float maxScore) throws IOException {
-    ifNeededWriteTypeAndValueKey("doclist");
-    super.writeStartDocumentList(name, start, size, numFound, maxScore);
-  }
   
   @Override
   public void writeStartDocumentList(String name, long start, int size, long numFound, Float maxScore, Boolean numFoundExact) throws IOException {

--- a/solr/core/src/java/org/apache/solr/response/JSONWriter.java
+++ b/solr/core/src/java/org/apache/solr/response/JSONWriter.java
@@ -131,36 +131,6 @@ public class JSONWriter extends TextResponseWriter implements JsonTextWriter {
   //       contained in an array or map, a negative value indicates
   //       that the size could not be reliably determined.
   //
-
-  /**
-   * This method will be removed in Solr 9
-   * @deprecated Use {{@link #writeStartDocumentList(String, long, int, long, Float, Boolean)}.
-   */
-  @Override
-  @Deprecated
-  public void writeStartDocumentList(String name,
-      long start, int size, long numFound, Float maxScore) throws IOException
-  {
-    writeMapOpener(headerSize(maxScore, null));
-    incLevel();
-    writeKey("numFound",false);
-    writeLong(null,numFound);
-    writeMapSeparator();
-    writeKey("start",false);
-    writeLong(null,start);
-
-    if (maxScore!=null) {
-      writeMapSeparator();
-      writeKey("maxScore",false);
-      writeFloat(null,maxScore);
-    }
-    writeMapSeparator();
-    // indent();
-    writeKey("docs",false);
-    writeArrayOpener(size);
-
-    incLevel();
-  }
   
   @Override
   public void writeStartDocumentList(String name,

--- a/solr/core/src/java/org/apache/solr/response/PHPSerializedResponseWriter.java
+++ b/solr/core/src/java/org/apache/solr/response/PHPSerializedResponseWriter.java
@@ -86,15 +86,7 @@ class PHPSerializedWriter extends JSONWriter {
   
   @Override
   public void writeNamedList(String name, @SuppressWarnings({"rawtypes"})NamedList val) throws IOException {
-    writeNamedListAsMapMangled(name,val);
-  }
-  
-  @Deprecated
-  @Override
-  public void writeStartDocumentList(String name, 
-      long start, int size, long numFound, Float maxScore) throws IOException
-  {
-    throw new UnsupportedOperationException();
+    writeNamedListAsMapMangled(name, val);
   }
 
   @Override

--- a/solr/core/src/java/org/apache/solr/response/SchemaXmlWriter.java
+++ b/solr/core/src/java/org/apache/solr/response/SchemaXmlWriter.java
@@ -465,11 +465,6 @@ public class SchemaXmlWriter extends TextResponseWriter {
     writer.write(tag);
     writer.write('>');
   }
-
-  @Override
-  public void writeStartDocumentList(String name, long start, int size, long numFound, Float maxScore) throws IOException {
-    // no-op
-  }
   
   @Override
   public void writeStartDocumentList(String name, long start, int size, long numFound, Float maxScore, Boolean numFoundExact) throws IOException {

--- a/solr/core/src/java/org/apache/solr/response/TabularResponseWriter.java
+++ b/solr/core/src/java/org/apache/solr/response/TabularResponseWriter.java
@@ -123,13 +123,6 @@ public abstract class TabularResponseWriter extends TextResponseWriter {
 
   @Override
   public void writeStartDocumentList(String name,
-                                     long start, int size, long numFound, Float maxScore) throws IOException
-  {
-    // nothing
-  }
-  
-  @Override
-  public void writeStartDocumentList(String name,
                                      long start, int size, long numFound, Float maxScore, Boolean numFoundExact) throws IOException
   {
     // nothing

--- a/solr/core/src/java/org/apache/solr/response/TextResponseWriter.java
+++ b/solr/core/src/java/org/apache/solr/response/TextResponseWriter.java
@@ -157,16 +157,7 @@ public abstract class TextResponseWriter implements TextWriter {
   // types of formats, including those where the name may come after the value (like
   // some XML formats).
 
-  //TODO: Make abstract in Solr 9.0
-  public void writeStartDocumentList(String name, long start, int size, long numFound, Float maxScore, Boolean numFoundExact) throws IOException {
-    writeStartDocumentList(name, start, size, numFound, maxScore);
-  }
-  
-  /**
-   * @deprecated Use {@link #writeStartDocumentList(String, long, int, long, Float, Boolean)}
-   */
-  @Deprecated
-  public abstract void writeStartDocumentList(String name, long start, int size, long numFound, Float maxScore) throws IOException;
+  public abstract void writeStartDocumentList(String name, long start, int size, long numFound, Float maxScore, Boolean numFoundExact) throws IOException;
 
   public abstract void writeSolrDocument(String name, SolrDocument doc, ReturnFields fields, int idx) throws IOException;
   

--- a/solr/core/src/java/org/apache/solr/response/XMLWriter.java
+++ b/solr/core/src/java/org/apache/solr/response/XMLWriter.java
@@ -187,26 +187,6 @@ public class XMLWriter extends TextResponseWriter {
 
     incLevel();
   }
-  
-  @Override
-  @Deprecated
-  public void writeStartDocumentList(String name,
-      long start, int size, long numFound, Float maxScore) throws IOException
-  {
-    if (doIndent) indent();
-
-    writer.write("<result");
-    writeAttr(NAME, name);
-    writeAttr("numFound",Long.toString(numFound));
-    writeAttr("start",Long.toString(start));
-    if(maxScore!=null) {
-      writeAttr("maxScore",Float.toString(maxScore));
-    }
-    writer.write(">");
-
-    incLevel();
-  }
-
 
   /**
    * The SolrDocument should already have multivalued fields implemented as

--- a/solr/solr-ref-guide/src/major-changes-in-solr-9.adoc
+++ b/solr/solr-ref-guide/src/major-changes-in-solr-9.adoc
@@ -124,7 +124,10 @@ _(raw; not yet edited)_
   monitors on Solr KPIs that mention "master" or "slave" will also now be "leader" and "follower"
 
 * SOLR-14783: Data Import Handler (DIH) has been removed from Solr. The community package is available at: https://github.com/rohitbemax/dataimporthandler (Alexandre Rafalovitch)
-  
+
+* SOLR-14510: The `writeStartDocumentList` in `TextResponseWriter` now receives an extra boolean parameter representing the "exactness" of the numFound value (exact vs approximation).
+  Any custom response writer extending `TextResponseWriter` will need to implement this abstract method now (instead previous with the same name but without the new boolean parameter).
+
 === Upgrade Prerequisites in Solr 9
 
 * Upgrade all collections in stateFormat=1 to stateFormat=2 *before* upgrading to Solr 9, as Solr 9 does not support the


### PR DESCRIPTION
With BMW support, we added a new method to Text response writers to include in the response if the numFound is exact or not. This PR is to remove the previously existing and deprecated methods and makes the new method abstract to force it's implementation in subclasses. This is intended for master branch only.