### PR TITLE
SOLR-11167: Avoid $SOLR_STOP_WAIT use during 'bin/solr start' if $SOLR_START_WAIT is supplied.

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -160,6 +160,9 @@ New Features
 
 * SOLR-10391: ConfigSet handler now supports overrides on existing configsets. (Tomás Fernández Löbbe)
 
+* SOLR-11167: Avoid $SOLR_STOP_WAIT use during 'bin/solr start' if $SOLR_START_WAIT is supplied.
+  (Omar Abdelnabi, Christine Poerschke)
+
 Improvements
 ---------------------
 

--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -132,6 +132,9 @@ fi
 if [ -z "$SOLR_STOP_WAIT" ]; then
   SOLR_STOP_WAIT=180
 fi
+if [ -z "$SOLR_START_WAIT" ]; then
+  SOLR_START_WAIT=$SOLR_STOP_WAIT # defaulting to $SOLR_STOP_WAIT for backwards compatibility reasons
+fi
 # test that Java exists, is executable and correct version
 JAVA_VER=$("$JAVA" -version 2>&1)
 if [[ $? -ne 0 ]] ; then
@@ -2263,7 +2266,7 @@ function start_solr() {
     fi
     # no lsof on cygwin though
     if lsof -v 2>&1 | grep -q revision; then
-      echo -n "Waiting up to $SOLR_STOP_WAIT seconds to see Solr running on port $SOLR_PORT"
+      echo -n "Waiting up to $SOLR_START_WAIT seconds to see Solr running on port $SOLR_PORT"
       # Launch in a subshell to show the spinner
       (loops=0
       while true
@@ -2271,11 +2274,11 @@ function start_solr() {
         running=$(lsof -t -PniTCP:$SOLR_PORT -sTCP:LISTEN)
         if [ -z "$running" ]; then
 	  slept=$((loops * 2))
-          if [ $slept -lt $SOLR_STOP_WAIT ]; then
+          if [ $slept -lt $SOLR_START_WAIT ]; then
             sleep 2
             loops=$[$loops+1]
           else
-            echo -e "Still not seeing Solr listening on $SOLR_PORT after $SOLR_STOP_WAIT seconds!"
+            echo -e "Still not seeing Solr listening on $SOLR_PORT after $SOLR_START_WAIT seconds!"
             tail -30 "$SOLR_LOGS_DIR/solr.log"
             exit # subshell!
           fi

--- a/solr/bin/solr.in.sh
+++ b/solr/bin/solr.in.sh
@@ -22,14 +22,14 @@
 #SOLR_JAVA_HOME=""
 
 # This controls the number of seconds that the solr script will wait for
-# Solr to start.  If the start fails, the script will give up waiting and
-# display the last few lines of the logfile.
-#SOLR_START_WAIT="180"
-
-# This controls the number of seconds that the solr script will wait for
 # Solr to stop gracefully.  If the graceful stop fails, the script will
 # forcibly stop Solr.
 #SOLR_STOP_WAIT="180"
+
+# This controls the number of seconds that the solr script will wait for
+# Solr to start.  If the start fails, the script will give up waiting and
+# display the last few lines of the logfile.
+#SOLR_START_WAIT="$SOLR_STOP_WAIT"
 
 # Increase Java Heap as needed to support your indexing / query needs
 #SOLR_HEAP="512m"

--- a/solr/bin/solr.in.sh
+++ b/solr/bin/solr.in.sh
@@ -22,9 +22,13 @@
 #SOLR_JAVA_HOME=""
 
 # This controls the number of seconds that the solr script will wait for
-# Solr to stop gracefully or Solr to start.  If the graceful stop fails,
-# the script will forcibly stop Solr.  If the start fails, the script will
-# give up waiting and display the last few lines of the logfile.
+# Solr to start.  If the start fails, the script will give up waiting and
+# display the last few lines of the logfile.
+#SOLR_START_WAIT="180"
+
+# This controls the number of seconds that the solr script will wait for
+# Solr to stop gracefully.  If the graceful stop fails, the script will
+# forcibly stop Solr.
 #SOLR_STOP_WAIT="180"
 
 # Increase Java Heap as needed to support your indexing / query needs


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-11167