### PR TITLE
LUCENE-9555: Advance conjuction Iterator for two phase iteration

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -142,9 +142,6 @@ Improvements
 
 Bug fixes
 
-* LUCENE-9555: For sort optimization, create conjunction between scorerIterator
-  and collectorIterator only if scorerIterator has not been advanced yet. (Mayya Sharipova)
-
 * LUCENE-8663: NRTCachingDirectory.slowFileExists may open a file while 
   it's inaccessible. (Dawid Weiss)
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -142,6 +142,9 @@ Improvements
 
 Bug fixes
 
+* LUCENE-9555: For sort optimization, create conjunction between scorerIterator
+  and collectorIterator only if scorerIterator has not been advanced yet. (Mayya Sharipova)
+
 * LUCENE-8663: NRTCachingDirectory.slowFileExists may open a file while 
   it's inaccessible. (Dawid Weiss)
 

--- a/lucene/core/src/java/org/apache/lucene/search/Weight.java
+++ b/lucene/core/src/java/org/apache/lucene/search/Weight.java
@@ -203,16 +203,10 @@ public abstract class Weight implements SegmentCacheable {
     public int score(LeafCollector collector, Bits acceptDocs, int min, int max) throws IOException {
       collector.setScorer(scorer);
       DocIdSetIterator scorerIterator = twoPhase == null ? iterator : twoPhase.approximation();
-
-      DocIdSetIterator filteredIterator = scorerIterator;
-      if (scorerIterator.docID() == -1) {
-        DocIdSetIterator collectorIterator = collector.competitiveIterator();
-        if (collectorIterator != null) {
-          // filter scorerIterator to keep only competitive docs as defined by collector
-          filteredIterator = ConjunctionDISI.intersectIterators(Arrays.asList(scorerIterator, collectorIterator));
-        }
-      }
-
+      DocIdSetIterator collectorIterator = collector.competitiveIterator();
+      // if possible filter scorerIterator to keep only competitive docs as defined by collector
+      DocIdSetIterator filteredIterator = collectorIterator == null ? scorerIterator :
+          ConjunctionDISI.intersectIterators(Arrays.asList(scorerIterator, collectorIterator));
       if (filteredIterator.docID() == -1 && min == 0 && max == DocIdSetIterator.NO_MORE_DOCS) {
         scoreAll(collector, filteredIterator, twoPhase, acceptDocs);
         return DocIdSetIterator.NO_MORE_DOCS;

--- a/lucene/core/src/java/org/apache/lucene/search/Weight.java
+++ b/lucene/core/src/java/org/apache/lucene/search/Weight.java
@@ -234,12 +234,11 @@ public abstract class Weight implements SegmentCacheable {
         }
         return currentDoc;
       } else {
-        final DocIdSetIterator approximation = twoPhase.approximation();
         while (currentDoc < end) {
           if ((acceptDocs == null || acceptDocs.get(currentDoc)) && twoPhase.matches()) {
             collector.collect(currentDoc);
           }
-          currentDoc = approximation.nextDoc();
+          currentDoc = iterator.nextDoc();
         }
         return currentDoc;
       }
@@ -258,8 +257,7 @@ public abstract class Weight implements SegmentCacheable {
         }
       } else {
         // The scorer has an approximation, so run the approximation first, then check acceptDocs, then confirm
-        final DocIdSetIterator approximation = twoPhase.approximation();
-        for (int doc = approximation.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = approximation.nextDoc()) {
+        for (int doc = iterator.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = iterator.nextDoc()) {
           if ((acceptDocs == null || acceptDocs.get(doc)) && twoPhase.matches()) {
             collector.collect(doc);
           }

--- a/lucene/core/src/java/org/apache/lucene/search/Weight.java
+++ b/lucene/core/src/java/org/apache/lucene/search/Weight.java
@@ -203,10 +203,16 @@ public abstract class Weight implements SegmentCacheable {
     public int score(LeafCollector collector, Bits acceptDocs, int min, int max) throws IOException {
       collector.setScorer(scorer);
       DocIdSetIterator scorerIterator = twoPhase == null ? iterator : twoPhase.approximation();
-      DocIdSetIterator collectorIterator = collector.competitiveIterator();
-      // if possible filter scorerIterator to keep only competitive docs as defined by collector
-      DocIdSetIterator filteredIterator = collectorIterator == null ? scorerIterator :
-          ConjunctionDISI.intersectIterators(Arrays.asList(scorerIterator, collectorIterator));
+
+      DocIdSetIterator filteredIterator = scorerIterator;
+      if (scorerIterator.docID() == -1) {
+        DocIdSetIterator collectorIterator = collector.competitiveIterator();
+        if (collectorIterator != null) {
+          // filter scorerIterator to keep only competitive docs as defined by collector
+          filteredIterator = ConjunctionDISI.intersectIterators(Arrays.asList(scorerIterator, collectorIterator));
+        }
+      }
+
       if (filteredIterator.docID() == -1 && min == 0 && max == DocIdSetIterator.NO_MORE_DOCS) {
         scoreAll(collector, filteredIterator, twoPhase, acceptDocs);
         return DocIdSetIterator.NO_MORE_DOCS;


### PR DESCRIPTION
PR #1351 introduced a sort optimization where
documents can be skipped.  
But there was a bug in case we were using two phase
approximation, as we would advance it without advancing
an overall conjunction iterator.

This patch fixed it.

Relates to #1351