### PR TITLE
Cleanup DWPT state handling

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterFlushControl.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterFlushControl.java
@@ -157,25 +157,18 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
   }
 
   DocumentsWriterPerThread doAfterDocument(DocumentsWriterPerThread perThread, boolean isUpdate) {
-    final long delta = perThread.getCommitLastBytesUsedDelta();
+    final long delta = perThread.commitLastBytesUsed();
     synchronized (this) {
-      // we need to commit this under lock but calculate it outside of the lock to minimize the time this lock is held
-      // per document. The reason we update this under lock is that we mark DWPTs as pending without acquiring it's
-      // lock in #setFlushPending and this also reads the committed bytes and modifies the flush/activeBytes.
-      // In the future we can clean this up to be more intuitive.
-      perThread.commitLastBytesUsed(delta);
       try {
         /*
          * We need to differentiate here if we are pending since setFlushPending
          * moves the perThread memory to the flushBytes and we could be set to
          * pending during a delete
          */
-        if (perThread.isFlushPending()) {
-          flushBytes += delta;
-          assert updatePeaks(delta);
-        } else {
-          activeBytes += delta;
-          assert updatePeaks(delta);
+        activeBytes += delta;
+        assert updatePeaks(delta);
+        if (perThread.isFlushPending() == false) {
+          assert perThread.getState() == DocumentsWriterPerThread.State.ACTIVE : "expected ACTIVE state but was: " + perThread.getState();
           if (isUpdate) {
             flushPolicy.onUpdate(this, perThread);
           } else {
@@ -235,7 +228,8 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
     assert flushingWriters.contains(dwpt);
     try {
       flushingWriters.remove(dwpt);
-      flushBytes -= dwpt.getLastCommittedBytesUsed();
+      dwpt.transitionTo(DocumentsWriterPerThread.State.FLUSHED);
+      flushBytes -= dwpt.ramBytesUsed();
       assert assertMemory();
     } finally {
       try {
@@ -295,27 +289,39 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
    * {@link DocumentsWriterPerThread} must have indexed at least on Document and must not be
    * already pending.
    */
-  public synchronized void setFlushPending(DocumentsWriterPerThread perThread) {
-    assert !perThread.isFlushPending();
+  synchronized void setFlushPending(DocumentsWriterPerThread perThread) {
+    assert !perThread.isFlushPending() : "state: " + perThread.getState();
     if (perThread.getNumDocsInRAM() > 0) {
-      perThread.setFlushPending(); // write access synced
-      final long bytes = perThread.getLastCommittedBytesUsed();
-      flushBytes += bytes;
-      activeBytes -= bytes;
+      perThread.transitionTo(DocumentsWriterPerThread.State.FLUSH_PENDING); // write access synced
       numPending++; // write access synced
-      assert assertMemory();
     } // don't assert on numDocs since we could hit an abort excp. while selecting that dwpt for flushing
-    
+  }
+
+  private void moveToFlushing(DocumentsWriterPerThread perThread) {
+    perThread.transitionTo(DocumentsWriterPerThread.State.FLUSHING);
+    final long bytes = perThread.ramBytesUsed();
+    flushBytes += bytes;
+    activeBytes -= bytes;
+    assert assertMemory();
   }
   
   synchronized void doOnAbort(DocumentsWriterPerThread perThread) {
     try {
       assert perThreadPool.isRegistered(perThread);
       assert perThread.isHeldByCurrentThread();
-      if (perThread.isFlushPending()) {
-        flushBytes -= perThread.getLastCommittedBytesUsed();
-      } else {
-        activeBytes -= perThread.getLastCommittedBytesUsed();
+      switch (perThread.getState()) {
+        case ACTIVE:
+        case FLUSH_PENDING:
+          activeBytes -= perThread.ramBytesUsed();
+          break;
+        case FLUSHING:
+          flushBytes -= perThread.ramBytesUsed();
+          break;
+        case FLUSHED:
+          assert false : "flushed writers must not be aborted";
+          break;
+        default:
+          throw new IllegalStateException("Unexpected value: " + perThread.getState());
       }
       assert assertMemory();
       // Take it out of the loop this DWPT is stale
@@ -335,6 +341,7 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
     assert perThread.isHeldByCurrentThread();
     assert perThread.isFlushPending() : "can not block non-pending threadstate";
     assert fullFlush : "can not block if fullFlush == false";
+    moveToFlushing(perThread);
     numPending--; // write access synced
     blockedFlushes.add(perThread);
     boolean checkedOut = perThreadPool.checkout(perThread);
@@ -347,6 +354,7 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
     assert perThread.isHeldByCurrentThread();
     assert perThreadPool.isRegistered(perThread);
     try {
+        moveToFlushing(perThread);
         addFlushingDWPT(perThread);
         numPending--; // write access synced
         boolean checkedOut = perThreadPool.checkout(perThread);
@@ -359,6 +367,7 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
 
   private void addFlushingDWPT(DocumentsWriterPerThread perThread) {
     assert flushingWriters.contains(perThread) == false : "DWPT is already flushing";
+    assert perThread.getState() == DocumentsWriterPerThread.State.FLUSHING;
     // Record the flushing DWPT to reduce flushBytes in doAfterFlush
     flushingWriters.add(perThread);
   }
@@ -676,7 +685,7 @@ final class DocumentsWriterFlushControl implements Accountable, Closeable {
     int count = 0;
     for (DocumentsWriterPerThread next : perThreadPool) {
       if (next.isFlushPending() == false && next.getNumDocsInRAM() > 0) {
-        final long nextRam = next.getLastCommittedBytesUsed();
+        final long nextRam = next.ramBytesUsed();
         if (infoStream.isEnabled("FP")) {
           infoStream.message("FP", "thread state has " + nextRam + " bytes; docInRAM=" + next.getNumDocsInRAM());
         }

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
@@ -2933,7 +2933,7 @@ public class TestIndexWriter extends LuceneTestCase {
     int numRamDocs = w.numRamDocs();
     int numDocsInDWPT = largestNonPendingWriter.getNumDocsInRAM();
     assertTrue(w.flushNextBuffer());
-    assertTrue(largestNonPendingWriter.hasFlushed());
+    assertEquals(DocumentsWriterPerThread.State.FLUSHED, largestNonPendingWriter.getState());
     assertEquals(numRamDocs-numDocsInDWPT, w.numRamDocs());
 
     // make sure it's not locked
@@ -2982,8 +2982,7 @@ public class TestIndexWriter extends LuceneTestCase {
     indexDocsForMultipleDWPTs(w);
     DocumentsWriterPerThread largestNonPendingWriter
         = w.docWriter.flushControl.findLargestNonPendingWriter();
-    assertFalse(largestNonPendingWriter.isFlushPending());
-    assertFalse(largestNonPendingWriter.hasFlushed());
+    assertEquals(DocumentsWriterPerThread.State.ACTIVE, largestNonPendingWriter.getState());
     int threadPoolSize = w.docWriter.perThreadPool.size();
     w.docWriter.flushControl.markForFullFlush();
     DocumentsWriterPerThread documentsWriterPerThread = w.docWriter.flushControl.checkoutLargestNonPendingWriter();
@@ -3002,8 +3001,7 @@ public class TestIndexWriter extends LuceneTestCase {
     int numDocs = indexDocsForMultipleDWPTs(w);
     DocumentsWriterPerThread largestNonPendingWriter
         = w.docWriter.flushControl.findLargestNonPendingWriter();
-    assertFalse(largestNonPendingWriter.isFlushPending());
-    assertFalse(largestNonPendingWriter.hasFlushed());
+    assertEquals(DocumentsWriterPerThread.State.ACTIVE, largestNonPendingWriter.getState());
 
     CountDownLatch wait = new CountDownLatch(1);
     CountDownLatch locked = new CountDownLatch(1);
@@ -3036,7 +3034,7 @@ public class TestIndexWriter extends LuceneTestCase {
     lockThread.join();
     flushThread.join();
 
-    assertTrue("largest DWPT should be flushed", largestNonPendingWriter.hasFlushed());
+    assertEquals("largest DWPT should be flushed", DocumentsWriterPerThread.State.FLUSHED, largestNonPendingWriter.getState());
     // make sure it's not locked
     largestNonPendingWriter.lock();
     largestNonPendingWriter.unlock();


### PR DESCRIPTION
DWPT currently has no real notion of a state but it's lifecycle really
requires such a notion. We move DWPTs from active to flush pending to flushing
and execute certain actions like RAM accounting based on these states. To simplify
the transitions and the concurrency involved in it, it makes sense to formalize the
transitions and if it can happen under lock or not.