### PR TITLE
SOLR-14802: Allow LLPSF fields as geodist argument

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -48,6 +48,8 @@ Improvements
 
 * SOLR-14722: Track timeAllowed from earlier in the request lifecycle. (David Smiley)
 
+* SOLR-14802: Support AbstractSpatialFieldType types as geodist argument (Tom Edge, Craig Wrigglesworth)
+
 Optimizations
 ---------------------
 

--- a/solr/core/src/java/org/apache/solr/search/FunctionQParser.java
+++ b/solr/core/src/java/org/apache/solr/search/FunctionQParser.java
@@ -239,9 +239,21 @@ public class FunctionQParser extends QParser {
    * @return List&lt;ValueSource&gt;
    */
   public List<ValueSource> parseValueSourceList() throws SyntaxError {
+    return parseValueSourceList(FLAG_DEFAULT | FLAG_CONSUME_DELIMITER);
+  }
+
+  /**
+   * Parse a list of ValueSource.  Must be the final set of arguments
+   * to a ValueSource.
+   *
+   * @param flags - customize parsing behavior
+   *
+   * @return List&lt;ValueSource&gt;
+   */
+  public List<ValueSource> parseValueSourceList(int flags) throws SyntaxError {
     List<ValueSource> sources = new ArrayList<>(3);
     while (hasMoreArguments()) {
-      sources.add(parseValueSource(FLAG_DEFAULT | FLAG_CONSUME_DELIMITER));
+      sources.add(parseValueSource(flags));
     }
     return sources;
   }

--- a/solr/core/src/java/org/apache/solr/search/function/distance/GeoDistValueSourceParser.java
+++ b/solr/core/src/java/org/apache/solr/search/function/distance/GeoDistValueSourceParser.java
@@ -16,17 +16,12 @@
  */
 package org.apache.solr.search.function.distance;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
 import org.apache.lucene.queries.function.ValueSource;
 import org.apache.lucene.queries.function.valuesource.ConstNumberSource;
 import org.apache.lucene.queries.function.valuesource.DoubleConstValueSource;
 import org.apache.lucene.queries.function.valuesource.MultiValueSource;
 import org.apache.lucene.queries.function.valuesource.VectorValueSource;
 import org.apache.lucene.spatial.SpatialStrategy;
-import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.SpatialParams;
 import org.apache.solr.schema.AbstractSpatialFieldType;
 import org.apache.solr.schema.FieldType;
@@ -34,11 +29,19 @@ import org.apache.solr.schema.SchemaField;
 import org.apache.solr.search.FunctionQParser;
 import org.apache.solr.search.SyntaxError;
 import org.apache.solr.search.ValueSourceParser;
+import org.apache.solr.search.function.FieldNameValueSource;
 import org.apache.solr.util.DistanceUnits;
 import org.apache.solr.util.SpatialUtils;
 import org.locationtech.spatial4j.context.SpatialContext;
 import org.locationtech.spatial4j.distance.DistanceUtils;
 import org.locationtech.spatial4j.shape.Point;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.solr.search.FunctionQParser.*;
 
 /**
  * Parses "geodist" creating {@link HaversineConstFunction} or {@link HaversineFunction}
@@ -50,21 +53,8 @@ public class GeoDistValueSourceParser extends ValueSourceParser {
   public ValueSource parse(FunctionQParser fp) throws SyntaxError {
     // TODO: dispatch through SpatialQueryable in the future?
 
-    //note: parseValueSourceList can't handle a field reference to an AbstractSpatialFieldType,
-    // so those fields are expressly handled via sfield=
-    List<ValueSource> sources;
-    try {
-      sources = fp.parseValueSourceList();
-    } catch (SolrException e) {
-      if (e.getMessage().equals("A ValueSource isn't directly available from this field. " +
-          "Instead try a query using the distance as the score.")) {
-        throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, "geodist() does not support field names in its arguments " +
-            "when stated fields are solr.LatLonPointSpatialField spatial type, requires sfield param instead");
-      }
-      else {
-        throw e;
-      }
-    }
+    //note: return fields as FieldNameValueSource from parser to support AbstractSpatialFieldType as geodist argument
+    List<ValueSource> sources = transformFieldSources(fp, fp.parseValueSourceList(FLAG_DEFAULT | FLAG_CONSUME_DELIMITER | FLAG_USE_FIELDNAME_SOURCE));
 
     // "m" is a multi-value source, "x" is a single-value source
     // allow (m,m) (m,x,x) (x,x,m) (x,x,x,x)
@@ -93,7 +83,6 @@ public class GeoDistValueSourceParser extends ValueSourceParser {
       }
     } else if (sources.size()==3) {
       ValueSource vs1 = sources.get(0);
-      ValueSource vs2 = sources.get(1);
       if (vs1 instanceof MultiValueSource) {     // (m,x,x)
         mv1 = (MultiValueSource)vs1;
         mv2 = makeMV(sources.subList(1, 3), sources);
@@ -108,7 +97,7 @@ public class GeoDistValueSourceParser extends ValueSourceParser {
     } else if (sources.size()==4) {
       mv1 = makeMV(sources.subList(0, 2), sources);
       mv2 = makeMV(sources.subList(2, 4), sources);
-    } else if (sources.size() > 4) {
+    } else {
       throw new SyntaxError("geodist - invalid parameters:" + sources);
     }
 
@@ -139,14 +128,14 @@ public class GeoDistValueSourceParser extends ValueSourceParser {
     // * HaversineConstFunction
     // * HaversineFunction
 
-    // sfield can only be in mv2, according to the logic above
-    if (mv2 instanceof SpatialStrategyMultiValueSource) {
+    SpatialStrategyMultiValueSource spatialStrategyMultiValueSource = findSpatialStrategyMultiValueSource(mv1, mv2);
+    if (spatialStrategyMultiValueSource != null) {
       if (constants == null)
         throw new SyntaxError("When using AbstractSpatialFieldType (e.g. RPT not LatLonType)," +
             " the point must be supplied as constants");
       // note: uses Haversine by default but can be changed via distCalc=...
-      SpatialStrategy strategy = ((SpatialStrategyMultiValueSource) mv2).strategy;
-      DistanceUnits distanceUnits = ((SpatialStrategyMultiValueSource) mv2).distanceUnits;
+      SpatialStrategy strategy = spatialStrategyMultiValueSource.strategy;
+      DistanceUnits distanceUnits = spatialStrategyMultiValueSource.distanceUnits;
       Point queryPoint = strategy.getSpatialContext().makePoint(constants[1], constants[0]);
       return ValueSource.fromDoubleValuesSource(strategy.makeDistanceValueSource(queryPoint, distanceUnits.multiplierFromDegreesToThisUnit()));
     }
@@ -156,6 +145,29 @@ public class GeoDistValueSourceParser extends ValueSourceParser {
     }
 
     return new HaversineFunction(mv1, mv2, DistanceUtils.EARTH_MEAN_RADIUS_KM, true);
+  }
+
+  private SpatialStrategyMultiValueSource findSpatialStrategyMultiValueSource(MultiValueSource mv1, MultiValueSource mv2) {
+    if (mv1 instanceof SpatialStrategyMultiValueSource) {
+      return (SpatialStrategyMultiValueSource) mv1;
+    } else if (mv2 instanceof SpatialStrategyMultiValueSource) {
+      return (SpatialStrategyMultiValueSource) mv2;
+    } else {
+      return null;
+    }
+  }
+
+  private List<ValueSource> transformFieldSources(FunctionQParser fp, List<ValueSource> sources) throws SyntaxError {
+    List<ValueSource> result = new ArrayList<>(sources.size());
+    for (ValueSource valueSource : sources) {
+      if (valueSource instanceof FieldNameValueSource) {
+        String fieldName = ((FieldNameValueSource) valueSource).getFieldName();
+        result.add(getMultiValueSource(fp, fieldName));
+      } else {
+        result.add(valueSource);
+      }
+    }
+    return result;
   }
 
   /** make a MultiValueSource from two non MultiValueSources */
@@ -169,17 +181,17 @@ public class GeoDistValueSourceParser extends ValueSourceParser {
     return  new VectorValueSource(sources);
   }
 
-  private MultiValueSource parsePoint(FunctionQParser fp) throws SyntaxError {
+  private MultiValueSource parsePoint(FunctionQParser fp) {
     String ptStr = fp.getParam(SpatialParams.POINT);
     if (ptStr == null) return null;
     Point point = SpatialUtils.parsePointSolrException(ptStr, SpatialContext.GEO);
     //assume Lat Lon order
     return new VectorValueSource(
-        Arrays.<ValueSource>asList(new DoubleConstValueSource(point.getY()), new DoubleConstValueSource(point.getX())));
+        Arrays.asList(new DoubleConstValueSource(point.getY()), new DoubleConstValueSource(point.getX())));
   }
 
   private double[] getConstants(MultiValueSource vs) {
-    if (!(vs instanceof VectorValueSource)) return null;
+    if (vs instanceof SpatialStrategyMultiValueSource || !(vs instanceof VectorValueSource)) return null;
     List<ValueSource> sources = ((VectorValueSource)vs).getSources();
     if (sources.get(0) instanceof ConstNumberSource && sources.get(1) instanceof ConstNumberSource) {
       return new double[] { ((ConstNumberSource) sources.get(0)).getDouble(), ((ConstNumberSource) sources.get(1)).getDouble()};
@@ -190,6 +202,10 @@ public class GeoDistValueSourceParser extends ValueSourceParser {
   private MultiValueSource parseSfield(FunctionQParser fp) throws SyntaxError {
     String sfield = fp.getParam(SpatialParams.FIELD);
     if (sfield == null) return null;
+    return getMultiValueSource(fp, sfield);
+  }
+
+  private MultiValueSource getMultiValueSource(FunctionQParser fp, String sfield) throws SyntaxError {
     SchemaField sf = fp.getReq().getSchema().getField(sfield);
     FieldType type = sf.getType();
     if (type instanceof AbstractSpatialFieldType) {

--- a/solr/core/src/test/org/apache/solr/search/TestSolr4Spatial2.java
+++ b/solr/core/src/test/org/apache/solr/search/TestSolr4Spatial2.java
@@ -369,14 +369,76 @@ public class TestSolr4Spatial2 extends SolrTestCaseJ4 {
     assertQ(req(params), "*[count(//doc)=1]", "count(//lst[@name='highlighting']/*)=1");
   }
 
-  @Test
-  public void testErrorHandlingGeodist() throws Exception{
-    assertU(adoc("id", "1", "llp", "32.7693246, -79.9289094"));
-    assertQEx("wrong test exception message","sort param could not be parsed as a query, " +
-            "and is not a field that exists in the index: geodist(llp,47.36667,8.55)",
-        req(
+  @Test // SOLR-14802
+  public void testGeodistSortPossibleWithLatLonPointSpatialFieldOrSpatialRecursivePrefixTreeField() throws Exception {
+    assertU(adoc("id", "1", "llp", "53.4721936,-2.24703", "srpt_quad", "53.425272,-2.322356"));
+    assertU(commit());
+
+    assertJQ(req(
             "q", "*:*",
-            "sort", "geodist(llp,47.36667,8.55) asc"
-        ), SolrException.ErrorCode.BAD_REQUEST);
+            "fq", "{!geofilt}",
+            "d", "50",
+            "pt", "53.4721936,-2.24703",
+            "sfield", "srpt_quad",
+            "sort", "min(geodist(),geodist(llp,53.4721936,-2.24703)) asc"
+            ),
+            "/response/docs/[0]/id=='1'");
+
+    assertJQ(req(
+            "q", "*:*",
+            "fq", "{!geofilt}",
+            "d", "50",
+            "pt", "53.4721936,-2.24703",
+            "sfield", "srpt_quad",
+            "sort", "min(geodist(),geodist(53.4721936,-2.24703,llp)) asc"
+            ),
+            "/response/docs/[0]/id=='1'");
+
+    assertJQ(req(
+            "q", "*:*",
+            "fq", "{!geofilt}",
+            "d", "50",
+            "pt", "53.4721936,-2.24703",
+            "sfield", "llp",
+            "sort", "min(geodist(),geodist(53.4721936,-2.24703,srpt_quad)) asc"
+            ),
+            "/response/docs/[0]/id=='1'");
+  }
+
+  @Test // SOLR-14802
+  public void testGeodistSortOrderCorrectWithLatLonPointSpatialFieldAndSpatialRecursivePrefixTreeField() throws Exception {
+    assertU(adoc("id", "1", "llp", "53.4721936,-2.24703", "srpt_quad", "53.4721936,-2.24703"));
+    assertU(adoc("id", "2", "llp", "53.425272,-2.322356", "srpt_quad", "55.4721936,-2.24703"));
+    assertU(commit());
+
+    assertJQ(req(
+            "q", "*:*",
+            "fq", "{!geofilt}",
+            "d", "50",
+            "pt", "53.431669,-2.318720",
+            "sfield", "srpt_quad",
+            "sort", "min(geodist(),geodist(llp,53.431669,-2.318720)) asc"
+            ),
+            "/response/docs/[0]/id=='2'");
+
+    assertJQ(req(
+            "q", "*:*",
+            "fq", "{!geofilt}",
+            "d", "50",
+            "pt", "53.4721936,-2.24703",
+            "sfield", "srpt_quad",
+            "sort", "min(geodist(),geodist(53.4721936,-2.24703,llp)) asc"
+            ),
+            "/response/docs/[0]/id=='1'");
+
+    assertJQ(req(
+            "q", "*:*",
+            "fq", "{!geofilt}",
+            "d", "50",
+            "pt", "55.4721936,-2.24703",
+            "sfield", "srpt_quad",
+            "sort", "min(geodist(),geodist(55.4721936,-2.24703,llp)) asc"
+            ),
+            "/response/docs/[0]/id=='2'");
   }
 }


### PR DESCRIPTION
# Description

Allows LLPSF fields to be used as arguments to geodist function

# Solution

Moves resolving of field arguments from FunctionQParser to GeoDistValueSourceParser where the required strategy can be used, same as for existing sfield support

# Tests

Tests multiple usages of geodist in same query, with arguments of type LatLonPointSpatialField and without

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have developed this patch against the `master` branch.
- [ ] I have run `./gradlew check`.
- [X] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
