### PR TITLE
Improve TestConfigSetsAPI

### DIFF
--- a/solr/test-framework/src/java/org/apache/solr/cloud/MiniSolrCloudCluster.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/MiniSolrCloudCluster.java
@@ -46,7 +46,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.servlet.Filter;
 
 import org.apache.lucene.util.LuceneTestCase;
-import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.embedded.JettyConfig;
 import org.apache.solr.client.solrj.embedded.JettySolrRunner;
 import org.apache.solr.client.solrj.embedded.SSLConfig;
@@ -78,6 +77,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.MetricRegistry;
+
+import static org.apache.solr.core.ConfigSetProperties.DEFAULT_FILENAME;
 
 /**
  * "Mini" SolrCloud cluster to be used for testing
@@ -587,7 +588,7 @@ public class MiniSolrCloudCluster {
 
   }
   
-  public void deleteAllConfigSets() throws SolrServerException, IOException {
+  public void deleteAllConfigSets() throws Exception {
 
     List<String> configSetNames = new ConfigSetAdminRequest.List().process(solrClient).getConfigSets();
 
@@ -595,6 +596,10 @@ public class MiniSolrCloudCluster {
       if (configSet.equals("_default")) {
         continue;
       }
+      try {
+        // cleanup any property before removing the configset
+        getZkClient().delete(ZkConfigManager.CONFIGS_ZKNODE + "/" + configSet + "/" + DEFAULT_FILENAME, -1, true);
+      } catch (KeeperException.NoNodeException nne) { }
       new ConfigSetAdminRequest.Delete()
           .setConfigSetName(configSet)
           .process(solrClient);


### PR DESCRIPTION
This PR includes some improvements to TestConfigSetsAPI:
* Extend `SolrCloudTestCase`: This is mainly because before, the test was creating clusters for every unit test vs. a single one for the suite
* Use Mock authentication: This test is not to test the authentication framework, The `ConfigSetHandler` only needs to know if an auth plugin was configured and if credentials were provided, so the Mock components do just that. This makes the tests easier and faster
*Cleanup a bunch of exceptions from the logs
* Enabled back `testUploadWithLibDirective`