### PR TITLE
SOLR-13181: param macro expansion could throw

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -224,6 +224,10 @@ Bug Fixes
 * SOLR-14821: {!terms} docValuesTermsFilterTopLevel method now works with single-valued strings (Anatolii Siuniaev
   via Jason Gerlowski)
 
+* SOLR-13181: macro expansion of parameters could result in a StringIndexOutOfBoundsException.
+  Also, params with macros will be processed more strictly by LTR FeatureWeight.
+  (David Smiley, Cesar Rodriguez, Christine Poerschke)
+
 Other Changes
 ---------------------
 

--- a/solr/core/src/java/org/apache/solr/request/macro/MacroExpander.java
+++ b/solr/core/src/java/org/apache/solr/request/macro/MacroExpander.java
@@ -144,7 +144,7 @@ public class MacroExpander {
       final int matchedStart = idx;
       idx += macroStart.length();
 
-      int rbrace = val.indexOf('}', idx);
+      int rbrace = val.indexOf('}', matchedStart + macroStart.length());
       if (rbrace == -1) {
         // no matching close brace...
         continue;

--- a/solr/core/src/java/org/apache/solr/request/macro/MacroExpander.java
+++ b/solr/core/src/java/org/apache/solr/request/macro/MacroExpander.java
@@ -142,7 +142,6 @@ public class MacroExpander {
 
       // found unescaped "${"
       final int matchedStart = idx;
-      idx += macroStart.length();
 
       int rbrace = val.indexOf('}', matchedStart + macroStart.length());
       if (rbrace == -1) {
@@ -161,7 +160,7 @@ public class MacroExpander {
       // update "start" to be at the end of ${...}
       idx = start = rbrace + 1;
 
-      // String in-between = val.substring(idx, rbrace);
+      // String in-between braces
       StrParser parser = new StrParser(val, matchedStart + macroStart.length(), rbrace);
       try {
         String paramName = parser.getId();

--- a/solr/core/src/java/org/apache/solr/request/macro/MacroExpander.java
+++ b/solr/core/src/java/org/apache/solr/request/macro/MacroExpander.java
@@ -119,8 +119,8 @@ public class MacroExpander {
     int start = 0;  // start of the unprocessed part of the string
     StringBuilder sb = null;
     for (;;) {
+      assert idx >= start;
       idx = val.indexOf(macroStart, idx);
-      int matchedStart = idx;
 
       // check if escaped
       if (idx > 0) {
@@ -136,11 +136,12 @@ public class MacroExpander {
       }
       else if (idx < 0) {
         if (sb == null) return val;
-        sb.append(val.substring(start));
+        sb.append(val, start, val.length());
         return sb.toString();
       }
 
       // found unescaped "${"
+      int matchedStart = idx;
       idx += macroStart.length();
 
       int rbrace = val.indexOf('}', idx);
@@ -154,14 +155,14 @@ public class MacroExpander {
       }
 
       if (matchedStart > 0) {
-        sb.append(val.substring(start, matchedStart));
+        sb.append(val, start, matchedStart);
       }
 
       // update "start" to be at the end of ${...}
-      start = rbrace + 1;
+      idx = start = rbrace + 1;
 
-      // String inbetween = val.substring(idx, rbrace);
-      StrParser parser = new StrParser(val, idx, rbrace);
+      // String in-between = val.substring(idx, rbrace);
+      StrParser parser = new StrParser(val, matchedStart + macroStart.length(), rbrace);
       try {
         String paramName = parser.getId();
         String defVal = null;
@@ -188,7 +189,7 @@ public class MacroExpander {
 
       } catch (SyntaxError syntaxError) {
         // append the part we would have skipped
-        sb.append( val.substring(matchedStart, start) );
+        sb.append(val, matchedStart, start);
         continue;
       }
 

--- a/solr/core/src/java/org/apache/solr/request/macro/MacroExpander.java
+++ b/solr/core/src/java/org/apache/solr/request/macro/MacroExpander.java
@@ -141,7 +141,7 @@ public class MacroExpander {
       }
 
       // found unescaped "${"
-      int matchedStart = idx;
+      final int matchedStart = idx;
       idx += macroStart.length();
 
       int rbrace = val.indexOf('}', idx);

--- a/solr/core/src/java/org/apache/solr/request/macro/MacroExpander.java
+++ b/solr/core/src/java/org/apache/solr/request/macro/MacroExpander.java
@@ -135,9 +135,7 @@ public class MacroExpander {
         }
       }
       else if (idx < 0) {
-        if (sb == null) return val;
-        sb.append(val, start, val.length());
-        return sb.toString();
+        break;
       }
 
       // found unescaped "${"
@@ -146,7 +144,10 @@ public class MacroExpander {
       int rbrace = val.indexOf('}', matchedStart + macroStart.length());
       if (rbrace == -1) {
         // no matching close brace...
-        continue;
+        if (failOnMissingParams) {
+          return null;
+        }
+        break;
       }
 
       if (sb == null) {
@@ -187,13 +188,19 @@ public class MacroExpander {
         }
 
       } catch (SyntaxError syntaxError) {
+        if (failOnMissingParams) {
+          return null;
+        }
         // append the part we would have skipped
         sb.append(val, matchedStart, start);
-        continue;
       }
+    } // loop idx
 
+    if (sb == null) {
+      return val;
     }
-
+    sb.append(val, start, val.length());
+    return sb.toString();
   }
 
 

--- a/solr/core/src/test/org/apache/solr/request/macro/TestMacroExpander.java
+++ b/solr/core/src/test/org/apache/solr/request/macro/TestMacroExpander.java
@@ -155,10 +155,15 @@ public class TestMacroExpander extends SolrTestCase {
 
   @Test
   public void testUnbalanced() { // SOLR-13181
-    final MacroExpander meSkipOnMissingParams = new MacroExpander(Collections.emptyMap());
-    final MacroExpander meFailOnMissingParams = new MacroExpander(Collections.emptyMap(), true);
+    final Map<String, String[]> request = Collections.singletonMap("answer", new String[]{ "42" });
+    final MacroExpander meSkipOnMissingParams = new MacroExpander(request);
+    final MacroExpander meFailOnMissingParams = new MacroExpander(request, true);
     assertEquals("${noClose", meSkipOnMissingParams.expand("${noClose"));
+    assertEquals("42 ${noClose", meSkipOnMissingParams.expand("${answer} ${noClose"));
+    assertEquals("42 ${noClose fooBar", meSkipOnMissingParams.expand("${answer} ${noClose fooBar"));
     assertNull(meFailOnMissingParams.expand("${noClose"));
+    assertNull(meFailOnMissingParams.expand("${answer} ${noClose"));
+    assertNull(meFailOnMissingParams.expand("${answer} ${noClose fooBar"));
 
     assertEquals("${${b}}", meSkipOnMissingParams.expand("${${b}}"));
     assertNull(meFailOnMissingParams.expand("${${b}}"));


### PR DESCRIPTION
StringIndexOutOfBoundsException on bad syntax

TODO run tests etc.

https://issues.apache.org/jira/browse/SOLR-13181