### PR TITLE
LUCENE-9444 Utility class to get facet labels from taxonomy for a fac…

### DIFF
--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacetLabels.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacetLabels.java
@@ -16,7 +16,6 @@
  */
 package org.apache.lucene.facet.taxonomy;
 
-import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.util.IntsRef;
 
@@ -43,10 +42,6 @@ public class TaxonomyFacetLabels {
    */
   private final TaxonomyReader taxoReader;
 
-  /**
-   * {@code FacetsConfig} provided to the constructor
-   */
-  private final FacetsConfig config;
 
   /**
    * {@code OrdinalsReader} to decode ordinals previously indexed into the {@code BinaryDocValues} facet field
@@ -56,9 +51,8 @@ public class TaxonomyFacetLabels {
   /**
    * Sole constructor.  Do not close the provided {@link TaxonomyReader} while still using this instance!
    */
-  public TaxonomyFacetLabels(TaxonomyReader taxoReader, FacetsConfig config, String indexFieldName) throws IOException {
+  public TaxonomyFacetLabels(TaxonomyReader taxoReader, String indexFieldName) throws IOException {
     this.taxoReader = taxoReader;
-    this.config = config;
     this.indexFieldName = indexFieldName;
     this.ordsReader = new DocValuesOrdinalsReader(indexFieldName);
   }

--- a/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacetLabels.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/taxonomy/TaxonomyFacetLabels.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.facet.taxonomy;
+
+import org.apache.lucene.facet.FacetsConfig;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.util.IntsRef;
+
+import java.io.IOException;
+
+import static org.apache.lucene.facet.taxonomy.TaxonomyReader.INVALID_ORDINAL;
+import static org.apache.lucene.facet.taxonomy.TaxonomyReader.ROOT_ORDINAL;
+
+/**
+ * Utility class to easily retrieve previously indexed facet labels, allowing you to skip also adding stored fields for these values,
+ * reducing your index size.
+ *
+ * @lucene.experimental
+ **/
+public class TaxonomyFacetLabels {
+
+  /**
+   * Index field name provided to the constructor
+   */
+  private final String indexFieldName;
+
+  /**
+   * {@code TaxonomyReader} provided to the constructor
+   */
+  private final TaxonomyReader taxoReader;
+
+  /**
+   * {@code FacetsConfig} provided to the constructor
+   */
+  private final FacetsConfig config;
+
+  /**
+   * {@code OrdinalsReader} to decode ordinals previously indexed into the {@code BinaryDocValues} facet field
+   */
+  private final OrdinalsReader ordsReader;
+
+  /**
+   * Sole constructor.  Do not close the provided {@link TaxonomyReader} while still using this instance!
+   */
+  public TaxonomyFacetLabels(TaxonomyReader taxoReader, FacetsConfig config, String indexFieldName) throws IOException {
+    this.taxoReader = taxoReader;
+    this.config = config;
+    this.indexFieldName = indexFieldName;
+    this.ordsReader = new DocValuesOrdinalsReader(indexFieldName);
+  }
+
+  /**
+   * Create and return an instance of {@link FacetLabelReader} to retrieve facet labels for
+   * multiple documents and (optionally) for a specific dimension.  You must create this per-segment,
+   * and then step through all hits, in order, for that segment.
+   *
+   * <p><b>NOTE</b>: This class is not thread-safe, so you must use a new instance of this
+   * class for each thread.</p>
+   *
+   * @param readerContext LeafReaderContext used to access the {@code BinaryDocValues} facet field
+   * @return an instance of {@link FacetLabelReader}
+   * @throws IOException when a low-level IO issue occurs
+   */
+  public FacetLabelReader getFacetLabelReader(LeafReaderContext readerContext) throws IOException {
+    return new FacetLabelReader(ordsReader, readerContext);
+  }
+
+  /**
+   * Utility class to retrieve facet labels for multiple documents.
+   *
+   * @lucene.experimental
+   */
+  public class FacetLabelReader {
+    private final OrdinalsReader.OrdinalsSegmentReader ordinalsSegmentReader;
+    private final IntsRef decodedOrds = new IntsRef();
+    private int currentDocId = -1;
+    private int currentPos = -1;
+
+    // Lazily set when nextFacetLabel(int docId, String facetDimension) is first called
+    private int[] parents;
+
+    /**
+     * Sole constructor.
+     */
+    public FacetLabelReader(OrdinalsReader ordsReader, LeafReaderContext readerContext) throws IOException {
+      ordinalsSegmentReader = ordsReader.getReader(readerContext);
+    }
+
+    /**
+     * Retrieves the next {@link FacetLabel} for the specified {@code docId}, or {@code null} if there are no more.
+     * This method has state: if the provided {@code docId} is the same as the previous invocation, it returns the
+     * next {@link FacetLabel} for that document.  Otherwise, it advances to the new {@code docId} and provides the
+     * first {@link FacetLabel} for that document, or {@code null} if that document has no indexed facets.  Each
+     * new {@code docId} must be in strictly monotonic (increasing) order.
+     *
+     * @param docId input docId provided in monotonic (non-decreasing) order
+     * @return the first or next {@link FacetLabel}, or {@code null} if there are no more
+     * @throws IOException when a low-level IO issue occurs
+     */
+    public FacetLabel nextFacetLabel(int docId) throws IOException {
+      if (currentDocId != docId) {
+        assert docId > currentDocId: "docs out of order!  currentDocId=" + currentDocId + " docId=" + docId;
+        ordinalsSegmentReader.get(docId, decodedOrds);
+        currentDocId = docId;
+        currentPos = decodedOrds.offset;
+      }
+
+      int endPos = decodedOrds.offset + decodedOrds.length;
+      assert currentPos <= endPos;
+
+      if (currentPos == endPos) {
+        // no more FacetLabels
+        return null;
+      }
+
+      int ord = decodedOrds.ints[currentPos++];
+      return taxoReader.getPath(ord);
+    }
+
+    private boolean isDescendant(int ord, int ancestorOrd) {
+      while (ord != INVALID_ORDINAL && ord != ROOT_ORDINAL) {
+        if (parents[ord] == ancestorOrd) {
+          return true;
+        }
+        ord = parents[ord];
+      }
+      return false;
+    }
+
+    /**
+     * Retrieves the next {@link FacetLabel} for the specified {@code docId} under the requested {@code facetDimension},
+     * or {@code null} if there are no more. This method has state: if the provided {@code docId} is the same as the
+     * previous invocation, it returns the next {@link FacetLabel} for that document.  Otherwise, it advances to
+     * the new {@code docId} and provides the first {@link FacetLabel} for that document, or {@code null} if that document
+     * has no indexed facets.  Each new {@code docId} must be in strictly monotonic (increasing) order.
+     *
+     * <p><b>NOTE</b>: this method loads the {@code int[] parents} array from the taxonomy index</p>
+     *
+     * @param docId input docId provided in non-decreasing order
+     * @return the first or next {@link FacetLabel}, or {@code null} if there are no more
+     * @throws IOException if {@link TaxonomyReader} has problems getting path for an ordinal
+     */
+    public FacetLabel nextFacetLabel(int docId, String facetDimension) throws IOException {
+      final int parentOrd = taxoReader.getOrdinal(new FacetLabel(facetDimension));
+      assert parentOrd != INVALID_ORDINAL : "Category ordinal not found for facet dimension: " + facetDimension;
+
+      if (currentDocId != docId) {
+        assert docId > currentDocId: "docs out of order!  currentDocId=" + currentDocId + " docId=" + docId;
+        ordinalsSegmentReader.get(docId, decodedOrds);
+        currentPos = decodedOrds.offset;
+        currentDocId = docId;
+      }
+
+      if (parents == null) {
+        parents = taxoReader.getParallelTaxonomyArrays().parents();
+      }
+
+      int endPos = decodedOrds.offset + decodedOrds.length;
+      assert currentPos <= endPos;
+
+      for (; currentPos < endPos; ) {
+        int ord = decodedOrds.ints[currentPos++];
+        if (isDescendant(ord, parentOrd) == true) {
+          return taxoReader.getPath(ord);
+        }
+      }
+      return null;
+    }
+  }
+}

--- a/lucene/facet/src/test/org/apache/lucene/facet/FacetTestCase.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/FacetTestCase.java
@@ -25,18 +25,22 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.lucene.facet.FacetsCollector.MatchingDocs;
 import org.apache.lucene.facet.taxonomy.CachedOrdinalsReader;
 import org.apache.lucene.facet.taxonomy.DocValuesOrdinalsReader;
+import org.apache.lucene.facet.taxonomy.FacetLabel;
 import org.apache.lucene.facet.taxonomy.FastTaxonomyFacetCounts;
 import org.apache.lucene.facet.taxonomy.OrdinalsReader;
 import org.apache.lucene.facet.taxonomy.TaxonomyFacetCounts;
+import org.apache.lucene.facet.taxonomy.TaxonomyFacetLabels;
 import org.apache.lucene.facet.taxonomy.TaxonomyReader;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.TestUtil;
 
 public abstract class FacetTestCase extends LuceneTestCase {
-  
+
   public Facets getTaxonomyFacetCounts(TaxonomyReader taxoReader, FacetsConfig config, FacetsCollector c) throws IOException {
     return getTaxonomyFacetCounts(taxoReader, config, c, FacetsConfig.DEFAULT_INDEX_FIELD_NAME);
   }
@@ -54,6 +58,28 @@ public abstract class FacetTestCase extends LuceneTestCase {
     }
 
     return facets;
+  }
+
+  public List<List<FacetLabel>> getTaxonomyFacetLabels(TaxonomyReader taxoReader, FacetsConfig config, FacetsCollector fc) throws IOException {
+    List<List<FacetLabel>> actualLabels = new ArrayList<>();
+    TaxonomyFacetLabels taxoLabels = new TaxonomyFacetLabels(taxoReader, config, FacetsConfig.DEFAULT_INDEX_FIELD_NAME);
+
+    for (MatchingDocs m : fc.getMatchingDocs()) {
+      TaxonomyFacetLabels.FacetLabelReader facetLabelReader = taxoLabels.getFacetLabelReader(m.context);
+
+      DocIdSetIterator disi = m.bits.iterator();
+      while (disi.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+        List<FacetLabel> facetLabels = new ArrayList<>();
+        int docId = disi.docID();
+        FacetLabel facetLabel = facetLabelReader.nextFacetLabel(docId);
+        while (facetLabel != null) {
+          facetLabels.add(facetLabel);
+          facetLabel = facetLabelReader.nextFacetLabel(docId);
+        }
+        actualLabels.add(facetLabels);
+      }
+    }
+    return actualLabels;
   }
 
   protected String[] getRandomTokens(int count) {

--- a/lucene/facet/src/test/org/apache/lucene/facet/FacetTestCase.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/FacetTestCase.java
@@ -64,15 +64,13 @@ public abstract class FacetTestCase extends LuceneTestCase {
   /**
    * Utility method that uses {@link FacetLabelReader} to get facet labels
    * for each hit in {@link MatchingDocs}. The method returns {@code List<List<FacetLabel>>}
-   * where outer list has at most one entry per document and inner list has all {@link FacetLabel}
-   * entries that belong to a document.
-   *
-   * <p><b>NOTE</b>: A hit that has no facet labels will not have an entry in the outer list.
-   * The outer list, however is always non-null</p>
+   * where outer list has one entry per document and inner list has all {@link FacetLabel}
+   * entries that belong to a document. The inner list may be empty if no {@link FacetLabel}
+   * are found for a hit.
    *
    * @param taxoReader {@link TaxonomyReader} used to read taxonomy during search. This instance is expected to be open for reading.
    * @param fc         {@link FacetsCollector} A collector with matching hits.
-   * @return {@code List<List<FacetLabel>} where outer list has at most one entry per document
+   * @return {@code List<List<FacetLabel>} where outer list has one non-null entry per document
    * and inner list contain all {@link FacetLabel} entries that belong to a document.
    * @throws IOException when a low-level IO issue occurs.
    */
@@ -92,9 +90,7 @@ public abstract class FacetTestCase extends LuceneTestCase {
           facetLabels.add(facetLabel);
           facetLabel = facetLabelReader.nextFacetLabel(docId);
         }
-        if (facetLabels.size() > 0) {
-          actualLabels.add(facetLabels);
-        }
+        actualLabels.add(facetLabels);
       }
     }
     return actualLabels;

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts.java
@@ -702,7 +702,7 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
               facetLabels.add(new FacetLabel("dim" + j, doc.dims[j]));
             }
           }
