### PR TITLE
SOLR-13528: Implement API Based Config For Rate Limiters

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/RateLimiterConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/RateLimiterConfig.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.solr.servlet;
+package org.apache.solr.core;
 
 import org.apache.solr.client.solrj.SolrRequest;
 

--- a/solr/core/src/java/org/apache/solr/handler/ClusterAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/ClusterAPI.java
@@ -56,7 +56,7 @@ import static org.apache.solr.security.PermissionNameProvider.Name.COLL_EDIT_PER
 import static org.apache.solr.security.PermissionNameProvider.Name.COLL_READ_PERM;
 import static org.apache.solr.security.PermissionNameProvider.Name.CONFIG_EDIT_PERM;
 import static org.apache.solr.security.PermissionNameProvider.Name.CONFIG_READ_PERM;
-import static org.apache.solr.servlet.RateLimiterConfig.RL_CONFIG_KEY;
+import static org.apache.solr.core.RateLimiterConfig.RL_CONFIG_KEY;
 
 /** All V2 APIs that have  a prefix of /api/cluster/
  *

--- a/solr/core/src/java/org/apache/solr/handler/ClusterAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/ClusterAPI.java
@@ -26,6 +26,7 @@ import org.apache.solr.api.PayloadObj;
 import org.apache.solr.client.solrj.request.beans.ClusterPropInfo;
 import org.apache.solr.client.solrj.request.beans.CreateConfigInfo;
 import org.apache.solr.cloud.OverseerConfigSetMessageHandler;
+import org.apache.solr.client.solrj.request.beans.RateLimiterMeta;
 import org.apache.solr.cluster.placement.impl.PlacementPluginConfigImpl;
 import org.apache.solr.common.MapWriterMap;
 import org.apache.solr.common.SolrException;
@@ -230,19 +231,18 @@ public class ClusterAPI {
       }
     }
 
-    @Command(name = "set-ratelimiters")
-    public void setRateLimiters(PayloadObj<Map<String, Object>> obj) {
-      Map<String, Object> rateLimiterConfig = obj.getDataMap();
-      final boolean unset = rateLimiterConfig.isEmpty();
-      ClusterProperties clusterProperties = new ClusterProperties(getCoreContainer().getZkController().getZkClient());
-
+    @Command(name = "set-ratelimiter")
+    public void setRateLimiters(PayloadObj<RateLimiterMeta> payLoad) {
+      RateLimiterMeta rateLimiterConfig = payLoad.get();
+      final boolean unset = rateLimiterConfig == null;
+      ClusterProperties clusterProperties = new ClusterProperties(coreContainer.getZkController().getZkClient());
       try {
         clusterProperties.setClusterProperties(
             Collections.singletonMap(RL_CONFIG_KEY, null));
 
         if (!unset) {
           clusterProperties.setClusterProperties(
-              Collections.singletonMap(RL_CONFIG_KEY, rateLimiterConfig));
+              Collections.singletonMap(RL_CONFIG_KEY, Utils.toJSONString(rateLimiterConfig)));
         }
       } catch (Exception e) {
         throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "Error in API", e);

--- a/solr/core/src/java/org/apache/solr/handler/ClusterAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/ClusterAPI.java
@@ -235,7 +235,8 @@ public class ClusterAPI {
     public void setRateLimiters(PayloadObj<RateLimiterMeta> payLoad) {
       RateLimiterMeta rateLimiterConfig = payLoad.get();
       final boolean unset = rateLimiterConfig == null;
-      ClusterProperties clusterProperties = new ClusterProperties(coreContainer.getZkController().getZkClient());
+      ClusterProperties clusterProperties = new ClusterProperties(getCoreContainer().getZkController().getZkClient());
+
       try {
         clusterProperties.setClusterProperties(
             Collections.singletonMap(RL_CONFIG_KEY, null));

--- a/solr/core/src/java/org/apache/solr/handler/ClusterAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/ClusterAPI.java
@@ -234,7 +234,7 @@ public class ClusterAPI {
 
     @Command(name = "set-ratelimiter")
     public void setRateLimiters(PayloadObj<RateLimiterMeta> payLoad) {
-      RateLimiterMeta rateLimiterConfig = payLoad.get();g
+      RateLimiterMeta rateLimiterConfig = payLoad.get();
       ClusterProperties clusterProperties = new ClusterProperties(getCoreContainer().getZkController().getZkClient());
 
       try {

--- a/solr/core/src/java/org/apache/solr/handler/ClusterAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/ClusterAPI.java
@@ -17,7 +17,6 @@
 
 package org.apache.solr.handler;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -26,8 +25,8 @@ import org.apache.solr.api.EndPoint;
 import org.apache.solr.api.PayloadObj;
 import org.apache.solr.client.solrj.request.beans.ClusterPropInfo;
 import org.apache.solr.client.solrj.request.beans.CreateConfigInfo;
-import org.apache.solr.cloud.OverseerConfigSetMessageHandler;
 import org.apache.solr.client.solrj.request.beans.RateLimiterMeta;
+import org.apache.solr.cloud.OverseerConfigSetMessageHandler;
 import org.apache.solr.cluster.placement.impl.PlacementPluginConfigImpl;
 import org.apache.solr.common.MapWriterMap;
 import org.apache.solr.common.SolrException;
@@ -53,11 +52,11 @@ import static org.apache.solr.common.params.CollectionParams.CollectionAction.AD
 import static org.apache.solr.common.params.CollectionParams.CollectionAction.CLUSTERPROP;
 import static org.apache.solr.common.params.CollectionParams.CollectionAction.OVERSEERSTATUS;
 import static org.apache.solr.common.params.CollectionParams.CollectionAction.REMOVEROLE;
+import static org.apache.solr.core.RateLimiterConfig.RL_CONFIG_KEY;
 import static org.apache.solr.security.PermissionNameProvider.Name.COLL_EDIT_PERM;
 import static org.apache.solr.security.PermissionNameProvider.Name.COLL_READ_PERM;
 import static org.apache.solr.security.PermissionNameProvider.Name.CONFIG_EDIT_PERM;
 import static org.apache.solr.security.PermissionNameProvider.Name.CONFIG_READ_PERM;
-import static org.apache.solr.core.RateLimiterConfig.RL_CONFIG_KEY;
 
 /** All V2 APIs that have  a prefix of /api/cluster/
  *

--- a/solr/core/src/java/org/apache/solr/handler/ClusterAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/ClusterAPI.java
@@ -17,6 +17,7 @@
 
 package org.apache.solr.handler;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -233,18 +234,14 @@ public class ClusterAPI {
 
     @Command(name = "set-ratelimiter")
     public void setRateLimiters(PayloadObj<RateLimiterMeta> payLoad) {
-      RateLimiterMeta rateLimiterConfig = payLoad.get();
-      final boolean unset = rateLimiterConfig == null;
+      RateLimiterMeta rateLimiterConfig = payLoad.get();g
       ClusterProperties clusterProperties = new ClusterProperties(getCoreContainer().getZkController().getZkClient());
 
       try {
-        clusterProperties.setClusterProperties(
-            Collections.singletonMap(RL_CONFIG_KEY, null));
-
-        if (!unset) {
-          clusterProperties.setClusterProperties(
-              Collections.singletonMap(RL_CONFIG_KEY, Utils.toJSONString(rateLimiterConfig)));
-        }
+        clusterProperties.update(rateLimiterConfig == null?
+                null:
+                rateLimiterConfig,
+                RL_CONFIG_KEY);
       } catch (Exception e) {
         throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "Error in API", e);
       }

--- a/solr/core/src/java/org/apache/solr/servlet/QueryRateLimiter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/QueryRateLimiter.java
@@ -50,7 +50,7 @@ public class QueryRateLimiter extends RequestRateLimiter {
       return;
     }
 
-    RateLimiterMeta rateLimiterMeta = mapper.readValue(configInputg, RateLimiterMeta.class);
+    RateLimiterMeta rateLimiterMeta = mapper.readValue(configInput, RateLimiterMeta.class);
 
     constructQueryRateLimiterConfigInternal(rateLimiterMeta, rateLimiterConfig);
   }

--- a/solr/core/src/java/org/apache/solr/servlet/QueryRateLimiter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/QueryRateLimiter.java
@@ -25,6 +25,7 @@ import org.apache.solr.client.solrj.SolrRequest;
 
 import static org.apache.solr.servlet.RateLimitManager.DEFAULT_CONCURRENT_REQUESTS;
 import static org.apache.solr.servlet.RateLimitManager.DEFAULT_SLOT_ACQUISITION_TIMEOUT_MS;
+import static org.apache.solr.servlet.RateLimiterConfig.RL_CONFIG_KEY;
 
 /** Implementation of RequestRateLimiter specific to query request types. Most of the actual work is delegated
  *  to the parent class but specific configurations and parsing are handled by this class.
@@ -42,25 +43,26 @@ public class QueryRateLimiter extends RequestRateLimiter {
 
   public void processConfigChange(Map<String, Object> properties) {
     RateLimiterConfig rateLimiterConfig = getRateLimiterConfig();
+    Map<String, Object> propertiesMap = (Map<String, Object>) properties.get(RL_CONFIG_KEY);
 
-    if (properties.get(RateLimiterConfig.RL_ALLOWED_REQUESTS) != null) {
-      rateLimiterConfig.allowedRequests = Integer.parseInt(properties.get(RateLimiterConfig.RL_ALLOWED_REQUESTS).toString());
+    if (propertiesMap.get(RateLimiterConfig.RL_ALLOWED_REQUESTS) != null) {
+      rateLimiterConfig.allowedRequests = Integer.parseInt(propertiesMap.get(RateLimiterConfig.RL_ALLOWED_REQUESTS).toString());
     }
 
-    if (properties.get(RateLimiterConfig.RL_ENABLED) != null) {
-      rateLimiterConfig.isEnabled = Boolean.parseBoolean(properties.get(RateLimiterConfig.RL_ENABLED).toString());
+    if (propertiesMap.get(RateLimiterConfig.RL_ENABLED) != null) {
+      rateLimiterConfig.isEnabled = Boolean.parseBoolean(propertiesMap.get(RateLimiterConfig.RL_ENABLED).toString());
     }
 
-    if (properties.get(RateLimiterConfig.RL_GUARANTEED_SLOTS) != null) {
-      rateLimiterConfig.guaranteedSlotsThreshold = Integer.parseInt(properties.get(RateLimiterConfig.RL_GUARANTEED_SLOTS).toString());
+    if (propertiesMap.get(RateLimiterConfig.RL_GUARANTEED_SLOTS) != null) {
+      rateLimiterConfig.guaranteedSlotsThreshold = Integer.parseInt(propertiesMap.get(RateLimiterConfig.RL_GUARANTEED_SLOTS).toString());
     }
 
-    if (properties.get(RateLimiterConfig.RL_SLOT_BORROWING_ENABLED) != null) {
-      rateLimiterConfig.isSlotBorrowingEnabled = Boolean.parseBoolean(properties.get(RateLimiterConfig.RL_SLOT_BORROWING_ENABLED).toString());
+    if (propertiesMap.get(RateLimiterConfig.RL_SLOT_BORROWING_ENABLED) != null) {
+      rateLimiterConfig.isSlotBorrowingEnabled = Boolean.parseBoolean(propertiesMap.get(RateLimiterConfig.RL_SLOT_BORROWING_ENABLED).toString());
     }
 
-    if (properties.get(RateLimiterConfig.RL_TIME_SLOT_ACQUISITION) != null) {
-      rateLimiterConfig.waitForSlotAcquisition = Long.parseLong(properties.get(RateLimiterConfig.RL_TIME_SLOT_ACQUISITION).toString());
+    if (propertiesMap.get(RateLimiterConfig.RL_TIME_SLOT_ACQUISITION_INMS) != null) {
+      rateLimiterConfig.waitForSlotAcquisition = Long.parseLong(propertiesMap.get(RateLimiterConfig.RL_TIME_SLOT_ACQUISITION_INMS).toString());
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/servlet/QueryRateLimiter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/QueryRateLimiter.java
@@ -49,6 +49,11 @@ public class QueryRateLimiter extends RequestRateLimiter {
   @SuppressWarnings({"unchecked"})
   private static RateLimiterConfig constructQueryRateLimiterConfig(SolrZkClient zkClient) {
     try {
+
+      if (zkClient == null) {
+        return new RateLimiterConfig(SolrRequest.SolrRequestType.QUERY);
+      }
+
       Map<String, Object> clusterPropsJson = (Map<String, Object>) Utils.fromJSON(zkClient.getData(ZkStateReader.CLUSTER_PROPS, null, new Stat(), true));
       Map<String, Object> propertiesMap = (Map<String, Object>) clusterPropsJson.get(RL_CONFIG_KEY);
       RateLimiterConfig rateLimiterConfig = new RateLimiterConfig(SolrRequest.SolrRequestType.QUERY);
@@ -64,6 +69,11 @@ public class QueryRateLimiter extends RequestRateLimiter {
   }
 
   private static void constructQueryRateLimiterConfigInternal(Map<String, Object> propertiesMap, RateLimiterConfig rateLimiterConfig) {
+
+    if (propertiesMap == null) {
+      // No Rate limiter configuration defined in clusterprops.json
+      return;
+    }
 
     if (propertiesMap.get(RateLimiterConfig.RL_ALLOWED_REQUESTS) != null) {
       rateLimiterConfig.allowedRequests = Integer.parseInt(propertiesMap.get(RateLimiterConfig.RL_ALLOWED_REQUESTS).toString());

--- a/solr/core/src/java/org/apache/solr/servlet/QueryRateLimiter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/QueryRateLimiter.java
@@ -26,11 +26,12 @@ import org.apache.solr.client.solrj.request.beans.RateLimiterMeta;
 import org.apache.solr.common.cloud.SolrZkClient;
 import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.common.util.Utils;
+import org.apache.solr.core.RateLimiterConfig;
 import org.apache.solr.util.SolrJacksonAnnotationInspector;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.Stat;
 
-import static org.apache.solr.servlet.RateLimiterConfig.RL_CONFIG_KEY;
+import static org.apache.solr.core.RateLimiterConfig.RL_CONFIG_KEY;
 
 /** Implementation of RequestRateLimiter specific to query request types. Most of the actual work is delegated
  *  to the parent class but specific configurations and parsing are handled by this class.

--- a/solr/core/src/java/org/apache/solr/servlet/QueryRateLimiter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/QueryRateLimiter.java
@@ -17,7 +17,6 @@
 
 package org.apache.solr.servlet;
 
-import javax.servlet.FilterConfig;
 import java.util.Map;
 
 import org.apache.solr.client.solrj.SolrRequest;
@@ -27,8 +26,6 @@ import org.apache.solr.common.util.Utils;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.Stat;
 
-import static org.apache.solr.servlet.RateLimitManager.DEFAULT_CONCURRENT_REQUESTS;
-import static org.apache.solr.servlet.RateLimitManager.DEFAULT_SLOT_ACQUISITION_TIMEOUT_MS;
 import static org.apache.solr.servlet.RateLimiterConfig.RL_CONFIG_KEY;
 
 /** Implementation of RequestRateLimiter specific to query request types. Most of the actual work is delegated
@@ -40,6 +37,7 @@ public class QueryRateLimiter extends RequestRateLimiter {
     super(constructQueryRateLimiterConfig(solrZkClient));
   }
 
+  @SuppressWarnings({"unchecked"})
   public void processConfigChange(Map<String, Object> properties) {
     RateLimiterConfig rateLimiterConfig = getRateLimiterConfig();
     Map<String, Object> propertiesMap = (Map<String, Object>) properties.get(RL_CONFIG_KEY);
@@ -48,6 +46,7 @@ public class QueryRateLimiter extends RequestRateLimiter {
   }
 
   // To be used in initialization
+  @SuppressWarnings({"unchecked"})
   private static RateLimiterConfig constructQueryRateLimiterConfig(SolrZkClient zkClient) {
     try {
       Map<String, Object> clusterPropsJson = (Map<String, Object>) Utils.fromJSON(zkClient.getData(ZkStateReader.CLUSTER_PROPS, null, new Stat(), true));

--- a/solr/core/src/java/org/apache/solr/servlet/QueryRateLimiter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/QueryRateLimiter.java
@@ -19,6 +19,8 @@ package org.apache.solr.servlet;
 
 import javax.servlet.FilterConfig;
 
+import java.util.Map;
+
 import org.apache.solr.client.solrj.SolrRequest;
 
 import static org.apache.solr.servlet.RateLimitManager.DEFAULT_CONCURRENT_REQUESTS;
@@ -38,8 +40,32 @@ public class QueryRateLimiter extends RequestRateLimiter {
     super(constructQueryRateLimiterConfig(filterConfig));
   }
 
-  protected static RequestRateLimiter.RateLimiterConfig constructQueryRateLimiterConfig(FilterConfig filterConfig) {
-    RequestRateLimiter.RateLimiterConfig queryRateLimiterConfig = new RequestRateLimiter.RateLimiterConfig();
+  public void processConfigChange(Map<String, Object> properties) {
+    RateLimiterConfig rateLimiterConfig = getRateLimiterConfig();
+
+    if (properties.get(RateLimiterConfig.RL_ALLOWED_REQUESTS) != null) {
+      rateLimiterConfig.allowedRequests = Integer.parseInt(properties.get(RateLimiterConfig.RL_ALLOWED_REQUESTS).toString());
+    }
+
+    if (properties.get(RateLimiterConfig.RL_ENABLED) != null) {
+      rateLimiterConfig.isEnabled = Boolean.parseBoolean(properties.get(RateLimiterConfig.RL_ENABLED).toString());
+    }
+
+    if (properties.get(RateLimiterConfig.RL_GUARANTEED_SLOTS) != null) {
+      rateLimiterConfig.guaranteedSlotsThreshold = Integer.parseInt(properties.get(RateLimiterConfig.RL_GUARANTEED_SLOTS).toString());
+    }
+
+    if (properties.get(RateLimiterConfig.RL_SLOT_BORROWING_ENABLED) != null) {
+      rateLimiterConfig.isSlotBorrowingEnabled = Boolean.parseBoolean(properties.get(RateLimiterConfig.RL_SLOT_BORROWING_ENABLED).toString());
+    }
+
+    if (properties.get(RateLimiterConfig.RL_TIME_SLOT_ACQUISITION) != null) {
+      rateLimiterConfig.waitForSlotAcquisition = Long.parseLong(properties.get(RateLimiterConfig.RL_TIME_SLOT_ACQUISITION).toString());
+    }
+  }
+
+  protected static RateLimiterConfig constructQueryRateLimiterConfig(FilterConfig filterConfig) {
+    RateLimiterConfig queryRateLimiterConfig = new RateLimiterConfig();
 
     queryRateLimiterConfig.requestType = SolrRequest.SolrRequestType.QUERY;
     queryRateLimiterConfig.isEnabled = getParamAndParseBoolean(filterConfig, IS_QUERY_RATE_LIMITER_ENABLED, false);

--- a/solr/core/src/java/org/apache/solr/servlet/QueryRateLimiter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/QueryRateLimiter.java
@@ -112,7 +112,7 @@ public class QueryRateLimiter extends RequestRateLimiter {
     }
 
     if (rateLimiterMeta.slotAcquisitionTimeoutInMS != null) {
-      rateLimiterConfig.waitForSlotAcquisition = rateLimiterMeta.slotAcquisitionTimeoutInMS;
+      rateLimiterConfig.waitForSlotAcquisition = rateLimiterMeta.slotAcquisitionTimeoutInMS.longValue();
     }
   }
 }

--- a/solr/core/src/java/org/apache/solr/servlet/RateLimitManager.java
+++ b/solr/core/src/java/org/apache/solr/servlet/RateLimitManager.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.common.annotation.SolrThreadSafe;
 import org.apache.solr.common.cloud.ClusterPropertiesListener;
+import org.apache.solr.common.cloud.SolrZkClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -178,16 +179,16 @@ public class RateLimitManager implements ClusterPropertiesListener {
   }
 
   public static class Builder {
-    protected FilterConfig config;
+    protected SolrZkClient solrZkClient;
 
-    public Builder(FilterConfig config) {
-      this.config = config;
+    public Builder(SolrZkClient solrZkClient) {
+      this.solrZkClient = solrZkClient;
     }
 
     public RateLimitManager build() {
       RateLimitManager rateLimitManager = new RateLimitManager();
 
-      rateLimitManager.registerRequestRateLimiter(new QueryRateLimiter(config), SolrRequest.SolrRequestType.QUERY);
+      rateLimitManager.registerRequestRateLimiter(new QueryRateLimiter(solrZkClient), SolrRequest.SolrRequestType.QUERY);
 
       return rateLimitManager;
     }

--- a/solr/core/src/java/org/apache/solr/servlet/RateLimitManager.java
+++ b/solr/core/src/java/org/apache/solr/servlet/RateLimitManager.java
@@ -17,7 +17,6 @@
 
 package org.apache.solr.servlet;
 
-import javax.servlet.FilterConfig;
 import javax.servlet.http.HttpServletRequest;
 import java.lang.invoke.MethodHandles;
 import java.util.HashMap;

--- a/solr/core/src/java/org/apache/solr/servlet/RateLimitManager.java
+++ b/solr/core/src/java/org/apache/solr/servlet/RateLimitManager.java
@@ -18,6 +18,7 @@
 package org.apache.solr.servlet;
 
 import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
 import java.util.Map;
@@ -64,7 +65,11 @@ public class RateLimitManager implements ClusterPropertiesListener {
     QueryRateLimiter queryRateLimiter = (QueryRateLimiter) requestRateLimiterMap.get(SolrRequest.SolrRequestType.QUERY);
 
     if (queryRateLimiter != null) {
-      queryRateLimiter.processConfigChange(properties);
+      try {
+        queryRateLimiter.processConfigChange(properties);
+      } catch (IOException e) {
+        throw new RuntimeException("Encountered IOException: " + e.getMessage());
+      }
     }
 
     return false;

--- a/solr/core/src/java/org/apache/solr/servlet/RateLimiterConfig.java
+++ b/solr/core/src/java/org/apache/solr/servlet/RateLimiterConfig.java
@@ -20,6 +20,7 @@ package org.apache.solr.servlet;
 import org.apache.solr.client.solrj.SolrRequest;
 
 import static org.apache.solr.servlet.RateLimitManager.DEFAULT_CONCURRENT_REQUESTS;
+import static org.apache.solr.servlet.RateLimitManager.DEFAULT_SLOT_ACQUISITION_TIMEOUT_MS;
 
 public class RateLimiterConfig {
   public static final String RL_CONFIG_KEY = "rate-limiters";
@@ -37,6 +38,7 @@ public class RateLimiterConfig {
     this.allowedRequests = DEFAULT_CONCURRENT_REQUESTS;
     this.isSlotBorrowingEnabled = false;
     this.guaranteedSlotsThreshold = this.allowedRequests / 2;
+    this.waitForSlotAcquisition = DEFAULT_SLOT_ACQUISITION_TIMEOUT_MS;
   }
 
   public RateLimiterConfig(SolrRequest.SolrRequestType requestType, boolean isEnabled, int guaranteedSlotsThreshold,

--- a/solr/core/src/java/org/apache/solr/servlet/RateLimiterConfig.java
+++ b/solr/core/src/java/org/apache/solr/servlet/RateLimiterConfig.java
@@ -19,6 +19,8 @@ package org.apache.solr.servlet;
 
 import org.apache.solr.client.solrj.SolrRequest;
 
+import static org.apache.solr.servlet.RateLimitManager.DEFAULT_CONCURRENT_REQUESTS;
+
 public class RateLimiterConfig {
   public static final String RL_CONFIG_KEY = "rate-limiters";
   public static final String RL_ENABLED = "rlEnabled";
@@ -34,7 +36,13 @@ public class RateLimiterConfig {
   public boolean isSlotBorrowingEnabled;
   public int guaranteedSlotsThreshold;
 
-  public RateLimiterConfig() { }
+  public RateLimiterConfig(SolrRequest.SolrRequestType requestType) {
+    this.requestType = requestType;
+    this.isEnabled = false;
+    this.allowedRequests = DEFAULT_CONCURRENT_REQUESTS;
+    this.isSlotBorrowingEnabled = false;
+    this.guaranteedSlotsThreshold = this.allowedRequests / 2;
+  }
 
   public RateLimiterConfig(SolrRequest.SolrRequestType requestType, boolean isEnabled, int guaranteedSlotsThreshold,
                            long waitForSlotAcquisition, int allowedRequests, boolean isSlotBorrowingEnabled) {

--- a/solr/core/src/java/org/apache/solr/servlet/RateLimiterConfig.java
+++ b/solr/core/src/java/org/apache/solr/servlet/RateLimiterConfig.java
@@ -20,11 +20,12 @@ package org.apache.solr.servlet;
 import org.apache.solr.client.solrj.SolrRequest;
 
 public class RateLimiterConfig {
+  public static final String RL_CONFIG_KEY = "rate-limiters";
   public static final String RL_ENABLED = "rlEnabled";
   public static final String RL_GUARANTEED_SLOTS = "rlGuaranteedSlots";
   public static final String RL_ALLOWED_REQUESTS = "rlAllowedRequests";
   public static final String RL_SLOT_BORROWING_ENABLED = "rlSlotBorrowingEnabled";
-  public static final String RL_TIME_SLOT_ACQUISITION = "rlSlotAcquisitionTimeout";
+  public static final String RL_TIME_SLOT_ACQUISITION_INMS = "rlSlotAcquisitionTimeoutInMS";
 
   public SolrRequest.SolrRequestType requestType;
   public boolean isEnabled;

--- a/solr/core/src/java/org/apache/solr/servlet/RateLimiterConfig.java
+++ b/solr/core/src/java/org/apache/solr/servlet/RateLimiterConfig.java
@@ -23,11 +23,6 @@ import static org.apache.solr.servlet.RateLimitManager.DEFAULT_CONCURRENT_REQUES
 
 public class RateLimiterConfig {
   public static final String RL_CONFIG_KEY = "rate-limiters";
-  public static final String RL_ENABLED = "rlEnabled";
-  public static final String RL_GUARANTEED_SLOTS = "rlGuaranteedSlots";
-  public static final String RL_ALLOWED_REQUESTS = "rlAllowedRequests";
-  public static final String RL_SLOT_BORROWING_ENABLED = "rlSlotBorrowingEnabled";
-  public static final String RL_TIME_SLOT_ACQUISITION_INMS = "rlSlotAcquisitionTimeoutInMS";
 
   public SolrRequest.SolrRequestType requestType;
   public boolean isEnabled;

--- a/solr/core/src/java/org/apache/solr/servlet/RateLimiterConfig.java
+++ b/solr/core/src/java/org/apache/solr/servlet/RateLimiterConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.servlet;
+
+import org.apache.solr.client.solrj.SolrRequest;
+
+public class RateLimiterConfig {
+  public static final String RL_ENABLED = "rlEnabled";
+  public static final String RL_GUARANTEED_SLOTS = "rlGuaranteedSlots";
+  public static final String RL_ALLOWED_REQUESTS = "rlAllowedRequests";
+  public static final String RL_SLOT_BORROWING_ENABLED = "rlSlotBorrowingEnabled";
+  public static final String RL_TIME_SLOT_ACQUISITION = "rlSlotAcquisitionTimeout";
+
+  public SolrRequest.SolrRequestType requestType;
+  public boolean isEnabled;
+  public long waitForSlotAcquisition;
+  public int allowedRequests;
+  public boolean isSlotBorrowingEnabled;
+  public int guaranteedSlotsThreshold;
+
+  public RateLimiterConfig() { }
+
+  public RateLimiterConfig(SolrRequest.SolrRequestType requestType, boolean isEnabled, int guaranteedSlotsThreshold,
+                           long waitForSlotAcquisition, int allowedRequests, boolean isSlotBorrowingEnabled) {
+    this.requestType = requestType;
+    this.isEnabled = isEnabled;
+    this.guaranteedSlotsThreshold = guaranteedSlotsThreshold;
+    this.waitForSlotAcquisition = waitForSlotAcquisition;
+    this.allowedRequests = allowedRequests;
+    this.isSlotBorrowingEnabled = isSlotBorrowingEnabled;
+  }
+}

--- a/solr/core/src/java/org/apache/solr/servlet/RequestRateLimiter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/RequestRateLimiter.java
@@ -21,6 +21,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.solr.common.annotation.SolrThreadSafe;
+import org.apache.solr.core.RateLimiterConfig;
 
 /**
  * Handles rate limiting for a specific request type.

--- a/solr/core/src/java/org/apache/solr/servlet/RequestRateLimiter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/RequestRateLimiter.java
@@ -17,7 +17,6 @@
 
 package org.apache.solr.servlet;
 
-import javax.servlet.FilterConfig;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
@@ -92,36 +91,6 @@ public class RequestRateLimiter {
 
   public RateLimiterConfig getRateLimiterConfig() {
     return rateLimiterConfig;
-  }
-
-  static long getParamAndParseLong(FilterConfig config, String parameterName, long defaultValue) {
-    String tempBuffer = config.getInitParameter(parameterName);
-
-    if (tempBuffer != null) {
-      return Long.parseLong(tempBuffer);
-    }
-
-    return defaultValue;
-  }
-
-  static int getParamAndParseInt(FilterConfig config, String parameterName, int defaultValue) {
-    String tempBuffer = config.getInitParameter(parameterName);
-
-    if (tempBuffer != null) {
-      return Integer.parseInt(tempBuffer);
-    }
-
-    return defaultValue;
-  }
-
-  static boolean getParamAndParseBoolean(FilterConfig config, String parameterName, boolean defaultValue) {
-    String tempBuffer = config.getInitParameter(parameterName);
-
-    if (tempBuffer != null) {
-      return Boolean.parseBoolean(tempBuffer);
-    }
-
-    return defaultValue;
   }
 
   // Represents the metadata for a slot

--- a/solr/core/src/java/org/apache/solr/servlet/RequestRateLimiter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/RequestRateLimiter.java
@@ -21,7 +21,6 @@ import javax.servlet.FilterConfig;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.common.annotation.SolrThreadSafe;
 
 /**
@@ -123,28 +122,6 @@ public class RequestRateLimiter {
     }
 
     return defaultValue;
-  }
-
-  /* Rate limiter config for a specific request rate limiter instance */
-  static class RateLimiterConfig {
-    public SolrRequest.SolrRequestType requestType;
-    public boolean isEnabled;
-    public long waitForSlotAcquisition;
-    public int allowedRequests;
-    public boolean isSlotBorrowingEnabled;
-    public int guaranteedSlotsThreshold;
-
-    public RateLimiterConfig() { }
-
-    public RateLimiterConfig(SolrRequest.SolrRequestType requestType, boolean isEnabled, int guaranteedSlotsThreshold,
-                             long waitForSlotAcquisition, int allowedRequests, boolean isSlotBorrowingEnabled) {
-      this.requestType = requestType;
-      this.isEnabled = isEnabled;
-      this.guaranteedSlotsThreshold = guaranteedSlotsThreshold;
-      this.waitForSlotAcquisition = waitForSlotAcquisition;
-      this.allowedRequests = allowedRequests;
-      this.isSlotBorrowingEnabled = isSlotBorrowingEnabled;
-    }
   }
 
   // Represents the metadata for a slot

