### PR TITLE
LUCENE-7882: First idea of using Java 15 hidden anonymous classes for Lucene expressions

### DIFF
--- a/lucene/expressions/src/java/org/apache/lucene/expressions/js/JavascriptCompiler.java
+++ b/lucene/expressions/src/java/org/apache/lucene/expressions/js/JavascriptCompiler.java
@@ -239,6 +239,8 @@ public final class JavascriptCompiler {
   }
 
   private Class<? extends Expression> defineClass(ClassLoader parent, byte[] bc) throws IllegalAccessException {
+    // if we are on Java 15+ and the classloader is our own classloader, we can create an
+    // anonymous hidden class (JEP-371):
     if (MH_defineHiddenClass != null && parent == getClass().getClassLoader()) {
       final Lookup hiddenLookup;
       try {

--- a/lucene/expressions/src/test/org/apache/lucene/expressions/js/TestCustomFunctions.java
+++ b/lucene/expressions/src/test/org/apache/lucene/expressions/js/TestCustomFunctions.java
@@ -263,7 +263,7 @@ public class TestCustomFunctions extends LuceneTestCase {
     PrintWriter pw = new PrintWriter(sw);
     expected.printStackTrace(pw);
     pw.flush();
-    assertTrue(sw.toString().contains("JavascriptCompiler$CompiledExpression.evaluate(" + source + ")"));
+    assertTrue(sw.toString(), sw.toString().contains("JavascriptCompiler$CompiledExpression.evaluate(" + source + ")"));
   }
 
   /** test that namespaces work with custom expressions. */


### PR DESCRIPTION
This PR is a first (but already working) idea of using Java 15 hidden classes (see https://openjdk.java.net/jeps/371) to implement the Lucene expressions. The big advantages:
- No classloader for every expression is needed, because the class is completely anonymous and has no strong reference to a classloader. Actually the class has a classloader to lookup any referenced other class, but it is NOT loaded by any classloader
- The class can easily be unloaded
- The performance of loading that class is better, as no locks can occur (classloaders have locks when looking up classes), see https://issues.apache.org/jira/browse/LUCENE-7882

Backside:
- The class and its methods do not appear in any stack trace. This also fails one test in the test suite. When using this for Lucene expressions, we have to think about a better way how to make the source code and method calls visible in stack traces. Like lambda frames the hidden class is not visible (unless enabled in JVM to show hidden frames). I have a question open on openjdk mailing list: https://mail.openjdk.java.net/pipermail/core-libs-dev/2020-September/068542.html
- It currently does not work if you pass a different classloader than Lucene's to the expressions module. To allow this we need to change APIs a bit (Classloader -> Lookup).

@mikemccand can you test this with JDK 15 (release candidate) and your test. You should not see any locks anymore, speed should be higher, and the created anonymous classes should be unloaded very fast.