-
+          // facetLabels will be non-empty only if a document has one or more non-null dimensions
           if (facetLabels.size() > 0) {
             expectedLabels.add(facetLabels);
           }
@@ -724,7 +724,7 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
       }
 
       // Test facet labels for each matching test doc
-      List<List<FacetLabel>> actualLabels = getTaxonomyFacetLabels(tr, config, fc);
+      List<List<FacetLabel>> actualLabels = getAllTaxonomyFacetLabels(tr, fc);
       assertEquals(expectedLabels.size(), actualLabels.size());
       assertTrue(sortedFacetLabels(expectedLabels).equals(sortedFacetLabels(actualLabels)));
 
@@ -744,19 +744,13 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
   }
 
   private static List<List<FacetLabel>> sortedFacetLabels(List<List<FacetLabel>> allfacetLabels) {
+    // sort each inner list since there is no guaranteed order in which FacetLabels
+    // are expected to be retrieved for each document
     for (List<FacetLabel> facetLabels : allfacetLabels) {
       Collections.sort(facetLabels);
     }
 
     Collections.sort(allfacetLabels, (o1, o2) -> {
-      if (o1 == null) {
-        return -1;
-      }
-
-      if (o2 == null) {
-        return 1;
-      }
-
       int diff = o1.size() - o2.size();
       if (diff != 0) {
         return diff;

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts.java
@@ -685,11 +685,10 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
         expectedCounts[i] = new HashMap<>();
       }
 
-      for(TestDoc doc : testDocs) {
+      for (TestDoc doc : testDocs) {
         if (doc.content.equals(searchToken)) {
           List<FacetLabel> facetLabels = new ArrayList<>();
-
-          for(int j=0;j<numDims;j++) {
+          for (int j = 0; j < numDims; j++) {
             if (doc.dims[j] != null) {
               Integer v = expectedCounts[j].get(doc.dims[j]);
               if (v == null) {
@@ -702,10 +701,7 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
               facetLabels.add(new FacetLabel("dim" + j, doc.dims[j]));
             }
           }
-          // facetLabels will be non-empty only if a document has one or more non-null dimensions
-          if (facetLabels.size() > 0) {
-            expectedLabels.add(facetLabels);
-          }
+          expectedLabels.add(facetLabels);
         }
       }
 
@@ -743,14 +739,14 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
     IOUtils.close(tw, searcher.getIndexReader(), tr, indexDir, taxoDir);
   }
 
-  private static List<List<FacetLabel>> sortedFacetLabels(List<List<FacetLabel>> allfacetLabels) {
+  private static List<List<FacetLabel>> sortedFacetLabels(List<List<FacetLabel>> allFacetLabels) {
     // sort each inner list since there is no guaranteed order in which FacetLabels
     // are expected to be retrieved for each document
-    for (List<FacetLabel> facetLabels : allfacetLabels) {
+    for (List<FacetLabel> facetLabels : allFacetLabels) {
       Collections.sort(facetLabels);
     }
 
-    Collections.sort(allfacetLabels, (o1, o2) -> {
+    Collections.sort(allFacetLabels, (o1, o2) -> {
       int diff = o1.size() - o2.size();
       if (diff != 0) {
         return diff;
@@ -767,7 +763,7 @@ public class TestTaxonomyFacetCounts extends FacetTestCase {
       return 0;
     });
 
-    return allfacetLabels;
+    return allFacetLabels;
   }
 
   private static Facets getAllFacets(String indexFieldName, IndexSearcher searcher, TaxonomyReader taxoReader, FacetsConfig config) throws IOException {

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetCounts.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetLabels.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyFacetLabels.java
@@ -39,7 +39,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class TestTaxonomyLabels extends FacetTestCase {
+public class TestTaxonomyFacetLabels extends FacetTestCase {
 
   private List<Document> prepareDocuments() {
     List<Document> docs = new ArrayList<>();
@@ -147,7 +147,7 @@ public class TestTaxonomyLabels extends FacetTestCase {
     FacetsCollector fc = new FacetsCollector();
     searcher.search(new MatchAllDocsQuery(), fc);
 
-    TaxonomyFacetLabels taxoLabels = new TaxonomyFacetLabels(taxoReader, config, FacetsConfig.DEFAULT_INDEX_FIELD_NAME);
+    TaxonomyFacetLabels taxoLabels = new TaxonomyFacetLabels(taxoReader, FacetsConfig.DEFAULT_INDEX_FIELD_NAME);
 
     // Check labels for all dimensions
     List<FacetLabel> facetLabels = lookupFacetLabels(taxoLabels, fc.getMatchingDocs());

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyLabels.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyLabels.java
@@ -151,7 +151,9 @@ public class TestTaxonomyLabels extends FacetTestCase {
 
     // Check labels for all dimensions
     List<FacetLabel> facetLabels = lookupFacetLabels(taxoLabels, fc.getMatchingDocs());
-    assertTrue(facetLabels.size() == 10);
+    assertEquals("Incorrect number of facet labels received", 10, facetLabels.size());
+
+    // Check labels for all dimensions
     assertTrue(facetLabels.stream()
         .filter(l -> "Author".equals(l.components[0]))
         .map(l -> l.components[1]).collect(Collectors.toSet())
@@ -163,26 +165,26 @@ public class TestTaxonomyLabels extends FacetTestCase {
         .collect(Collectors.toSet())
         .equals(Set.of("2010/10/15", "2010/10/20", "2012/1/1", "2012/1/7", "1999/5/5")));
 
-    // Check labels for specific dimension
+    // Check labels for a specific dimension
     facetLabels = lookupFacetLabels(taxoLabels, fc.getMatchingDocs(), "Publish Date");
-    assertTrue(facetLabels.size() == 5);
+    assertEquals("Incorrect number of facet labels received for 'Publish Date'", 5, facetLabels.size());
+
     assertTrue(facetLabels.stream()
-        .filter(l -> "Publish Date".equals(l.components[0]))
         .map(l -> String.join("/", l.components[1], l.components[2], l.components[3]))
         .collect(Collectors.toSet())
         .equals(Set.of("2010/10/15", "2010/10/20", "2012/1/1", "2012/1/7", "1999/5/5")));
 
     try {
       facetLabels = lookupFacetLabels(taxoLabels, fc.getMatchingDocs(), null, true);
-      fail("Assertion error was not thrown for using docIds supplied in decreasing order");
-    } catch (AssertionError ae) {
+      fail("IllegalArgumentException was not thrown for using docIds supplied in decreasing order");
+    } catch (IllegalArgumentException ae) {
       assertTrue(ae.getMessage().contains("docs out of order"));
     }
 
     try {
       facetLabels = lookupFacetLabels(taxoLabels, fc.getMatchingDocs(), "Publish Date", true);
       fail("Assertion error was not thrown for using docIds supplied in decreasing order");
-    } catch (AssertionError ae) {
+    } catch (IllegalArgumentException ae) {
       assertTrue(ae.getMessage().contains("docs out of order"));
     }
 

--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyLabels.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/TestTaxonomyLabels.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.facet.taxonomy;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.facet.FacetField;
+import org.apache.lucene.facet.FacetTestCase;
+import org.apache.lucene.facet.FacetsCollector;
+import org.apache.lucene.facet.FacetsCollector.MatchingDocs;
+import org.apache.lucene.facet.FacetsConfig;
+import org.apache.lucene.facet.taxonomy.directory.DirectoryTaxonomyReader;
+import org.apache.lucene.facet.taxonomy.directory.DirectoryTaxonomyWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.RandomIndexWriter;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.IOUtils;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class TestTaxonomyLabels extends FacetTestCase {
+
+  private List<Document> prepareDocuments() {
+    List<Document> docs = new ArrayList<>();
+
+    Document doc = new Document();
+    doc.add(new FacetField("Author", "Bob"));
+    doc.add(new FacetField("Publish Date", "2010", "10", "15"));
+    docs.add(doc);
+
+    doc = new Document();
+    doc.add(new FacetField("Author", "Lisa"));
+    doc.add(new FacetField("Publish Date", "2010", "10", "20"));
+    docs.add(doc);
+
+    doc = new Document();
+    doc.add(new FacetField("Author", "Tom"));
+    doc.add(new FacetField("Publish Date", "2012", "1", "1"));
+    docs.add(doc);
+
+    doc = new Document();
+    doc.add(new FacetField("Author", "Susan"));
+    doc.add(new FacetField("Publish Date", "2012", "1", "7"));
+    docs.add(doc);
+
+    doc = new Document();
+    doc.add(new FacetField("Author", "Frank"));
+    doc.add(new FacetField("Publish Date", "1999", "5", "5"));
+    docs.add(doc);
+
+    return docs;
+  }
+
+  private List<Integer> allDocIds(MatchingDocs m, boolean decreasingDocIds) throws IOException {
+    DocIdSetIterator disi = m.bits.iterator();
+    List<Integer> docIds = new ArrayList<>();
+    while (disi.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+      docIds.add(disi.docID());
+    }
+
+    if (decreasingDocIds == true) {
+      Collections.reverse(docIds);
+    }
+    return docIds;
+  }
+
+  private List<FacetLabel> lookupFacetLabels(TaxonomyFacetLabels taxoLabels,
+                                             List<MatchingDocs> matchingDocs) throws IOException {
+    return lookupFacetLabels(taxoLabels, matchingDocs, null, false);
+  }
+
+  private List<FacetLabel> lookupFacetLabels(TaxonomyFacetLabels taxoLabels,
+                                             List<MatchingDocs> matchingDocs,
+                                             String dimension) throws IOException {
+    return lookupFacetLabels(taxoLabels, matchingDocs, dimension, false);
+  }
+
+  private List<FacetLabel> lookupFacetLabels(TaxonomyFacetLabels taxoLabels, List<MatchingDocs> matchingDocs, String dimension,
+                                             boolean decreasingDocIds) throws IOException {
+    List<FacetLabel> facetLabels = new ArrayList<>();
+
+    for (MatchingDocs m : matchingDocs) {
+      TaxonomyFacetLabels.FacetLabelReader facetLabelReader = taxoLabels.getFacetLabelReader(m.context);
+      List<Integer> docIds = allDocIds(m, decreasingDocIds);
+      FacetLabel facetLabel;
+      for (Integer docId : docIds) {
+        while (true) {
+          if (dimension != null) {
+            facetLabel = facetLabelReader.nextFacetLabel(docId, dimension);
+          } else {
+            facetLabel = facetLabelReader.nextFacetLabel(docId);
+          }
+
+          if (facetLabel == null) {
+            break;
+          }
+          facetLabels.add(facetLabel);
+        }
+      }
+    }
+
+    return facetLabels;
+  }
+
+
+  public void testBasic() throws Exception {
+    Directory dir = newDirectory();
+    Directory taxoDir = newDirectory();
+
+    // Writes facet ords to a separate directory from the main index:
+    DirectoryTaxonomyWriter taxoWriter = new DirectoryTaxonomyWriter(taxoDir, IndexWriterConfig.OpenMode.CREATE);
+    RandomIndexWriter writer = new RandomIndexWriter(random(), dir);
+
+    FacetsConfig config = new FacetsConfig();
+    config.setHierarchical("Publish Date", true);
+
+    for (Document doc : prepareDocuments()) {
+      writer.addDocument(config.build(taxoWriter, doc));
+    }
+
+    // NRT open
+    IndexSearcher searcher = newSearcher(writer.getReader());
+    // NRT open
+    TaxonomyReader taxoReader = new DirectoryTaxonomyReader(taxoWriter);
+
+    FacetsCollector fc = new FacetsCollector();
+    searcher.search(new MatchAllDocsQuery(), fc);
+
+    TaxonomyFacetLabels taxoLabels = new TaxonomyFacetLabels(taxoReader, config, FacetsConfig.DEFAULT_INDEX_FIELD_NAME);
+
+    // Check labels for all dimensions
+    List<FacetLabel> facetLabels = lookupFacetLabels(taxoLabels, fc.getMatchingDocs());
+    assertTrue(facetLabels.size() == 10);
+    assertTrue(facetLabels.stream()
+        .filter(l -> "Author".equals(l.components[0]))
+        .map(l -> l.components[1]).collect(Collectors.toSet())
+        .equals(Set.of("Bob", "Lisa", "Susan", "Frank", "Tom")));
+
+    assertTrue(facetLabels.stream()
+        .filter(l -> "Publish Date".equals(l.components[0]))
+        .map(l -> String.join("/", l.components[1], l.components[2], l.components[3]))
+        .collect(Collectors.toSet())
+        .equals(Set.of("2010/10/15", "2010/10/20", "2012/1/1", "2012/1/7", "1999/5/5")));
+
+    // Check labels for specific dimension
+    facetLabels = lookupFacetLabels(taxoLabels, fc.getMatchingDocs(), "Publish Date");
+    assertTrue(facetLabels.size() == 5);
+    assertTrue(facetLabels.stream()
+        .filter(l -> "Publish Date".equals(l.components[0]))
+        .map(l -> String.join("/", l.components[1], l.components[2], l.components[3]))
+        .collect(Collectors.toSet())
+        .equals(Set.of("2010/10/15", "2010/10/20", "2012/1/1", "2012/1/7", "1999/5/5")));
+
+    try {
+      facetLabels = lookupFacetLabels(taxoLabels, fc.getMatchingDocs(), null, true);
+      fail("Assertion error was not thrown for using docIds supplied in decreasing order");
+    } catch (AssertionError ae) {
+      assertTrue(ae.getMessage().contains("docs out of order"));
+    }
+
+    try {
+      facetLabels = lookupFacetLabels(taxoLabels, fc.getMatchingDocs(), "Publish Date", true);
+      fail("Assertion error was not thrown for using docIds supplied in decreasing order");
+    } catch (AssertionError ae) {
+      assertTrue(ae.getMessage().contains("docs out of order"));
+    }
+
+    writer.close();
+    IOUtils.close(taxoWriter, searcher.getIndexReader(), taxoReader, taxoDir, dir);
+  }
+}


### PR DESCRIPTION
…et field. This is useful if a facet field is requested in the list of return fields for each hit.

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

This pull request adds a convenience class that allows an application to get facet labels for a facet field without knowing the internals of faceting implementation.

# Solution

Simple class with APIs to get facet labels for a facet field and (optionally) a facet dimension

# Tests

Tests were added to demonstrate expected API usage and ensure correctness of implementation

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [x] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
