### PR TITLE
SOLR-14910: Use in-line tags for logger declarations in Gradle ValidateLogCalls that are non-standard, change //logok to //nowarn

### DIFF
--- a/gradle/validation/validate-log-calls.gradle
+++ b/gradle/validation/validate-log-calls.gradle
@@ -67,7 +67,7 @@ class ValidateLogCallsTask extends DefaultTask {
     boolean violation = false
 
     // If the line has been explicitly OK'd, then it's OK!
-    if (line.replaceAll("\\s", "").toLowerCase().contains("//logok")) {
+    if (line.replaceAll("\\s", "").toLowerCase().contains("//nowarn")) {
       return
     }
     // Strip all of the comments, things in quotes and the like.
@@ -133,7 +133,7 @@ class ValidateLogCallsTask extends DefaultTask {
     }
 
     // Always report toString(). Note, this over-reports some constructs
-    // but just add //logOK if it's really OK.
+    // but just add //nowarn if it's really OK.
     if (violation == false) {
       if (line.contains("toString(") == true && prevLineNotIf) {
         cause = "Line contains toString"
@@ -151,27 +151,13 @@ class ValidateLogCallsTask extends DefaultTask {
     return
   }
 
-// Require all our logger definitions lower case "log", except a couple of special ones.
+// Require all our logger definitions lower case "log", except if they have //nowarn
   def checkLogName(File file, String line) {
     // It's many times faster to do check this way than use a regex
     if (line.contains("static ") && line.contains("getLogger") && line.contains(" log ") == false) {
-      String name = file.name
-      if (name.equals("LoggerFactory.java")) {
+      if (line.replaceAll("\\s", "").toLowerCase().contains("//nowarn")) {
         return
       }
-      if (name.equals("SolrCore.java") && (line.contains("requestLog") || line.contains("slowLog"))) {
-        return
-      }
-      if (name.equals("StartupLoggingUtils.java") && line.contains("getLoggerImplStr")) {
-        return
-      }
-      // Apparently the Hadoop code expectes upper-case LOG, so...
-
-      if ((name.equals("HttpServer2.java") || name.equals("BlockPoolSlice.java") || name.equals("FileUtil.java"))
-        && line.contains(" LOG ")) {
-        return
-      }
-
       reportViolation("Change the logger name to lower-case 'log' in " + file.name + " " + line + " project" + project)
     }
   }

--- a/help/validateLogCalls.txt
+++ b/help/validateLogCalls.txt
@@ -60,7 +60,7 @@ NOTES:
   simple concatenation. This last is something of a style check.
 
 - You can get into some pretty convolued consructs trying to pass some of these
-  checks. Adding //logok, with or without spaces will cause the line to pass
+  checks. Adding //nowarn, with or without spaces will cause the line to pass
   no matter what. Please use this hack sparingly and be conscientious about
   surrounding with 'if (log.is*Enabled)'.
 

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/StrategyTestCase.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/StrategyTestCase.java
@@ -67,7 +67,7 @@ public abstract class StrategyTestCase extends SpatialTestCase {
   protected boolean storeShape = true;
 
   protected void executeQueries(SpatialMatchConcern concern, String... testQueryFile) throws IOException {
-    log.info("testing queried for strategy "+strategy); // logOk
+    log.info("testing queried for strategy "+strategy); // nowarn
     for( String path : testQueryFile ) {
       Iterator<SpatialTestQuery> testQueryIterator = getTestQueries(path, ctx);
       runTestQueries(testQueryIterator, concern);

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/prefix/HeatmapFacetCounterTest.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/prefix/HeatmapFacetCounterTest.java
@@ -67,7 +67,7 @@ public class HeatmapFacetCounterTest extends StrategyTestCase {
 
   @After
   public void after() {
-    log.info("Validated " + cellsValidated + " cells, " + cellValidatedNonZero + " non-zero"); // logOK
+    log.info("Validated " + cellsValidated + " cells, " + cellValidatedNonZero + " non-zero"); // nowarn
   }
 
   @Test

--- a/lucene/spatial-extras/src/test/org/apache/lucene/spatial/prefix/RandomSpatialOpFuzzyPrefixTreeTest.java
+++ b/lucene/spatial-extras/src/test/org/apache/lucene/spatial/prefix/RandomSpatialOpFuzzyPrefixTreeTest.java
@@ -87,7 +87,7 @@ public class RandomSpatialOpFuzzyPrefixTreeTest extends StrategyTestCase {
       ((PrefixTreeStrategy) strategy).setPointsOnly(true);
     }
 
-    log.info("Strategy: " +  strategy.toString()); // logOk
+    log.info("Strategy: " +  strategy.toString()); // nowarn
   }
 
   private void setupCtx2D(SpatialContext ctx) {

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -126,6 +126,9 @@ Other Changes
 
 * SOLR-14036: Remove distrib=false from /terms handler's default parameters (David Smiley, Munendra S N)
 
+* SOLR-14910: Use in-line tags for logger declarations in Gradle ValidateLogCalls that are non-standard,
+              change //logok to //nowarn (Erick Erickson)
+
 Bug Fixes
 ---------------------
 * SOLR-14546: Fix for a relatively hard to hit issue in OverseerTaskProcessor that could lead to out of order execution

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -126,9 +126,6 @@ Other Changes
 
 * SOLR-14036: Remove distrib=false from /terms handler's default parameters (David Smiley, Munendra S N)
 
-* SOLR-14910: Use in-line tags for logger declarations in Gradle ValidateLogCalls that are non-standard,
-              change //logok to //nowarn (Erick Erickson)
-
 Bug Fixes
 ---------------------
 * SOLR-14546: Fix for a relatively hard to hit issue in OverseerTaskProcessor that could lead to out of order execution
@@ -296,6 +293,9 @@ Other Changes
 
 * SOLR-12987: Deprecated plugins/features are now logged once and with log category org.apache.solr.DEPRECATED
   (David Smiley)
+
+* SOLR-14910: Use in-line tags for logger declarations in Gradle ValidateLogCalls that are non-standard,
+              change //logok to //nowarn (Erick Erickson)
 
 ==================  8.6.2 ==================
 

--- a/solr/contrib/clustering/src/java/org/apache/solr/handler/clustering/carrot2/CarrotClusteringEngine.java
+++ b/solr/contrib/clustering/src/java/org/apache/solr/handler/clustering/carrot2/CarrotClusteringEngine.java
@@ -163,7 +163,7 @@ public class CarrotClusteringEngine extends SearchClusteringEngine {
       if (attributeXmls.length > 0) {
         if (attributeXmls.length > 1) {
           log.warn("More than one attribute file found, first one will be used: {}"
-              , Arrays.toString(attributeXmls)); // logOk
+              , Arrays.toString(attributeXmls)); // nowarn
         }
 
         withContextClassLoader(core.getResourceLoader().getClassLoader(), () -> {

--- a/solr/contrib/extraction/src/java/org/apache/solr/handler/extraction/ExtractingDocumentLoader.java
+++ b/solr/contrib/extraction/src/java/org/apache/solr/handler/extraction/ExtractingDocumentLoader.java
@@ -230,7 +230,7 @@ public class ExtractingDocumentLoader extends ContentStreamLoader {
         } catch (TikaException e) {
           if(ignoreTikaException)
             log.warn(new StringBuilder("skip extracting text due to ").append(e.getLocalizedMessage())
-                .append(". metadata=").append(metadata.toString()).toString()); // logOk
+                .append(". metadata=").append(metadata.toString()).toString()); // nowarn
           else
             throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, e);
         }

--- a/solr/contrib/prometheus-exporter/src/java/org/apache/solr/prometheus/collector/SchedulerMetricsCollector.java
+++ b/solr/contrib/prometheus-exporter/src/java/org/apache/solr/prometheus/collector/SchedulerMetricsCollector.java
@@ -93,7 +93,7 @@ public class SchedulerMetricsCollector implements Closeable {
         try {
           metricSamples.addAll(future.get());
         } catch (ExecutionException e) {
-          log.error("Error occurred during metrics collection", e.getCause());//logok
+          log.error("Error occurred during metrics collection", e.getCause());//nowarn
           // continue any ways; do not fail
         }
       }

--- a/solr/core/src/java/org/apache/solr/cloud/ActiveReplicaWatcher.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ActiveReplicaWatcher.java
@@ -119,11 +119,11 @@ public class ActiveReplicaWatcher implements CollectionStateWatcher {
       log.debug("-- onStateChanged@{}: replicaIds={}, solrCoreNames={} {}\ncollectionState {}"
           , Long.toHexString(hashCode()), replicaIds, solrCoreNames
           , (latch != null ? "\nlatch count=" + latch.getCount() : "")
-          , collectionState); // logOk
+          , collectionState); // nowarn
     }
     if (collectionState == null) { // collection has been deleted - don't wait
       if (log.isDebugEnabled()) {
-        log.debug("-- collection deleted, decrementing latch by {} ", replicaIds.size() + solrCoreNames.size()); // logOk
+        log.debug("-- collection deleted, decrementing latch by {} ", replicaIds.size() + solrCoreNames.size()); // nowarn
       }
       if (latch != null) {
         for (int i = 0; i < replicaIds.size() + solrCoreNames.size(); i++) {

--- a/solr/core/src/java/org/apache/solr/cloud/CloudUtil.java
+++ b/solr/core/src/java/org/apache/solr/cloud/CloudUtil.java
@@ -93,7 +93,7 @@ public class CloudUtil {
             }
             log.error("{}",
                 new SolrException(ErrorCode.SERVER_ERROR, "Will not load SolrCore " + desc.getName()
-                    + " because it has been replaced due to failover.")); // logOk
+                    + " because it has been replaced due to failover.")); // nowarn
             throw new SolrException(ErrorCode.SERVER_ERROR,
                 "Will not load SolrCore " + desc.getName()
                     + " because it has been replaced due to failover.");

--- a/solr/core/src/java/org/apache/solr/cloud/OverseerTaskProcessor.java
+++ b/solr/core/src/java/org/apache/solr/cloud/OverseerTaskProcessor.java
@@ -632,9 +632,9 @@ public class OverseerTaskProcessor implements Runnable, Closeable {
   private void printTrackingMaps() {
     if (log.isDebugEnabled()) {
       log.debug("RunningTasks: {}", runningTasks);
-      log.debug("BlockedTasks: {}", blockedTasks.keySet()); // logOk
-      log.debug("CompletedTasks: {}", completedTasks.keySet()); // logOk
-      log.debug("RunningZKTasks: {}", runningZKTasks); // logOk
+      log.debug("BlockedTasks: {}", blockedTasks.keySet()); // nowarn
+      log.debug("CompletedTasks: {}", completedTasks.keySet()); // nowarn
+      log.debug("RunningZKTasks: {}", runningZKTasks); // nowarn
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -189,8 +189,8 @@ public final class SolrCore implements SolrInfoBean, Closeable {
   public static final String version = "1.0";
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-  private static final Logger requestLog = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass().getName() + ".Request");
-  private static final Logger slowLog = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass().getName() + ".SlowRequest");
+  private static final Logger requestLog = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass().getName() + ".Request"); //nowarn
+  private static final Logger slowLog = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass().getName() + ".SlowRequest"); //nowarn
 
   private String name;
   private String logid; // used to show what name is set

--- a/solr/core/src/java/org/apache/solr/handler/IndexFetcher.java
+++ b/solr/core/src/java/org/apache/solr/handler/IndexFetcher.java
@@ -437,7 +437,7 @@ public class IndexFetcher {
 
       if (log.isInfoEnabled()) {
         log.info("Follower's generation: {}", commit.getGeneration());
-        log.info("Follower's version: {}", IndexDeletionPolicyWrapper.getCommitTimestamp(commit)); // logOK
+        log.info("Follower's version: {}", IndexDeletionPolicyWrapper.getCommitTimestamp(commit)); // nowarn
       }
 
       if (latestVersion == 0L) {
@@ -1249,7 +1249,7 @@ public class IndexFetcher {
       try {
         if (log.isInfoEnabled()) {
           log.info("From dir files: {}", Arrays.asList(tmpIdxDir.listAll()));
-          log.info("To dir files: {}", Arrays.asList(indexDir.listAll())); //logOk
+          log.info("To dir files: {}", Arrays.asList(indexDir.listAll())); //nowarn
         }
       } catch (IOException e) {
         throw new RuntimeException(e);

--- a/solr/core/src/java/org/apache/solr/handler/ReplicationHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/ReplicationHandler.java
@@ -1606,7 +1606,7 @@ public class ReplicationHandler extends RequestHandlerBase implements SolrCoreAw
           }
           fos.write(buf, 0, read);
           fos.flush();
-          log.debug("Wrote {} bytes for file {}", offset + read, fileName); // logOK
+          log.debug("Wrote {} bytes for file {}", offset + read, fileName); // nowarn
 
           //Pause if necessary
           maxBytesBeforePause += read;

--- a/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
@@ -1349,7 +1349,7 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
           success = true;
           break;
         }
-        log.warn("Force leader attempt {}. Waiting 5 secs for an active leader. State of the slice: {}", (i + 1), slice); //logok
+        log.warn("Force leader attempt {}. Waiting 5 secs for an active leader. State of the slice: {}", (i + 1), slice); //nowarn
       }
 
       if (success) {

--- a/solr/core/src/java/org/apache/solr/handler/admin/PrepRecoveryOp.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/PrepRecoveryOp.java
@@ -135,7 +135,7 @@ class PrepRecoveryOp implements CoreAdminHandler.CoreAdminOp {
                       ", live=" + live + ", checkLive=" + checkLive + ", currentState=" + state
                       + ", localState=" + localState + ", nodeName=" + nodeName +
                       ", coreNodeName=" + coreNodeName + ", onlyIfActiveCheckResult=" + onlyIfActiveCheckResult
-                      + ", nodeProps: " + replica); //LOGOK
+                      + ", nodeProps: " + replica); //nowarn
             }
             if (!onlyIfActiveCheckResult && replica != null && (state == waitForState || leaderDoesNotNeedRecovery)) {
               if (checkLive == null) {

--- a/solr/core/src/java/org/apache/solr/security/HadoopAuthPlugin.java
+++ b/solr/core/src/java/org/apache/solr/security/HadoopAuthPlugin.java
@@ -233,7 +233,7 @@ public class HadoopAuthPlugin extends AuthenticationPlugin {
       log.info("----------HTTP Request---------");
       if (log.isInfoEnabled()) {
         log.info("{} : {}", request.getMethod(), request.getRequestURI());
-        log.info("Query : {}", request.getQueryString()); // logOk
+        log.info("Query : {}", request.getQueryString()); // nowarn
       }
       log.info("Headers :");
       Enumeration<String> headers = request.getHeaderNames();

--- a/solr/core/src/java/org/apache/solr/servlet/HttpSolrCall.java
+++ b/solr/core/src/java/org/apache/solr/servlet/HttpSolrCall.java
@@ -493,7 +493,7 @@ public class HttpSolrCall {
     }
     if (statusCode == AuthorizationResponse.FORBIDDEN.statusCode) {
       if (log.isDebugEnabled()) {
-        log.debug("UNAUTHORIZED auth header {} context : {}, msg: {}", req.getHeader("Authorization"), context, authResponse.getMessage()); // logOk
+        log.debug("UNAUTHORIZED auth header {} context : {}, msg: {}", req.getHeader("Authorization"), context, authResponse.getMessage()); // nowarn
       }
       sendError(statusCode,
           "Unauthorized request, Response code: " + statusCode);
@@ -503,7 +503,7 @@ public class HttpSolrCall {
       return RETURN;
     }
     if (!(statusCode == HttpStatus.SC_ACCEPTED) && !(statusCode == HttpStatus.SC_OK)) {
-      log.warn("ERROR {} during authentication: {}", statusCode, authResponse.getMessage()); // logOk
+      log.warn("ERROR {} during authentication: {}", statusCode, authResponse.getMessage()); // nowarn
       sendError(statusCode,
           "ERROR during authorization, Response code: " + statusCode);
       if (shouldAudit(EventType.ERROR)) {

--- a/solr/core/src/java/org/apache/solr/spelling/SpellCheckCollator.java
+++ b/solr/core/src/java/org/apache/solr/spelling/SpellCheckCollator.java
@@ -184,7 +184,7 @@ public class SpellCheckCollator {
         collations.add(collation);
       }
       if (log.isDebugEnabled()) {
-        log.debug("Collation: {} {}", collationQueryStr, (verifyCandidateWithQuery ? (" will return " + hits + " hits.") : "")); // logOk
+        log.debug("Collation: {} {}", collationQueryStr, (verifyCandidateWithQuery ? (" will return " + hits + " hits.") : "")); // nowarn
       }
     }
     return collations;

--- a/solr/core/src/java/org/apache/solr/update/SolrIndexSplitter.java
+++ b/solr/core/src/java/org/apache/solr/update/SolrIndexSplitter.java
@@ -312,7 +312,7 @@ public class SolrIndexSplitter {
           for (int segmentNumber = 0; segmentNumber<leaves.size(); segmentNumber++) {
             if (log.isInfoEnabled()) {
               log.info("SolrIndexSplitter: partition # {} partitionCount={} {} segment #={} segmentCount={}", partitionNumber, numPieces
-                  , (ranges != null ? " range=" + ranges.get(partitionNumber) : ""), segmentNumber, leaves.size()); // logOk
+                  , (ranges != null ? " range=" + ranges.get(partitionNumber) : ""), segmentNumber, leaves.size()); // nowarn
             }
             CodecReader subReader = SlowCodecReaderWrapper.wrap(leaves.get(segmentNumber).reader());
             iw.addIndexes(new LiveDocsReader(subReader, segmentDocSets.get(segmentNumber)[partitionNumber]));

--- a/solr/core/src/java/org/apache/solr/util/StartupLoggingUtils.java
+++ b/solr/core/src/java/org/apache/solr/util/StartupLoggingUtils.java
@@ -53,7 +53,7 @@ public final class StartupLoggingUtils {
     }
   }
 
-  public static String getLoggerImplStr() {
+  public static String getLoggerImplStr() { //nowarn
     return binder.getLoggerFactoryClassStr();
   }
 

--- a/solr/core/src/test/org/apache/hadoop/fs/FileUtil.java
+++ b/solr/core/src/test/org/apache/hadoop/fs/FileUtil.java
@@ -76,7 +76,8 @@ import org.slf4j.LoggerFactory;
 public class FileUtil {
   public static final Object SOLR_HACK_FOR_CLASS_VERIFICATION = new Object();
 
-  private static final Logger LOG = LoggerFactory.getLogger(FileUtil.class);
+  // Apparently the Hadoop code expectes upper-case LOG, so...
+  private static final Logger LOG = LoggerFactory.getLogger(FileUtil.class); //nowarn
 
   /* The error code is defined in winutils to indicate insufficient
    * privilege to create symbolic links. This value need to keep in

--- a/solr/core/src/test/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/BlockPoolSlice.java
+++ b/solr/core/src/test/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/BlockPoolSlice.java
@@ -81,7 +81,8 @@ import com.google.common.annotations.VisibleForTesting;
 public class BlockPoolSlice {
   public static final Object SOLR_HACK_FOR_CLASS_VERIFICATION = new Object();
 
-  static final Logger LOG = LoggerFactory.getLogger(BlockPoolSlice.class);
+  // Apparently the Hadoop code expectes upper-case LOG, so...
+  static final Logger LOG = LoggerFactory.getLogger(BlockPoolSlice.class); //nowarn
 
   private final String bpid;
   private final FsVolumeImpl volume; // volume to which this BlockPool belongs to

--- a/solr/core/src/test/org/apache/hadoop/http/HttpServer2.java
+++ b/solr/core/src/test/org/apache/hadoop/http/HttpServer2.java
@@ -118,7 +118,8 @@ import org.slf4j.LoggerFactory;
 public final class HttpServer2 implements FilterContainer {
   public static final Object SOLR_HACK_FOR_CLASS_VERIFICATION = new Object();
 
-  public static final Logger LOG = LoggerFactory.getLogger(HttpServer2.class);
+  // Apparently the Hadoop code expectes upper-case LOG, so...
+  public static final Logger LOG = LoggerFactory.getLogger(HttpServer2.class); //nowarn
 
   public static final String HTTP_SCHEME = "http";
   public static final String HTTPS_SCHEME = "https";

--- a/solr/core/src/test/org/apache/solr/cloud/ChaosMonkeySafeLeaderWithPullReplicasTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ChaosMonkeySafeLeaderWithPullReplicasTest.java
@@ -206,7 +206,7 @@ public class ChaosMonkeySafeLeaderWithPullReplicasTest extends AbstractFullDistr
 
     if (log.isInfoEnabled()) {
       log.info("control docs:{}\n\n", controlClient.query(new SolrQuery("*:*")).getResults().getNumFound());
-      log.info("collection state: {}", printClusterStateInfo(DEFAULT_COLLECTION)); // logOk
+      log.info("collection state: {}", printClusterStateInfo(DEFAULT_COLLECTION)); // nowarn
     }
     
     waitForReplicationFromReplicas(DEFAULT_COLLECTION, cloudClient.getZkStateReader(), new TimeOut(30, TimeUnit.SECONDS, TimeSource.NANO_TIME));

--- a/solr/core/src/test/org/apache/solr/cloud/OverseerRolesTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/OverseerRolesTest.java
@@ -99,7 +99,7 @@ public class OverseerRolesTest extends SolrCloudTestCase {
   private void logOverseerState() throws KeeperException, InterruptedException {
     if (log.isInfoEnabled()) {
       log.info("Overseer: {}", getLeaderNode(zkClient()));
-      log.info("Election queue: {}", getSortedElectionNodes(zkClient(), "/overseer_elect/election")); // logOk
+      log.info("Election queue: {}", getSortedElectionNodes(zkClient(), "/overseer_elect/election")); // nowarn
     }
   }
 

--- a/solr/core/src/test/org/apache/solr/cloud/OverseerTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/OverseerTest.java
@@ -1171,14 +1171,14 @@ public class OverseerTest extends SolrTestCaseJ4 {
     Snapshot snapshot = timer.getSnapshot();
     if (log.isInfoEnabled()) {
       log.info("\t avgRequestsPerSecond: {}", timer.getMeanRate());
-      log.info("\t 5minRateRequestsPerSecond: {}", timer.getFiveMinuteRate()); // logOk
-      log.info("\t 15minRateRequestsPerSecond: {}", timer.getFifteenMinuteRate()); // logOk
-      log.info("\t avgTimePerRequest: {}", nsToMs(snapshot.getMean())); // logOk
-      log.info("\t medianRequestTime: {}", nsToMs(snapshot.getMedian())); // logOk
-      log.info("\t 75thPcRequestTime: {}", nsToMs(snapshot.get75thPercentile())); // logOk
-      log.info("\t 95thPcRequestTime: {}", nsToMs(snapshot.get95thPercentile())); // logOk
-      log.info("\t 99thPcRequestTime: {}", nsToMs(snapshot.get99thPercentile())); // logOk
-      log.info("\t 999thPcRequestTime: {}", nsToMs(snapshot.get999thPercentile())); // logOk
+      log.info("\t 5minRateRequestsPerSecond: {}", timer.getFiveMinuteRate()); // nowarn
+      log.info("\t 15minRateRequestsPerSecond: {}", timer.getFifteenMinuteRate()); // nowarn
+      log.info("\t avgTimePerRequest: {}", nsToMs(snapshot.getMean())); // nowarn
+      log.info("\t medianRequestTime: {}", nsToMs(snapshot.getMedian())); // nowarn
+      log.info("\t 75thPcRequestTime: {}", nsToMs(snapshot.get75thPercentile())); // nowarn
+      log.info("\t 95thPcRequestTime: {}", nsToMs(snapshot.get95thPercentile())); // nowarn
+      log.info("\t 99thPcRequestTime: {}", nsToMs(snapshot.get99thPercentile())); // nowarn
+      log.info("\t 999thPcRequestTime: {}", nsToMs(snapshot.get999thPercentile())); // nowarn
     }
   }
 

--- a/solr/core/src/test/org/apache/solr/cloud/RollingRestartTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/RollingRestartTest.java
@@ -83,7 +83,7 @@ public class RollingRestartTest extends AbstractFullDistribZkTestBase {
     boolean sawLiveDesignate = false;
     int numRestarts = 1 + random().nextInt(TEST_NIGHTLY ? 12 : 2);
     for (int i = 0; i < numRestarts; i++) {
-      log.info("Rolling restart #{}", i + 1); // logOk
+      log.info("Rolling restart #{}", i + 1); // nowarn
       for (CloudJettyRunner cloudJetty : designateJettys) {
         log.info("Restarting {}", cloudJetty);
         chaosMonkey.stopJetty(cloudJetty);

--- a/solr/core/src/test/org/apache/solr/handler/TestReplicationHandler.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestReplicationHandler.java
@@ -752,7 +752,7 @@ public class TestReplicationHandler extends SolrTestCaseJ4 {
           break;
         } catch (NumberFormatException | AssertionError notYet) {
           if (log.isInfoEnabled()) {
-            log.info("{}th attempt failure on {} details are {}", retries + 1, notYet, followerDetails); // logOk
+            log.info("{}th attempt failure on {} details are {}", retries + 1, notYet, followerDetails); // nowarn
           }
           if (retries>9) {
             log.error("giving up: ", notYet);

--- a/solr/core/src/test/org/apache/solr/security/BasicAuthIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/security/BasicAuthIntegrationTest.java
@@ -265,7 +265,7 @@ public class BasicAuthIntegrationTest extends SolrCloudAuthTestCase {
         assertTrue(obj.containsKey("memory"));
       } catch (Exception e) {
         log.error("RunExampleTool failed due to: {}; stdout from tool prior to failure: {}"
-            , e, baos.toString(StandardCharsets.UTF_8.name())); // logOk
+            , e, baos.toString(StandardCharsets.UTF_8.name())); // nowarn
       }
 
       SolrParams params = new MapSolrParams(Collections.singletonMap("q", "*:*"));

--- a/solr/core/src/test/org/apache/solr/update/TestInPlaceUpdatesDistrib.java
+++ b/solr/core/src/test/org/apache/solr/update/TestInPlaceUpdatesDistrib.java
@@ -943,7 +943,7 @@ public class TestInPlaceUpdatesDistrib extends AbstractFullDistribZkTestBase {
 
     if (log.isInfoEnabled()) {
       log.info("Non leader 0: {}", ((HttpSolrClient) NONLEADERS.get(0)).getBaseURL());
-      log.info("Non leader 1: {}", ((HttpSolrClient) NONLEADERS.get(1)).getBaseURL()); // logOk
+      log.info("Non leader 1: {}", ((HttpSolrClient) NONLEADERS.get(1)).getBaseURL()); // nowarn
     }
     
     SolrDocument doc0 = NONLEADERS.get(0).getById(String.valueOf(0), params("distrib", "false"));
@@ -1034,7 +1034,7 @@ public class TestInPlaceUpdatesDistrib extends AbstractFullDistribZkTestBase {
       if (log.isInfoEnabled()) {
         log.info("Testing client (Fetch missing test): {}", ((HttpSolrClient) client).getBaseURL());
         log.info("Version at {} is: {}"
-            , ((HttpSolrClient) client).getBaseURL(), getReplicaValue(client, 1, "_version_")); // logOk
+            , ((HttpSolrClient) client).getBaseURL(), getReplicaValue(client, 1, "_version_")); // nowarn
       }
       assertReplicaValue(client, 1, "inplace_updatable_float", (newinplace_updatable_float + 2.0f),
           "inplace_updatable_float didn't match for replica at client: " + ((HttpSolrClient) client).getBaseURL());
@@ -1344,7 +1344,7 @@ public class TestInPlaceUpdatesDistrib extends AbstractFullDistribZkTestBase {
       if (log.isInfoEnabled()) {
         log.info("Testing client (testDBQUsingUpdatedFieldFromDroppedUpdate): {}", ((HttpSolrClient) client).getBaseURL());
         log.info("Version at {} is: {}", ((HttpSolrClient) client).getBaseURL(),
-            getReplicaValue(client, 1, "_version_")); // logOk
+            getReplicaValue(client, 1, "_version_")); // nowarn
       }
       assertNull(client.getById("1", params("distrib", "false")));
     }

--- a/solr/core/src/test/org/apache/solr/update/processor/CategoryRoutedAliasUpdateProcessorTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/CategoryRoutedAliasUpdateProcessorTest.java
@@ -76,7 +76,7 @@ public class CategoryRoutedAliasUpdateProcessorTest extends RoutedAliasUpdatePro
     //log this to help debug potential causes of problems
     if (log.isInfoEnabled()) {
       log.info("SolrClient: {}", solrClient);
-      log.info("ClusterStateProvider {}", solrClient.getClusterStateProvider()); // logOk
+      log.info("ClusterStateProvider {}", solrClient.getClusterStateProvider()); // nowarn
     }
   }
 

--- a/solr/core/src/test/org/apache/solr/update/processor/DimensionalRoutedAliasUpdateProcessorTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/DimensionalRoutedAliasUpdateProcessorTest.java
@@ -74,7 +74,7 @@ public class DimensionalRoutedAliasUpdateProcessorTest extends RoutedAliasUpdate
     //log this to help debug potential causes of problems
     if (log.isInfoEnabled()) {
       log.info("SolrClient: {}", solrClient);
-      log.info("ClusterStateProvider {}", solrClient.getClusterStateProvider()); // logOk
+      log.info("ClusterStateProvider {}", solrClient.getClusterStateProvider()); // nowarn
     }
   }
 

--- a/solr/core/src/test/org/apache/solr/update/processor/TimeRoutedAliasUpdateProcessorTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/TimeRoutedAliasUpdateProcessorTest.java
@@ -91,7 +91,7 @@ public class TimeRoutedAliasUpdateProcessorTest extends RoutedAliasUpdateProcess
     //log this to help debug potential causes of problems
     if (log.isInfoEnabled()) {
       log.info("SolrClient: {}", solrClient);
-      log.info("ClusterStateProvider {}", solrClient.getClusterStateProvider()); // logOk
+      log.info("ClusterStateProvider {}", solrClient.getClusterStateProvider()); // nowarn
     }
   }
 

--- a/solr/core/src/test/org/apache/solr/util/TestSolrCLIRunExample.java
+++ b/solr/core/src/test/org/apache/solr/util/TestSolrCLIRunExample.java
@@ -359,7 +359,7 @@ public class TestSolrCLIRunExample extends SolrTestCaseJ4 {
         assertEquals("it should be ok "+tool+" "+Arrays.toString(toolArgs),0, status);
       } catch (Exception e) {
         log.error("RunExampleTool failed due to: {}; stdout from tool prior to failure: {}"
-            , e , baos.toString(StandardCharsets.UTF_8.name())); // logOk
+            , e , baos.toString(StandardCharsets.UTF_8.name())); // nowarn
         throw e;
       }
   

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/NodesSysPropsCacher.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/NodesSysPropsCacher.java
@@ -154,10 +154,10 @@ public class NodesSysPropsCacher implements SolrCloseable {
           Thread.sleep(backOffTime);
         } catch (InterruptedException e1) {
           Thread.currentThread().interrupt();
-          log.info("Exception on caching node:{} system.properties:{}, retry {}/{}", node, tags, i+1, NUM_RETRY, e); // logOk
+          log.info("Exception on caching node:{} system.properties:{}, retry {}/{}", node, tags, i+1, NUM_RETRY, e); // nowarn
           break;
         }
-        log.info("Exception on caching node:{} system.properties:{}, retry {}/{}", node, tags, i+1, NUM_RETRY, e); // logOk
+        log.info("Exception on caching node:{} system.properties:{}, retry {}/{}", node, tags, i+1, NUM_RETRY, e); // nowarn
       }
     }
   }

--- a/solr/solrj/src/java/org/apache/solr/common/util/Utils.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/Utils.java
@@ -800,7 +800,7 @@ public class Utils {
     int statusCode = rsp.getStatusLine().getStatusCode();
     if (statusCode != 200) {
       try {
-        log.error("Failed a request to: {}, status: {}, body: {}", url, rsp.getStatusLine(), EntityUtils.toString(rsp.getEntity(), StandardCharsets.UTF_8)); // logOk
+        log.error("Failed a request to: {}, status: {}, body: {}", url, rsp.getStatusLine(), EntityUtils.toString(rsp.getEntity(), StandardCharsets.UTF_8)); // nowarn
       } catch (IOException e) {
         log.error("could not print error", e);
       }

--- a/solr/test-framework/src/java/org/apache/solr/cloud/AbstractFullDistribZkTestBase.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/AbstractFullDistribZkTestBase.java
@@ -431,7 +431,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
         if (useTlogReplicas()) {
           if (log.isInfoEnabled()) {
             log.info("create jetty {} in directory {} of type {} in shard {}"
-                , i, jettyDir, Replica.Type.TLOG, ((currentI % sliceCount) + 1)); // logOk
+                , i, jettyDir, Replica.Type.TLOG, ((currentI % sliceCount) + 1)); // nowarn
           }
           customThreadPool.submit(() -> {
             try {
@@ -463,7 +463,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
         } else {
           if (log.isInfoEnabled()) {
             log.info("create jetty {} in directory {} of type {} for shard{}"
-                , i, jettyDir, Replica.Type.NRT, ((currentI % sliceCount) + 1)); // logOk
+                , i, jettyDir, Replica.Type.NRT, ((currentI % sliceCount) + 1)); // nowarn
           }
           
           customThreadPool.submit(() -> {
@@ -492,7 +492,7 @@ public abstract class AbstractFullDistribZkTestBase extends AbstractDistribZkTes
           addedReplicas++;
         }
       } else {
-        log.info("create jetty {} in directory {} of type {} for shard{}", i, jettyDir, Replica.Type.PULL, ((currentI % sliceCount) + 1)); // logOk
+        log.info("create jetty {} in directory {} of type {} for shard{}", i, jettyDir, Replica.Type.PULL, ((currentI % sliceCount) + 1)); // nowarn
         customThreadPool.submit(() -> {
           try {
             JettySolrRunner j = createJetty(jettyDir, useJettyDataDir ? getDataDir(testDir + "/jetty"


### PR DESCRIPTION
Most of this is just changing //logok to //nowarn. 

The substantive changes are in validate-log-calls.gradle, taking out the special handling for several files and _not_ producing failures if there's a //nowarn on the line instead, plus adding a few //nowarn tags in the files that were handled specially.