### PR TITLE
LUCENE-9535: Make ByteBuffersDataOutput#ramBytesUsed run in constant-time.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataOutput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataOutput.java
@@ -33,6 +33,7 @@ import java.util.function.IntFunction;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.UnicodeUtil;
 
 /**
@@ -404,7 +405,7 @@ public final class ByteBuffersDataOutput extends DataOutput implements Accountab
       return 0L;
     } else {
       // All blocks have the same capacity.
-      return first.capacity() * blocks.size();
+      return (first.capacity() + RamUsageEstimator.NUM_BYTES_OBJECT_REF) * blocks.size();
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataOutput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataOutput.java
@@ -400,8 +400,13 @@ public final class ByteBuffersDataOutput extends DataOutput implements Accountab
   public long ramBytesUsed() {
     // Return a rough estimation for allocated blocks. Note that we do not make
     // any special distinction for direct memory buffers.
-    return RamUsageEstimator.NUM_BYTES_OBJECT_REF * blocks.size() + 
-           blocks.stream().mapToLong(buf -> buf.capacity()).sum();
+    ByteBuffer first = blocks.peek();
+    if (first == null) {
+      return 0L;
+    } else {
+      // All blocks have the same capacity.
+      return first.capacity() * blocks.size();
+    }
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataOutput.java
+++ b/lucene/core/src/java/org/apache/lucene/store/ByteBuffersDataOutput.java
@@ -33,7 +33,6 @@ import java.util.function.IntFunction;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.UnicodeUtil;
 
 /**


### PR DESCRIPTION
This is called transitively from `DocumentsWriterFlushControl#doAfterDocument` which is synchronized and appears to be a point of contention.