--- a/solr/core/src/java/org/apache/solr/servlet/SolrDispatchFilter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/SolrDispatchFilter.java
@@ -187,7 +187,7 @@ public class SolrDispatchFilter extends BaseSolrFilter {
       coresInit = createCoreContainer(solrHomePath, extraProperties);
       this.httpClient = coresInit.getUpdateShardHandler().getDefaultHttpClient();
       setupJvmMetrics(coresInit);
-      RateLimitManager.Builder builder = new RateLimitManager.Builder(config);
+      RateLimitManager.Builder builder = new RateLimitManager.Builder(cores.zkClientSupplier.get());
 
       this.rateLimitManager = builder.build();
 

--- a/solr/core/src/java/org/apache/solr/servlet/SolrDispatchFilter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/SolrDispatchFilter.java
@@ -190,6 +190,9 @@ public class SolrDispatchFilter extends BaseSolrFilter {
       RateLimitManager.Builder builder = new RateLimitManager.Builder(config);
 
       this.rateLimitManager = builder.build();
+
+      cores.getZkController().zkStateReader.registerClusterPropertiesListener(this.rateLimitManager);
+
       if (log.isDebugEnabled()) {
         log.debug("user.dir={}", System.getProperty("user.dir"));
       }

--- a/solr/core/src/test/org/apache/solr/servlet/TestRequestRateLimiter.java
+++ b/solr/core/src/test/org/apache/solr/servlet/TestRequestRateLimiter.java
@@ -58,7 +58,7 @@ public class TestRequestRateLimiter extends SolrCloudTestCase {
 
     SolrDispatchFilter solrDispatchFilter = cluster.getJettySolrRunner(0).getSolrDispatchFilter();
 
-    RequestRateLimiter.RateLimiterConfig rateLimiterConfig = new RequestRateLimiter.RateLimiterConfig(SolrRequest.SolrRequestType.QUERY,
+    RateLimiterConfig rateLimiterConfig = new RateLimiterConfig(SolrRequest.SolrRequestType.QUERY,
         true, 1, DEFAULT_SLOT_ACQUISITION_TIMEOUT_MS, 5 /* allowedRequests */, true /* isSlotBorrowing */);
     // We are fine with a null FilterConfig here since we ensure that MockBuilder never invokes its parent here
     RateLimitManager.Builder builder = new MockBuilder(null /* dummy FilterConfig */, new MockRequestRateLimiter(rateLimiterConfig, 5));
@@ -91,9 +91,9 @@ public class TestRequestRateLimiter extends SolrCloudTestCase {
 
     SolrDispatchFilter solrDispatchFilter = cluster.getJettySolrRunner(0).getSolrDispatchFilter();
 
-    RequestRateLimiter.RateLimiterConfig queryRateLimiterConfig = new RequestRateLimiter.RateLimiterConfig(SolrRequest.SolrRequestType.QUERY,
+    RateLimiterConfig queryRateLimiterConfig = new RateLimiterConfig(SolrRequest.SolrRequestType.QUERY,
         true, 1, DEFAULT_SLOT_ACQUISITION_TIMEOUT_MS, 5 /* allowedRequests */, true /* isSlotBorrowing */);
-    RequestRateLimiter.RateLimiterConfig indexRateLimiterConfig = new RequestRateLimiter.RateLimiterConfig(SolrRequest.SolrRequestType.UPDATE,
+    RateLimiterConfig indexRateLimiterConfig = new RateLimiterConfig(SolrRequest.SolrRequestType.UPDATE,
         true, 1, DEFAULT_SLOT_ACQUISITION_TIMEOUT_MS, 5 /* allowedRequests */, true /* isSlotBorrowing */);
     // We are fine with a null FilterConfig here since we ensure that MockBuilder never invokes its parent
     RateLimitManager.Builder builder = new MockBuilder(null /*dummy FilterConfig */, new MockRequestRateLimiter(queryRateLimiterConfig, 5), new MockRequestRateLimiter(indexRateLimiterConfig, 5));

--- a/solr/core/src/test/org/apache/solr/servlet/TestRequestRateLimiter.java
+++ b/solr/core/src/test/org/apache/solr/servlet/TestRequestRateLimiter.java
@@ -32,6 +32,7 @@ import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.cloud.SolrCloudTestCase;
 import org.apache.solr.common.SolrInputDocument;
+import org.apache.solr.common.cloud.SolrZkClient;
 import org.apache.solr.common.util.ExecutorUtil;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -61,7 +62,7 @@ public class TestRequestRateLimiter extends SolrCloudTestCase {
     RateLimiterConfig rateLimiterConfig = new RateLimiterConfig(SolrRequest.SolrRequestType.QUERY,
         true, 1, DEFAULT_SLOT_ACQUISITION_TIMEOUT_MS, 5 /* allowedRequests */, true /* isSlotBorrowing */);
     // We are fine with a null FilterConfig here since we ensure that MockBuilder never invokes its parent here
-    RateLimitManager.Builder builder = new MockBuilder(null /* dummy FilterConfig */, new MockRequestRateLimiter(rateLimiterConfig, 5));
+    RateLimitManager.Builder builder = new MockBuilder(null /* dummy SolrZkClient */, new MockRequestRateLimiter(rateLimiterConfig, 5));
     RateLimitManager rateLimitManager = builder.build();
 
     solrDispatchFilter.replaceRateLimitManager(rateLimitManager);
@@ -96,7 +97,7 @@ public class TestRequestRateLimiter extends SolrCloudTestCase {
     RateLimiterConfig indexRateLimiterConfig = new RateLimiterConfig(SolrRequest.SolrRequestType.UPDATE,
         true, 1, DEFAULT_SLOT_ACQUISITION_TIMEOUT_MS, 5 /* allowedRequests */, true /* isSlotBorrowing */);
     // We are fine with a null FilterConfig here since we ensure that MockBuilder never invokes its parent
-    RateLimitManager.Builder builder = new MockBuilder(null /*dummy FilterConfig */, new MockRequestRateLimiter(queryRateLimiterConfig, 5), new MockRequestRateLimiter(indexRateLimiterConfig, 5));
+    RateLimitManager.Builder builder = new MockBuilder(null /*dummy SolrZkClient */, new MockRequestRateLimiter(queryRateLimiterConfig, 5), new MockRequestRateLimiter(indexRateLimiterConfig, 5));
     RateLimitManager rateLimitManager = builder.build();
 
     solrDispatchFilter.replaceRateLimitManager(rateLimitManager);
@@ -205,15 +206,15 @@ public class TestRequestRateLimiter extends SolrCloudTestCase {
     private final RequestRateLimiter queryRequestRateLimiter;
     private final RequestRateLimiter indexRequestRateLimiter;
 
-    public MockBuilder(FilterConfig config, RequestRateLimiter queryRequestRateLimiter) {
-      super(config);
+    public MockBuilder(SolrZkClient zkClient, RequestRateLimiter queryRequestRateLimiter) {
+      super(zkClient);
 
       this.queryRequestRateLimiter = queryRequestRateLimiter;
       this.indexRequestRateLimiter = null;
     }
 
-    public MockBuilder(FilterConfig config, RequestRateLimiter queryRequestRateLimiter, RequestRateLimiter indexRequestRateLimiter) {
-      super(config);
+    public MockBuilder(SolrZkClient zkClient, RequestRateLimiter queryRequestRateLimiter, RequestRateLimiter indexRequestRateLimiter) {
+      super(zkClient);
 
       this.queryRequestRateLimiter = queryRequestRateLimiter;
       this.indexRequestRateLimiter = indexRequestRateLimiter;

--- a/solr/core/src/test/org/apache/solr/servlet/TestRequestRateLimiter.java
+++ b/solr/core/src/test/org/apache/solr/servlet/TestRequestRateLimiter.java
@@ -33,6 +33,7 @@ import org.apache.solr.cloud.SolrCloudTestCase;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.cloud.SolrZkClient;
 import org.apache.solr.common.util.ExecutorUtil;
+import org.apache.solr.core.RateLimiterConfig;
 import org.junit.BeforeClass;
 import org.junit.Test;
 

--- a/solr/core/src/test/org/apache/solr/servlet/TestRequestRateLimiter.java
+++ b/solr/core/src/test/org/apache/solr/servlet/TestRequestRateLimiter.java
@@ -17,7 +17,6 @@
 
 package org.apache.solr.servlet;
 
-import javax.servlet.FilterConfig;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;

--- a/solr/solr-ref-guide/src/rate-limiters.adoc
+++ b/solr/solr-ref-guide/src/rate-limiters.adoc
@@ -34,12 +34,12 @@ resources for indexing.
 The default rate limiter is search rate limiter. Accordingly, it can be configured using the following command:
 
  curl -X POST -H 'Content-type:application/json' -d '{
-   "set-ratelimiters": {
-     "rlEnabled": "true",
-     "rlGuaranteedSlots":5,
-     "rlAllowedRequests":20,
-     "rlSlotBorrowingEnabled":true,
-     "rlSlotAcquisitionTimeoutInMS":70
+   "set-ratelimiter": {
+     "enabled": true,
+     "guaranteedSlots":5,
+     "allowedRequests":20,
+     "slotBorrowingEnabled":true,
+     "slotAcquisitionTimeoutInMS":70
    }
  }' http://localhost:8983/api/cluster
 

--- a/solr/solr-ref-guide/src/rate-limiters.adoc
+++ b/solr/solr-ref-guide/src/rate-limiters.adoc
@@ -34,7 +34,7 @@ resources for indexing.
 The default rate limiter is search rate limiter. Accordingly, it can be configured using the following command:
 
  curl -X POST -H 'Content-type:application/json' -d '{
-   "set-rate-limiters": {
+   "set-ratelimiters": {
      "rlEnabled": "true",
      "rlGuaranteedSlots":5,
      "rlAllowedRequests":20,

--- a/solr/solr-ref-guide/src/rate-limiters.adoc
+++ b/solr/solr-ref-guide/src/rate-limiters.adoc
@@ -46,12 +46,12 @@ The default rate limiter is search rate limiter. Accordingly, it can be configur
 === Enable Query Rate Limiter
 Controls enabling of query rate limiter. Default value is `false`.
 
-  "rlEnabled": "true"
+  "enabled": true
 
 === Maximum Number Of Concurrent Requests
 Allows setting maximum concurrent search requests at a given point in time. Default value is number of cores * 3.
 
- "rlAllowedRequests":20
+ "allowedRequests":20
 
 === Request Slot Allocation Wait Time
 Wait time in ms for which a request will wait for a slot to be available when all slots are full,
@@ -60,7 +60,7 @@ the unavailability of the request slots for this rate limiter is a transient phe
 is -1, indicating no wait. 0 will represent the same -- no wait. Note that higher request allocation times
 can lead to larger queue times and can potentially lead to longer wait times for queries.
 
- "rlSlotAcquisitionTimeoutInMS":70
+ "slotAcquisitionTimeoutInMS":70
 
 === Slot Borrowing Enabled
 If slot borrowing (described below) is enabled or not. Default value is false.
@@ -68,7 +68,7 @@ If slot borrowing (described below) is enabled or not. Default value is false.
 NOTE: This feature is experimental and can cause slots to be blocked if the
 borrowing request is long lived.
 
- "rlSlotBorrowingEnabled":true,
+ "slotBorrowingEnabled":true,
 
 === Guaranteed Slots
 The number of guaranteed slots that the query rate limiter will reserve irrespective
@@ -79,7 +79,7 @@ borrow slots from its quota. Default value is allowed number of concurrent reque
 NOTE: This feature is experimental and can cause slots to be blocked if the
 borrowing request is long lived.
 
- "rlGuaranteedSlots":5,
+ "guaranteedSlots":5,
 
 == Salient Points
 

--- a/solr/solr-ref-guide/src/rate-limiters.adoc
+++ b/solr/solr-ref-guide/src/rate-limiters.adoc
@@ -31,37 +31,27 @@ pronounced under high stress in production workloads. The current implementation
 resources for indexing.
 
 == Rate Limiter Configurations
-The default rate limiter is search rate limiter. Accordingly, it can be configured in `web.xml` under `initParams` for
-`SolrRequestFilter`.
+The default rate limiter is search rate limiter. Accordingly, it can be configured using the following command:
 
-[source,xml]
-----
-<filter-name>SolrRequestFilter</filter-name>
-----
+ curl -X POST -H 'Content-type:application/json' -d '{
+   "set-rate-limiters": {
+     "rlEnabled": "true",
+     "rlGuaranteedSlots":5,
+     "rlAllowedRequests":20,
+     "rlSlotBorrowingEnabled":true,
+     "rlSlotAcquisitionTimeoutInMS":70
+   }
+ }' http://localhost:8983/api/cluster
 
 === Enable Query Rate Limiter
 Controls enabling of query rate limiter. Default value is `false`.
 
-[source,xml]
-----
-<param-name>isQueryRateLimiterEnabled</param-name>
-----
-[source,xml]
-----
-<param-value>true</param-value>
-----
+  "rlEnabled": "true"
 
 === Maximum Number Of Concurrent Requests
 Allows setting maximum concurrent search requests at a given point in time. Default value is number of cores * 3.
 
-[source,xml]
-----
-<param-name>maxQueryRequests</param-name>
-----
-[source,xml]
-----
-<param-value>15</param-value>
-----
+ "rlAllowedRequests":20
 
 === Request Slot Allocation Wait Time
 Wait time in ms for which a request will wait for a slot to be available when all slots are full,
@@ -69,14 +59,8 @@ before the request is put into the wait queue. This allows requests to have a ch
 the unavailability of the request slots for this rate limiter is a transient phenomenon. Default value
 is -1, indicating no wait. 0 will represent the same -- no wait. Note that higher request allocation times
 can lead to larger queue times and can potentially lead to longer wait times for queries.
-[source,xml]
-----
-<param-name>queryWaitForSlotAllocationInMS</param-name>
-----
-[source,xml]
-----
-<param-value>100</param-value>
-----
+
+ "rlSlotAcquisitionTimeoutInMS":70
 
 === Slot Borrowing Enabled
 If slot borrowing (described below) is enabled or not. Default value is false.
@@ -84,14 +68,7 @@ If slot borrowing (described below) is enabled or not. Default value is false.
 NOTE: This feature is experimental and can cause slots to be blocked if the
 borrowing request is long lived.
 
-[source,xml]
-----
-<param-name>queryAllowSlotBorrowing</param-name>
-----
-[source,xml]
-----
-<param-value>true</param-value>
-----
+ "rlSlotBorrowingEnabled":true,
 
 === Guaranteed Slots
 The number of guaranteed slots that the query rate limiter will reserve irrespective
@@ -102,14 +79,7 @@ borrow slots from its quota. Default value is allowed number of concurrent reque
 NOTE: This feature is experimental and can cause slots to be blocked if the
 borrowing request is long lived.
 
-[source,xml]
-----
-<param-name>queryGuaranteedSlots</param-name>
-----
-[source,xml]
-----
-<param-value>200</param-value>
-----
+ "rlGuaranteedSlots":5,
 
 == Salient Points
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/beans/RateLimiterMeta.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/beans/RateLimiterMeta.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.client.solrj.request.beans;
+
+import java.util.Objects;
+
+import org.apache.solr.common.annotation.JsonProperty;
+import org.apache.solr.common.util.ReflectMapWriter;
+
+/**
+ * POJO for Rate Limiter Metadata Configuration
+ */
+public class RateLimiterMeta implements ReflectMapWriter {
+  @JsonProperty
+  public Boolean enabled;
+
+  @JsonProperty
+  public Integer guaranteedSlots;
+
+  @JsonProperty
+  public Integer allowedRequests;
+
+  @JsonProperty
+  public Boolean slotBorrowingEnabled;
+
+  @JsonProperty
+  public Long slotAcquisitionTimeoutInMS;
+
+  public RateLimiterMeta copy() {
+    RateLimiterMeta result = new RateLimiterMeta();
+
+    result.enabled = enabled;
+    result.guaranteedSlots = guaranteedSlots;
+    result.allowedRequests = allowedRequests;
+    result.slotBorrowingEnabled = slotBorrowingEnabled;
+    result.slotAcquisitionTimeoutInMS = slotAcquisitionTimeoutInMS;
+
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof RateLimiterMeta) {
+      RateLimiterMeta that = (RateLimiterMeta) obj;
+      return Objects.equals(this.enabled, that.enabled) &&
+          Objects.equals(this.guaranteedSlots, that.guaranteedSlots) &&
+          Objects.equals(this.allowedRequests, that.allowedRequests) &&
+          Objects.equals(this.slotBorrowingEnabled, that.slotBorrowingEnabled) &&
+          Objects.equals(this.slotAcquisitionTimeoutInMS, that.slotAcquisitionTimeoutInMS);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(enabled, guaranteedSlots, allowedRequests, slotBorrowingEnabled, slotAcquisitionTimeoutInMS);
+  }
+}

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/beans/RateLimiterMeta.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/beans/RateLimiterMeta.java
@@ -39,7 +39,7 @@ public class RateLimiterMeta implements ReflectMapWriter {
   public Boolean slotBorrowingEnabled;
 
   @JsonProperty
-  public Long slotAcquisitionTimeoutInMS;
+  public Integer slotAcquisitionTimeoutInMS;
 
   public RateLimiterMeta copy() {
     RateLimiterMeta result = new RateLimiterMeta();


### PR DESCRIPTION
This commit moves rate limiters configuration from web.xml to clusterprops.json and allows setting the configuration using a newly added command.