### PR TITLE
SOLR-9607: Finalize move of Terms component and request handler into the implicit definitions

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -131,6 +131,8 @@ Other Changes
 * LUCENE-9531: Consolidated CharStream and FastCharStream classes: these have been moved from each query parser
                package to org.apache.lucene.queryparser.charstream (Dawid Weiss).
 
+* SOLR-9607: Remove /terms configuration from solrconfig.xml, as implicit definition is up-to-par now (Alexandre Rafalovitch)
+
 Bug Fixes
 ---------------------
 * SOLR-14546: Fix for a relatively hard to hit issue in OverseerTaskProcessor that could lead to out of order execution

--- a/solr/core/src/resources/ImplicitPlugins.json
+++ b/solr/core/src/resources/ImplicitPlugins.json
@@ -131,7 +131,11 @@
       "useParams":"_TERMS",
       "components": [
         "terms"
-      ]
+      ],
+      "defaults": {
+        "terms": true,
+        "distrib": false
+      }
     },
     "/analysis/document": {
       "class": "solr.DocumentAnalysisRequestHandler",

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-minhash.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-minhash.xml
@@ -295,15 +295,6 @@
     </lst>
   </searchComponent>
 
-  <searchComponent name="termsComp" class="org.apache.solr.handler.component.TermsComponent"/>
-
-  <requestHandler name="/terms" class="org.apache.solr.handler.component.SearchHandler">
-    <arr name="components">
-      <str>termsComp</str>
-    </arr>
-  </requestHandler>
-  
-  
   <!--
   The SpellingQueryConverter to convert raw (CommonParams.Q) queries into tokens.  Uses a simple regular expression
    to strip off field markup, boosts, ranges, etc. but it is not guaranteed to match an exact parse from the query parser.
@@ -545,7 +536,7 @@
   </restManager>
 
   <!-- warning: not a best practice; requests generally ought to be explicit to thus not require this -->
-  <initParams path="/select,/dismax,/defaults,/lazy,/spellCheckCompRH,/spellCheckWithWordbreak,/spellCheckCompRH_Direct,/spellCheckCompRH1,/mltrh,/tvrh,/search-facet-def,/search-facet-invariants,/terms">
+  <initParams path="/select,/dismax,/defaults,/lazy,/spellCheckCompRH,/spellCheckWithWordbreak,/spellCheckCompRH_Direct,/spellCheckCompRH1,/mltrh,/tvrh,/search-facet-def,/search-facet-invariants">
     <lst name="defaults">
       <str name="df">text</str>
     </lst>

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-plugcollector.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-plugcollector.xml
@@ -283,13 +283,6 @@
     </lst>
   </searchComponent>
 
-  <searchComponent name="termsComp" class="org.apache.solr.handler.component.TermsComponent"/>
-
-  <requestHandler name="/terms" class="org.apache.solr.handler.component.SearchHandler">
-    <arr name="components">
-      <str>termsComp</str>
-    </arr>
-  </requestHandler>
   <!--
   The SpellingQueryConverter to convert raw (CommonParams.Q) queries into tokens.  Uses a simple regular expression
    to strip off field markup, boosts, ranges, etc. but it is not guaranteed to match an exact parse from the query parser.
@@ -523,7 +516,7 @@
     <processor class="solr.RunUpdateProcessorFactory" />
   </updateRequestProcessorChain>
 
-  <initParams path="/select,/dismax,/defaults,/lazy,/spellCheckCompRH,/spellCheckWithWordbreak,/spellCheckCompRH_Direct,/spellCheckCompRH1,/mltrh,/tvrh,/terms">
+  <initParams path="/select,/dismax,/defaults,/lazy,/spellCheckCompRH,/spellCheckWithWordbreak,/spellCheckCompRH_Direct,/spellCheckCompRH1,/mltrh,/tvrh">
     <lst name="defaults">
       <str name="df">text</str>
     </lst>

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig.xml
@@ -294,6 +294,7 @@
     </lst>
   </searchComponent>
 
+    <!-- This is now part of the implicit configuration together with terms=true and distrib=false defaults
   <searchComponent name="termsComp" class="org.apache.solr.handler.component.TermsComponent"/>
 
   <requestHandler name="/terms" class="org.apache.solr.handler.component.SearchHandler">
@@ -301,6 +302,7 @@
       <str>termsComp</str>
     </arr>
   </requestHandler>
+  -->
   
   
   <!--
@@ -544,7 +546,7 @@
   </restManager>
 
   <!-- warning: not a best practice; requests generally ought to be explicit to thus not require this -->
-  <initParams path="/select,/dismax,/defaults,/lazy,/spellCheckCompRH,/spellCheckWithWordbreak,/spellCheckCompRH_Direct,/spellCheckCompRH1,/mltrh,/tvrh,/search-facet-def,/search-facet-invariants,/terms">
+  <initParams path="/select,/dismax,/defaults,/lazy,/spellCheckCompRH,/spellCheckWithWordbreak,/spellCheckCompRH_Direct,/spellCheckCompRH1,/mltrh,/tvrh,/search-facet-def,/search-facet-invariants">
     <lst name="defaults">
       <str name="df">text</str>
     </lst>

--- a/solr/core/src/test/org/apache/solr/handler/component/DistributedTermsComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/DistributedTermsComponentTest.java
@@ -51,11 +51,11 @@ public class DistributedTermsComponentTest extends BaseDistributedSearchTestCase
     del("*:*");
 
     index(id, random.nextInt(), "b_t", "snake a,b spider shark snail slug seal", "foo_i_p", "1");
-    query("qt", "/terms", "shards.qt", "/terms", "terms", "true", "terms.fl", "foo_i_p");
+    query("qt", "/terms", "shards.qt", "/terms", "terms.fl", "foo_i_p");
     del("*:*");
 
     // verify point field on empty index
-    query("qt", "/terms", "shards.qt", "/terms", "terms", "true", "terms.fl", "foo_i_p");
+    query("qt", "/terms", "shards.qt", "/terms", "terms.fl", "foo_i_p");
 
     index(id, random.nextInt(), "b_t", "snake a,b spider shark snail slug seal", "foo_i", "1");
     index(id, random.nextInt(), "b_t", "snake spider shark snail slug", "foo_i", "2", "foo_date_p", "2015-01-03T14:30:00Z");
@@ -70,25 +70,25 @@ public class DistributedTermsComponentTest extends BaseDistributedSearchTestCase
     handle.clear();
     handle.put("terms", UNORDERED);
 
-    query("qt", "/terms", "shards.qt", "/terms", "terms", "true", "terms.fl", "b_t");
-    query("qt", "/terms", "shards.qt", "/terms", "terms.limit", 5, "terms", "true", "terms.fl", "b_t", "terms.lower", "s");
-    query("qt", "/terms", "shards.qt", "/terms", "terms.limit", 5, "terms", "true", "terms.fl", "b_t", "terms.prefix", "sn", "terms.lower", "sn");
-    query("qt", "/terms", "shards.qt", "/terms", "terms.limit", 5, "terms", "true", "terms.fl", "b_t", "terms.prefix", "s", "terms.lower", "s", "terms.upper", "sn");
+    query("qt", "/terms", "shards.qt", "/terms", "terms.fl", "b_t");
+    query("qt", "/terms", "shards.qt", "/terms", "terms.limit", 5, "terms.fl", "b_t", "terms.lower", "s");
+    query("qt", "/terms", "shards.qt", "/terms", "terms.limit", 5, "terms.fl", "b_t", "terms.prefix", "sn", "terms.lower", "sn");
+    query("qt", "/terms", "shards.qt", "/terms", "terms.limit", 5, "terms.fl", "b_t", "terms.prefix", "s", "terms.lower", "s", "terms.upper", "sn");
     // terms.sort
-    query("qt", "/terms", "shards.qt", "/terms", "terms.limit", 5, "terms", "true", "terms.fl", "b_t", "terms.prefix", "s", "terms.lower", "s", "terms.sort", "index");
-    query("qt", "/terms", "shards.qt", "/terms", "terms.limit", 5, "terms", "true", "terms.fl", "b_t", "terms.prefix", "s", "terms.lower", "s", "terms.upper", "sn", "terms.sort", "index");
-    query("qt", "/terms", "shards.qt", "/terms", "terms", "true", "terms.fl", "b_t", "terms.sort", "index");
+    query("qt", "/terms", "shards.qt", "/terms", "terms.limit", 5, "terms.fl", "b_t", "terms.prefix", "s", "terms.lower", "s", "terms.sort", "index");
+    query("qt", "/terms", "shards.qt", "/terms", "terms.limit", 5, "terms.fl", "b_t", "terms.prefix", "s", "terms.lower", "s", "terms.upper", "sn", "terms.sort", "index");
+    query("qt", "/terms", "shards.qt", "/terms", "terms.fl", "b_t", "terms.sort", "index");
     // terms.list
-    query("qt", "/terms", "shards.qt", "/terms", "terms", "true", "terms.fl", "b_t", "terms.list", "snake,zebra,ant,bad");
-    query("qt", "/terms", "shards.qt", "/terms", "terms", "true", "terms.fl", "foo_i", "terms.list", "2,3,1");
-    query("qt", "/terms", "shards.qt", "/terms", "terms", "true", "terms.fl", "foo_i", "terms.stats", "true","terms.list", "2,3,1");
-    query("qt", "/terms", "shards.qt", "/terms", "terms", "true", "terms.fl", "b_t", "terms.list", "snake,zebra", "terms.ttf", "true");
-    query("qt", "/terms", "shards.qt", "/terms", "terms", "true", "terms.fl", "b_t", "terms.fl", "c_t", "terms.list", "snake,ant,zebra", "terms.ttf", "true");
+    query("qt", "/terms", "shards.qt", "/terms", "terms.fl", "b_t", "terms.list", "snake,zebra,ant,bad");
+    query("qt", "/terms", "shards.qt", "/terms", "terms.fl", "foo_i", "terms.list", "2,3,1");
+    query("qt", "/terms", "shards.qt", "/terms", "terms.fl", "foo_i", "terms.stats", "true","terms.list", "2,3,1");
+    query("qt", "/terms", "shards.qt", "/terms", "terms.fl", "b_t", "terms.list", "snake,zebra", "terms.ttf", "true");
+    query("qt", "/terms", "shards.qt", "/terms", "terms.fl", "b_t", "terms.fl", "c_t", "terms.list", "snake,ant,zebra", "terms.ttf", "true");
 
     // for date point field
-    query("qt", "/terms", "shards.qt", "/terms", "terms", "true", "terms.fl", "foo_date_p");
+    query("qt", "/terms", "shards.qt", "/terms", "terms.fl", "foo_date_p");
     // terms.ttf=true doesn't work for point fields
-    //query("qt", "/terms", "shards.qt", "/terms", "terms", "true", "terms.fl", "foo_date_p", "terms.ttf", "true");
+    //query("qt", "/terms", "shards.qt", "/terms", "terms.fl", "foo_date_p", "terms.ttf", "true");
   }
   
   protected QueryResponse query(Object... q) throws Exception {

--- a/solr/core/src/test/org/apache/solr/handler/component/TermsComponentTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/TermsComponentTest.java
@@ -86,7 +86,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
 
   @Test
   public void testEmptyLower() throws Exception {
-    assertQ(req("indent","true", "qt","/terms",  "terms","true", "terms.fl","lowerfilt", "terms.upper","b")
+    assertQ(req("indent","true", "qt","/terms",  "terms.fl","lowerfilt", "terms.upper","b")
         ,"count(//lst[@name='lowerfilt']/*)=6"
         ,"//int[@name='a'] "
         ,"//int[@name='aa'] "
@@ -100,7 +100,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
 
   @Test
   public void testMultipleFields() throws Exception {
-    assertQ(req("indent","true", "qt","/terms",  "terms","true",
+    assertQ(req("indent","true", "qt","/terms",
         "terms.fl","lowerfilt", "terms.upper","b",
         "terms.fl","standardfilt")
         ,"count(//lst[@name='lowerfilt']/*)=6"
@@ -111,13 +111,13 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
 
   @Test
   public void testUnlimitedRows() throws Exception {
-    assertQ(req("indent","true", "qt","/terms",  "terms","true",
+    assertQ(req("indent","true", "qt","/terms",
         "terms.fl","lowerfilt",
         "terms.fl","standardfilt")
         ,"count(//lst[@name='lowerfilt']/*)=9"
         ,"count(//lst[@name='standardfilt']/*)=10"
     );
-    assertQ(req("indent","true", "qt","/terms",  "terms","true",
+    assertQ(req("indent","true", "qt","/terms",
         "terms.fl","lowerfilt",
         "terms.fl","standardfilt",
         "terms.limit","-1")
@@ -130,7 +130,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
 
   @Test
   public void testPrefix() throws Exception {
-    assertQ(req("indent","true", "qt","/terms",  "terms","true",
+    assertQ(req("indent","true", "qt","/terms",
         "terms.fl","lowerfilt", "terms.upper","b",
         "terms.fl","standardfilt",
         "terms.lower","aa", "terms.lower.incl","false", "terms.prefix","aa", "terms.upper","b", "terms.limit","50")
@@ -141,7 +141,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
 
   @Test
   public void testRegexp() throws Exception {
-    assertQ(req("indent","true", "qt","/terms",  "terms","true",
+    assertQ(req("indent","true", "qt","/terms",
         "terms.fl","standardfilt",
         "terms.lower","a", "terms.lower.incl","false",
         "terms.upper","c", "terms.upper.incl","true",
@@ -168,7 +168,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   @Test
   public void testRegexpWithFlags() throws Exception {
     // TODO: there are no uppercase or mixed-case terms in the index!
-    assertQ(req("indent", "true", "qt", "/terms", "terms", "true",
+    assertQ(req("indent", "true", "qt", "/terms",
             "terms.fl", "standardfilt",
             "terms.lower", "a", "terms.lower.incl", "false",
             "terms.upper", "c", "terms.upper.incl", "true",
@@ -180,7 +180,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
 
   @Test
   public void testSortCount() throws Exception {
-    assertQ(req("indent","true", "qt","/terms",  "terms","true",
+    assertQ(req("indent","true", "qt","/terms",
         "terms.fl","standardfilt",
         "terms.lower","s", "terms.lower.incl","false",
         "terms.prefix","s",
@@ -196,7 +196,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   @Test
   public void testTermsList() throws Exception {
     //Terms list always returns in index order
-    assertQ(req("indent","true", "qt","/terms",  "terms","true",
+    assertQ(req("indent","true", "qt","/terms",
             "terms.fl","standardfilt",
             "terms.list","spider,snake,a\\,b,shark,ddddd,bad")
         ,"count(//lst[@name='standardfilt']/*)=5"
@@ -209,7 +209,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
 
 
     //Test with numeric terms
-    assertQ(req("indent","true", "qt","/terms",  "terms","true",
+    assertQ(req("indent","true", "qt","/terms",
             "terms.fl","foo_i",
             "terms.list","2,1")
         ,"count(//lst[@name='foo_i']/*)=2"
@@ -222,7 +222,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   @Test
   public void testStats() throws Exception {
     //Terms list always returns in index order
-    assertQ(req("indent", "true", "qt", "/terms", "terms", "true",
+    assertQ(req("indent", "true", "qt", "/terms",
             "terms.fl", "standardfilt","terms.stats", "true",
             "terms.list", "spider,snake,shark,ddddd,bad")
         , "//lst[@name='indexstats']/long[1][@name='numDocs'][.='24']"
@@ -231,7 +231,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
 
   @Test
   public void testSortIndex() throws Exception {
-    assertQ(req("indent","true", "qt","/terms",  "terms","true",
+    assertQ(req("indent","true", "qt","/terms",
         "terms.fl","standardfilt",
         "terms.lower","s", "terms.lower.incl","false",
         "terms.prefix","s",
@@ -245,7 +245,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   
   @Test
   public void testPastUpper() throws Exception {
-    assertQ(req("indent","true", "qt","/terms",  "terms","true",
+    assertQ(req("indent","true", "qt","/terms",
         "terms.fl","lowerfilt",
         //no upper bound, lower bound doesn't exist
         "terms.lower","d")
@@ -255,7 +255,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
 
   @Test
   public void testLowerExclusive() throws Exception {
-     assertQ(req("indent","true", "qt","/terms",  "terms","true",
+     assertQ(req("indent","true", "qt","/terms",
         "terms.fl","lowerfilt",
         "terms.lower","a", "terms.lower.incl","false",
         "terms.upper","b")
@@ -267,7 +267,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
         ,"//int[@name='abc'] "
     );
 
-    assertQ(req("indent","true", "qt","/terms",  "terms","true",
+    assertQ(req("indent","true", "qt","/terms",
         "terms.fl","standardfilt",
         "terms.lower","cc", "terms.lower.incl","false",
         "terms.upper","d")
@@ -277,7 +277,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
 
   @Test
   public void test() throws Exception {
-    assertQ(req("indent","true", "qt","/terms",  "terms","true",
+    assertQ(req("indent","true", "qt","/terms",
        "terms.fl","lowerfilt",
        "terms.lower","a",
        "terms.upper","b")
@@ -290,7 +290,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
        ,"//int[@name='abc'] "
     );
 
-    assertQ(req("indent","true", "qt","/terms",  "terms","true",
+    assertQ(req("indent","true", "qt","/terms",
        "terms.fl","lowerfilt",
        "terms.lower","a",
        "terms.upper","b",
@@ -301,20 +301,20 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
        ,"//int[@name='aa']"
     );
 
-    assertQ(req("indent","true", "qt","/terms",  "terms","true",
+    assertQ(req("indent","true", "qt","/terms",
        "terms.fl","foo_i")
        ,"//int[@name='1'][.='2']"
     );
 
     /* terms.raw only applies to indexed fields
-    assertQ(req("indent","true", "qt","/terms",  "terms","true",
+    assertQ(req("indent","true", "qt","/terms",
        "terms.fl","foo_i", "terms.raw","true")
        ,"not(//int[@name='1'][.='2'])"
     );
     */
 
     // check something at the end of the index
-    assertQ(req("indent","true", "qt","/terms",  "terms","true",
+    assertQ(req("indent","true", "qt","/terms",
        "terms.fl","zzz_i")
         ,"count(//lst[@name='zzz_i']/*)=0"
     );
@@ -322,7 +322,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
 
   @Test
   public void testMinMaxFreq() throws Exception {
-    assertQ(req("indent","true", "qt","/terms",  "terms","true",
+    assertQ(req("indent","true", "qt","/terms",
        "terms.fl","lowerfilt",
        "terms.lower","a",
        "terms.mincount","2",
@@ -331,7 +331,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
        ,"count(//lst[@name='lowerfilt']/*)=1"
     );
 
-    assertQ(req("indent","true", "qt","/terms",  "terms","true",
+    assertQ(req("indent","true", "qt","/terms",
        "terms.fl","standardfilt",
        "terms.lower","d",
        "terms.mincount","2",
@@ -344,7 +344,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
   @Test
   public void testTermsWithJSON() throws Exception {
     ModifiableSolrParams params = params(
-        "qt", "/terms", "terms", "true", "terms.fl", "standardfilt", "terms.lower", "a",
+        "qt", "/terms", "terms.fl", "standardfilt", "terms.lower", "a",
         "terms.sort", "index", "wt", "json"
     );
 
@@ -376,7 +376,6 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
     SolrQueryRequest req = req(
         "indent","true",
         "qt", "/terms",
-        "terms", "true",
         "terms.fl", "standardfilt",
         "terms.ttf", "true",
         "terms.list", "snake,spider,shark,ddddd");
@@ -395,7 +394,6 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
     req = req(
         "indent","true",
         "qt", "/terms",
-        "terms", "true",
         "terms.fl", "standardfilt",
         "terms.ttf", "true",
         "terms.limit", "-1",
@@ -418,7 +416,6 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
     SolrQueryRequest req = req(
         "indent","true",
         "qt", "/terms",
-        "terms", "true",
         "terms.fl", "standardfilt",
         "terms.ttf", "true",
         "terms.list", "boo,snake");
@@ -433,7 +430,6 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
     SolrQueryRequest req = req(
         "indent","true",
         "qt", "/terms",
-        "terms", "true",
         "terms.fl", "lowerfilt",
         "terms.fl", "standardfilt",
         "terms.ttf", "true",
@@ -458,7 +454,6 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
     req = req(
         "indent","true",
         "qt", "/terms",
-        "terms", "true",
         "terms.fl", "lowerfilt",
         "terms.fl", "standardfilt",
         "terms.ttf", "true",
@@ -509,7 +504,6 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
 
     SolrQueryRequest req = req(
         "qt", "/terms",
-        "terms", "true",
         "terms.fl", "foo_pi");
     ;
     try {
@@ -588,7 +582,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
       }
       assert(i==nvals);
 
-      assertQ(req("indent","true", "qt","/terms",  "terms","true",
+      assertQ(req("indent","true", "qt","/terms",
           "terms.fl","foo_pi", "terms.sort","index", "terms.limit","2")
           ,"count(//lst[@name='foo_pi']/*)=2"
           ,"//lst[@name='foo_pi']/int[1][@name='" +val1+ "']"
@@ -637,7 +631,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
     assertU(adoc("id", Integer.toString(100102), "foo_pdt", dates[1]));
     assertU(commit());
 
-    assertQ(req("indent","true", "qt","/terms", "terms","true",
+    assertQ(req("indent","true", "qt","/terms",
         "terms.fl","foo_pdt", "terms.sort","count"),
         "count(//lst[@name='foo_pdt']/*)=2",
         "//lst[@name='foo_pdt']/int[1][@name='" + dates[1] + "'][.='51']",
@@ -648,7 +642,7 @@ public class TermsComponentTest extends SolrTestCaseJ4 {
     assertU(delQ("*:*"));
     assertU(commit());
 
-    assertQ(req("indent","true", "qt","/terms", "terms","true",
+    assertQ(req("indent","true", "qt","/terms",
         "terms.fl","foo_pdt", "terms.sort","count"),
         "count(//lst[@name='foo_pdt']/*)=0"
     );

--- a/solr/core/src/test/org/apache/solr/update/TestNestedUpdateProcessor.java
+++ b/solr/core/src/test/org/apache/solr/update/TestNestedUpdateProcessor.java
@@ -127,7 +127,7 @@ public class TestNestedUpdateProcessor extends SolrTestCaseJ4 {
   public void testNumberInName() throws Exception {
     // child named "grandChild99"  (has a number in it)
     indexSampleData(jDoc.replace("grandChild", "grandChild99"));
-    //assertQ(req("qt", "/terms", "terms", "true", "terms.fl", IndexSchema.NEST_PATH_FIELD_NAME), "false"); // for debugging
+    //assertQ(req("qt", "/terms", "terms.fl", IndexSchema.NEST_PATH_FIELD_NAME), "false"); // for debugging
 
     // find it
     assertJQ(req("q", "{!field f=" + IndexSchema.NEST_PATH_FIELD_NAME + "}/children/grandChild99"),

--- a/solr/server/solr/configsets/_default/conf/solrconfig.xml
+++ b/solr/server/solr/configsets/_default/conf/solrconfig.xml
@@ -848,6 +848,7 @@
        <searchComponent name="mlt"       class="solr.MoreLikeThisComponent" />
        <searchComponent name="highlight" class="solr.HighlightComponent" />
        <searchComponent name="stats"     class="solr.StatsComponent" />
+       <searchComponent name="terms"     class="solr.TermsComponent" />
        <searchComponent name="debug"     class="solr.DebugComponent" />
 
        Default configuration in a requestHandler would look like:
@@ -963,26 +964,6 @@
     </lst>
     <arr name="last-components">
       <str>spellcheck</str>
-    </arr>
-  </requestHandler>
-
-  <!-- Terms Component
-
-       http://wiki.apache.org/solr/TermsComponent
-
-       A component to return terms and document frequency of those
-       terms
-    -->
-  <searchComponent name="terms" class="solr.TermsComponent"/>
-
-  <!-- A request handler for demonstrating the terms component -->
-  <requestHandler name="/terms" class="solr.SearchHandler" startup="lazy">
-    <lst name="defaults">
-      <bool name="terms">true</bool>
-      <bool name="distrib">false</bool>
-    </lst>
-    <arr name="components">
-      <str>terms</str>
     </arr>
   </requestHandler>
 

--- a/solr/server/solr/configsets/sample_techproducts_configs/conf/solrconfig.xml
+++ b/solr/server/solr/configsets/sample_techproducts_configs/conf/solrconfig.xml
@@ -899,6 +899,7 @@
        <searchComponent name="mlt"       class="solr.MoreLikeThisComponent" />
        <searchComponent name="highlight" class="solr.HighlightComponent" />
        <searchComponent name="stats"     class="solr.StatsComponent" />
+       <searchComponent name="terms"     class="solr.TermsComponent" />
        <searchComponent name="debug"     class="solr.DebugComponent" />
 
        Default configuration in a requestHandler would look like:
@@ -1196,26 +1197,6 @@
     </lst>
     <arr name="last-components">
       <str>clustering</str>
-    </arr>
-  </requestHandler>
-
-  <!-- Terms Component
-
-       http://wiki.apache.org/solr/TermsComponent
-
-       A component to return terms and document frequency of those
-       terms
-    -->
-  <searchComponent name="terms" class="solr.TermsComponent"/>
-
-  <!-- A request handler for demonstrating the terms component -->
-  <requestHandler name="/terms" class="solr.SearchHandler" startup="lazy">
-     <lst name="defaults">
-      <bool name="terms">true</bool>
-      <bool name="distrib">false</bool>
-    </lst>
-    <arr name="components">
-      <str>terms</str>
     </arr>
   </requestHandler>
 

--- a/solr/solr-ref-guide/src/requesthandlers-and-searchcomponents-in-solrconfig.adoc
+++ b/solr/solr-ref-guide/src/requesthandlers-and-searchcomponents-in-solrconfig.adoc
@@ -123,8 +123,9 @@ There are several default search components that work with all SearchHandlers wi
 |mlt |`solr.MoreLikeThisComponent` |Described in the section <<morelikethis.adoc#morelikethis,MoreLikeThis>>.
 |highlight |`solr.HighlightComponent` |Described in the section <<highlighting.adoc#highlighting,Highlighting>>.
 |stats |`solr.StatsComponent` |Described in the section <<the-stats-component.adoc#the-stats-component,The Stats Component>>.
-|debug |`solr.DebugComponent` |Described in the section on <<common-query-parameters.adoc#debug-parameter,Common Query Parameters>>.
 |expand |`solr.ExpandComponent` |Described in the section <<collapse-and-expand-results.adoc#collapse-and-expand-results,Collapse and Expand Results>>.
+|terms |`solr.TermsComponent` |Described in the section <<the-terms-component.adoc#the-terms-component,The Terms Component>>.
+|debug |`solr.DebugComponent` |Described in the section on <<common-query-parameters.adoc#debug-parameter,Common Query Parameters>>.
 |===
 
 If you register a new search component with one of these default names, the newly defined component will be used instead of the default.
@@ -168,7 +169,6 @@ Many of the other useful components are described in sections of this Guide for 
 * `SpellCheckComponent`, described in the section <<spell-checking.adoc#spell-checking,Spell Checking>>.
 * `TermVectorComponent`, described in the section <<the-term-vector-component.adoc#the-term-vector-component,The Term Vector Component>>.
 * `QueryElevationComponent`, described in the section <<the-query-elevation-component.adoc#the-query-elevation-component,The Query Elevation Component>>.
-* `TermsComponent`, described in the section <<the-terms-component.adoc#the-terms-component,The Terms Component>>.
 * `RealTimeGetComponent`, described in the section <<realtime-get.adoc#realtime-get,RealTime Get>>.
 * `ClusteringComponent`, described in the section <<result-clustering.adoc#result-clustering,Result Clustering>>.
 * `SuggestComponent`, described in the section <<suggester.adoc#suggester,Suggester>>.

--- a/solr/solr-ref-guide/src/the-terms-component.adoc
+++ b/solr/solr-ref-guide/src/the-terms-component.adoc
@@ -22,26 +22,22 @@ In a sense, this search component provides fast field-faceting over the whole in
 
 == Configuring the Terms Component
 
-By default, the Terms Component is already configured in `solrconfig.xml` for each collection.
+Terms Component is one of  <<requesthandlers-and-searchcomponents-in-solrconfig.adoc#search-components,the default search components>>
+and does not need to be defined in `solrconfig.xml`.
 
-=== Defining the Terms Component
-
-Defining the Terms search component is straightforward: simply give it a name and use the class `solr.TermsComponent`.
+The definition is equivalent to:
 
 [source,xml]
 ----
 <searchComponent name="terms" class="solr.TermsComponent"/>
 ----
 
-This makes the component available for use, but by itself will not be useable until included with a request handler.
-
 === Using the Terms Component in a Request Handler
 
-The terms component is included with the `/terms` request handler, which is among Solr's out-of-the-box request handlers - see <<implicit-requesthandlers.adoc#implicit-requesthandlers,Implicit RequestHandlers>>.
+Solr comes with an <<implicit-requesthandlers.adoc#query-handlers,Implicit RequestHandler>> definition `/terms`, which enables (only) Terms component.
+This handler, by default, can only be used on a single Solr core (`distrib=false`).
 
-Note that the defaults for this request handler set the parameter "terms" to true, which allows terms to be returned on request. The parameter "distrib" is set to false, which allows this handler to be used only on a single Solr core.
-
-You could add this component to another handler if you wanted to, and pass "terms=true" in the HTTP request in order to get terms back. If it is only defined in a separate handler, you must use that handler when querying in order to get terms and not regular documents as results.
+If you want to enable Terms component when using another Request Handler, `terms=true` parameter needs to be passed during the request or be set in the handler's defaults.
 
 === Terms Component Parameters
 
@@ -243,6 +239,46 @@ Results:
   </lst>
 </response>
 ----
+
+=== Using Terms Component as part of another handler
+
+This query augments a regular search with terms information.
+
+[source,text]
+http://localhost:8983/solr/techproducts/select?q=corsair&fl=id,name&rows=1&echoParams=none&wt=xml&terms=true&terms.fl=name
+
+Results (notice that the term counts are not affected by the query):
+
+[source,xml]
+----
+<response>
+
+<lst name="responseHeader">
+  <int name="status">0</int>
+  <int name="QTime">1</int>
+</lst>
+<result name="response" numFound="2" start="0" numFoundExact="true">
+  <doc>
+    <str name="id">VS1GB400C3</str>
+    <str name="name">CORSAIR ValueSelect 1GB 184-Pin DDR SDRAM Unbuffered DDR 400 (PC 3200) System Memory - Retail</str></doc>
+</result>
+<lst name="terms">
+  <lst name="name">
+    <int name="one">5</int>
+    <int name="184">3</int>
+    <int name="1gb">3</int>
+    <int name="3200">3</int>
+    <int name="400">3</int>
+    <int name="ddr">3</int>
+    <int name="gb">3</int>
+    <int name="ipod">3</int>
+    <int name="memory">3</int>
+    <int name="pc">3</int>
+  </lst>
+</lst>
+</response>
+----
+
 
 === SolrJ Invocation
 


### PR DESCRIPTION
# Description

We moved Terms Components and Terms Request Handler into default definition, but the request handler did not define any defaults. Therefore, we still had an overriding definition hanging around in solrconfig.xml, confusing things. Additionally, documentation was out of date too.

# Solution

1. Updated default definition for /terms request handler to match what solrconfig.xml had (terms=true to actually make that handler useful and distrib=false)
2. Removed definition from default configsets
3. Cleaned up tests that no longer needed to enable the component every time
4. Updated documentation to reflect the implicit aspects and to give an example of using it with other handlers

# Tests
1. No new tests, but updated the existing ones to rely on updated definition and not to declare it explicitly.

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [X] I have developed this patch against the `master` branch.
- [X] I have run `./gradlew check`.
- [X] I have added (updated) tests for my changes.
- [X] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
