### PR TITLE
SOLR 13528: Move Rate Limiter Configuration To Be A Plugin

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/NodeConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/NodeConfig.java
@@ -48,6 +48,8 @@ public class NodeConfig {
 
   private final PluginInfo shardHandlerFactoryConfig;
 
+  private final PluginInfo rateLimitManagerConfig;
+
   private final UpdateShardHandlerConfig updateShardHandlerConfig;
 
   private final String coreAdminHandlerClass;
@@ -90,7 +92,7 @@ public class NodeConfig {
 
   private NodeConfig(String nodeName, Path coreRootDirectory, Path solrDataHome, Integer booleanQueryMaxClauseCount,
                      Path configSetBaseDirectory, String sharedLibDirectory,
-                     PluginInfo shardHandlerFactoryConfig, UpdateShardHandlerConfig updateShardHandlerConfig,
+                     PluginInfo shardHandlerFactoryConfig, PluginInfo rateLimitManagerConfig, UpdateShardHandlerConfig updateShardHandlerConfig,
                      String coreAdminHandlerClass, String collectionsAdminHandlerClass,
                      String healthCheckHandlerClass, String infoHandlerClass, String configSetsHandlerClass,
                      LogWatcherConfig logWatcherConfig, CloudConfig cloudConfig, Integer coreLoadThreads, int replayUpdatesThreads,
@@ -107,6 +109,7 @@ public class NodeConfig {
     this.configSetBaseDirectory = configSetBaseDirectory;
     this.sharedLibDirectory = sharedLibDirectory;
     this.shardHandlerFactoryConfig = shardHandlerFactoryConfig;
+    this.rateLimitManagerConfig = rateLimitManagerConfig;
     this.updateShardHandlerConfig = updateShardHandlerConfig;
     this.coreAdminHandlerClass = coreAdminHandlerClass;
     this.collectionsAdminHandlerClass = collectionsAdminHandlerClass;
@@ -161,6 +164,10 @@ public class NodeConfig {
   
   public PluginInfo getShardHandlerFactoryPluginInfo() {
     return shardHandlerFactoryConfig;
+  }
+
+  public PluginInfo getRateLimitManagerConfig() {
+    return rateLimitManagerConfig;
   }
 
   public UpdateShardHandlerConfig getUpdateShardHandlerConfig() {
@@ -282,6 +289,7 @@ public class NodeConfig {
     private Path configSetBaseDirectory;
     private String sharedLibDirectory;
     private PluginInfo shardHandlerFactoryConfig;
+    private PluginInfo rateLimitManagerConfig;
     private UpdateShardHandlerConfig updateShardHandlerConfig = UpdateShardHandlerConfig.DEFAULT;
     private String coreAdminHandlerClass = DEFAULT_ADMINHANDLERCLASS;
     private String collectionsAdminHandlerClass = DEFAULT_COLLECTIONSHANDLERCLASS;
@@ -368,6 +376,11 @@ public class NodeConfig {
 
     public NodeConfigBuilder setShardHandlerFactoryConfig(PluginInfo shardHandlerFactoryConfig) {
       this.shardHandlerFactoryConfig = shardHandlerFactoryConfig;
+      return this;
+    }
+
+    public NodeConfigBuilder setRateLimitManagerConfig(PluginInfo rateLimitManagerConfig) {
+      this.rateLimitManagerConfig = rateLimitManagerConfig;
       return this;
     }
 
@@ -479,7 +492,7 @@ public class NodeConfig {
         loader = new SolrResourceLoader(solrHome);
       }
       return new NodeConfig(nodeName, coreRootDirectory, solrDataHome, booleanQueryMaxClauseCount,
-                            configSetBaseDirectory, sharedLibDirectory, shardHandlerFactoryConfig,
+                            configSetBaseDirectory, sharedLibDirectory, shardHandlerFactoryConfig, rateLimitManagerConfig,
                             updateShardHandlerConfig, coreAdminHandlerClass, collectionsAdminHandlerClass, healthCheckHandlerClass, infoHandlerClass, configSetsHandlerClass,
                             logWatcherConfig, cloudConfig, coreLoadThreads, replayUpdatesThreads, transientCacheSize, useSchemaCache, managementPath,
                             solrHome, loader, solrProperties,

--- a/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
@@ -105,6 +105,7 @@ public class SolrXmlConfig {
     configBuilder.setSolrResourceLoader(config.getResourceLoader());
     configBuilder.setUpdateShardHandlerConfig(updateConfig);
     configBuilder.setShardHandlerFactoryConfig(getShardHandlerFactoryPluginInfo(config));
+    configBuilder.setRateLimitManagerConfig(getRateLimitManagerPluginInfo(config));
     configBuilder.setSolrCoreCacheFactoryConfig(getTransientCoreCacheFactoryPluginInfo(config));
     configBuilder.setTracerConfig(getTracerPluginInfo(config));
     configBuilder.setLogWatcherConfig(loadLogWatcherConfig(config, "solr/logging/*[@name]", "solr/logging/watcher/*[@name]"));
@@ -485,6 +486,11 @@ public class SolrXmlConfig {
   private static PluginInfo getShardHandlerFactoryPluginInfo(XmlConfigFile config) {
     Node node = config.getNode("solr/shardHandlerFactory", false);
     return (node == null) ? null : new PluginInfo(node, "shardHandlerFactory", false, true);
+  }
+
+  private static PluginInfo getRateLimitManagerPluginInfo(XmlConfigFile config) {
+    Node node = config.getNode("solr/rateLimitManager", false);
+    return (node == null) ? null : new PluginInfo(node, "rateLimitManager", false, true);
   }
 
   private static PluginInfo[] getBackupRepositoryPluginInfos(XmlConfigFile config) {

--- a/solr/core/src/java/org/apache/solr/servlet/QueryRateLimiter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/QueryRateLimiter.java
@@ -17,9 +17,9 @@
 
 package org.apache.solr.servlet;
 
-import javax.servlet.FilterConfig;
-
 import org.apache.solr.client.solrj.SolrRequest;
+import org.apache.solr.core.NodeConfig;
+import org.apache.solr.core.PluginInfo;
 
 import static org.apache.solr.servlet.RateLimitManager.DEFAULT_CONCURRENT_REQUESTS;
 import static org.apache.solr.servlet.RateLimitManager.DEFAULT_SLOT_ACQUISITION_TIMEOUT_MS;
@@ -34,21 +34,22 @@ public class QueryRateLimiter extends RequestRateLimiter {
   final static String QUERY_GUARANTEED_SLOTS = "queryGuaranteedSlots";
   final static String QUERY_ALLOW_SLOT_BORROWING = "queryAllowSlotBorrowing";
 
-  public QueryRateLimiter(FilterConfig filterConfig) {
-    super(constructQueryRateLimiterConfig(filterConfig));
+  public QueryRateLimiter(NodeConfig nodeConfig) {
+    super(constructQueryRateLimiterConfig(nodeConfig));
   }
 
-  protected static RequestRateLimiter.RateLimiterConfig constructQueryRateLimiterConfig(FilterConfig filterConfig) {
+  protected static RequestRateLimiter.RateLimiterConfig constructQueryRateLimiterConfig(NodeConfig nodeConfig) {
     RequestRateLimiter.RateLimiterConfig queryRateLimiterConfig = new RequestRateLimiter.RateLimiterConfig();
+    PluginInfo pluginInfo = nodeConfig.getRateLimitManagerConfig();
 
     queryRateLimiterConfig.requestType = SolrRequest.SolrRequestType.QUERY;
-    queryRateLimiterConfig.isEnabled = getParamAndParseBoolean(filterConfig, IS_QUERY_RATE_LIMITER_ENABLED, false);
-    queryRateLimiterConfig.waitForSlotAcquisition = getParamAndParseLong(filterConfig, QUERY_WAIT_FOR_SLOT_ALLOCATION_INMS,
+    queryRateLimiterConfig.isEnabled = getParamAndParseBoolean(pluginInfo, IS_QUERY_RATE_LIMITER_ENABLED, false);
+    queryRateLimiterConfig.waitForSlotAcquisition = getParamAndParseLong(pluginInfo, QUERY_WAIT_FOR_SLOT_ALLOCATION_INMS,
         DEFAULT_SLOT_ACQUISITION_TIMEOUT_MS);
-    queryRateLimiterConfig.allowedRequests = getParamAndParseInt(filterConfig, MAX_QUERY_REQUESTS,
+    queryRateLimiterConfig.allowedRequests = getParamAndParseInt(pluginInfo, MAX_QUERY_REQUESTS,
         DEFAULT_CONCURRENT_REQUESTS);
-    queryRateLimiterConfig.isSlotBorrowingEnabled = getParamAndParseBoolean(filterConfig, QUERY_ALLOW_SLOT_BORROWING, false);
-    queryRateLimiterConfig.guaranteedSlotsThreshold = getParamAndParseInt(filterConfig, QUERY_GUARANTEED_SLOTS, queryRateLimiterConfig.allowedRequests / 2);
+    queryRateLimiterConfig.isSlotBorrowingEnabled = getParamAndParseBoolean(pluginInfo, QUERY_ALLOW_SLOT_BORROWING, false);
+    queryRateLimiterConfig.guaranteedSlotsThreshold = getParamAndParseInt(pluginInfo, QUERY_GUARANTEED_SLOTS, queryRateLimiterConfig.allowedRequests / 2);
 
     return queryRateLimiterConfig;
   }

--- a/solr/core/src/java/org/apache/solr/servlet/QueryRateLimiter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/QueryRateLimiter.java
@@ -40,7 +40,12 @@ public class QueryRateLimiter extends RequestRateLimiter {
 
   protected static RequestRateLimiter.RateLimiterConfig constructQueryRateLimiterConfig(NodeConfig nodeConfig) {
     RequestRateLimiter.RateLimiterConfig queryRateLimiterConfig = new RequestRateLimiter.RateLimiterConfig();
-    PluginInfo pluginInfo = nodeConfig.getRateLimitManagerConfig();
+
+    PluginInfo pluginInfo = null;
+
+    if (nodeConfig != null) {
+      pluginInfo = nodeConfig.getRateLimitManagerConfig();
+    }
 
     queryRateLimiterConfig.requestType = SolrRequest.SolrRequestType.QUERY;
     queryRateLimiterConfig.isEnabled = getParamAndParseBoolean(pluginInfo, IS_QUERY_RATE_LIMITER_ENABLED, false);

--- a/solr/core/src/java/org/apache/solr/servlet/RateLimitManager.java
+++ b/solr/core/src/java/org/apache/solr/servlet/RateLimitManager.java
@@ -17,7 +17,6 @@
 
 package org.apache.solr.servlet;
 
-import javax.servlet.FilterConfig;
 import javax.servlet.http.HttpServletRequest;
 import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
@@ -26,6 +25,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.common.annotation.SolrThreadSafe;
+import org.apache.solr.core.NodeConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -164,9 +164,9 @@ public class RateLimitManager {
   }
 
   public static class Builder {
-    protected FilterConfig config;
+    protected NodeConfig config;
 
-    public Builder(FilterConfig config) {
+    public Builder(NodeConfig config) {
       this.config = config;
     }
 

--- a/solr/core/src/java/org/apache/solr/servlet/RequestRateLimiter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/RequestRateLimiter.java
@@ -17,12 +17,13 @@
 
 package org.apache.solr.servlet;
 
-import javax.servlet.FilterConfig;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.common.annotation.SolrThreadSafe;
+import org.apache.solr.common.util.NamedList;
+import org.apache.solr.core.PluginInfo;
 
 /**
  * Handles rate limiting for a specific request type.
@@ -95,34 +96,40 @@ public class RequestRateLimiter {
     return rateLimiterConfig;
   }
 
-  static long getParamAndParseLong(FilterConfig config, String parameterName, long defaultValue) {
-    String tempBuffer = config.getInitParameter(parameterName);
+  static long getParamAndParseLong(PluginInfo config, String parameterName, long defaultValue) {
+    long result = defaultValue;
 
-    if (tempBuffer != null) {
-      return Long.parseLong(tempBuffer);
+    if (config != null) {
+      NamedList args = config.initArgs;
+
+      result = Long.parseLong(args._getStr(parameterName, String.valueOf(defaultValue)));
     }
 
-    return defaultValue;
+    return result;
   }
 
-  static int getParamAndParseInt(FilterConfig config, String parameterName, int defaultValue) {
-    String tempBuffer = config.getInitParameter(parameterName);
+  static int getParamAndParseInt(PluginInfo config, String parameterName, int defaultValue) {
+    int result = defaultValue;
 
-    if (tempBuffer != null) {
-      return Integer.parseInt(tempBuffer);
+    if (config != null) {
+      NamedList args = config.initArgs;
+
+      result = Integer.parseInt(args._getStr(parameterName, String.valueOf(defaultValue)));
     }
 
-    return defaultValue;
+    return result;
   }
 
-  static boolean getParamAndParseBoolean(FilterConfig config, String parameterName, boolean defaultValue) {
-    String tempBuffer = config.getInitParameter(parameterName);
+  static boolean getParamAndParseBoolean(PluginInfo config, String parameterName, boolean defaultValue) {
+    boolean result = defaultValue;
 
-    if (tempBuffer != null) {
-      return Boolean.parseBoolean(tempBuffer);
+    if (config != null) {
+      NamedList args = config.initArgs;
+
+      result = Boolean.parseBoolean(args._getStr(parameterName, String.valueOf(defaultValue)));
     }
 
-    return defaultValue;
+    return result;
   }
 
   /* Rate limiter config for a specific request rate limiter instance */

--- a/solr/core/src/java/org/apache/solr/servlet/RequestRateLimiter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/RequestRateLimiter.java
@@ -96,6 +96,7 @@ public class RequestRateLimiter {
     return rateLimiterConfig;
   }
 
+  @SuppressWarnings({"rawtypes"})
   static long getParamAndParseLong(PluginInfo config, String parameterName, long defaultValue) {
     long result = defaultValue;
 
@@ -108,6 +109,7 @@ public class RequestRateLimiter {
     return result;
   }
 
+  @SuppressWarnings({"rawtypes"})
   static int getParamAndParseInt(PluginInfo config, String parameterName, int defaultValue) {
     int result = defaultValue;
 
@@ -120,6 +122,7 @@ public class RequestRateLimiter {
     return result;
   }
 
+  @SuppressWarnings({"rawtypes"})
   static boolean getParamAndParseBoolean(PluginInfo config, String parameterName, boolean defaultValue) {
     boolean result = defaultValue;
 

--- a/solr/core/src/java/org/apache/solr/servlet/SolrDispatchFilter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/SolrDispatchFilter.java
@@ -187,7 +187,7 @@ public class SolrDispatchFilter extends BaseSolrFilter {
       coresInit = createCoreContainer(solrHomePath, extraProperties);
       this.httpClient = coresInit.getUpdateShardHandler().getDefaultHttpClient();
       setupJvmMetrics(coresInit);
-      RateLimitManager.Builder builder = new RateLimitManager.Builder(config);
+      RateLimitManager.Builder builder = new RateLimitManager.Builder(cores.getConfig());
 
       this.rateLimitManager = builder.build();
       if (log.isDebugEnabled()) {

--- a/solr/core/src/java/org/apache/solr/servlet/SolrDispatchFilter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/SolrDispatchFilter.java
@@ -187,7 +187,7 @@ public class SolrDispatchFilter extends BaseSolrFilter {
       coresInit = createCoreContainer(solrHomePath, extraProperties);
       this.httpClient = coresInit.getUpdateShardHandler().getDefaultHttpClient();
       setupJvmMetrics(coresInit);
-      RateLimitManager.Builder builder = new RateLimitManager.Builder(cores.getConfig());
+      RateLimitManager.Builder builder = new RateLimitManager.Builder(cores == null ? null : cores.getConfig());
 
       this.rateLimitManager = builder.build();
       if (log.isDebugEnabled()) {

--- a/solr/core/src/test/org/apache/solr/servlet/TestRequestRateLimiter.java
+++ b/solr/core/src/test/org/apache/solr/servlet/TestRequestRateLimiter.java
@@ -17,7 +17,6 @@
 
 package org.apache.solr.servlet;
 
-import javax.servlet.FilterConfig;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -33,6 +32,7 @@ import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.cloud.SolrCloudTestCase;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.util.ExecutorUtil;
+import org.apache.solr.core.NodeConfig;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -60,8 +60,8 @@ public class TestRequestRateLimiter extends SolrCloudTestCase {
 
     RequestRateLimiter.RateLimiterConfig rateLimiterConfig = new RequestRateLimiter.RateLimiterConfig(SolrRequest.SolrRequestType.QUERY,
         true, 1, DEFAULT_SLOT_ACQUISITION_TIMEOUT_MS, 5 /* allowedRequests */, true /* isSlotBorrowing */);
-    // We are fine with a null FilterConfig here since we ensure that MockBuilder never invokes its parent here
-    RateLimitManager.Builder builder = new MockBuilder(null /* dummy FilterConfig */, new MockRequestRateLimiter(rateLimiterConfig, 5));
+    // We are fine with a null NodeConfig here since we ensure that MockBuilder never invokes its parent here
+    RateLimitManager.Builder builder = new MockBuilder(null /* dummy NodeConfig */, new MockRequestRateLimiter(rateLimiterConfig, 5));
     RateLimitManager rateLimitManager = builder.build();
 
     solrDispatchFilter.replaceRateLimitManager(rateLimitManager);
@@ -95,8 +95,8 @@ public class TestRequestRateLimiter extends SolrCloudTestCase {
         true, 1, DEFAULT_SLOT_ACQUISITION_TIMEOUT_MS, 5 /* allowedRequests */, true /* isSlotBorrowing */);
     RequestRateLimiter.RateLimiterConfig indexRateLimiterConfig = new RequestRateLimiter.RateLimiterConfig(SolrRequest.SolrRequestType.UPDATE,
         true, 1, DEFAULT_SLOT_ACQUISITION_TIMEOUT_MS, 5 /* allowedRequests */, true /* isSlotBorrowing */);
-    // We are fine with a null FilterConfig here since we ensure that MockBuilder never invokes its parent
-    RateLimitManager.Builder builder = new MockBuilder(null /*dummy FilterConfig */, new MockRequestRateLimiter(queryRateLimiterConfig, 5), new MockRequestRateLimiter(indexRateLimiterConfig, 5));
+    // We are fine with a null NodeConfig here since we ensure that MockBuilder never invokes its parent
+    RateLimitManager.Builder builder = new MockBuilder(null /*dummy NodeConfig */, new MockRequestRateLimiter(queryRateLimiterConfig, 5), new MockRequestRateLimiter(indexRateLimiterConfig, 5));
     RateLimitManager rateLimitManager = builder.build();
 
     solrDispatchFilter.replaceRateLimitManager(rateLimitManager);
@@ -205,14 +205,14 @@ public class TestRequestRateLimiter extends SolrCloudTestCase {
     private final RequestRateLimiter queryRequestRateLimiter;
     private final RequestRateLimiter indexRequestRateLimiter;
 
-    public MockBuilder(FilterConfig config, RequestRateLimiter queryRequestRateLimiter) {
+    public MockBuilder(NodeConfig config, RequestRateLimiter queryRequestRateLimiter) {
       super(config);
 
       this.queryRequestRateLimiter = queryRequestRateLimiter;
       this.indexRequestRateLimiter = null;
     }
 
-    public MockBuilder(FilterConfig config, RequestRateLimiter queryRequestRateLimiter, RequestRateLimiter indexRequestRateLimiter) {
+    public MockBuilder(NodeConfig config, RequestRateLimiter queryRequestRateLimiter, RequestRateLimiter indexRequestRateLimiter) {
       super(config);
 
       this.queryRequestRateLimiter = queryRequestRateLimiter;

--- a/solr/solr-ref-guide/src/rate-limiters.adoc
+++ b/solr/solr-ref-guide/src/rate-limiters.adoc
@@ -31,12 +31,17 @@ pronounced under high stress in production workloads. The current implementation
 resources for indexing.
 
 == Rate Limiter Configurations
-The default rate limiter is search rate limiter. Accordingly, it can be configured in `web.xml` under `initParams` for
-`SolrRequestFilter`.
+The default rate limiter is search rate limiter. Accordingly, it can be configured in `solr.xml`.
 
 [source,xml]
 ----
-<filter-name>SolrRequestFilter</filter-name>
+  <rateLimitManager class="RateLimitManager">
+    <str name="isQueryRateLimiterEnabled">true</str>
+    <str name="maxQueryRequests">15</int>
+    <str name="queryWaitForSlotAllocationInMS">150</str>
+    <str name="queryGuaranteedSlots">8</str>
+    <str name="queryAllowSlotBorrowing">true</str>
+  </rateLimitManager>
 ----
 
 === Enable Query Rate Limiter
@@ -44,11 +49,7 @@ Controls enabling of query rate limiter. Default value is `false`.
 
 [source,xml]
 ----
-<param-name>isQueryRateLimiterEnabled</param-name>
-----
-[source,xml]
-----
-<param-value>true</param-value>
+<str name="isQueryRateLimiterEnabled">true</str>
 ----
 
 === Maximum Number Of Concurrent Requests
@@ -56,11 +57,7 @@ Allows setting maximum concurrent search requests at a given point in time. Defa
 
 [source,xml]
 ----
-<param-name>maxQueryRequests</param-name>
-----
-[source,xml]
-----
-<param-value>15</param-value>
+<str name="maxQueryRequests">15</int>
 ----
 
 === Request Slot Allocation Wait Time
@@ -71,11 +68,7 @@ is -1, indicating no wait. 0 will represent the same -- no wait. Note that highe
 can lead to larger queue times and can potentially lead to longer wait times for queries.
 [source,xml]
 ----
-<param-name>queryWaitForSlotAllocationInMS</param-name>
-----
-[source,xml]
-----
-<param-value>100</param-value>
+<str name="queryWaitForSlotAllocationInMS">100</str>
 ----
 
 === Slot Borrowing Enabled
@@ -86,11 +79,7 @@ borrowing request is long lived.
 
 [source,xml]
 ----
-<param-name>queryAllowSlotBorrowing</param-name>
-----
-[source,xml]
-----
-<param-value>true</param-value>
+<str name="queryAllowSlotBorrowing">true</str>
 ----
 
 === Guaranteed Slots
@@ -104,12 +93,9 @@ borrowing request is long lived.
 
 [source,xml]
 ----
-<param-name>queryGuaranteedSlots</param-name>
+<str name="queryGuaranteedSlots">8</str>
 ----
-[source,xml]
-----
-<param-value>200</param-value>
-----
+
 
 == Salient Points
 


### PR DESCRIPTION
This commit refactors rate limiters configuration to now be modelled as a plugin and move its configuration from web.xml to a dedicated section in solr.xml