### PR TITLE
SOLR-14789: Rename docker tests task, adding missing credit in CHANGES

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -20,7 +20,7 @@ should be used instead, such as autoscaling policy or rules-based placement.
 
 New Features
 ---------------------
-* SOLR-14789: Migrate docker image creation from docker-solr repo to solr/docker. (Houston Putman, Tim Potter, David Smiley, janhoy, Mike Drob)
+* SOLR-14789: Migrate docker image creation from docker-solr repo to solr/docker. (Houston Putman, Martijn Koster, Tim Potter, David Smiley, janhoy, Mike Drob)
 
 * SOLR-14440: Introduce new Certificate Authentication Plugin to load Principal from certificate subject. (Mike Drob)
 

--- a/solr/docker/build.gradle
+++ b/solr/docker/build.gradle
@@ -87,6 +87,6 @@ abstract class DockerTestSuite extends DefaultTask {
   }
 }
 
-task test(type: DockerTestSuite) {
+task testDocker(type: DockerTestSuite) {
   outputDir = project.file("$buildDir/tmp/tests")
 }


### PR DESCRIPTION
This is so that the docker tests do not run by default on the Apache Jenkins test jobs.