### PR TITLE
SOLR-14878: Expose solr.xml's coreRootDirectory property via the System Settings API (part 2)

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -48,6 +48,8 @@ Improvements
 
 * SOLR-14799: JWT authentication plugin only requires "sub" claim when principalClaim=sub. (Erik Hatcher)
 
+* SOLR-14878: Report solr.xml's coreRootDirectory property via System Settings API, when set (Alexandre Rafalovitch)
+
 Other Changes
 ----------------------
 * SOLR-14656: Autoscaling framework removed (Ishan Chattopadhyaya, noble, Ilan Ginzburg)

--- a/solr/core/src/java/org/apache/solr/handler/admin/SystemInfoHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/SystemInfoHandler.java
@@ -23,7 +23,6 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
 import java.lang.management.RuntimeMXBean;
 import java.net.InetAddress;
-import java.nio.file.Path;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.Date;

--- a/solr/core/src/java/org/apache/solr/handler/admin/SystemInfoHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/SystemInfoHandler.java
@@ -23,6 +23,7 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
 import java.lang.management.RuntimeMXBean;
 import java.net.InetAddress;
+import java.nio.file.Path;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.Date;
@@ -139,8 +140,19 @@ public class SystemInfoHandler extends RequestHandlerBase
     if (solrCloudMode) {
       rsp.add("zkHost", getCoreContainer(req, core).getZkController().getZkServerAddress());
     }
-    if (cc != null)
-      rsp.add( "solr_home", cc.getSolrHome());
+    if (cc != null) {
+      String solrHome = cc.getSolrHome();
+      rsp.add("solr_home", solrHome);
+
+      Path coreRootDirectory = cc.getCoreRootDirectory();
+      if (coreRootDirectory != null) {
+        String coreRootDirectoryString = coreRootDirectory.toString();
+        if (!coreRootDirectoryString.equals(solrHome)) {
+          rsp.add("solr_core_root", coreRootDirectoryString);
+        }
+      }
+    }
+
     rsp.add( "lucene", getLuceneInfo() );
     rsp.add( "jvm", getJvmInfo() );
     rsp.add( "security", getSecurityInfo(req) );

--- a/solr/core/src/java/org/apache/solr/handler/admin/SystemInfoHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/SystemInfoHandler.java
@@ -141,16 +141,8 @@ public class SystemInfoHandler extends RequestHandlerBase
       rsp.add("zkHost", getCoreContainer(req, core).getZkController().getZkServerAddress());
     }
     if (cc != null) {
-      String solrHome = cc.getSolrHome();
-      rsp.add("solr_home", solrHome);
-
-      Path coreRootDirectory = cc.getCoreRootDirectory();
-      if (coreRootDirectory != null) {
-        String coreRootDirectoryString = coreRootDirectory.toString();
-        if (!coreRootDirectoryString.equals(solrHome)) {
-          rsp.add("solr_core_root", coreRootDirectoryString);
-        }
-      }
+      rsp.add("solr_home", cc.getSolrHome());
+      rsp.add("core_root", cc.getCoreRootDirectory().toString());
     }
 
     rsp.add( "lucene", getLuceneInfo() );


### PR DESCRIPTION
# Description

Adjustment based on comments in - merged - #1894

# Solution

1. Shorten the name solr_core_root->core_root
2. Always return the value, even if not explicitly defined