### PR TITLE
Move 9x upgrade notes out of changes.txt

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -8,15 +8,6 @@ https://github.com/apache/lucene-solr/blob/master/solr/solr-ref-guide/src/solr-u
 
 Consult the lucene/CHANGES.txt file for additional, low level, changes in this release.
 
-Upgrade Notes
----------------------
-* SOLR-12847: maxShardsPerNode parameter has been removed because it was broken and
-inconsistent with other replica placement strategies. Other relevant placement strategies
-should be used instead, such as autoscaling policy or rules-based placement.
-
-* SOLR-14654 : plugins cannot be loaded using "runtimeLib=true" option. Use the package manager to use
-  and load plugins
-
 New Features
 ---------------------
 * SOLR-14789: Migrate docker image creation from docker-solr repo to solr/docker. (Houston Putman, Martijn Koster, Tim Potter, David Smiley, janhoy, Mike Drob)

--- a/solr/solr-ref-guide/src/major-changes-in-solr-9.adoc
+++ b/solr/solr-ref-guide/src/major-changes-in-solr-9.adoc
@@ -128,6 +128,11 @@ _(raw; not yet edited)_
 * SOLR-14510: The `writeStartDocumentList` in `TextResponseWriter` now receives an extra boolean parameter representing the "exactness" of the numFound value (exact vs approximation).
   Any custom response writer extending `TextResponseWriter` will need to implement this abstract method now (instead previous with the same name but without the new boolean parameter).
 
+* SOLR-12847: maxShardsPerNode parameter has been removed because it was broken and inconsistent with other replica placement strategies. Other relevant placement strategies
+  should be used instead, such as autoscaling policy or rules-based placement.
+
+* SOLR-14654: plugins cannot be loaded using "runtimeLib=true" option. Use the package manager to use and load plugins
+
 === Upgrade Prerequisites in Solr 9
 
 * Upgrade all collections in stateFormat=1 to stateFormat=2 *before* upgrading to Solr 9, as Solr 9 does not support the


### PR DESCRIPTION
Upgrade notes have been moved out of changes.txt. While working on PR #1900, I found there were few entries which were still present in changes.txt (most likely added at a later time)