### PR TITLE
LUCENE-9500: Separate the Deflater hack from the Lucene code to a subclass of java.util.zip.Deflater

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene87/BugfixDeflater_JDK8252739.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene87/BugfixDeflater_JDK8252739.java
@@ -27,6 +27,26 @@ import java.util.zip.Inflater;
  */
 final class BugfixDeflater_JDK8252739 extends Deflater {
   
+  public static final boolean IS_BUGGY_JDK = detectBuggyJDK();
+
+  /**
+   * Creates a {@link Deflater} instance, which works around JDK-8252739.
+   * <p>
+   * Use this whenever you intend to call {@link #setDictionary(byte[], int, int)} or
+   * {@link #setDictionary(java.nio.ByteBuffer)} on a {@code Deflater}.
+   * */
+  public static Deflater createDeflaterInstance(int level, boolean nowrap, int dictLength) {
+    if (dictLength < 0) {
+      throw new IllegalArgumentException("dictLength must be >= 0");
+    }
+    if (IS_BUGGY_JDK) {
+      return new BugfixDeflater_JDK8252739(level, nowrap, dictLength);
+    } else {
+      return new Deflater(level, nowrap);
+    }
+  }
+  
+  
   private final byte[] dictBytesScratch;
 
   private BugfixDeflater_JDK8252739(int level, boolean nowrap, int dictLength) {
@@ -44,17 +64,6 @@ final class BugfixDeflater_JDK8252739 extends Deflater {
     }
   }
 
-  public static Deflater createDeflaterInstance(int level, boolean nowrap, int dictLength) {
-    if (dictLength < 0) {
-      throw new IllegalArgumentException("dictLength must be >= 0");
-    }
-    if (IS_BUGGY_JDK) {
-      return new BugfixDeflater_JDK8252739(level, nowrap, dictLength);
-    } else {
-      return new Deflater(level, nowrap);
-    }
-  }
-  
   private static boolean detectBuggyJDK() {
     final byte[] testData = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 };
     final byte[] compressed = new byte[32]; // way enough space
@@ -100,6 +109,4 @@ final class BugfixDeflater_JDK8252739 extends Deflater {
     return false;
   }
   
-  public static final boolean IS_BUGGY_JDK = detectBuggyJDK();
-
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene87/BugfixDeflater_JDK8252739.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene87/BugfixDeflater_JDK8252739.java
@@ -22,7 +22,7 @@ import org.apache.lucene.util.Constants;
 
 /**
  * This class is a workaround for JDK bug
- * <a href="https://bugs.openjdk.java.net/browse/JDK-8252739">JDK8252739</a>.
+ * <a href="https://bugs.openjdk.java.net/browse/JDK-8252739">JDK-8252739</a>.
  */
 final class BugfixDeflater_JDK8252739 extends Deflater {
   

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene87/BugfixDeflater_JDK8252739.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene87/BugfixDeflater_JDK8252739.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.lucene87;
+
+import java.util.zip.Deflater;
+
+import org.apache.lucene.util.Constants;
+
+/**
+ * This class is a workaround for JDK bug
+ * <a href="https://bugs.openjdk.java.net/browse/JDK-8252739">JDK8252739</a>.
+ */
+final class BugfixDeflater_JDK8252739 extends Deflater {
+  
+  private final byte[] dictBytesScratch;
+
+  private BugfixDeflater_JDK8252739(int level, boolean nowrap, int dictLength) {
+    super(level, nowrap);
+    this.dictBytesScratch = new byte[dictLength];
+  }
+  
+  @Override
+  public void setDictionary(byte[] dictBytes, int off, int len) {
+    if (off > 0) {
+      if (len > this.dictBytesScratch.length) {
+        throw new IllegalArgumentException("Too large dictionary");
+      }
+      System.arraycopy(dictBytes, off, dictBytesScratch, 0, len);
+      super.setDictionary(dictBytesScratch, 0, len);
+    } else {
+      super.setDictionary(dictBytes, off, len);
+    }
+  }
+
+  public static Deflater createDeflaterInstance(int level, boolean nowrap, int dictLength) {
+    if (dictLength < 0) {
+      throw new IllegalArgumentException("dictLength must be >= 0");
+    }
+    if (Constants.JRE_IS_MINIMUM_JAVA11) {
+      return new BugfixDeflater_JDK8252739(level, nowrap, dictLength);
+    } else {
+      return new Deflater(level, nowrap);
+    }
+  }
+
+}

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene87/BugfixDeflater_JDK8252739.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene87/BugfixDeflater_JDK8252739.java
@@ -59,27 +59,34 @@ final class BugfixDeflater_JDK8252739 extends Deflater {
     final byte[] testData = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 };
     final byte[] compressed = new byte[32]; // way enough space
     final Deflater deflater = new Deflater(6, true);
+    int compressedSize;
     try {
       deflater.reset();
       deflater.setDictionary(testData, 4, 4);
       deflater.setInput(testData);
       deflater.finish();
-      deflater.deflate(compressed, 0, compressed.length, Deflater.FULL_FLUSH);
+      compressedSize = deflater.deflate(compressed, 0, compressed.length, Deflater.FULL_FLUSH);
     } finally {
       deflater.end();
     }
+    
+    // in nowrap mode we need extra 0-byte as padding, add explicit:
+    compressed[compressedSize] = 0;
+    compressedSize++;
     
     final Inflater inflater = new Inflater(true);
     final byte[] restored = new byte[testData.length];
     try {
       inflater.reset();
       inflater.setDictionary(testData, 4, 4);
-      inflater.setInput(compressed);
+      inflater.setInput(compressed, 0, compressedSize);
       final int restoredLength = inflater.inflate(restored);
       if (restoredLength != testData.length) {
         return true;
       }
     } catch (DataFormatException e) {
+      return true;
+    } catch(RuntimeException e) {
       return true;
     } finally {
       inflater.end();

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene87/BugfixDeflater_JDK8252739.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene87/BugfixDeflater_JDK8252739.java
@@ -36,9 +36,6 @@ final class BugfixDeflater_JDK8252739 extends Deflater {
   @Override
   public void setDictionary(byte[] dictBytes, int off, int len) {
     if (off > 0) {
-      if (len > this.dictBytesScratch.length) {
-        throw new IllegalArgumentException("Too large dictionary");
-      }
       System.arraycopy(dictBytes, off, dictBytesScratch, 0, len);
       super.setDictionary(dictBytesScratch, 0, len);
     } else {

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene87/BugfixDeflater_JDK8252739.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene87/BugfixDeflater_JDK8252739.java
@@ -101,9 +101,5 @@ final class BugfixDeflater_JDK8252739 extends Deflater {
   }
   
   public static final boolean IS_BUGGY_JDK = detectBuggyJDK();
-  
-  static {
-    System.err.println("JDK is buggy: " + IS_BUGGY_JDK);
-  }
 
 }

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene87/TestLucene87StoredFieldsFormatHighCompression.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene87/TestLucene87StoredFieldsFormatHighCompression.java
@@ -77,4 +77,8 @@ public class TestLucene87StoredFieldsFormatHighCompression extends BaseStoredFie
       new Lucene87StoredFieldsFormat(null);
     });
   }
+  
+  public void testShowJDKBugStatus() {
+    System.err.println("JDK is buggy (JDK-8252739): " + BugfixDeflater_JDK8252739.IS_BUGGY_JDK);
+  }
 }


### PR DESCRIPTION
A factory method allows to return a different instance depending on Java version (for now everything after Java 11 is disallowed).

We can improve this when we exactly know which versions are affected. Once the bug is fixed and Lucene uses a later minimum version, we can easily remove the class.

TODO: We should add a forbiddenapis to disallow direct use of deflater by disallowing its constructor.