### PR TITLE
SOLR-14878: Expose solr.xml's coreRootDirectory property via the System Settings API

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -48,6 +48,8 @@ Improvements
 
 * SOLR-14799: JWT authentication plugin only requires "sub" claim when principalClaim=sub. (Erik Hatcher)
 
+* SOLR-14878: Report solr.xml's coreRootDirectory property via System Settings API, when set (Alexandre Rafalovitch)
+
 Other Changes
 ----------------------
 * SOLR-14656: Autoscaling framework removed (Ishan Chattopadhyaya, noble, Ilan Ginzburg)

--- a/solr/core/src/java/org/apache/solr/handler/admin/SystemInfoHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/SystemInfoHandler.java
@@ -23,6 +23,7 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
 import java.lang.management.RuntimeMXBean;
 import java.net.InetAddress;
+import java.nio.file.Path;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.Date;
@@ -139,8 +140,19 @@ public class SystemInfoHandler extends RequestHandlerBase
     if (solrCloudMode) {
       rsp.add("zkHost", getCoreContainer(req, core).getZkController().getZkServerAddress());
     }
-    if (cc != null)
-      rsp.add( "solr_home", cc.getSolrHome());
+    if (cc != null) {
+      String solrHome = cc.getSolrHome();
+      rsp.add("solr_home", solrHome);
+
+      Path coreRootDirectory = cc.getCoreRootDirectory();
+      if (coreRootDirectory != null) {
+        String coreRootDirectoryString = coreRootDirectory.toString();
+        if (!coreRootDirectoryString.equals(solrHome)) {
+          rsp.add("solr_core_root", coreRootDirectoryString);
+        }
+      }
+    }
+
     rsp.add( "lucene", getLuceneInfo() );
     rsp.add( "jvm", getJvmInfo() );
     rsp.add( "security", getSecurityInfo(req) );


### PR DESCRIPTION
# Description

Even if coreRootDirectory was set in solr.xml, external applications could not access it through the API. It was not exposed. This means it is not possible to run a command such as *bin/solr create_core -c test* as the code that pre-populates the core directory is doing it in the wrong place (if at all).

# Solution
Expose the property if it is defined and is different from solr_home


# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [X] I have developed this patch against the `master` branch.
- [X] I have run `./gradlew check`.