### PR TITLE
LUCENE-9501: Fix invariant violation in IndexSortSortedNumericDocValuesRangeQuery.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -226,6 +226,9 @@ Bug Fixes
   already exists instead of opening an IndexInput on the file which might throw a AccessDeniedException
   in some Directory implementations. (Simon Willnauer)
 
+* LUCENE-9501: Fix a bug in IndexSortSortedNumericDocValuesRangeQuery where it could violate the
+  DocIdSetIterator contract. (Julie Tibshirani)
+
 Documentation
 ---------------------
 

--- a/lucene/sandbox/src/java/org/apache/lucene/search/IndexSortSortedNumericDocValuesRangeQuery.java
+++ b/lucene/sandbox/src/java/org/apache/lucene/search/IndexSortSortedNumericDocValuesRangeQuery.java
@@ -287,10 +287,10 @@ public class IndexSortSortedNumericDocValuesRangeQuery extends Query {
       int result = delegate.advance(target);
       if (result < lastDoc) {
         docID = result;
-        return docID;
       } else {
-        return NO_MORE_DOCS;
+        docID = NO_MORE_DOCS;
       }
+      return docID;
     }
 
     @Override

--- a/lucene/sandbox/src/test/org/apache/lucene/search/TestIndexSortSortedNumericDocValuesRangeQuery.java
+++ b/lucene/sandbox/src/test/org/apache/lucene/search/TestIndexSortSortedNumericDocValuesRangeQuery.java
@@ -65,7 +65,7 @@ public class TestIndexSortSortedNumericDocValuesRangeQuery extends LuceneTestCas
         iw.deleteDocuments(LongPoint.newRangeQuery("idx", 0L, 10L));
       }
       final IndexReader reader = iw.getReader();
-      final IndexSearcher searcher = newSearcher(reader, false);
+      final IndexSearcher searcher = newSearcher(reader);
       iw.close();
 
       for (int i = 0; i < 100; ++i) {


### PR DESCRIPTION
Previously the DocIdSetIterator returned an old value for docID even after
advance returned NO_MORE_DOCS. This violates the DocIdSetIterator contract and
made it possible for the iterator's advance method to be called even after it
was already exhausted.