### PR TITLE
SOLR-14701: GuessSchemaFields URP to replace AddSchemaFields URP in schemaless mode

### DIFF
--- a/solr/core/src/java/org/apache/solr/update/processor/GuessSchemaFieldsUpdateProcessorFactory.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/GuessSchemaFieldsUpdateProcessorFactory.java
@@ -1,0 +1,637 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.update.processor;
+
+import org.apache.solr.common.SolrException;
+import org.apache.solr.common.SolrInputDocument;
+import org.apache.solr.common.SolrInputField;
+import org.apache.solr.common.util.NamedList;
+import org.apache.solr.core.SolrCore;
+import org.apache.solr.core.SolrResourceLoader;
+import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.response.SolrQueryResponse;
+import org.apache.solr.schema.IndexSchema;
+import org.apache.solr.schema.ManagedIndexSchema;
+import org.apache.solr.schema.SchemaField;
+import org.apache.solr.update.AddUpdateCommand;
+import org.apache.solr.update.CommitUpdateCommand;
+import org.apache.solr.update.processor.FieldMutatingUpdateProcessor.FieldNameSelector;
+import org.apache.solr.update.processor.FieldMutatingUpdateProcessorFactory.SelectorParams;
+import org.apache.solr.util.plugin.SolrCoreAware;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.apache.solr.common.SolrException.ErrorCode.BAD_REQUEST;
+import static org.apache.solr.common.SolrException.ErrorCode.SERVER_ERROR;
+import static org.apache.solr.core.ConfigSetProperties.IMMUTABLE_CONFIGSET_ARG;
+
+
+/**
+ * <p>
+ * This processor will dynamically add fields to the schema if an input document contains
+ * one or more fields that don't match any field or dynamic field in the schema.
+ * </p>
+ * <p>
+ * By default, this processor selects all fields that don't match a schema field or
+ * dynamic field.  The "fieldName" and "fieldRegex" selectors may be specified to further
+ * restrict the selected fields, but the other selectors ("typeName", "typeClass", and
+ * "fieldNameMatchesSchemaField") may not be specified.
+ * </p>
+ * <p>
+ * This processor is configured to map from each field's values' class(es) to the schema
+ * field type that will be used when adding the new field to the schema.  All new fields
+ * are then added to the schema in a single batch.  If schema addition fails for any
+ * field, addition is re-attempted only for those that don’t match any schema
+ * field.  This process is repeated, either until all new fields are successfully added,
+ * or until there are no new fields (presumably because the fields that were new when
+ * this processor started its work were subsequently added by a different update
+ * request, possibly on a different node).
+ * </p>
+ * <p>
+ * This processor takes as configuration a sequence of zero or more "typeMapping"-s from
+ * one or more "valueClass"-s, specified as either an <code>&lt;arr&gt;</code> of 
+ * <code>&lt;str&gt;</code>, or multiple <code>&lt;str&gt;</code> with the same name,
+ * to an existing schema "fieldType".
+ * </p>
+ * <p>
+ * If more than one "valueClass" is specified in a "typeMapping", field values with any
+ * of the specified "valueClass"-s will be mapped to the specified target "fieldType".
+ * The "typeMapping"-s are attempted in the specified order; if a field value's class
+ * is not specified in a "valueClass", the next "typeMapping" is attempted. If no
+ * "typeMapping" succeeds, then either the "typeMapping" configured with 
+ * <code>&lt;bool name="default"&gt;true&lt;/bool&gt;</code> is used, or if none is so
+ * configured, the <code>lt;str name="defaultFieldType"&gt;...&lt;/str&gt;</code> is
+ * used.
+ * </p>
+ * <p>
+ * Zero or more "copyField" directives may be included with each "typeMapping", using a
+ * <code>&lt;lst&gt;</code>. The copy field source is automatically set to the new field
+ * name; "dest" must specify the destination field or dynamic field in a
+ * <code>&lt;str&gt;</code>; and "maxChars" may optionally be specified in an
+ * <code>&lt;int&gt;</code>.
+ * </p>
+ * <p>
+ * Example configuration:
+ * </p>
+ * 
+ * <pre class="prettyprint">
+ * &lt;updateProcessor class="solr.GuessSchemaFieldsUpdateProcessorFactory" name="add-schema-fields"&gt;
+ *   &lt;lst name="typeMapping"&gt;
+ *     &lt;str name="valueClass"&gt;java.lang.String&lt;/str&gt;
+ *     &lt;str name="fieldType"&gt;text_general&lt;/str&gt;
+ *     &lt;lst name="copyField"&gt;
+ *       &lt;str name="dest"&gt;*_str&lt;/str&gt;
+ *       &lt;int name="maxChars"&gt;256&lt;/int&gt;
+ *     &lt;/lst&gt;
+ *     &lt;!-- Use as default mapping instead of defaultFieldType --&gt;
+ *     &lt;bool name="default"&gt;true&lt;/bool&gt;
+ *   &lt;/lst&gt;
+ *   &lt;lst name="typeMapping"&gt;
+ *     &lt;str name="valueClass"&gt;java.lang.Boolean&lt;/str&gt;
+ *     &lt;str name="fieldType"&gt;booleans&lt;/str&gt;
+ *   &lt;/lst&gt;
+ *   &lt;lst name="typeMapping"&gt;
+ *     &lt;str name="valueClass"&gt;java.util.Date&lt;/str&gt;
+ *     &lt;str name="fieldType"&gt;pdates&lt;/str&gt;
+ *   &lt;/lst&gt;
+ *   &lt;lst name="typeMapping"&gt;
+ *     &lt;str name="valueClass"&gt;java.lang.Long&lt;/str&gt;
+ *     &lt;str name="valueClass"&gt;java.lang.Integer&lt;/str&gt;
+ *     &lt;str name="fieldType"&gt;plongs&lt;/str&gt;
+ *   &lt;/lst&gt;
+ *   &lt;lst name="typeMapping"&gt;
+ *     &lt;str name="valueClass"&gt;java.lang.Number&lt;/str&gt;
+ *     &lt;str name="fieldType"&gt;pdoubles&lt;/str&gt;
+ *   &lt;/lst&gt;
+ * &lt;/updateProcessor&gt;</pre>
+ * @since 4.4.0
+ */
+public class GuessSchemaFieldsUpdateProcessorFactory extends UpdateRequestProcessorFactory
+    implements SolrCoreAware, UpdateRequestProcessorFactory.RunAlways {
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private static final String TYPE_MAPPING_PARAM = "typeMapping";
+  private static final String VALUE_CLASS_PARAM = "valueClass";
+  private static final String FIELD_TYPE_PARAM = "fieldType";
+  private static final String DEFAULT_FIELD_TYPE_PARAM = "defaultFieldType";
+  private static final String COPY_FIELD_PARAM = "copyField";
+  private static final String DEST_PARAM = "dest";
+  private static final String MAX_CHARS_PARAM = "maxChars";
+  private static final String IS_DEFAULT_PARAM = "default";
+
+  private List<TypeMapping> typeMappings = Collections.emptyList();
+  private TreeMap<String, TypeMapping> typeMappingsIndex = new TreeMap<>();
+
+  private SelectorParams inclusions = new SelectorParams();
+  private Collection<SelectorParams> exclusions = new ArrayList<>();
+  private SolrResourceLoader solrResourceLoader = null;
+  private String defaultFieldTypeName;
+
+  private static final Map<String, String> OPTION_MULTIVALUED = Collections.singletonMap("multiValued", "true");
+
+  private Map<String, FieldValueTypeInfo> fieldValueTypeMap = new TreeMap<>();
+
+  @Override
+  public UpdateRequestProcessor getInstance(SolrQueryRequest req, 
+                                            SolrQueryResponse rsp, 
+                                            UpdateRequestProcessor next) {
+    return new GuessSchemaFieldsUpdateProcessor(next);
+  }
+
+  @Override
+  public void init(@SuppressWarnings({"rawtypes"})NamedList args) {
+    inclusions = FieldMutatingUpdateProcessorFactory.parseSelectorParams(args);
+    validateSelectorParams(inclusions);
+    inclusions.fieldNameMatchesSchemaField = false;  // Explicitly (non-configurably) require unknown field names
+    exclusions = FieldMutatingUpdateProcessorFactory.parseSelectorExclusionParams(args);
+    for (SelectorParams exclusion : exclusions) {
+      validateSelectorParams(exclusion);
+    }
+    Object defaultFieldTypeParam = args.remove(DEFAULT_FIELD_TYPE_PARAM);
+    if (null != defaultFieldTypeParam) {
+      if (!(defaultFieldTypeParam instanceof CharSequence)) {
+        throw new SolrException(SERVER_ERROR, "Init param '" + DEFAULT_FIELD_TYPE_PARAM + "' must be a <str>");
+      }
+      defaultFieldTypeName = defaultFieldTypeParam.toString();
+    }
+
+    TypeMapping flaggedDefaultType = null;
+
+    typeMappings = parseTypeMappings(args);
+    for (TypeMapping typeMapping : typeMappings) {
+      for (String valueClassName : typeMapping.valueClassNames) {
+        if (typeMappingsIndex.containsKey(valueClassName)) {
+          if (log.isWarnEnabled()) {
+            log.warn("Guess Schema has multiple mappings for same valueClass: {}", valueClassName);
+          }
+        } else {
+          typeMappingsIndex.put(valueClassName, typeMapping);
+          if (typeMapping.isDefault()) {
+            flaggedDefaultType = typeMapping;
+          }
+        }
+      }
+    }
+
+    if (defaultFieldTypeName == null) {
+      if (flaggedDefaultType != null) {
+        defaultFieldTypeName = flaggedDefaultType.fieldTypeName;
+      } else {
+        throw new SolrException(SERVER_ERROR, "Must specify either '" + DEFAULT_FIELD_TYPE_PARAM +
+                "' or declare one typeMapping as default.");
+      }
+    } else if (defaultFieldTypeName != null) {
+      throw new SolrException(SERVER_ERROR, "Must specify either '" + DEFAULT_FIELD_TYPE_PARAM +
+              "' or declare one typeMapping as default. Not both!");
+    }
+
+    super.init(args);
+  }
+
+  @Override
+  public void inform(SolrCore core) {
+    solrResourceLoader = core.getResourceLoader();
+
+    for (TypeMapping typeMapping : typeMappings) {
+      typeMapping.populateValueClasses(core);
+    }
+  }
+
+  private static List<TypeMapping> parseTypeMappings(@SuppressWarnings({"rawtypes"})NamedList args) {
+    List<TypeMapping> typeMappings = new ArrayList<>();
+    @SuppressWarnings({"unchecked"})
+    List<Object> typeMappingsParams = args.getAll(TYPE_MAPPING_PARAM);
+    for (Object typeMappingObj : typeMappingsParams) {
+      if (null == typeMappingObj) {
+        throw new SolrException(SERVER_ERROR, "'" + TYPE_MAPPING_PARAM + "' init param cannot be null");
+      }
+      if ( ! (typeMappingObj instanceof NamedList) ) {
+        throw new SolrException(SERVER_ERROR, "'" + TYPE_MAPPING_PARAM + "' init param must be a <lst>");
+      }
+      @SuppressWarnings({"rawtypes"})
+      NamedList typeMappingNamedList = (NamedList)typeMappingObj;
+
+      Object fieldTypeObj = typeMappingNamedList.remove(FIELD_TYPE_PARAM);
+      if (null == fieldTypeObj) {
+        throw new SolrException(SERVER_ERROR,
+            "Each '" + TYPE_MAPPING_PARAM + "' <lst/> must contain a '" + FIELD_TYPE_PARAM + "' <str>");
+      }
+      if ( ! (fieldTypeObj instanceof CharSequence)) {
+        throw new SolrException(SERVER_ERROR, "'" + FIELD_TYPE_PARAM + "' init param must be a <str>");
+      }
+      if (null != typeMappingNamedList.get(FIELD_TYPE_PARAM)) {
+        throw new SolrException(SERVER_ERROR,
+            "Each '" + TYPE_MAPPING_PARAM + "' <lst/> may contain only one '" + FIELD_TYPE_PARAM + "' <str>");
+      }
+      String fieldType = fieldTypeObj.toString();
+
+      @SuppressWarnings({"unchecked"})
+      Collection<String> valueClasses
+          = typeMappingNamedList.removeConfigArgs(VALUE_CLASS_PARAM);
+      if (valueClasses.isEmpty()) {
+        throw new SolrException(SERVER_ERROR, 
+            "Each '" + TYPE_MAPPING_PARAM + "' <lst/> must contain at least one '" + VALUE_CLASS_PARAM + "' <str>");
+      }
+
+      // isDefault (optional)
+      Boolean isDefault = false;
+      Object isDefaultObj = typeMappingNamedList.remove(IS_DEFAULT_PARAM);
+      if (null != isDefaultObj) {
+        if ( ! (isDefaultObj instanceof Boolean)) {
+          throw new SolrException(SERVER_ERROR, "'" + IS_DEFAULT_PARAM + "' init param must be a <bool>");
+        }
+        if (null != typeMappingNamedList.get(IS_DEFAULT_PARAM)) {
+          throw new SolrException(SERVER_ERROR,
+              "Each '" + COPY_FIELD_PARAM + "' <lst/> may contain only one '" + IS_DEFAULT_PARAM + "' <bool>");
+        }
+        isDefault = Boolean.parseBoolean(isDefaultObj.toString());
+      }
+      
+      Collection<CopyFieldDef> copyFieldDefs = new ArrayList<>(); 
+      while (typeMappingNamedList.get(COPY_FIELD_PARAM) != null) {
+        Object copyFieldObj = typeMappingNamedList.remove(COPY_FIELD_PARAM);
+        if ( ! (copyFieldObj instanceof NamedList)) {
+          throw new SolrException(SERVER_ERROR, "'" + COPY_FIELD_PARAM + "' init param must be a <lst>");
+        }
+        @SuppressWarnings({"rawtypes"})
+        NamedList copyFieldNamedList = (NamedList)copyFieldObj;
+        // dest
+        Object destObj = copyFieldNamedList.remove(DEST_PARAM);
+        if (null == destObj) {
+          throw new SolrException(SERVER_ERROR,
+              "Each '" + COPY_FIELD_PARAM + "' <lst/> must contain a '" + DEST_PARAM + "' <str>");
+        }
+        if ( ! (destObj instanceof CharSequence)) {
+          throw new SolrException(SERVER_ERROR, "'" + COPY_FIELD_PARAM + "' init param must be a <str>");
+        }
+        if (null != copyFieldNamedList.get(COPY_FIELD_PARAM)) {
+          throw new SolrException(SERVER_ERROR,
+              "Each '" + COPY_FIELD_PARAM + "' <lst/> may contain only one '" + COPY_FIELD_PARAM + "' <str>");
+        }
+        String dest = destObj.toString();
+        // maxChars (optional)
+        Integer maxChars = 0;
+        Object maxCharsObj = copyFieldNamedList.remove(MAX_CHARS_PARAM);
+        if (null != maxCharsObj) {
+          if ( ! (maxCharsObj instanceof Integer)) {
+            throw new SolrException(SERVER_ERROR, "'" + MAX_CHARS_PARAM + "' init param must be a <int>");
+          }
+          if (null != copyFieldNamedList.get(MAX_CHARS_PARAM)) {
+            throw new SolrException(SERVER_ERROR,
+                "Each '" + COPY_FIELD_PARAM + "' <lst/> may contain only one '" + MAX_CHARS_PARAM + "' <str>");
+          }
+          maxChars = Integer.parseInt(maxCharsObj.toString());
+        }
+        copyFieldDefs.add(new CopyFieldDef(dest, maxChars));
+      }
+      typeMappings.add(new TypeMapping(fieldType, valueClasses, isDefault, copyFieldDefs));
+      
+      if (0 != typeMappingNamedList.size()) {
+        throw new SolrException(SERVER_ERROR, 
+            "Unexpected '" + TYPE_MAPPING_PARAM + "' init sub-param(s): '" + typeMappingNamedList.toString() + "'");
+      }
+      args.remove(TYPE_MAPPING_PARAM);
+    }
+    return typeMappings;
+  }
+
+  private void validateSelectorParams(SelectorParams params) {
+    if ( ! params.typeName.isEmpty()) {
+      throw new SolrException(SERVER_ERROR, "'typeName' init param is not allowed in this processor");
+    }
+    if ( ! params.typeClass.isEmpty()) {
+      throw new SolrException(SERVER_ERROR, "'typeClass' init param is not allowed in this processor");
+    }
+    if (null != params.fieldNameMatchesSchemaField) {
+      throw new SolrException(SERVER_ERROR, "'fieldNameMatchesSchemaField' init param is not allowed in this processor");
+    }
+  }
+
+  private static class TypeMapping {
+    public String fieldTypeName;
+    public Collection<String> valueClassNames;
+    public Collection<CopyFieldDef> copyFieldDefs;
+    public Set<Class<?>> valueClasses;
+    public Boolean isDefault;
+
+    public TypeMapping(String fieldTypeName, Collection<String> valueClassNames, boolean isDefault,
+                       Collection<CopyFieldDef> copyFieldDefs) {
+      this.fieldTypeName = fieldTypeName;
+      this.valueClassNames = valueClassNames;
+      this.isDefault = isDefault;
+      this.copyFieldDefs = copyFieldDefs;
+      // this.valueClasses population is delayed until the schema is available
+    }
+
+    public void populateValueClasses(SolrCore core) {
+      IndexSchema schema = core.getLatestSchema();
+      ClassLoader loader = core.getResourceLoader().getClassLoader();
+      if (null == schema.getFieldTypeByName(fieldTypeName)) {
+        throw new SolrException(SERVER_ERROR, "fieldType '" + fieldTypeName + "' not found in the schema");
+      }
+      valueClasses = new HashSet<>();
+      for (String valueClassName : valueClassNames) {
+        try {
+          valueClasses.add(loader.loadClass(valueClassName));
+        } catch (ClassNotFoundException e) {
+          throw new SolrException(SERVER_ERROR,
+              "valueClass '" + valueClassName + "' not found for fieldType '" + fieldTypeName + "'");
+        }
+      }
+    }
+
+    public boolean isDefault() {
+      return isDefault;
+    }
+  }
+
+  private static class CopyFieldDef {
+    private final String destGlob;
+    private final Integer maxChars;
+
+    public CopyFieldDef(String destGlob, Integer maxChars) {
+      this.destGlob = destGlob;
+      this.maxChars = maxChars;
+      if (destGlob.contains("*") && (!destGlob.startsWith("*") && !destGlob.endsWith("*"))) {
+        throw new SolrException(SERVER_ERROR, "dest '" + destGlob + 
+            "' is invalid. Must either be a plain field name or start or end with '*'");
+      }
+    }
+    
+    public Integer getMaxChars() {
+      return maxChars;
+    }
+    
+    public String getDest(String srcFieldName) {
+      if (!destGlob.contains("*")) {
+        return destGlob;
+      } else if (destGlob.startsWith("*")) {
+        return srcFieldName + destGlob.substring(1);
+      } else {
+        return destGlob.substring(0,destGlob.length()-1) + srcFieldName;
+      }
+    }
+  }
+
+  public class FieldValueTypeInfo {
+
+    private String valueTypeName;
+    private boolean multiValued;
+    private int widenIndex;
+
+    private final String WIDENING_ORDER = "java.lang.Integer java.lang.Long java.lang.Number";
+    private final String TYPE_STRING = "java.lang.String";
+
+    public FieldValueTypeInfo(String valueTypeName, boolean multiValued) {
+      this.valueTypeName = valueTypeName;
+      this.multiValued = multiValued;
+
+      //if -1 (no match), we cannot widen
+      widenIndex = WIDENING_ORDER.indexOf(valueTypeName);
+    }
+
+    public void widen(String newTypeName, boolean newMultiValued) {
+      multiValued = multiValued || newMultiValued;
+
+      if (valueTypeName.equals(newTypeName)) {
+        return;
+      } //nothing to do
+
+      if (widenIndex < 0) {
+        // mismatch
+        valueTypeName = TYPE_STRING; //because it may have been date or boolean before, not just string
+        return;
+      }
+
+      int newWidenIndex = WIDENING_ORDER.indexOf(newTypeName);
+      if (newWidenIndex < 0) {
+        //mismatch the other way
+        valueTypeName = TYPE_STRING;
+        return;
+      }
+
+      //finally, we are compatible, let's check which type is wider
+      if (newWidenIndex > widenIndex) {
+        //new value type is wider (later in order) than current
+        valueTypeName = newTypeName;
+        widenIndex = newWidenIndex;
+      }
+      // else we stick with the old one
+    }
+
+    public String getValueTypeName() {
+      return valueTypeName;
+    }
+
+    public boolean isMultiValued() {
+      return multiValued;
+    }
+
+  }
+
+  private class GuessSchemaFieldsUpdateProcessor extends UpdateRequestProcessor {
+
+    public static final String GUESS_SCHEMA_FLAG = "guess-schema";
+
+    public GuessSchemaFieldsUpdateProcessor(UpdateRequestProcessor next) {
+      super(next);
+    }
+
+
+    @Override
+    public void processAdd(AddUpdateCommand cmd) throws IOException {
+      if (!cmd.getReq().getParams().getBool(GUESS_SCHEMA_FLAG, false)) {
+        super.processAdd(cmd);
+        return;
+      }
+
+      final SolrInputDocument doc = cmd.getSolrInputDocument();
+      for (String fieldName : doc.getFieldNames()) {
+        SolrInputField field = doc.getField(fieldName);
+        int valueCount = field.getValueCount();
+        if (valueCount == 0) {
+          continue;
+        }
+
+        String newTypeName = field.getFirstValue().getClass().getName();
+        boolean newMultiValued = valueCount > 1;
+
+        if (!fieldValueTypeMap.containsKey(fieldName)) {
+          fieldValueTypeMap.put(fieldName, new FieldValueTypeInfo(newTypeName, newMultiValued));
+        } else {
+          FieldValueTypeInfo existingTypeInfo = fieldValueTypeMap.get(fieldName);
+          existingTypeInfo.widen(newTypeName, newMultiValued);
+        }
+      }
+      // do not process further. risky?
+      // super.processAdd(cmd);
+    }
+
+    @Override
+    public void processCommit(CommitUpdateCommand cmd) throws IOException {
+      if (!cmd.getReq().getParams().getBool(GUESS_SCHEMA_FLAG, false)) {
+        super.processCommit(cmd);
+        return;
+      }
+
+      IndexSchema currentSchema = cmd.getReq().getSchema();
+      if ( ! currentSchema.isMutable()) {
+        final String message = "Adding new Schema fields requires mutable schema. This one is not (or locked).";
+        throw new SolrException(BAD_REQUEST, message);
+      }
+
+      //Skip the elaborated field matches using selectors for now. Just do plain there/not there
+
+      synchronized(currentSchema.getSchemaUpdateLock()) {
+        IndexSchema newSchema = currentSchema; //start the iterations
+
+        for (String fieldName : fieldValueTypeMap.keySet()) {
+          if (currentSchema.hasExplicitField(fieldName) || currentSchema.isDynamicField(fieldName)) {
+            if (log.isDebugEnabled()) {
+              log.debug("Schema already contains field: {}", fieldName);
+            }
+            continue;
+          }
+
+          FieldValueTypeInfo fieldValueTypeInfo = fieldValueTypeMap.get(fieldName);
+          TypeMapping typeMapping = typeMappingsIndex.get(fieldValueTypeInfo.valueTypeName);
+          String fieldTypeName =
+                  (typeMapping != null)
+                  ?typeMapping.fieldTypeName
+                  :defaultFieldTypeName;
+
+          SchemaField newField = currentSchema.newField(
+                  fieldName, fieldTypeName,
+                  fieldValueTypeInfo.isMultiValued() ? OPTION_MULTIVALUED : Collections.emptyMap());
+          if (log.isDebugEnabled()) {
+            log.debug("Adding new schema field: {}", newField);
+          }
+          newSchema = newSchema.addField(newField, false);
+
+          if (typeMapping != null && typeMapping.copyFieldDefs != null) {
+            for (CopyFieldDef copyFieldDef : typeMapping.copyFieldDefs) {
+              newSchema = newSchema.addCopyFields(
+                      fieldName,
+                      Collections.singleton(copyFieldDef.getDest(fieldName)),
+                      copyFieldDef.getMaxChars()
+                      );
+            }
+          }
+        }
+
+        //finished with all definitions
+        ((ManagedIndexSchema)newSchema).persistManagedSchema(false);
+        cmd.getReq().getCore().setLatestSchema(newSchema);
+        cmd.getReq().updateSchemaToLatest();
+        if (log.isDebugEnabled()) {
+          log.debug("Successfully added field(s) and copyField(s) to the schema.");
+        }
+      } //end synchronized
+      super.processCommit(cmd);
+    }
+
+    /**
+     * Recursively find unknown fields in the given doc and its child documents, if any.
+     */
+    private void getUnknownFields
+    (FieldNameSelector selector, SolrInputDocument doc, Map<String,List<SolrInputField>> unknownFields) {
+      for (final String fieldName : doc.getFieldNames()) {
+        //We do a assert and a null check because even after SOLR-12710 is addressed
+        //older SolrJ versions can send null values causing an NPE
+        assert fieldName != null;
+        if (fieldName != null) {
+          if (selector.shouldMutate(fieldName)) { // returns false if the field already exists in the current schema
+            List<SolrInputField> solrInputFields = unknownFields.get(fieldName);
+            if (null == solrInputFields) {
+              solrInputFields = new ArrayList<>();
+              unknownFields.put(fieldName, solrInputFields);
+            }
+            solrInputFields.add(doc.getField(fieldName));
+          }
+        }
+      }
+      List<SolrInputDocument> childDocs = doc.getChildDocuments();
+      if (null != childDocs) {
+        for (SolrInputDocument childDoc : childDocs) {
+          getUnknownFields(selector, childDoc, unknownFields);
+        }
+      }
+    }
+
+    /**
+     * Maps all given field values' classes to a typeMapping object
+     *
+     * @param fields one or more (same-named) field values from one or more documents
+     */
+    private TypeMapping mapValueClassesToFieldType(List<SolrInputField> fields) {
+      NEXT_TYPE_MAPPING: for (TypeMapping typeMapping : typeMappings) {
+        for (SolrInputField field : fields) {
+          //We do a assert and a null check because even after SOLR-12710 is addressed
+          //older SolrJ versions can send null values causing an NPE
+          assert field.getValues() != null;
+          if (field.getValues() != null) {
+            NEXT_FIELD_VALUE: for (Object fieldValue : field.getValues()) {
+              for (Class<?> valueClass : typeMapping.valueClasses) {
+                if (valueClass.isInstance(fieldValue)) {
+                  continue NEXT_FIELD_VALUE;
+                }
+              }
+              // This fieldValue is not an instance of any of the mapped valueClass-s,
+              // so mapping fails - go try the next type mapping.
+              continue NEXT_TYPE_MAPPING;
+            }
+          }
+        }
+        // Success! Each of this field's values is an instance of a mapped valueClass
+        return typeMapping;
+      }
+      // At least one of this field's values is not an instance of any of the mapped valueClass-s
+      // Return the typeMapping marked as default, if we have one, else return null to use fallback type
+      List<TypeMapping> defaultMappings = typeMappings.stream().filter(TypeMapping::isDefault).collect(Collectors.toList());
+      if (defaultMappings.size() > 1) {
+        throw new SolrException(SERVER_ERROR, "Only one typeMapping can be default");
+      } else if (defaultMappings.size() == 1) {
+        return defaultMappings.get(0);
+      } else {
+        return null;
+      }
+    }
+
+    private FieldNameSelector buildSelector(IndexSchema schema) {
+      FieldNameSelector selector = FieldMutatingUpdateProcessor.createFieldNameSelector
+        (solrResourceLoader, schema, inclusions, fieldName -> null == schema.getFieldTypeNoEx(fieldName));
+
+      for (SelectorParams exc : exclusions) {
+        selector = FieldMutatingUpdateProcessor.wrap(selector, FieldMutatingUpdateProcessor.createFieldNameSelector
+          (solrResourceLoader, schema, exc, FieldMutatingUpdateProcessor.SELECT_NO_FIELDS));
+      }
+      return selector;
+    }
+
+    private boolean isImmutableConfigSet(SolrCore core) {
+      @SuppressWarnings({"rawtypes"})
+      NamedList args = core.getConfigSetProperties();
+      Object immutable = args != null ? args.get(IMMUTABLE_CONFIGSET_ARG) : null;
+      return immutable != null ? Boolean.parseBoolean(immutable.toString()) : false;
+    }
+  }
+}

