### PR TITLE
LUCENE-9539: Remove caches from SortingCodecReader

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -274,6 +274,13 @@ Documentation
 
 * LUCENE-9424: Add a performance warning to AttributeSource.captureState javadocs (Haoyu Zhai)
 
+Changes in Runtime Behavior
+---------------------
+
+* LUCENE-9539: SortingCodecReader now doesn't cache doc values fields anymore. Previously, SortingCodecReader
+  used to cache all doc values fields after they were loaded into memory. This reader should only be used
+  to sort segments after the fact using IndexWriter#addIndices. (Simon Willnauer) 
+
 
 Other
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/index/BinaryDocValuesWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/BinaryDocValuesWriter.java
@@ -113,9 +113,9 @@ class BinaryDocValuesWriter extends DocValuesWriter<BinaryDocValues> {
     if (finalLengths == null) {
       finalLengths = this.lengths.build();
     }
-    final CachedBinaryDVs sorted;
+    final BinaryDVs sorted;
     if (sortMap != null) {
-      sorted = new CachedBinaryDVs(state.segmentInfo.maxDoc(), sortMap,
+      sorted = new BinaryDVs(state.segmentInfo.maxDoc(), sortMap,
           new BufferedBinaryDocValues(finalLengths, maxLength, bytes.getDataInput(), docsWithField.iterator()));
     } else {
       sorted = null;
@@ -189,11 +189,11 @@ class BinaryDocValuesWriter extends DocValuesWriter<BinaryDocValues> {
   }
 
   static class SortingBinaryDocValues extends BinaryDocValues {
-    private final CachedBinaryDVs dvs;
+    private final BinaryDVs dvs;
     private final BytesRefBuilder spare = new BytesRefBuilder();
     private int docID = -1;
 
-    SortingBinaryDocValues(CachedBinaryDVs dvs) {
+    SortingBinaryDocValues(BinaryDVs dvs) {
       this.dvs = dvs;
     }
 
@@ -235,10 +235,10 @@ class BinaryDocValuesWriter extends DocValuesWriter<BinaryDocValues> {
     }
   }
 
-  static final class CachedBinaryDVs {
+  static final class BinaryDVs {
     final int[] offsets;
     final BytesRefArray values;
-    CachedBinaryDVs(int maxDoc, Sorter.DocMap sortMap, BinaryDocValues oldValues) throws IOException {
+    BinaryDVs(int maxDoc, Sorter.DocMap sortMap, BinaryDocValues oldValues) throws IOException {
       offsets = new int[maxDoc];
       values = new BytesRefArray(Counter.newCounter());
       int offset = 1; // 0 means no values for this document

--- a/lucene/core/src/java/org/apache/lucene/index/NormValuesWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/NormValuesWriter.java
@@ -70,7 +70,7 @@ class NormValuesWriter {
 
   public void flush(SegmentWriteState state, Sorter.DocMap sortMap, NormsConsumer normsConsumer) throws IOException {
     final PackedLongValues values = pending.build();
-    final NumericDocValuesWriter.CachedNumericDVs sorted;
+    final NumericDocValuesWriter.NumericDVs sorted;
     if (sortMap != null) {
       sorted = NumericDocValuesWriter.sortDocValues(state.segmentInfo.maxDoc(), sortMap,
           new BufferedNorms(values, docsWithField.iterator()));

--- a/lucene/core/src/java/org/apache/lucene/index/NumericDocValuesWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/NumericDocValuesWriter.java
@@ -77,7 +77,7 @@ class NumericDocValuesWriter extends DocValuesWriter<NumericDocValues> {
     return new BufferedNumericDocValues(finalValues, docsWithField.iterator());
   }
 
-  static CachedNumericDVs sortDocValues(int maxDoc, Sorter.DocMap sortMap, NumericDocValues oldDocValues) throws IOException {
+  static NumericDVs sortDocValues(int maxDoc, Sorter.DocMap sortMap, NumericDocValues oldDocValues) throws IOException {
     FixedBitSet docsWithField = new FixedBitSet(maxDoc);
     long[] values = new long[maxDoc];
     while (true) {
@@ -89,7 +89,7 @@ class NumericDocValuesWriter extends DocValuesWriter<NumericDocValues> {
       docsWithField.set(newDocID);
       values[newDocID] = oldDocValues.longValue();
     }
-    return new CachedNumericDVs(values, docsWithField);
+    return new NumericDVs(values, docsWithField);
   }
 
   @Override
@@ -97,7 +97,7 @@ class NumericDocValuesWriter extends DocValuesWriter<NumericDocValues> {
     if (finalValues == null) {
       finalValues = pending.build();
     }
-    final CachedNumericDVs sorted;
+    final NumericDVs sorted;
     if (sortMap != null) {
       NumericDocValues oldValues = new BufferedNumericDocValues(finalValues, docsWithField.iterator());
       sorted = sortDocValues(state.segmentInfo.maxDoc(), sortMap, oldValues);
@@ -169,11 +169,11 @@ class NumericDocValuesWriter extends DocValuesWriter<NumericDocValues> {
 
   static class SortingNumericDocValues extends NumericDocValues {
 
-    private final CachedNumericDVs dvs;
+    private final NumericDVs dvs;
     private int docID = -1;
     private long cost = -1;
 
-    SortingNumericDocValues(CachedNumericDVs dvs) {
+    SortingNumericDocValues(NumericDVs dvs) {
       this.dvs = dvs;
     }
 
@@ -218,11 +218,11 @@ class NumericDocValuesWriter extends DocValuesWriter<NumericDocValues> {
     }
   }
 
-  static class CachedNumericDVs {
+  static class NumericDVs {
     private final long[] values;
     private final BitSet docsWithField;
 
-    CachedNumericDVs(long[] values, BitSet docsWithField) {
+    NumericDVs(long[] values, BitSet docsWithField) {
       this.values = values;
       this.docsWithField = docsWithField;
     }

--- a/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
@@ -140,10 +140,6 @@ public final class SortingCodecReader extends FilterCodecReader {
     }
   }
 
-
-
-
-
   /** Return a sorted view of <code>reader</code> according to the order
    *  defined by <code>sort</code>. If the reader is already sorted, this
    *  method might return the reader as-is. */
@@ -313,8 +309,7 @@ public final class SortingCodecReader extends FilterCodecReader {
     return new NormsProducer() {
       @Override
       public NumericDocValues getNorms(FieldInfo field) throws IOException {
-        NumericDocValues oldNorms = delegate.getNorms(field);
-        return getNumericDocValues(oldNorms);
+        return getNumericDocValues(delegate.getNorms(field));
       }
 
       @Override
@@ -340,8 +335,7 @@ public final class SortingCodecReader extends FilterCodecReader {
     return new DocValuesProducer() {
       @Override
       public NumericDocValues getNumeric(FieldInfo field) throws IOException {
-        NumericDocValues oldNorms = delegate.getNumeric(field);
-        return getNumericDocValues(oldNorms);
+        return getNumericDocValues(delegate.getNumeric(field));
       }
 
       @Override
@@ -398,11 +392,8 @@ public final class SortingCodecReader extends FilterCodecReader {
   private NumericDocValues getNumericDocValues(NumericDocValues oldNorms) throws IOException {
     FixedBitSet docsWithField = new FixedBitSet(maxDoc());
     long[] values = new long[maxDoc()];
-    while (true) {
-      int docID = oldNorms.nextDoc();
-      if (docID == NO_MORE_DOCS) {
-        break;
-      }
+    int docID;
+    while ((docID = oldNorms.nextDoc()) != NO_MORE_DOCS) {
       int newDocID = docMap.oldToNew(docID);
       docsWithField.set(newDocID);
       values[newDocID] = oldNorms.longValue();

--- a/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
@@ -19,9 +19,7 @@ package org.apache.lucene.index;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Iterator;
-import java.util.Map;
 
 import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.codecs.FieldsProducer;
@@ -301,8 +299,6 @@ public final class SortingCodecReader extends FilterCodecReader {
     };
   }
 
-  private final Map<String, NumericDocValuesWriter.CachedNumericDVs> cachedNorms = new HashMap<>();
-
   @Override
   public NormsProducer getNormsReader() {
     final NormsProducer delegate = in.getNormsReader();
@@ -341,7 +337,7 @@ public final class SortingCodecReader extends FilterCodecReader {
       @Override
       public BinaryDocValues getBinary(FieldInfo field) throws IOException {
         final BinaryDocValues oldDocValues = delegate.getBinary(field);
-        return new BinaryDocValuesWriter.SortingBinaryDocValues(new BinaryDocValuesWriter.CachedBinaryDVs(maxDoc(), docMap, oldDocValues));
+        return new BinaryDocValuesWriter.SortingBinaryDocValues(new BinaryDocValuesWriter.BinaryDVs(maxDoc(), docMap, oldDocValues));
       }
 
       @Override
@@ -398,7 +394,7 @@ public final class SortingCodecReader extends FilterCodecReader {
       docsWithField.set(newDocID);
       values[newDocID] = oldNorms.longValue();
     }
-    return new NumericDocValuesWriter.SortingNumericDocValues(new NumericDocValuesWriter.CachedNumericDVs(values, docsWithField));
+    return new NumericDocValuesWriter.SortingNumericDocValues(new NumericDocValuesWriter.NumericDVs(values, docsWithField));
   }
 
   @Override

--- a/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
@@ -468,6 +468,7 @@ public final class SortingCodecReader extends FilterCodecReader {
     return getOrCreate(field, true, supplier);
   }
 
+  @SuppressWarnings("unchecked")
   private synchronized  <T> T getOrCreate(String field, boolean norms, IOSupplier<T> supplier) throws IOException {
     if ((field.equals(cachedField) && cacheIsNorms == norms) == false) {
       assert assertCreatedOnlyOnce(field, norms);

--- a/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
@@ -41,7 +41,7 @@ import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
  * {@link Sort}. This can be used to re-sort and index after it's been created by wrapping all
  * readers of the index with this reader and adding it to a fresh IndexWriter via
  * {@link IndexWriter#addIndexes(CodecReader...)}.
- * NOTE: This reader should only be used for merging. Pulling fields from this ready might be very costly and memory
+ * NOTE: This reader should only be used for merging. Pulling fields from this reader might be very costly and memory
  * intensive.
  *
  * @lucene.experimental

--- a/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
@@ -475,7 +475,6 @@ public final class SortingCodecReader extends FilterCodecReader {
       cachedObject = supplier.get();
       cachedField = field;
       cacheIsNorms = norms;
-
     }
     assert cachedObject != null;
     return (T) cachedObject;

--- a/lucene/core/src/test/org/apache/lucene/index/TestSortingCodecReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSortingCodecReader.java
@@ -120,6 +120,8 @@ public class TestSortingCodecReader extends LuceneTestCase {
           String s = RandomStrings.randomRealisticUnicodeOfLength(random(), 25);
           doc.add(new TextField("text_field", s, Field.Store.YES));
           doc.add(new BinaryDocValuesField("text_field", new BytesRef(s)));
+          doc.add(new TextField("another_text_field", s, Field.Store.YES));
+          doc.add(new BinaryDocValuesField("another_text_field", new BytesRef(s)));
           doc.add(new SortedNumericDocValuesField("sorted_numeric_dv", docId));
           doc.add(new SortedDocValuesField("binary_sorted_dv", new BytesRef(Integer.toString(docId))));
           doc.add(new BinaryDocValuesField("binary_dv", new BytesRef(Integer.toString(docId))));

--- a/lucene/core/src/test/org/apache/lucene/index/TestSortingCodecReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSortingCodecReader.java
@@ -115,14 +115,16 @@ public class TestSortingCodecReader extends LuceneTestCase {
         for (int i = 0; i < numDocs; i++) {
           int docId = docIds.get(i);
           Document doc = new Document();
-          doc.add(new NumericDocValuesField("foo", random().nextInt(20)));
           doc.add(new StringField("id", Integer.toString(docId), Field.Store.YES));
           doc.add(new LongPoint("id", docId));
-          doc.add(new TextField("text_field", RandomStrings.randomRealisticUnicodeOfLength(random(), 25), Field.Store.YES));
+          String s = RandomStrings.randomRealisticUnicodeOfLength(random(), 25);
+          doc.add(new TextField("text_field", s, Field.Store.YES));
+          doc.add(new BinaryDocValuesField("text_field", new BytesRef(s)));
           doc.add(new SortedNumericDocValuesField("sorted_numeric_dv", docId));
           doc.add(new SortedDocValuesField("binary_sorted_dv", new BytesRef(Integer.toString(docId))));
           doc.add(new BinaryDocValuesField("binary_dv", new BytesRef(Integer.toString(docId))));
           doc.add(new SortedSetDocValuesField("sorted_set_dv", new BytesRef(Integer.toString(docId))));
+          doc.add(new NumericDocValuesField("foo", random().nextInt(20)));
 
           FieldType ft = new FieldType(StringField.TYPE_NOT_STORED);
           ft.setStoreTermVectors(true);


### PR DESCRIPTION
SortingCodecReader keeps all docvalues in memory that are loaded from this reader.
Yet, this reader should only be used for merging which happens sequentially. This makes
caching docvalues unnecessary.
