### PR TITLE
Reuse crypto keys in reference impl

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -362,15 +362,13 @@ public class CoreContainer implements Closeable {
     solrMetricsContext = new SolrMetricsContext(metricManager, registryName, metricTag);
     try (ParWork work = new ParWork(this)) {
 
-      if (Boolean.getBoolean("solr.enablePublicKeyHandler")) {
-        work.collect("", () -> {
-          try {
-            containerHandlers.put(PublicKeyHandler.PATH, new PublicKeyHandler(cfg.getCloudConfig()));
-          } catch (IOException | InvalidKeySpecException e) {
-            throw new RuntimeException("Bad PublicKeyHandler configuration.", e);
-          }
-        });
-      }
+      work.collect("", () -> {
+        try {
+          containerHandlers.put(PublicKeyHandler.PATH, new PublicKeyHandler(cfg.getCloudConfig()));
+        } catch (IOException | InvalidKeySpecException e) {
+          throw new RuntimeException("Bad PublicKeyHandler configuration.", e);
+        }
+      });
 
       work.collect("",() -> {
         updateShardHandler = new UpdateShardHandler(cfg.getUpdateShardHandlerConfig());
@@ -744,11 +742,9 @@ public class CoreContainer implements Closeable {
         hostName = cfg.getNodeName();
 
         if (isZooKeeperAware()) {
-          if (!Boolean.getBoolean("solr.disablePublicKeyHandler")) {
-            pkiAuthenticationPlugin = new PKIAuthenticationPlugin(this, zkSys.getZkController().getNodeName(), (PublicKeyHandler) containerHandlers.get(PublicKeyHandler.PATH));
-            // use deprecated API for back-compat, remove in 9.0
-            pkiAuthenticationPlugin.initializeMetrics(solrMetricsContext, "/authentication/pki");
-          }
+          pkiAuthenticationPlugin = new PKIAuthenticationPlugin(this, zkSys.getZkController().getNodeName(), (PublicKeyHandler) containerHandlers.get(PublicKeyHandler.PATH));
+          // use deprecated API for back-compat, remove in 9.0
+          pkiAuthenticationPlugin.initializeMetrics(solrMetricsContext, "/authentication/pki");
           TracerConfigurator.loadTracer(loader, cfg.getTracerConfiguratorPluginInfo(), getZkController().getZkStateReader());
           packageLoader = new PackageLoader(this);
           containerHandlers.getApiBag().registerObject(packageLoader.getPackageAPI().editAPI);

--- a/solr/core/src/java/org/apache/solr/security/PublicKeyHandler.java
+++ b/solr/core/src/java/org/apache/solr/security/PublicKeyHandler.java
@@ -32,11 +32,13 @@ import java.security.spec.InvalidKeySpecException;
 public class PublicKeyHandler extends RequestHandlerBase {
   public static final String PATH = "/admin/info/key";
 
+  //This is an optimization for tests only
+  public static volatile CryptoKeys.RSAKeyPair REUSABLE_KEYPAIR ;
   final CryptoKeys.RSAKeyPair keyPair;
 
   @VisibleForTesting
-  public PublicKeyHandler() {
-    keyPair = new CryptoKeys.RSAKeyPair();
+  public PublicKeyHandler() throws IOException, InvalidKeySpecException {
+    keyPair = createKeyPair(null);
   }
 
   public PublicKeyHandler(CloudConfig config) throws IOException, InvalidKeySpecException {
@@ -44,6 +46,8 @@ public class PublicKeyHandler extends RequestHandlerBase {
   }
 
   private CryptoKeys.RSAKeyPair createKeyPair(CloudConfig config) throws IOException, InvalidKeySpecException {
+    CryptoKeys.RSAKeyPair reused = REUSABLE_KEYPAIR;
+    if(reused != null) return reused;
     if (config == null) {
       return new CryptoKeys.RSAKeyPair();
     }

--- a/solr/core/src/test/org/apache/solr/cloud/TestCryptoKeys.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestCryptoKeys.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
 import java.util.Map;
 
 import org.apache.solr.client.solrj.impl.Http2SolrClient;
-import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.common.LinkedHashMapWriter;
 import org.apache.solr.common.cloud.SolrZkClient;
 import org.apache.solr.common.util.Utils;
@@ -51,13 +50,13 @@ public class TestCryptoKeys extends AbstractFullDistribZkTestBase {
 
   @BeforeClass
   public static void setupCluster() throws Exception {
-    System.setProperty("solr.disablePublicKeyHandler", "false");
+    disableReuseOfCryptoKeys();
   }
 
   @Test
   public void test() throws Exception {
     System.setProperty("enable.runtime.lib", "true");
-    System.setProperty("solr.disablePublicKeyHandler", "true");
+    disableReuseOfCryptoKeys();
     setupRestTestHarnesses();
     String pk1sig = "G8LEW7uJ1is81Aqqfl3Sld3qDtOxPuVFeTLJHFJWecgDvUkmJNFXmf7nkHOVlXnDWahp1vqZf0W02VHXg37lBw==";
     String pk2sig = "pCyBQycB/0YvLVZfKLDIIqG1tFwM/awqzkp2QNpO7R3ThTqmmrj11wEJFDRLkY79efuFuQPHt40EE7jrOKoj9jLNELsfEqvU3jw9sZKiDONY+rV9Bj9QPeW8Pgt+F9Y1";

--- a/solr/core/src/test/org/apache/solr/cloud/TestSolrCloudWithDelegationTokens.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestSolrCloudWithDelegationTokens.java
@@ -68,7 +68,7 @@ public class TestSolrCloudWithDelegationTokens extends SolrTestCaseJ4 {
 
   @BeforeClass
   public static void startup() throws Exception {
-    System.setProperty("solr.disablePublicKeyHandler", "false");
+    disableReuseOfCryptoKeys();
     System.setProperty("authenticationPlugin", HttpParamDelegationTokenPlugin.class.getName());
     System.setProperty(KerberosPlugin.DELEGATION_TOKEN_ENABLED, "true");
     System.setProperty("solr.kerberos.cookie.domain", "127.0.0.1");

--- a/solr/core/src/test/org/apache/solr/security/BasicAuthIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/security/BasicAuthIntegrationTest.java
@@ -27,7 +27,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 import com.codahale.metrics.MetricRegistry;
 import org.apache.commons.io.IOUtils;
@@ -43,7 +42,6 @@ import org.apache.solr.client.solrj.embedded.JettySolrRunner;
 import org.apache.solr.client.solrj.impl.BaseHttpSolrClient;
 import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.client.solrj.impl.HttpClientUtil;
-import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.request.GenericSolrRequest;
 import org.apache.solr.client.solrj.request.QueryRequest;
@@ -83,7 +81,7 @@ public class BasicAuthIntegrationTest extends SolrCloudAuthTestCase {
 
   @Before
   public void setupCluster() throws Exception {
-    System.setProperty("solr.disablePublicKeyHandler", "false");
+    disableReuseOfCryptoKeys();
     System.setProperty("solr.disableDefaultJmxReporter", "false");
     useFactory(null);
     configureCluster(3)

--- a/solr/core/src/test/org/apache/solr/security/JWTAuthPluginIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/security/JWTAuthPluginIntegrationTest.java
@@ -82,7 +82,7 @@ public class JWTAuthPluginIntegrationTest extends SolrCloudAuthTestCase {
 
   @BeforeClass
   public static void beforeClass() throws Exception {
-    System.setProperty("solr.disablePublicKeyHandler", "false");
+    disableReuseOfCryptoKeys();
   }
 
   @Override

--- a/solr/core/src/test/org/apache/solr/security/JWTAuthPluginTest.java
+++ b/solr/core/src/test/org/apache/solr/security/JWTAuthPluginTest.java
@@ -82,7 +82,7 @@ public class JWTAuthPluginTest extends SolrTestCaseJ4 {
 
   @BeforeClass
   public static void beforeAll() throws Exception {
-    System.setProperty("solr.disablePublicKeyHandler", "false");
+    disableReuseOfCryptoKeys();
     JwtClaims claims = generateClaims();
     JsonWebSignature jws = new JsonWebSignature();
     jws.setPayload(claims.toJson());

--- a/solr/core/src/test/org/apache/solr/security/PKIAuthenticationIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/security/PKIAuthenticationIntegrationTest.java
@@ -47,7 +47,7 @@ public class PKIAuthenticationIntegrationTest extends SolrCloudAuthTestCase {
   
   @BeforeClass
   public static void setupCluster() throws Exception {
-    System.setProperty("solr.disablePublicKeyHandler", "false");
+    disableReuseOfCryptoKeys();
     final String SECURITY_CONF = Utils.toJSONString
       (makeMap("authorization", singletonMap("class", MockAuthorizationPlugin.class.getName()),
                "authentication", singletonMap("class", MockAuthenticationPlugin.class.getName())));

--- a/solr/core/src/test/org/apache/solr/security/TestAuthorizationFramework.java
+++ b/solr/core/src/test/org/apache/solr/security/TestAuthorizationFramework.java
@@ -21,14 +21,12 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.util.EntityUtils;
 import org.apache.lucene.util.LuceneTestCase;
-import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.client.solrj.impl.HttpClientUtil;
 import org.apache.solr.cloud.AbstractFullDistribZkTestBase;
 import org.apache.solr.common.cloud.ZkStateReader;
@@ -49,7 +47,7 @@ public class TestAuthorizationFramework extends AbstractFullDistribZkTestBase {
 
   @BeforeClass
   public static void beforeTestAuthorizationFramework() throws Exception {
-    System.setProperty("solr.disablePublicKeyHandler", "false");
+    disableReuseOfCryptoKeys();
   }
 
   static final int TIMEOUT = 10000;

--- a/solr/core/src/test/org/apache/solr/security/TestPKIAuthenticationPlugin.java
+++ b/solr/core/src/test/org/apache/solr/security/TestPKIAuthenticationPlugin.java
@@ -19,8 +19,10 @@ package org.apache.solr.security;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
 import java.security.Principal;
 import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
@@ -49,7 +51,7 @@ public class TestPKIAuthenticationPlugin extends SolrTestCaseJ4 {
 
     Map<String, PublicKey> remoteKeys = new ConcurrentHashMap<>();
 
-    public MockPKIAuthenticationPlugin(CoreContainer cores, String node) {
+    public MockPKIAuthenticationPlugin(CoreContainer cores, String node) throws IOException, InvalidKeySpecException {
       super(cores, node, new PublicKeyHandler());
     }
 

--- a/solr/core/src/test/org/apache/solr/security/hadoop/TestDelegationWithHadoopAuth.java
+++ b/solr/core/src/test/org/apache/solr/security/hadoop/TestDelegationWithHadoopAuth.java
@@ -21,12 +21,9 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
-import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 import org.apache.hadoop.security.authentication.client.PseudoAuthenticator;
 import org.apache.hadoop.util.Time;
 import org.apache.http.HttpStatus;
-import org.apache.lucene.util.QuickPatchThreadsFilter;
-import org.apache.solr.SolrIgnoredThreadsFilter;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.embedded.JettySolrRunner;
@@ -58,7 +55,7 @@ public class TestDelegationWithHadoopAuth extends SolrCloudTestCase {
 
   @BeforeClass
   public static void setupClass() throws Exception {
-    System.setProperty("solr.disablePublicKeyHandler", "false");
+    disableReuseOfCryptoKeys();
     HdfsTestUtil.checkAssumptions();
 
     configureCluster(NUM_SERVERS)// nodes

--- a/solr/core/src/test/org/apache/solr/security/hadoop/TestImpersonationWithHadoopAuth.java
+++ b/solr/core/src/test/org/apache/solr/security/hadoop/TestImpersonationWithHadoopAuth.java
@@ -55,7 +55,7 @@ public class TestImpersonationWithHadoopAuth  extends SolrCloudTestCase {
   @BeforeClass
   public static void setupClass() throws Exception {
     System.setProperty("solr.disableDefaultJmxReporter", "false");
-    System.setProperty("solr.disablePublicKeyHandler", "false");
+    disableReuseOfCryptoKeys();
     HdfsTestUtil.checkAssumptions();
 
     InetAddress loopback = InetAddress.getLoopbackAddress();

--- a/solr/core/src/test/org/apache/solr/security/hadoop/TestSolrCloudWithHadoopAuthPlugin.java
+++ b/solr/core/src/test/org/apache/solr/security/hadoop/TestSolrCloudWithHadoopAuthPlugin.java
@@ -22,10 +22,8 @@ import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.FileUtils;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.impl.CloudHttp2SolrClient;
-import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.client.solrj.response.QueryResponse;
-import org.apache.solr.cloud.AbstractDistribZkTestBase;
 import org.apache.solr.cloud.KerberosTestServices;
 import org.apache.solr.cloud.SolrCloudAuthTestCase;
 import org.apache.solr.cloud.hdfs.HdfsTestUtil;
@@ -44,7 +42,7 @@ public class TestSolrCloudWithHadoopAuthPlugin extends SolrCloudAuthTestCase {
   @BeforeClass
   public static void setupClass() throws Exception {
     System.setProperty("solr.disableDefaultJmxReporter", "false");
-    System.setProperty("solr.disablePublicKeyHandler", "false");
+    disableReuseOfCryptoKeys();
     HdfsTestUtil.checkAssumptions();
 
     setupMiniKdc();

--- a/solr/test-framework/src/java/org/apache/solr/SolrTestCase.java
+++ b/solr/test-framework/src/java/org/apache/solr/SolrTestCase.java
@@ -59,7 +59,9 @@ import org.apache.solr.common.util.ExecutorUtil;
 import org.apache.solr.common.util.ObjectReleaseTracker;
 import org.apache.solr.common.util.SolrQueuedThreadPool;
 import org.apache.solr.common.util.SysStats;
+import org.apache.solr.security.PublicKeyHandler;
 import org.apache.solr.servlet.SolrDispatchFilter;
+import org.apache.solr.util.CryptoKeys;
 import org.apache.solr.util.ExternalPaths;
 import org.apache.solr.util.RandomizeSSL;
 import org.apache.solr.util.RevertDefaultThreadHandlerRule;
@@ -123,6 +125,17 @@ public class SolrTestCase extends LuceneTestCase {
   private static volatile boolean failed = false;
 
   protected volatile static PerThreadExecService testExecutor;
+
+  private static final CryptoKeys.RSAKeyPair reusedKeys = new CryptoKeys.RSAKeyPair();
+
+  public static void enableReuseOfCryptoKeys() {
+    PublicKeyHandler.REUSABLE_KEYPAIR = reusedKeys;
+  }
+
+  public static void disableReuseOfCryptoKeys() {
+    PublicKeyHandler.REUSABLE_KEYPAIR = null;
+  }
+
 
   @Rule
   public TestRule solrTestRules =
@@ -225,7 +238,7 @@ public class SolrTestCase extends LuceneTestCase {
     System.setProperty("solr.clustering.enabled", "false");
     System.setProperty("solr.peerSync.useRangeVersions", String.valueOf(random().nextBoolean()));
     System.setProperty("zookeeper.nio.directBufferBytes", Integer.toString(32 * 1024 * 2));
-    System.setProperty("solr.disablePublicKeyHandler", "true");
+    enableReuseOfCryptoKeys();
 
     if (!TEST_NIGHTLY) {
       //TestInjection.randomDelayMaxInCoreCreationInSec = 2;
@@ -279,7 +292,6 @@ public class SolrTestCase extends LuceneTestCase {
       System.setProperty("solr.http2solrclient.maxpool.size", "12");
       System.setProperty("solr.http2solrclient.pool.keepalive", "1500");
 
-      System.setProperty("solr.disablePublicKeyHandler", "false");
       System.setProperty("solr.dependentupdate.timeout", "1500");
 
      // System.setProperty("lucene.cms.override_core_count", "3");

--- a/solr/test-framework/src/java/org/apache/solr/cloud/SolrCloudAuthTestCase.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/SolrCloudAuthTestCase.java
@@ -40,11 +40,12 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.message.AbstractHttpMessage;
 import org.apache.http.message.BasicHeader;
-import org.apache.http.util.EntityUtils;
 import org.apache.solr.client.solrj.embedded.JettySolrRunner;
 import org.apache.solr.common.util.Base64;
 import org.apache.solr.common.util.StrUtils;
 import org.apache.solr.common.util.Utils;
+import org.apache.solr.security.PublicKeyHandler;
+import org.apache.solr.util.CryptoKeys;
 import org.apache.solr.util.TimeOut;
 import org.jose4j.jws.JsonWebSignature;
 import org.jose4j.lang.JoseException;
@@ -74,7 +75,7 @@ public class SolrCloudAuthTestCase extends SolrCloudTestCase {
 
   @BeforeClass
   public static void beforeSolrCloudAuthTestCase() {
-    System.setProperty("solr.disablePublicKeyHandler", "false");
+   enableReuseOfCryptoKeys();
   }
   /**
    * Used to check metric counts for PKI auth


### PR DESCRIPTION
The key pair generation is expensive and instead of disabling public key handler We should just reuse a single key pair in the entire test suite. 