--- a/solr/core/src/test-files/solr/collection1/conf/schema-guess-schema-fields-update-processor.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/schema-guess-schema-fields-update-processor.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" ?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<schema name="add-schema-fields-update-processor" version="1.6">
+
+  <fieldType name="tint" class="${solr.tests.IntegerFieldType}" docValues="${solr.tests.numeric.dv}" precisionStep="8" multiValued="true" positionIncrementGap="0"/>
+  <fieldType name="tfloat" class="${solr.tests.FloatFieldType}" docValues="${solr.tests.numeric.dv}" precisionStep="8" multiValued="true" positionIncrementGap="0"/>
+  <fieldType name="tlong" class="${solr.tests.LongFieldType}" docValues="${solr.tests.numeric.dv}" precisionStep="8" multiValued="true" positionIncrementGap="0"/>
+  <fieldType name="tdouble" class="${solr.tests.DoubleFieldType}" docValues="${solr.tests.numeric.dv}" precisionStep="8" multiValued="true" positionIncrementGap="0"/>
+  <fieldType name="tdate" class="${solr.tests.DateFieldType}" docValues="${solr.tests.numeric.dv}" precisionStep="6" multiValued="true" positionIncrementGap="0"/>
+  <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true" multiValued="true"/>
+  <fieldType name="string" class="solr.StrField" sortMissingLast="true"/>
+  <fieldType name="long" class="${solr.tests.LongFieldType}" docValues="${solr.tests.numeric.dv}" precisionStep="0" positionIncrementGap="0"/>
+  <fieldType name="text" class="solr.TextField" multiValued="true" positionIncrementGap="100">
+    <analyzer>
+      <tokenizer class="solr.StandardTokenizerFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+    </analyzer>
+  </fieldType>
+
+  <fieldType name="pint" class="solr.IntPointField" docValues="true"/>
+  <fieldType name="pfloat" class="solr.FloatPointField" docValues="true"/>
+  <fieldType name="plong" class="solr.LongPointField" docValues="true"/>
+  <fieldType name="pdouble" class="solr.DoublePointField" docValues="true"/>
+  <fieldType name="pints" class="solr.IntPointField" docValues="true" multiValued="true"/>
+  <fieldType name="pfloats" class="solr.FloatPointField" docValues="true" multiValued="true"/>
+  <fieldType name="plongs" class="solr.LongPointField" docValues="true" multiValued="true"/>
+  <fieldType name="pdoubles" class="solr.DoublePointField" docValues="true" multiValued="true"/>
+  <fieldType name="pdate" class="solr.DatePointField" docValues="true"/>
+  <fieldType name="pdates" class="solr.DatePointField" docValues="true" multiValued="true"/>
+
+  <field name="id" type="string" indexed="true" stored="true" multiValued="false" required="true"/>
+  <field name="_version_" type="long" indexed="true" stored="true"/>
+  <field name="_root_" type="string" indexed="true" stored="true" multiValued="false"/>
+
+  <dynamicField name="*_str" type="string" stored="false" multiValued="true" docValues="true" useDocValuesAsStored="false"/>
+  <dynamicField name="*_t" type="text" indexed="true" stored="true"/>
+  <dynamicField name="*_ti" type="tint" indexed="true" stored="true"/>
+  <dynamicField name="*_tl" type="tlong" indexed="true" stored="true"/>
+  <dynamicField name="*_tf" type="tfloat" indexed="true" stored="true"/>
+  <dynamicField name="*_td" type="tdouble" indexed="true" stored="true"/>
+  <dynamicField name="*_tdt" type="tdate" indexed="true" stored="true"/>
+
+  <dynamicField name="*_pi" type="pint"    indexed="true"  stored="true"/>
+  <dynamicField name="*_pis" type="pints"    indexed="true"  stored="true"/>
+  <dynamicField name="*_pl" type="plong"   indexed="true"  stored="true"/>
+  <dynamicField name="*_pls" type="plongs"   indexed="true"  stored="true"/>
+  <dynamicField name="*_pf" type="pfloat"  indexed="true"  stored="true"/>
+  <dynamicField name="*_pfs" type="pfloats"  indexed="true"  stored="true"/>
+  <dynamicField name="*_pd" type="pdouble" indexed="true"  stored="true"/>
+  <dynamicField name="*_pds" type="pdoubles" indexed="true"  stored="true"/>
+  <dynamicField name="*_pdt" type="pdate"  indexed="true"  stored="true"/>
+  <dynamicField name="*_pdts" type="pdates"  indexed="true"  stored="true"/>
+
+  <uniqueKey>id</uniqueKey>
+
+</schema>

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-guess-schema-fields-update-processor-chains.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-guess-schema-fields-update-processor-chains.xml
@@ -1,0 +1,223 @@
+<?xml version="1.0" ?>
+
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<!--
+   Test Config that enumerates many different parsing update processor chain 
+   configurations.
+  -->
+<config>
+  <luceneMatchVersion>${tests.luceneMatchVersion:LATEST}</luceneMatchVersion>
+  <requestHandler name="/select" class="solr.SearchHandler"></requestHandler>
+  <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.RAMDirectoryFactory}"/>
+
+  <schemaFactory class="ManagedIndexSchemaFactory">
+    <bool name="mutable">true</bool>
+    <str name="managedSchemaResourceName">managed-schema</str>
+  </schemaFactory>
+
+  <updateRequestProcessorChain name="add-fields-no-run-processor">
+    <processor class="solr.GuessSchemaFieldsUpdateProcessorFactory">
+      <str name="defaultFieldType">text</str>
+      <lst name="typeMapping">
+        <str name="valueClass">java.lang.Boolean</str>
+        <str name="fieldType">boolean</str>
+      </lst>
+      <lst name="typeMapping">
+        <str name="valueClass">java.lang.Integer</str>
+        <str name="fieldType">pints</str>
+      </lst>
+      <lst name="typeMapping">
+        <str name="valueClass">java.lang.Float</str>
+        <str name="fieldType">pfloats</str>
+      </lst>
+      <lst name="typeMapping">
+        <str name="valueClass">java.util.Date</str>
+        <str name="fieldType">pdates</str>
+      </lst>
+      <lst name="typeMapping">
+        <str name="valueClass">java.lang.Long</str>
+        <str name="valueClass">java.lang.Integer</str>
+        <str name="fieldType">plongs</str>
+      </lst>
+      <lst name="typeMapping">
+        <arr name="valueClass">
+          <str>java.lang.Double</str>
+          <str>java.lang.Float</str>
+        </arr>
+        <str name="fieldType">pdoubles</str>
+      </lst>
+    </processor>
+  </updateRequestProcessorChain>
+
+  <updateRequestProcessorChain name="add-fields">
+    <processor class="solr.GuessSchemaFieldsUpdateProcessorFactory">
+      <str name="defaultFieldType">text</str>
+      <lst name="typeMapping">
+        <str name="valueClass">java.lang.String</str>
+        <str name="fieldType">text</str>
+        <lst name="copyField">
+          <str name="dest">*_str</str>
+        </lst>
+      </lst>
+      <lst name="typeMapping">
+        <str name="valueClass">java.lang.Boolean</str>
+        <str name="fieldType">boolean</str>
+      </lst>
+      <lst name="typeMapping">
+        <str name="valueClass">java.lang.Integer</str>
+        <str name="fieldType">pints</str>
+      </lst>
+      <lst name="typeMapping">
+        <str name="valueClass">java.lang.Float</str>
+        <str name="fieldType">pfloats</str>
+      </lst>
+      <lst name="typeMapping">
+        <str name="valueClass">java.util.Date</str>
+        <str name="fieldType">pdates</str>
+      </lst>
+      <lst name="typeMapping">
+        <str name="valueClass">java.lang.Long</str>
+        <str name="valueClass">java.lang.Integer</str>
+        <str name="fieldType">plongs</str>
+      </lst>
+      <lst name="typeMapping">
+        <str name="valueClass">java.lang.Number</str>
+        <str name="fieldType">pdoubles</str>
+      </lst>
+    </processor>
+    <processor class="solr.RunUpdateProcessorFactory" />
+  </updateRequestProcessorChain>
+
+  <updateRequestProcessorChain name="add-fields-maxchars">
+    <processor class="solr.AddSchemaFieldsUpdateProcessorFactory">
+      <str name="defaultFieldType">text</str>
+      <lst name="typeMapping">
+        <str name="valueClass">java.lang.String</str>
+        <str name="fieldType">text</str>
+        <lst name="copyField">
+          <str name="dest">*_str</str>
+          <int name="maxChars">10</int>
+        </lst>
+        <lst name="copyField">
+          <str name="dest">*_t</str>
+          <int name="maxChars">20</int>
+        </lst>
+        <lst name="copyField">
+          <str name="dest">*2_t</str>
+          <int name="maxChars">20</int>
+        </lst>
+      </lst>
+    </processor>
+    <processor class="solr.LogUpdateProcessorFactory" />
+    <processor class="solr.DistributedUpdateProcessorFactory" />
+    <processor class="solr.RunUpdateProcessorFactory" />
+  </updateRequestProcessorChain>
+  
+  <!-- This chain has one of the typeMappings set as default=true, instead of falling back to the defaultFieldType -->
+  <updateRequestProcessorChain name="add-fields-default-mapping">
+    <processor class="solr.AddSchemaFieldsUpdateProcessorFactory">
+      <lst name="typeMapping">
+        <str name="valueClass">java.lang.String</str>
+        <str name="fieldType">text</str>
+        <lst name="copyField">
+          <str name="dest">*_str</str>
+          <int name="maxChars">10</int>
+        </lst>
+        <!-- Use as default mapping instead of defaultFieldType -->
+        <bool name="default">true</bool>
+      </lst>
+      <lst name="typeMapping">
+        <str name="valueClass">java.lang.Boolean</str>
+        <str name="fieldType">boolean</str>
+      </lst>
+      <lst name="typeMapping">
+        <str name="valueClass">java.lang.Integer</str>
+        <str name="fieldType">pints</str>
+      </lst>
+      <lst name="typeMapping">
+        <str name="valueClass">java.lang.Float</str>
+        <str name="fieldType">pfloats</str>
+      </lst>
+      <lst name="typeMapping">
+        <str name="valueClass">java.util.Date</str>
+        <str name="fieldType">pdates</str>
+      </lst>
+      <lst name="typeMapping">
+        <str name="valueClass">java.lang.Long</str>
+        <str name="valueClass">java.lang.Integer</str>
+        <str name="fieldType">plongs</str>
+      </lst>
+      <lst name="typeMapping">
+        <str name="valueClass">java.lang.Number</str>
+        <str name="fieldType">pdoubles</str>
+      </lst>
+    </processor>
+    <processor class="solr.LogUpdateProcessorFactory" />
+    <processor class="solr.DistributedUpdateProcessorFactory" />
+    <processor class="solr.RunUpdateProcessorFactory" />
+  </updateRequestProcessorChain>
+
+  <updateRequestProcessorChain name="parse-and-add-fields">
+    <processor class="solr.ParseBooleanFieldUpdateProcessorFactory"/>
+    <processor class="solr.ParseLongFieldUpdateProcessorFactory"/>
+    <processor class="solr.ParseDoubleFieldUpdateProcessorFactory"/>
+    <processor class="solr.ParseDateFieldUpdateProcessorFactory">
+      <arr name="format">
+        <str>yyyy-MM-dd['T'[HH:mm[:ss[.SSS]][z</str>
+        <str>yyyy-MM-dd['T'[HH:mm[:ss[,SSS]][z</str>
+        <str>yyyy-MM-dd HH:mm[:ss[.SSS]][z</str>
+        <str>yyyy-MM-dd HH:mm[:ss[,SSS]][z</str>
+        <str>[EEE, ]dd MMM yyyy HH:mm[:ss] z</str>
+        <str>EEEE, dd-MMM-yy HH:mm:ss z</str>
+        <str>EEE MMM ppd HH:mm:ss [z ]yyyy</str>
+      </arr>
+    </processor>
+    <processor class="solr.AddSchemaFieldsUpdateProcessorFactory">
+      <str name="defaultFieldType">text</str>
+      <lst name="typeMapping">
+        <str name="valueClass">java.lang.Boolean</str>
+        <str name="fieldType">boolean</str>
+      </lst>
+      <lst name="typeMapping">
+        <str name="valueClass">java.lang.Integer</str>
+        <str name="fieldType">pints</str>
+      </lst>
+      <lst name="typeMapping">
+        <str name="valueClass">java.lang.Float</str>
+        <str name="fieldType">pfloats</str>
+      </lst>
+      <lst name="typeMapping">
+        <str name="valueClass">java.util.Date</str>
+        <str name="fieldType">pdates</str>
+      </lst>
+      <lst name="typeMapping">
+        <str name="valueClass">java.lang.Long</str>
+        <str name="valueClass">java.lang.Integer</str>
+        <str name="fieldType">plongs</str>
+      </lst>
+      <lst name="typeMapping">
+        <str name="valueClass">java.lang.Number</str>
+        <str name="fieldType">pdoubles</str>
+      </lst>
+    </processor>
+    <processor class="solr.LogUpdateProcessorFactory" />
+    <processor class="solr.DistributedUpdateProcessorFactory" />
+    <processor class="solr.RunUpdateProcessorFactory" />
+  </updateRequestProcessorChain>
+</config>

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-guess-schema-fields-update-processor-chains.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-guess-schema-fields-update-processor-chains.xml
@@ -43,25 +43,25 @@
       </lst>
       <lst name="typeMapping">
         <str name="valueClass">java.lang.Integer</str>
-        <str name="fieldType">pints</str>
+        <str name="fieldType">pint</str>
       </lst>
       <lst name="typeMapping">
         <str name="valueClass">java.lang.Float</str>
-        <str name="fieldType">pfloats</str>
+        <str name="fieldType">pfloat</str>
       </lst>
       <lst name="typeMapping">
         <str name="valueClass">java.util.Date</str>
-        <str name="fieldType">pdates</str>
+        <str name="fieldType">pdate</str>
       </lst>
       <lst name="typeMapping">
         <str name="valueClass">java.lang.Long</str>
-        <str name="fieldType">plongs</str>
+        <str name="fieldType">plong</str>
       </lst>
       <lst name="typeMapping">
         <arr name="valueClass">
           <str>java.lang.Double</str>
         </arr>
-        <str name="fieldType">pdoubles</str>
+        <str name="fieldType">pdouble</str>
       </lst>
     </processor>
   </updateRequestProcessorChain>
@@ -81,23 +81,23 @@
       </lst>
       <lst name="typeMapping">
         <str name="valueClass">java.lang.Integer</str>
-        <str name="fieldType">pints</str>
+        <str name="fieldType">pint</str>
       </lst>
       <lst name="typeMapping">
         <str name="valueClass">java.lang.Float</str>
-        <str name="fieldType">pfloats</str>
+        <str name="fieldType">pfloat</str>
       </lst>
       <lst name="typeMapping">
         <str name="valueClass">java.util.Date</str>
-        <str name="fieldType">pdates</str>
+        <str name="fieldType">pdate</str>
       </lst>
       <lst name="typeMapping">
         <str name="valueClass">java.lang.Long</str>
-        <str name="fieldType">plongs</str>
+        <str name="fieldType">plong</str>
       </lst>
       <lst name="typeMapping">
         <str name="valueClass">java.lang.Number</str>
-        <str name="fieldType">pdoubles</str>
+        <str name="fieldType">pdouble</str>
       </lst>
     </processor>
     <processor class="solr.RunUpdateProcessorFactory" />
@@ -144,23 +144,23 @@
       </lst>
       <lst name="typeMapping">
         <str name="valueClass">java.lang.Integer</str>
-        <str name="fieldType">pints</str>
+        <str name="fieldType">pint</str>
       </lst>
       <lst name="typeMapping">
         <str name="valueClass">java.lang.Float</str>
-        <str name="fieldType">pfloats</str>
+        <str name="fieldType">pfloat</str>
       </lst>
       <lst name="typeMapping">
         <str name="valueClass">java.util.Date</str>
-        <str name="fieldType">pdates</str>
+        <str name="fieldType">pdate</str>
       </lst>
       <lst name="typeMapping">
         <str name="valueClass">java.lang.Long</str>
-        <str name="fieldType">plongs</str>
+        <str name="fieldType">plong</str>
       </lst>
       <lst name="typeMapping">
         <str name="valueClass">java.lang.Number</str>
-        <str name="fieldType">pdoubles</str>
+        <str name="fieldType">pdouble</str>
       </lst>
     </processor>
     <processor class="solr.LogUpdateProcessorFactory" />
@@ -194,23 +194,23 @@
       </lst>
       <lst name="typeMapping">
         <str name="valueClass">java.lang.Integer</str>
-        <str name="fieldType">pints</str>
+        <str name="fieldType">pint</str>
       </lst>
       <lst name="typeMapping">
         <str name="valueClass">java.lang.Float</str>
-        <str name="fieldType">pfloats</str>
+        <str name="fieldType">pfloat</str>
       </lst>
       <lst name="typeMapping">
         <str name="valueClass">java.util.Date</str>
-        <str name="fieldType">pdates</str>
+        <str name="fieldType">pdate</str>
       </lst>
       <lst name="typeMapping">
         <str name="valueClass">java.lang.Long</str>
-        <str name="fieldType">plongs</str>
+        <str name="fieldType">plong</str>
       </lst>
       <lst name="typeMapping">
         <str name="valueClass">java.lang.Number</str>
-        <str name="fieldType">pdoubles</str>
+        <str name="fieldType">pdouble</str>
       </lst>
     </processor>
     <processor class="solr.LogUpdateProcessorFactory" />

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-guess-schema-fields-update-processor-chains.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-guess-schema-fields-update-processor-chains.xml
@@ -31,9 +31,12 @@
     <str name="managedSchemaResourceName">managed-schema</str>
   </schemaFactory>
 
-  <updateRequestProcessorChain name="add-fields-no-run-processor">
+   <updateRequestProcessorChain name="add-fields-no-run-processor">
     <processor class="solr.GuessSchemaFieldsUpdateProcessorFactory">
-      <str name="defaultFieldType">text</str>
+      <lst name="typeMapping">
+        <str name="valueClass">java.lang.String</str>
+        <str name="fieldType">text</str>
+      </lst>
       <lst name="typeMapping">
         <str name="valueClass">java.lang.Boolean</str>
         <str name="fieldType">boolean</str>
@@ -52,13 +55,11 @@
       </lst>
       <lst name="typeMapping">
         <str name="valueClass">java.lang.Long</str>
-        <str name="valueClass">java.lang.Integer</str>
         <str name="fieldType">plongs</str>
       </lst>
       <lst name="typeMapping">
         <arr name="valueClass">
           <str>java.lang.Double</str>
-          <str>java.lang.Float</str>
         </arr>
         <str name="fieldType">pdoubles</str>
       </lst>
@@ -67,7 +68,6 @@
 
   <updateRequestProcessorChain name="add-fields">
     <processor class="solr.GuessSchemaFieldsUpdateProcessorFactory">
-      <str name="defaultFieldType">text</str>
       <lst name="typeMapping">
         <str name="valueClass">java.lang.String</str>
         <str name="fieldType">text</str>
@@ -93,7 +93,6 @@
       </lst>
       <lst name="typeMapping">
         <str name="valueClass">java.lang.Long</str>
-        <str name="valueClass">java.lang.Integer</str>
         <str name="fieldType">plongs</str>
       </lst>
       <lst name="typeMapping">
@@ -105,8 +104,7 @@
   </updateRequestProcessorChain>
 
   <updateRequestProcessorChain name="add-fields-maxchars">
-    <processor class="solr.AddSchemaFieldsUpdateProcessorFactory">
-      <str name="defaultFieldType">text</str>
+    <processor class="solr.GuessSchemaFieldsUpdateProcessorFactory">
       <lst name="typeMapping">
         <str name="valueClass">java.lang.String</str>
         <str name="fieldType">text</str>
@@ -131,7 +129,7 @@
   
   <!-- This chain has one of the typeMappings set as default=true, instead of falling back to the defaultFieldType -->
   <updateRequestProcessorChain name="add-fields-default-mapping">
-    <processor class="solr.AddSchemaFieldsUpdateProcessorFactory">
+    <processor class="solr.GuessSchemaFieldsUpdateProcessorFactory">
       <lst name="typeMapping">
         <str name="valueClass">java.lang.String</str>
         <str name="fieldType">text</str>
@@ -139,8 +137,6 @@
           <str name="dest">*_str</str>
           <int name="maxChars">10</int>
         </lst>
-        <!-- Use as default mapping instead of defaultFieldType -->
-        <bool name="default">true</bool>
       </lst>
       <lst name="typeMapping">
         <str name="valueClass">java.lang.Boolean</str>
@@ -160,7 +156,6 @@
       </lst>
       <lst name="typeMapping">
         <str name="valueClass">java.lang.Long</str>
-        <str name="valueClass">java.lang.Integer</str>
         <str name="fieldType">plongs</str>
       </lst>
       <lst name="typeMapping">
@@ -188,8 +183,11 @@
         <str>EEE MMM ppd HH:mm:ss [z ]yyyy</str>
       </arr>
     </processor>
-    <processor class="solr.AddSchemaFieldsUpdateProcessorFactory">
-      <str name="defaultFieldType">text</str>
+    <processor class="solr.GuessSchemaFieldsUpdateProcessorFactory">
+      <lst name="typeMapping">
+        <str name="valueClass">java.lang.String</str>
+        <str name="fieldType">text</str>
+      </lst>
       <lst name="typeMapping">
         <str name="valueClass">java.lang.Boolean</str>
         <str name="fieldType">boolean</str>
@@ -208,7 +206,6 @@
       </lst>
       <lst name="typeMapping">
         <str name="valueClass">java.lang.Long</str>
-        <str name="valueClass">java.lang.Integer</str>
         <str name="fieldType">plongs</str>
       </lst>
       <lst name="typeMapping">

--- a/solr/core/src/test/org/apache/solr/update/processor/GuessSchemaFieldsUpdateProcessorFactoryTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/GuessSchemaFieldsUpdateProcessorFactoryTest.java
@@ -62,6 +62,8 @@ public class GuessSchemaFieldsUpdateProcessorFactoryTest extends UpdateProcessor
     initCore(SOLRCONFIG_XML, SCHEMA_XML, tmpSolrHome.getPath());
   }
 
+  //TODO: Explicitly test for multiValue detection, not just with XPATH
+
   public void testEmptyValue() {
     IndexSchema schema = h.getCore().getLatestSchema();
     final String fieldName = "newFieldABC";
@@ -88,7 +90,7 @@ public class GuessSchemaFieldsUpdateProcessorFactoryTest extends UpdateProcessor
     processCommit(chain);
     schema = h.getCore().getLatestSchema();
     assertNotNull(schema.getFieldOrNull(fieldName));
-    assertEquals("pdates", schema.getFieldType(fieldName).getTypeName());
+    assertEquals("pdate", schema.getFieldType(fieldName).getTypeName());
   }
 
   public void testSingleFieldRoundTrip() throws Exception {
@@ -105,19 +107,19 @@ public class GuessSchemaFieldsUpdateProcessorFactoryTest extends UpdateProcessor
 
     schema = h.getCore().getLatestSchema();
     assertNotNull(schema.getFieldOrNull(fieldName));
-    assertEquals("pfloats", schema.getFieldType(fieldName).getTypeName());
+    assertEquals("pfloat", schema.getFieldType(fieldName).getTypeName());
 
-    //now actual index it
+    //now actually index it
     SolrInputDocument e = processAdd(chain, doc(f("id", "2"), f(fieldName, floatValue)));
     assertNotNull(e);
+    assertU(commit());
 
     // just in case, retest the schema this once
     schema = h.getCore().getLatestSchema();
     assertNotNull(schema.getFieldOrNull(fieldName));
-    assertEquals("pfloats", schema.getFieldType(fieldName).getTypeName());
+    assertEquals("pfloat", schema.getFieldType(fieldName).getTypeName());
 
-    assertU(commit());
-    assertQ(req("id:2"), "//arr[@name='" + fieldName + "']/float[.='" + floatValue.toString() + "']");
+    assertQ(req("id:2"), "//float[@name='" + fieldName + "' and .='" + floatValue.toString() + "']");
   }
 
   public void testSingleFieldMixedFieldTypesRoundTrip() throws Exception {
@@ -134,7 +136,7 @@ public class GuessSchemaFieldsUpdateProcessorFactoryTest extends UpdateProcessor
 
     schema = h.getCore().getLatestSchema();
     assertNotNull(schema.getFieldOrNull(fieldName));
-    assertEquals("pdoubles", schema.getFieldType(fieldName).getTypeName());
+    assertEquals("pdouble", schema.getFieldType(fieldName).getTypeName());
 
     SolrInputDocument e = processAdd
         (chain, doc(f("id", "3"), f(fieldName, fieldValue1, fieldValue2)));
@@ -222,8 +224,8 @@ public class GuessSchemaFieldsUpdateProcessorFactoryTest extends UpdateProcessor
     schema = h.getCore().getLatestSchema();
     assertNotNull(schema.getFieldOrNull(fieldName1));
     assertNotNull(schema.getFieldOrNull(fieldName2));
-    assertEquals("pdoubles", schema.getFieldType(fieldName1).getTypeName());
-    assertEquals("plongs", schema.getFieldType(fieldName2).getTypeName());
+    assertEquals("pdouble", schema.getFieldType(fieldName1).getTypeName());
+    assertEquals("plong", schema.getFieldType(fieldName2).getTypeName());
 
     SolrInputDocument e = processAdd
             (chain, doc(f("id", "5"),
@@ -283,10 +285,10 @@ public class GuessSchemaFieldsUpdateProcessorFactoryTest extends UpdateProcessor
     assertNotNull(schema.getFieldOrNull(fieldName2));
     assertNotNull(schema.getFieldOrNull(fieldName3));
     assertNotNull(schema.getFieldOrNull(fieldName4));
-    assertEquals("pdoubles", schema.getFieldType(fieldName1).getTypeName());
-    assertEquals("plongs", schema.getFieldType(fieldName2).getTypeName());
+    assertEquals("pdouble", schema.getFieldType(fieldName1).getTypeName());
+    assertEquals("plong", schema.getFieldType(fieldName2).getTypeName());
     assertEquals("text", schema.getFieldType(fieldName3).getTypeName());
-    assertEquals("pdates", schema.getFieldType(fieldName4).getTypeName());
+    assertEquals("pdate", schema.getFieldType(fieldName4).getTypeName());
 
     SolrInputDocument e = processAdd
             (chain, doc(f("id", "6"), f(fieldName1, field1String1, field1String2, field1String3),
@@ -303,7 +305,7 @@ public class GuessSchemaFieldsUpdateProcessorFactoryTest extends UpdateProcessor
         ,"//arr[@name='" + fieldName2 + "']/long[.='" + field2Value2.toString() + "']"
         ,"//arr[@name='" + fieldName3 + "']/str[.='" + field3String1 + "']"
         ,"//arr[@name='" + fieldName3 + "']/str[.='" + field3String2 + "']"
-        ,"//arr[@name='" + fieldName4 + "']/date[.='" + field4Value1String + "']");
+        ,"//date[@name='" + fieldName4 + "' and .='" + field4Value1String + "']");
   }
 
   public void testStringWithCopyField() throws Exception {

--- a/solr/core/src/test/org/apache/solr/update/processor/GuessSchemaFieldsUpdateProcessorFactoryTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/GuessSchemaFieldsUpdateProcessorFactoryTest.java
@@ -1,0 +1,343 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.update.processor;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.solr.common.SolrInputDocument;
+import org.apache.solr.common.params.MapSolrParams;
+import org.apache.solr.common.params.ModifiableSolrParams;
+import org.apache.solr.schema.IndexSchema;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.File;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Tests for the field mutating update processors
+ * that parse Dates, Longs, Doubles, and Booleans.
+ */
+public class GuessSchemaFieldsUpdateProcessorFactoryTest extends UpdateProcessorTestBase {
+  private static final String SOLRCONFIG_XML = "solrconfig-guess-schema-fields-update-processor-chains.xml";
+  private static final String SCHEMA_XML     = "schema-guess-schema-fields-update-processor.xml";
+  public static final MapSolrParams PARAMS_GUESS_SCHEMA = new MapSolrParams(Map.of("guess-schema", "true"));
+
+  private static File tmpSolrHome;
+  private static File tmpConfDir;
+
+  private static final String collection = "collection1";
+  private static final String confDir = collection + "/conf";
+
+  @Before
+  private void initManagedSchemaCore() throws Exception {
+    tmpSolrHome = createTempDir().toFile();
+    tmpConfDir = new File(tmpSolrHome, confDir);
+    File testHomeConfDir = new File(TEST_HOME(), confDir);
+    FileUtils.copyFileToDirectory(new File(testHomeConfDir, SOLRCONFIG_XML), tmpConfDir);
+    FileUtils.copyFileToDirectory(new File(testHomeConfDir, SCHEMA_XML), tmpConfDir);
+
+    // initCore will trigger an upgrade to managed schema, since the solrconfig*.xml has
+    // <schemaFactory class="ManagedIndexSchemaFactory" ... />
+    initCore(SOLRCONFIG_XML, SCHEMA_XML, tmpSolrHome.getPath());
+  }
+
+  public void testEmptyValue() {
+    IndexSchema schema = h.getCore().getLatestSchema();
+    final String fieldName = "newFieldABC";
+    assertNull(schema.getFieldOrNull(fieldName));
+    //UpdateProcessorTestBase#doc doesn't deal with nulls
+    SolrInputDocument doc = new SolrInputDocument();
+    doc.addField("id", "1");
+    doc.addField(fieldName, null);
+
+    SolrInputDocument finalDoc = doc;
+    expectThrows(AssertionError.class, () -> processAdd("add-fields-no-run-processor", PARAMS_GUESS_SCHEMA, finalDoc));
+
+    expectThrows(AssertionError.class, () -> processAdd("add-fields-no-run-processor", PARAMS_GUESS_SCHEMA, new SolrInputDocument(null , null)));
+  }
+
+  public void testSingleField() throws Exception {
+    IndexSchema schema = h.getCore().getLatestSchema();
+    final String fieldName = "newfield1";
+    assertNull(schema.getFieldOrNull(fieldName));
+    Date date = Date.from(Instant.now());
+    String chain = "add-fields-no-run-processor";
+    SolrInputDocument d = processAdd(chain, PARAMS_GUESS_SCHEMA, doc(f("id", "1"), f(fieldName, date)));
+    assertNotNull(d);
+    processCommit(chain);
+    schema = h.getCore().getLatestSchema();
+    assertNotNull(schema.getFieldOrNull(fieldName));
+    assertEquals("pdates", schema.getFieldType(fieldName).getTypeName());
+  }
+
+  public void testSingleFieldRoundTrip() throws Exception {
+    IndexSchema schema = h.getCore().getLatestSchema();
+    final String fieldName = "newfield2";
+    assertNull(schema.getFieldOrNull(fieldName));
+    Float floatValue = -13258.992f;
+    String chain = "add-fields";
+
+    //create fields (but not index)
+    SolrInputDocument d = processAdd(chain, PARAMS_GUESS_SCHEMA, doc(f("id", "2"), f(fieldName, floatValue)));
+    assertNotNull(d);
+    processCommit(chain);
+
+    schema = h.getCore().getLatestSchema();
+    assertNotNull(schema.getFieldOrNull(fieldName));
+    assertEquals("pfloats", schema.getFieldType(fieldName).getTypeName());
+
+    //now actual index it
+    SolrInputDocument e = processAdd(chain, doc(f("id", "2"), f(fieldName, floatValue)));
+    assertNotNull(e);
+
+    // just in case, retest the schema this once
+    schema = h.getCore().getLatestSchema();
+    assertNotNull(schema.getFieldOrNull(fieldName));
+    assertEquals("pfloats", schema.getFieldType(fieldName).getTypeName());
+
+    assertU(commit());
+    assertQ(req("id:2"), "//arr[@name='" + fieldName + "']/float[.='" + floatValue.toString() + "']");
+  }
+
+  public void testSingleFieldMixedFieldTypesRoundTrip() throws Exception {
+    IndexSchema schema = h.getCore().getLatestSchema();
+    final String fieldName = "newfield3";
+    assertNull(schema.getFieldOrNull(fieldName));
+    Float fieldValue1 = -13258.0f;
+    Double fieldValue2 = 8.4828800808E10;
+    String chain = "add-fields";
+    SolrInputDocument d = processAdd
+        (chain, PARAMS_GUESS_SCHEMA, doc(f("id", "3"), f(fieldName, fieldValue1, fieldValue2)));
+    assertNotNull(d);
+    processCommit(chain);
+
+    schema = h.getCore().getLatestSchema();
+    assertNotNull(schema.getFieldOrNull(fieldName));
+    assertEquals("pdoubles", schema.getFieldType(fieldName).getTypeName());
+
+    SolrInputDocument e = processAdd
+        (chain, doc(f("id", "3"), f(fieldName, fieldValue1, fieldValue2)));
+    assertNotNull(e);
+    assertU(commit());
+    assertQ(req("id:3")
+        ,"//arr[@name='" + fieldName + "']/double[.='" + fieldValue1.toString() + "']"
+        ,"//arr[@name='" + fieldName + "']/double[.='" + fieldValue2.toString() + "']");
+  }
+
+  public void testSingleFieldDefaultFieldTypeRoundTrip() throws Exception {
+    IndexSchema schema = h.getCore().getLatestSchema();
+    final String fieldName = "newfield4";
+    assertNull(schema.getFieldOrNull(fieldName));
+    Float fieldValue1 = -13258.0f;
+    Double fieldValue2 = 8.4828800808E10;
+    String fieldValue3 = "blah blah";
+    String chain = "add-fields";
+    SolrInputDocument d = processAdd
+        (chain, PARAMS_GUESS_SCHEMA, doc(f("id", "4"), f(fieldName, fieldValue1, fieldValue2, fieldValue3)));
+    assertNotNull(d);
+    processCommit(chain);
+    schema = h.getCore().getLatestSchema();
+    assertNotNull(schema.getFieldOrNull(fieldName));
+    assertEquals("text", schema.getFieldType(fieldName).getTypeName());
+    assertEquals(0, schema.getCopyFieldProperties(true, Collections.singleton(fieldName), null).size());
+
+    SolrInputDocument e = processAdd
+            (chain, doc(f("id", "4"), f(fieldName, fieldValue1, fieldValue2, fieldValue3)));
+    assertNotNull(e);
+    assertU(commit());
+    assertQ(req("id:4")
+        ,"//arr[@name='" + fieldName + "']/str[.='" + fieldValue1.toString() + "']"
+        ,"//arr[@name='" + fieldName + "']/str[.='" + fieldValue2.toString() + "']"
+        ,"//arr[@name='" + fieldName + "']/str[.='" + fieldValue3.toString() + "']"
+    );
+  }
+
+  public void testSingleFieldDefaultTypeMappingRoundTrip() throws Exception {
+    IndexSchema schema = h.getCore().getLatestSchema();
+    final String fieldName = "newfield4";
+    assertNull(schema.getFieldOrNull(fieldName));
+    Float fieldValue1 = -13258.0f;
+    Double fieldValue2 = 8.4828800808E10;
+    String fieldValue3 = "blah blah";
+    SolrInputDocument d = processAdd
+        ("add-fields-default-mapping", doc(f("id", "4"), f(fieldName, fieldValue1, fieldValue2, fieldValue3)));
+    assertNotNull(d);
+    schema = h.getCore().getLatestSchema();
+    assertNotNull(schema.getFieldOrNull(fieldName));
+    assertEquals("text", schema.getFieldType(fieldName).getTypeName());
+    assertEquals(1, schema.getCopyFieldProperties(true, Collections.singleton(fieldName), null).size());
+    assertU(commit());
+    assertQ(req("id:4")
+        ,"//arr[@name='" + fieldName + "']/str[.='" + fieldValue1.toString() + "']"
+        ,"//arr[@name='" + fieldName + "']/str[.='" + fieldValue2.toString() + "']"
+        ,"//arr[@name='" + fieldName + "']/str[.='" + fieldValue3.toString() + "']"
+    );
+  }
+
+  public void testMultipleFieldsRoundTrip() throws Exception {
+    IndexSchema schema = h.getCore().getLatestSchema();
+    final String fieldName1 = "newfield5";
+    final String fieldName2 = "newfield6";
+    assertNull(schema.getFieldOrNull(fieldName1));
+    assertNull(schema.getFieldOrNull(fieldName2));
+    Float field1Value1 = -13258.0f;
+    Double field1Value2 = 8.4828800808E10;
+    Long field1Value3 = 999L;
+    Integer field2Value1 = 55123;
+    Long field2Value2 = 1234567890123456789L;
+    SolrInputDocument d = processAdd
+        ("add-fields", doc(f("id", "5"), f(fieldName1, field1Value1, field1Value2, field1Value3),
+                                         f(fieldName2, field2Value1, field2Value2)));
+    assertNotNull(d);
+    schema = h.getCore().getLatestSchema();
+    assertNotNull(schema.getFieldOrNull(fieldName1));
+    assertNotNull(schema.getFieldOrNull(fieldName2));
+    assertEquals("pdoubles", schema.getFieldType(fieldName1).getTypeName());
+    assertEquals("plongs", schema.getFieldType(fieldName2).getTypeName());
+    assertU(commit());
+    assertQ(req("id:5")
+        ,"//arr[@name='" + fieldName1 + "']/double[.='" + field1Value1.toString() + "']"
+        ,"//arr[@name='" + fieldName1 + "']/double[.='" + field1Value2.toString() + "']"
+        ,"//arr[@name='" + fieldName1 + "']/double[.='" + field1Value3.doubleValue() + "']"
+        ,"//arr[@name='" + fieldName2 + "']/long[.='" + field2Value1.toString() + "']"
+        ,"//arr[@name='" + fieldName2 + "']/long[.='" + field2Value2.toString() + "']");
+  }
+
+  public void testParseAndAddMultipleFieldsRoundTrip() throws Exception {
+    IndexSchema schema = h.getCore().getLatestSchema();
+    final String fieldName1 = "newfield7";
+    final String fieldName2 = "newfield8";
+    final String fieldName3 = "newfield9";
+    final String fieldName4 = "newfield10";
+    assertNull(schema.getFieldOrNull(fieldName1));
+    assertNull(schema.getFieldOrNull(fieldName2));
+    assertNull(schema.getFieldOrNull(fieldName3));
+    assertNull(schema.getFieldOrNull(fieldName4));
+    String field1String1 = "-13,258.0"; 
+    Float field1Value1 = -13258.0f;
+    String field1String2 = "84,828,800,808.0"; 
+    Double field1Value2 = 8.4828800808E10;
+    String field1String3 = "999";
+    Long field1Value3 = 999L;
+    String field2String1 = "55,123";
+    Integer field2Value1 = 55123;
+    String field2String2 = "1,234,567,890,123,456,789";
+    Long field2Value2 = 1234567890123456789L;
+    String field3String1 = "blah-blah";
+    String field3Value1 = field3String1;
+    String field3String2 = "-5.28E-3";
+    Double field3Value2 = -5.28E-3;
+    String field4String1 = "1999-04-17 17:42";
+    DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm", Locale.ROOT).withZone(ZoneOffset.UTC);
+    LocalDateTime dateTime = LocalDateTime.parse(field4String1, dateTimeFormatter);
+    Date field4Value1 = Date.from(dateTime.atZone(ZoneOffset.UTC).toInstant());
+    DateTimeFormatter dateTimeFormatter2 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss", Locale.ROOT).withZone(ZoneOffset.UTC);
+    String field4Value1String = dateTime.format(dateTimeFormatter2) + "Z";
+    
+    SolrInputDocument d = processAdd
+        ("parse-and-add-fields", doc(f("id", "6"), f(fieldName1, field1String1, field1String2, field1String3),
+                                                   f(fieldName2, field2String1, field2String2),
+                                                   f(fieldName3, field3String1, field3String2),
+                                                   f(fieldName4, field4String1)));
+    assertNotNull(d);
+    schema = h.getCore().getLatestSchema();
+    assertNotNull(schema.getFieldOrNull(fieldName1));
+    assertNotNull(schema.getFieldOrNull(fieldName2));
+    assertNotNull(schema.getFieldOrNull(fieldName3));
+    assertNotNull(schema.getFieldOrNull(fieldName4));
+    assertEquals("pdoubles", schema.getFieldType(fieldName1).getTypeName());
+    assertEquals("plongs", schema.getFieldType(fieldName2).getTypeName());
+    assertEquals("text", schema.getFieldType(fieldName3).getTypeName());
+    assertEquals("pdates", schema.getFieldType(fieldName4).getTypeName());
+    assertU(commit());
+    assertQ(req("id:6")
+        ,"//arr[@name='" + fieldName1 + "']/double[.='" + field1Value1.toString() + "']"
+        ,"//arr[@name='" + fieldName1 + "']/double[.='" + field1Value2.toString() + "']"
+        ,"//arr[@name='" + fieldName1 + "']/double[.='" + field1Value3.doubleValue() + "']"
+        ,"//arr[@name='" + fieldName2 + "']/long[.='" + field2Value1.toString() + "']"
+        ,"//arr[@name='" + fieldName2 + "']/long[.='" + field2Value2.toString() + "']"
+        ,"//arr[@name='" + fieldName3 + "']/str[.='" + field3String1 + "']"
+        ,"//arr[@name='" + fieldName3 + "']/str[.='" + field3String2 + "']"
+        ,"//arr[@name='" + fieldName4 + "']/date[.='" + field4Value1String + "']");
+  }
+
+  public void testStringWithCopyField() throws Exception {
+    IndexSchema schema = h.getCore().getLatestSchema();
+    final String fieldName = "stringField";
+    final String strFieldName = fieldName+"_str";
+    assertNull(schema.getFieldOrNull(fieldName));
+    String content = "This is a text that should be copied to a string field but not be cutoff";
+    SolrInputDocument d = processAdd("add-fields", doc(f("id", "1"), f(fieldName, content)));
+    assertNotNull(d);
+    schema = h.getCore().getLatestSchema();
+    assertNotNull(schema.getFieldOrNull(fieldName));
+    assertNotNull(schema.getFieldOrNull(strFieldName));
+    assertEquals("text", schema.getFieldType(fieldName).getTypeName());
+    assertEquals(1, schema.getCopyFieldProperties(true, Collections.singleton(fieldName), Collections.singleton(strFieldName)).size());
+  }
+
+  public void testStringWithCopyFieldAndMaxChars() throws Exception {
+    IndexSchema schema = h.getCore().getLatestSchema();
+    final String fieldName = "stringField";
+    final String strFieldName = fieldName+"_str";
+    assertNull(schema.getFieldOrNull(fieldName));
+    String content = "This is a text that should be copied to a string field and cutoff at 10 characters";
+    SolrInputDocument d = processAdd("add-fields-maxchars", doc(f("id", "1"), f(fieldName, content)));
+    assertNotNull(d);
+    System.out.println("Document is "+d);
+    schema = h.getCore().getLatestSchema();
+    assertNotNull(schema.getFieldOrNull(fieldName));
+    assertNotNull(schema.getFieldOrNull(strFieldName));
+    assertEquals("text", schema.getFieldType(fieldName).getTypeName());
+    // We have three copyFields, one with maxChars 10 and two with maxChars 20
+    assertEquals(3, schema.getCopyFieldProperties(true, Collections.singleton(fieldName), null).size());
+    assertEquals("The configured maxChars cutoff does not exist on the copyField", 10, 
+        schema.getCopyFieldProperties(true, Collections.singleton(fieldName), Collections.singleton(strFieldName))
+            .get(0).get("maxChars"));
+    assertEquals("The configured maxChars cutoff does not exist on the copyField", 20, 
+        schema.getCopyFieldProperties(true, Collections.singleton(fieldName), Collections.singleton(fieldName+"_t"))
+            .get(0).get("maxChars"));
+    assertEquals("The configured maxChars cutoff does not exist on the copyField", 20, 
+        schema.getCopyFieldProperties(true, Collections.singleton(fieldName), Collections.singleton(fieldName+"2_t"))
+            .get(0).get("maxChars"));
+  }
+  
+  public void testCopyFieldByIndexing() throws Exception {
+    String content = "This is a text that should be copied to a string field and cutoff at 10 characters";
+    SolrInputDocument d = processAdd("add-fields-default-mapping", doc(f("id", "1"), f("mynewfield", content)));
+    assertU(commit());
+
+    ModifiableSolrParams params = new ModifiableSolrParams();
+    params.add("q", "*:*").add("facet", "true").add("facet.field", "mynewfield_str");
+    assertQ(req(params)
+            , "*[count(//doc)=1]"
+            ,"//lst[@name='mynewfield_str']/int[@name='This is a '][.='1']"
+            );
+  }
+  
+  @After
+  private void deleteCoreAndTempSolrHomeDirectory() throws Exception {
+    deleteCore();
+  }
+}


### PR DESCRIPTION
#Description

New URP with tests. Everything is based on AddSchemaFieldsUpdateProcessorFactory but is sufficiently different to be a separate entry for backward compatibility.

# Solution

This solves the problem with original solution by:
- splitting accumulation of information about data seen (in processAdd) and actual schema modification (in commit)
- it uses parameter flag instead of disabling the whole chain, which causes problems if you do want to parse dates
- it supports parameter widening for numeric types to achieve sane results (e.g. Integer promoted to Double)
- It tracks multiplicity of values, so allows the baseline fieldTypes to be single-valued and fields declare multiValued as appropriate

It removes
- Sub-selecting which fields this process applies to. Mostly because we are now much more explicit about it being a learning schema. But also because nobody seems to be using that. Nor was it tested.
- Default options. They were interactive in non-predictable ways and the only sane option is mapping for String type anyway. 

Not in this PR 
- RefGuide 
- New Examples
- Change file notice
They should be done together in a separate Jira, as they may need additional discussion.

# Tests
The existing schemaless tests were copied and adjusted to work with new limitations. A couple more tests could be added later to test better for multiplicity (already tested with xpath), but also to test type widening more directly.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [-] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
