### PR TITLE
LUCENE-6744: equals methods should compare classes directly, not use instanceof

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -131,6 +131,8 @@ Improvements
 
 Bug fixes
 
+* LUCENE-6744: Replaced instanceOf with getClass. (Puneeth Bikkumanla)
+
 * LUCENE-8663: NRTCachingDirectory.slowFileExists may open a file while 
   it's inaccessible. (Dawid Weiss)
 

--- a/solr/core/src/java/org/apache/solr/search/function/distance/GeohashFunction.java
+++ b/solr/core/src/java/org/apache/solr/search/function/distance/GeohashFunction.java
@@ -74,7 +74,7 @@ public class GeohashFunction extends ValueSource {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof GeohashFunction)) return false;
+    if (o == null || o.getClass() != this.getClass()) return false;
 
     GeohashFunction that = (GeohashFunction) o;
 

--- a/solr/core/src/java/org/apache/solr/search/function/distance/StringDistanceFunction.java
+++ b/solr/core/src/java/org/apache/solr/search/function/distance/StringDistanceFunction.java
@@ -91,7 +91,7 @@ public class StringDistanceFunction extends ValueSource {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof StringDistanceFunction)) return false;
+    if (o == null || o.getClass() != this.getClass()) return false;
 
     StringDistanceFunction that = (StringDistanceFunction) o;
 

--- a/solr/core/src/java/org/apache/solr/search/function/distance/VectorDistanceFunction.java
+++ b/solr/core/src/java/org/apache/solr/search/function/distance/VectorDistanceFunction.java
@@ -188,7 +188,7 @@ public class VectorDistanceFunction extends ValueSource {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof VectorDistanceFunction)) return false;
+    if (o == null || o.getClass() != this.getClass()) return false;
 
     VectorDistanceFunction that = (VectorDistanceFunction) o;
 


### PR DESCRIPTION
# Description

Hey everyone, this is my first PR to Lucene/Solr. 

Earlier, the equals method was asymmetrically comparing two objects with `instanceOf` whereas now it uses `getClass`. Note that I didn't change all of the files mentioned in this ticket. 

# Solution

Instead of using `instanceOf` I used `getClass` in the `equals` method as described in the original Jira ticket

# Tests

Please describe the tests you've developed or run to confirm this patch implements the feature or solves the problem.

Currently, there are no tests that test this directly though I would appreciate any guidance on what is the best way to include tests for this if required. 

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
