### PR TITLE
LUCENE-9541 ConjunctionDISI sub-iterators check

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/ConjunctionDISI.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ConjunctionDISI.java
@@ -147,7 +147,7 @@ public final class ConjunctionDISI extends DocIdSetIterator {
     boolean iteratorsOnTheSameDoc = allIterators.stream().allMatch(it -> it.docID() == curDoc);
     iteratorsOnTheSameDoc = iteratorsOnTheSameDoc && twoPhaseIterators.stream().allMatch(it -> it.approximation().docID() == curDoc);
     if (iteratorsOnTheSameDoc == false) {
-      throw new IllegalArgumentException("Sub-iterators of ConjunctionDISI are not the same document!");
+      throw new IllegalArgumentException("Sub-iterators of ConjunctionDISI are not on the same document!");
     }
 
     long minCost = allIterators.stream().mapToLong(DocIdSetIterator::cost).min().getAsLong();
@@ -238,7 +238,7 @@ public final class ConjunctionDISI extends DocIdSetIterator {
 
   @Override
   public int advance(int target) throws IOException {
-    assert assertItersOnSameDoc() : "Sub-iterators of ConjunctionDISI are not the same document!";
+    assert assertItersOnSameDoc() : "Sub-iterators of ConjunctionDISI are not one the same document!";
     return doNext(lead1.advance(target));
   }
 
@@ -249,7 +249,7 @@ public final class ConjunctionDISI extends DocIdSetIterator {
 
   @Override
   public int nextDoc() throws IOException {
-    assert assertItersOnSameDoc() : "Sub-iterators of ConjunctionDISI are not the same document!";
+    assert assertItersOnSameDoc() : "Sub-iterators of ConjunctionDISI are not on the same document!";
     return doNext(lead1.nextDoc());
   }
 
@@ -300,13 +300,13 @@ public final class ConjunctionDISI extends DocIdSetIterator {
 
     @Override
     public int nextDoc() throws IOException {
-      assert assertItersOnSameDoc() : "Sub-iterators of ConjunctionDISI are not the same document!";
+      assert assertItersOnSameDoc() : "Sub-iterators of ConjunctionDISI are not on the same document!";
       return doNext(lead.nextDoc());
     }
 
     @Override
     public int advance(int target) throws IOException {
-      assert assertItersOnSameDoc() : "Sub-iterators of ConjunctionDISI are not the same document!";
+      assert assertItersOnSameDoc() : "Sub-iterators of ConjunctionDISI are not on the same document!";
       return doNext(lead.advance(target));
     }
 

--- a/lucene/core/src/test/org/apache/lucene/search/TestConjunctionDISI.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestConjunctionDISI.java
@@ -393,6 +393,7 @@ public class TestConjunctionDISI extends LuceneTestCase {
   }
 
   public void testIllegalAdvancementOfSubIteratorsTripsAssertion() throws IOException {
+    assumeTrue("Assertions must be enabled for this test!", LuceneTestCase.assertsAreEnabled);
     int maxDoc = 100;
     final int numIterators = TestUtil.nextInt(random(), 2, 5);
     FixedBitSet set = randomSet(maxDoc);
@@ -405,6 +406,6 @@ public class TestConjunctionDISI extends LuceneTestCase {
     int idx = TestUtil.nextInt(random() , 0, iterators.length-1);
     iterators[idx].nextDoc(); // illegally advancing one of the sub-iterators outside of the conjunction iterator
     AssertionError ex = expectThrows(AssertionError.class, () -> conjunction.nextDoc());
-    assertEquals(ex.getMessage(), "Sub-iterators of ConjunctionDISI are not the same document!");
+    assertEquals("Sub-iterators of ConjunctionDISI are not on the same document!", ex.getMessage());
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestConjunctionDISI.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestConjunctionDISI.java
@@ -41,7 +41,7 @@ public class TestConjunctionDISI extends LuceneTestCase {
     return new TwoPhaseIterator(approximation) {
 
       @Override
-      public boolean matches() throws IOException {
+      public boolean matches() {
         return confirmed.get(approximation.docID());
       }
 
@@ -390,5 +390,21 @@ public class TestConjunctionDISI extends LuceneTestCase {
 
   public void testCollapseSubConjunctionScorers() throws IOException {
     testCollapseSubConjunctions(true);
+  }
+
+  public void testIllegalAdvancementOfSubIteratorsTripsAssertion() throws IOException {
+    int maxDoc = 100;
+    final int numIterators = TestUtil.nextInt(random(), 2, 5);
+    FixedBitSet set = randomSet(maxDoc);
+
+    DocIdSetIterator[] iterators = new DocIdSetIterator[numIterators];
+    for (int i = 0; i < iterators.length; ++i) {
+      iterators[i] = new BitDocIdSet(set).iterator();
+    }
+    final DocIdSetIterator conjunction = ConjunctionDISI.intersectIterators(Arrays.asList(iterators));
+    int idx = TestUtil.nextInt(random() , 0, iterators.length-1);
+    iterators[idx].nextDoc(); // illegally advancing one of the sub-iterators outside of the conjunction iterator
+    AssertionError ex = expectThrows(AssertionError.class, () -> conjunction.nextDoc());
+    assertEquals(ex.getMessage(), "Sub-iterators of ConjunctionDISI are not the same document!");
   }
 }


### PR DESCRIPTION
Ensure sub-iterators of a conjunction iterator don't advance outside
of it.
Add assertions for checking that all sub-iterators are always on the
same document.