### PR TITLE
SOLR-14691: Reduce object creation by using MapWriter / IteratorWriter.

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/ReplicationHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/ReplicationHandler.java
@@ -1112,10 +1112,7 @@ public class ReplicationHandler extends RequestHandlerBase implements SolrCoreAw
   }
 
   private void addVal(MapWriter.EntryWriter ew, String key, Properties props, @SuppressWarnings({"rawtypes"})Class clzz) {
-    Object val = formatVal(key, props, clzz);
-    if (val != null) {
-      ew.putNoEx(key, val);
-    }
+    ew.putIfNotNullNoEx(key, formatVal(key, props, clzz));
   }
 
   private Object formatVal(String key, Properties props, @SuppressWarnings({"rawtypes"})Class clzz) {

--- a/solr/core/src/java/org/apache/solr/handler/ReplicationHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/ReplicationHandler.java
@@ -68,6 +68,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.RateLimiter;
+import org.apache.solr.common.MapWriter;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrException.ErrorCode;
 import org.apache.solr.common.params.CommonParams;
@@ -894,7 +895,7 @@ public class ReplicationHandler extends RequestHandlerBase implements SolrCoreAw
          true, "isLeader", getCategory().toString(), scope);
     solrMetricsContext.gauge(() -> isFollower,
          true, "isFollower", getCategory().toString(), scope);
-    final MetricsMap fetcherMap = new MetricsMap((detailed, map) -> {
+    final MetricsMap fetcherMap = new MetricsMap(map -> {
       IndexFetcher fetcher = currentIndexFetcher;
       if (fetcher != null) {
         map.put(LEADER_URL, fetcher.getLeaderUrl());
@@ -1110,10 +1111,10 @@ public class ReplicationHandler extends RequestHandlerBase implements SolrCoreAw
     }
   }
 
-  private void addVal(Map<String, Object> map, String key, Properties props, @SuppressWarnings({"rawtypes"})Class clzz) {
+  private void addVal(MapWriter.EntryWriter ew, String key, Properties props, @SuppressWarnings({"rawtypes"})Class clzz) {
     Object val = formatVal(key, props, clzz);
     if (val != null) {
-      map.put(key, val);
+      ew.putNoEx(key, val);
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/handler/RequestHandlerBase.java
+++ b/solr/core/src/java/org/apache/solr/handler/RequestHandlerBase.java
@@ -157,8 +157,8 @@ public abstract class RequestHandlerBase implements SolrRequestHandler, SolrInfo
     numClientErrors = solrMetricsContext.meter("clientErrors", getCategory().toString(), scope);
     numTimeouts = solrMetricsContext.meter("timeouts", getCategory().toString(), scope);
     requests = solrMetricsContext.counter("requests", getCategory().toString(), scope);
-    MetricsMap metricsMap = new MetricsMap((detail, map) ->
-        shardPurposes.forEach((k, v) -> map.put(k, v.getCount())));
+    MetricsMap metricsMap = new MetricsMap(map ->
+        shardPurposes.forEach((k, v) -> map.putNoEx(k, v.getCount())));
     solrMetricsContext.gauge(metricsMap, true, "shardRequests", getCategory().toString(), scope);
     requestTimes = solrMetricsContext.timer("requestTimes", getCategory().toString(), scope);
     distribRequestTimes = solrMetricsContext.timer("requestTimes", getCategory().toString(), scope, "distrib");

--- a/solr/core/src/java/org/apache/solr/handler/admin/MetricsHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/MetricsHandler.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -113,7 +114,7 @@ public class MetricsHandler extends RequestHandlerBase implements PermissionName
       return;
     }
     MetricFilter mustMatchFilter = parseMustMatchFilter(params);
-    MetricUtils.PropertyFilter propertyFilter = parsePropertyFilter(params);
+    Predicate<CharSequence> propertyFilter = parsePropertyFilter(params);
     List<MetricType> metricTypes = parseMetricTypes(params);
     List<MetricFilter> metricFilters = metricTypes.stream().map(MetricType::asMetricFilter).collect(Collectors.toList());
     Set<String> requestedRegistries = parseRegistries(params);
@@ -157,7 +158,7 @@ public class MetricsHandler extends RequestHandlerBase implements PermissionName
         errors.add(key, "metric '" + metricName + "' not found");
         continue;
       }
-      MetricUtils.PropertyFilter propertyFilter = MetricUtils.PropertyFilter.ALL;
+      Predicate<CharSequence> propertyFilter = MetricUtils.ALL_PROPERTIES;
       if (propertyName != null) {
         propertyFilter = (name) -> name.equals(propertyName);
         // use escaped versions
@@ -230,10 +231,10 @@ public class MetricsHandler extends RequestHandlerBase implements PermissionName
     return mustMatchFilter;
   }
 
-  private MetricUtils.PropertyFilter parsePropertyFilter(SolrParams params) {
+  private Predicate<CharSequence> parsePropertyFilter(SolrParams params) {
     String[] props = params.getParams(PROPERTY_PARAM);
     if (props == null || props.length == 0) {
-      return MetricUtils.PropertyFilter.ALL;
+      return MetricUtils.ALL_PROPERTIES;
     }
     final Set<String> filter = new HashSet<>();
     for (String prop : props) {
@@ -242,7 +243,7 @@ public class MetricsHandler extends RequestHandlerBase implements PermissionName
       }
     }
     if (filter.isEmpty()) {
-      return MetricUtils.PropertyFilter.ALL;
+      return MetricUtils.ALL_PROPERTIES;
     } else {
       return (name) -> filter.contains(name);
     }

--- a/solr/core/src/java/org/apache/solr/handler/component/SuggestComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SuggestComponent.java
@@ -357,10 +357,10 @@ public class SuggestComponent extends SearchComponent implements SolrCoreAware, 
     super.initializeMetrics(parentContext, scope);
 
     this.solrMetricsContext.gauge(() -> ramBytesUsed(), true, "totalSizeInBytes", getCategory().toString());
-    MetricsMap suggestersMap = new MetricsMap((detailed, map) -> {
+    MetricsMap suggestersMap = new MetricsMap(map -> {
       for (Map.Entry<String, SolrSuggester> entry : suggesters.entrySet()) {
         SolrSuggester suggester = entry.getValue();
-        map.put(entry.getKey(), suggester.toString());
+        map.putNoEx(entry.getKey(), suggester.toString());
       }
     });
     this.solrMetricsContext.gauge(suggestersMap, true, "suggesters", getCategory().toString(), scope);

--- a/solr/core/src/java/org/apache/solr/metrics/MetricsMap.java
+++ b/solr/core/src/java/org/apache/solr/metrics/MetricsMap.java
@@ -70,6 +70,7 @@ public class MetricsMap implements Gauge<Map<String,Object>>, MapWriter, Dynamic
    * @param mapInitializer function to populate the Map result.
    * @deprecated use {@link #MetricsMap(MapWriter)} instead.
    */
+  @Deprecated(since = "8.7")
   public MetricsMap(BiConsumer<Boolean, Map<String,Object>> mapInitializer) {
     this.mapInitializer = mapInitializer;
   }

--- a/solr/core/src/java/org/apache/solr/metrics/reporters/solr/SolrReporter.java
+++ b/solr/core/src/java/org/apache/solr/metrics/reporters/solr/SolrReporter.java
@@ -453,7 +453,7 @@ public class SolrReporter extends ScheduledReporter {
         }
         final String effectiveGroup = group;
         MetricUtils.toSolrInputDocuments(metricManager.registry(registryName), Collections.singletonList(report.filter), MetricFilter.ALL,
-            MetricUtils.PropertyFilter.ALL, skipHistograms, skipAggregateValues, compact, metadata, doc -> {
+            MetricUtils.ALL_PROPERTIES, skipHistograms, skipAggregateValues, compact, metadata, doc -> {
               doc.setField(REGISTRY_ID, registryName);
               doc.setField(GROUP_ID, effectiveGroup);
               if (effectiveLabel != null) {

--- a/solr/core/src/java/org/apache/solr/search/CaffeineCache.java
+++ b/solr/core/src/java/org/apache/solr/search/CaffeineCache.java
@@ -364,7 +364,7 @@ public class CaffeineCache<K, V> extends SolrCacheBase implements SolrCache<K, V
   @Override
   public void initializeMetrics(SolrMetricsContext parentContext, String scope) {
     solrMetricsContext = parentContext.getChildContext(this);
-    cacheMap = new MetricsMap((detailed, map) -> {
+    cacheMap = new MetricsMap(map -> {
       if (cache != null) {
         CacheStats stats = cache.stats();
         long insertCount = inserts.sum();

--- a/solr/core/src/java/org/apache/solr/search/SolrFieldCacheBean.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrFieldCacheBean.java
@@ -49,8 +49,8 @@ public class SolrFieldCacheBean implements SolrInfoBean {
   @Override
   public void initializeMetrics(SolrMetricsContext parentContext, String scope) {
     this.solrMetricsContext = parentContext;
-    MetricsMap metricsMap = new MetricsMap((detailed, map) -> {
-      if (detailed && !disableEntryList && !disableJmxEntryList) {
+    MetricsMap metricsMap = new MetricsMap(map -> {
+      if (!disableEntryList && !disableJmxEntryList) {
         UninvertingReader.FieldCacheStats fieldCacheStats = UninvertingReader.getUninvertedStats();
         String[] entries = fieldCacheStats.info;
         map.put("entries_count", entries.length);

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -2298,8 +2298,8 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     }, true, "indexCommitSize", Category.SEARCHER.toString(), scope);
     // statsCache metrics
     parentContext.gauge(
-        new MetricsMap((detailed, map) -> {
-          statsCache.getCacheMetrics().getSnapshot(map::put);
+        new MetricsMap(map -> {
+          statsCache.getCacheMetrics().getSnapshot(map::putNoEx);
           map.put("statsCacheImpl", statsCache.getClass().getSimpleName());
         }), true, "statsCache", Category.CACHE.toString(), scope);
   }

--- a/solr/core/src/java/org/apache/solr/servlet/SolrDispatchFilter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/SolrDispatchFilter.java
@@ -235,10 +235,10 @@ public class SolrDispatchFilter extends BaseSolrFilter {
       metricManager.registerAll(registryName, new GarbageCollectorMetricSet(), SolrMetricManager.ResolutionStrategy.IGNORE, "gc");
       metricManager.registerAll(registryName, new MemoryUsageGaugeSet(), SolrMetricManager.ResolutionStrategy.IGNORE, "memory");
       metricManager.registerAll(registryName, new ThreadStatesGaugeSet(), SolrMetricManager.ResolutionStrategy.IGNORE, "threads"); // todo should we use CachedThreadStatesGaugeSet instead?
-      MetricsMap sysprops = new MetricsMap((detailed, map) -> {
+      MetricsMap sysprops = new MetricsMap(map -> {
         System.getProperties().forEach((k, v) -> {
           if (!hiddenSysProps.contains(k)) {
-            map.put(String.valueOf(k), v);
+            map.putNoEx(String.valueOf(k), v);
           }
         });
       });

--- a/solr/core/src/java/org/apache/solr/store/blockcache/Metrics.java
+++ b/solr/core/src/java/org/apache/solr/store/blockcache/Metrics.java
@@ -59,7 +59,7 @@ public class Metrics extends SolrCacheBase implements SolrInfoBean {
   @Override
   public void initializeMetrics(SolrMetricsContext parentContext, String scope) {
     solrMetricsContext = parentContext.getChildContext(this);
-    metricsMap = new MetricsMap((detailed, map) -> {
+    metricsMap = new MetricsMap(map -> {
       long now = System.nanoTime();
       long delta = Math.max(now - previous, 1);
       double seconds = delta / 1000000000.0;

--- a/solr/core/src/java/org/apache/solr/store/hdfs/HdfsLocalityReporter.java
+++ b/solr/core/src/java/org/apache/solr/store/hdfs/HdfsLocalityReporter.java
@@ -93,7 +93,7 @@ public class HdfsLocalityReporter implements SolrInfoBean {
   @Override
   public void initializeMetrics(SolrMetricsContext parentContext, String scope) {
     solrMetricsContext = parentContext.getChildContext(this);
-    MetricsMap metricsMap = new MetricsMap((detailed, map) -> {
+    MetricsMap metricsMap = new MetricsMap(map -> {
       long totalBytes = 0;
       long localBytes = 0;
       int totalCount = 0;

--- a/solr/core/src/java/org/apache/solr/util/stats/MetricUtils.java
+++ b/solr/core/src/java/org/apache/solr/util/stats/MetricUtils.java
@@ -91,8 +91,9 @@ public class MetricUtils {
 
   /**
    * This filter can limit what properties of a metric are returned.
-   * @deprecated use {@link Predicate<CharSequence>} instead.
+   * @deprecated use {@link Predicate} instead.
    */
+  @Deprecated(since = "8.7")
   public interface PropertyFilter {
     PropertyFilter ALL = (name) -> true;
 
@@ -158,6 +159,7 @@ public class MetricUtils {
    * @param consumer consumer that accepts produced {@link SolrInputDocument}-s
    * @deprecated use {@link #toSolrInputDocuments(MetricRegistry, List, MetricFilter, Predicate, boolean, boolean, boolean, Map, Consumer)} instead.
    */
+  @Deprecated(since = "8.7")
   public static void toSolrInputDocuments(MetricRegistry registry, List<MetricFilter> shouldMatchFilters,
                                           MetricFilter mustMatchFilter, PropertyFilter propertyFilter, boolean skipHistograms,
                                           boolean skipAggregateValues, boolean compact,
@@ -261,6 +263,7 @@ public class MetricUtils {
    * @param consumer consumer that accepts produced objects
    * @deprecated use {@link #toMaps(MetricRegistry, List, MetricFilter, Predicate, boolean, boolean, boolean, boolean, BiConsumer)} instead.
    */
+  @Deprecated(since = "8.7")
   public static void toMaps(MetricRegistry registry, List<MetricFilter> shouldMatchFilters,
                             MetricFilter mustMatchFilter, PropertyFilter propertyFilter,
                             boolean skipHistograms, boolean skipAggregateValues,
@@ -349,6 +352,7 @@ public class MetricUtils {
    * @param consumer consumer that accepts produced objects
    * @deprecated use {@link #convertMetric(String, Metric, Predicate, boolean, boolean, boolean, boolean, String, BiConsumer)} instead.
    */
+  @Deprecated(since = "8.7")
   public static void convertMetric(String n, Metric metric, PropertyFilter propertyFilter, boolean skipHistograms, boolean skipAggregateValues,
                                    boolean compact, boolean simple, String separator, BiConsumer<String, Object> consumer) {
     convertMetric(n, metric, PropertyFilter.toPredicate(propertyFilter),
@@ -523,6 +527,7 @@ public class MetricUtils {
    * @param consumer consumer that accepts produced objects
    * @deprecated use {@link #convertTimer(String, Timer, Predicate, boolean, boolean, String, BiConsumer)} instead.
    */
+  @Deprecated(since = "8.7")
   public static void convertTimer(String name, Timer timer, PropertyFilter propertyFilter, boolean skipHistograms,
                                   boolean simple, String separator, BiConsumer<String, Object> consumer) {
     convertTimer(name, timer, PropertyFilter.toPredicate(propertyFilter),

--- a/solr/core/src/test/org/apache/solr/core/MockInfoBean.java
+++ b/solr/core/src/test/org/apache/solr/core/MockInfoBean.java
@@ -50,7 +50,7 @@ class MockInfoBean implements SolrInfoBean, SolrMetricProducer {
   @Override
   public void initializeMetrics(SolrMetricsContext parentContext, String scope) {
     solrMetricsContext = parentContext.getChildContext(this);
-    MetricsMap metricsMap = new MetricsMap((detailed, map) -> {
+    MetricsMap metricsMap = new MetricsMap(map -> {
       map.put("Integer", 123);
       map.put("Double",567.534);
       map.put("Long", 32352463l);

--- a/solr/core/src/test/org/apache/solr/handler/admin/MetricsHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/MetricsHandlerTest.java
@@ -463,7 +463,7 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
     @Override
     public void initializeMetrics(SolrMetricsContext parentContext, String scope) {
       super.initializeMetrics(parentContext, scope);
-      MetricsMap metrics = new MetricsMap((detailed, map) -> map.putAll(gaugevals));
+      MetricsMap metrics = new MetricsMap(map -> gaugevals.forEach((k, v) -> map.putNoEx(k, v)));
       solrMetricsContext.gauge(
            metrics,  true, "dumphandlergauge", getCategory().toString(), scope);
 

--- a/solr/core/src/test/org/apache/solr/handler/admin/MetricsHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/MetricsHandlerTest.java
@@ -313,7 +313,7 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
 
     val = resp.getValues()._get( "metrics/" + key1, null);
     assertNotNull(val);
-    val = resp.getValues()._get( "metrics/" + key2,null);
+    val = resp.getValues()._get( "metrics/" + key2, null);
     assertNotNull(val);
     val = resp.getValues()._get( "metrics/" + key3, null);
     assertNotNull(val);

--- a/solr/core/src/test/org/apache/solr/handler/admin/MetricsHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/MetricsHandlerTest.java
@@ -18,10 +18,12 @@
 package org.apache.solr.handler.admin;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 
 import com.codahale.metrics.Counter;
 import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.common.MapWriter;
 import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
@@ -84,15 +86,17 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
     assertNotNull(nl);
     Object o = nl.get("SEARCHER.new.errors");
     assertNotNull(o); // counter type
-    assertTrue(o instanceof Map);
+    assertTrue(o instanceof MapWriter);
     // response wasn't serialized so we get here whatever MetricUtils produced instead of NamedList
-    assertNotNull(((Map) o).get("count"));
-    assertEquals(0L, ((Map) nl.get("SEARCHER.new.errors")).get("count"));
+    assertNotNull(((MapWriter) o)._get("count", null));
+    assertEquals(0L, ((MapWriter) nl.get("SEARCHER.new.errors"))._get("count", null));
     nl = (NamedList) values.get("solr.node");
     assertNotNull(nl.get("CONTAINER.cores.loaded")); // int gauge
-    assertEquals(1, ((Map) nl.get("CONTAINER.cores.loaded")).get("value"));
+    assertEquals(1, ((MapWriter) nl.get("CONTAINER.cores.loaded"))._get("value", null));
     assertNotNull(nl.get("ADMIN./admin/authorization.clientErrors")); // timer type
-    assertEquals(5, ((Map) nl.get("ADMIN./admin/authorization.clientErrors")).size());
+    Map<String, Object> map = new HashMap<>();
+    ((MapWriter) nl.get("ADMIN./admin/authorization.clientErrors")).toMap(map);
+    assertEquals(5, map.size());
 
     resp = new SolrQueryResponse();
     handler.handleRequestBody(req(CommonParams.QT, "/admin/metrics", MetricsHandler.COMPACT_PARAM, "false", CommonParams.WT, "json", "group", "jvm,jetty"), resp);
@@ -184,9 +188,9 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
     values = (NamedList) values.get("solr.core.collection1");
     assertEquals(1, values.size());
     @SuppressWarnings({"rawtypes"})
-    Map m = (Map) values.get("CACHE.core.fieldCache");
-    assertNotNull(m);
-    assertNotNull(m.get("entries_count"));
+    MapWriter writer = (MapWriter) values.get("CACHE.core.fieldCache");
+    assertNotNull(writer);
+    assertNotNull(writer._get("entries_count", null));
 
     resp = new SolrQueryResponse();
     handler.handleRequestBody(req(CommonParams.QT, "/admin/metrics", MetricsHandler.COMPACT_PARAM, "false", CommonParams.WT, "json", "group", "jvm", "prefix", "CONTAINER.cores"), resp);
@@ -200,8 +204,8 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
     values = resp.getValues();
     assertNotNull(values.get("metrics"));
     @SuppressWarnings({"rawtypes"})
-    SimpleOrderedMap map = (SimpleOrderedMap) values.get("metrics");
-    assertEquals(0, map.size());
+    SimpleOrderedMap map1 = (SimpleOrderedMap) values.get("metrics");
+    assertEquals(0, map1.size());
     handler.close();
   }
 
@@ -243,9 +247,9 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
     assertNotNull(nl);
     assertTrue(nl.size() > 0);
     nl.forEach((k, v) -> {
-      assertTrue(v instanceof Map);
-      @SuppressWarnings({"rawtypes"})
-      Map map = (Map) v;
+      assertTrue(v instanceof MapWriter);
+      Map<String, Object> map = new HashMap<>();
+      ((MapWriter) v).toMap(map);
       assertTrue(map.size() > 2);
     });
 
@@ -259,10 +263,10 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
     assertNotNull(nl);
     assertTrue(nl.size() > 0);
     nl.forEach((k, v) -> {
-      assertTrue(v instanceof Map);
-      @SuppressWarnings({"rawtypes"})
-      Map map = (Map) v;
-      assertEquals(2, map.size());
+      assertTrue(v instanceof MapWriter);
+      Map<String, Object> map = new HashMap<>();
+      ((MapWriter) v).toMap(map);
+      assertEquals("k=" + k + ", v=" + map, 2, map.size());
       assertNotNull(map.get("inserts"));
       assertNotNull(map.get("size"));
     });
@@ -281,15 +285,19 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
     NamedList values = resp.getValues();
     Object val = values.findRecursive("metrics", key1);
     assertNotNull(val);
-    assertTrue(val instanceof Map);
-    assertTrue(((Map) val).size() >= 2);
+    assertTrue(val instanceof MapWriter);
+    Map<String, Object> map = new HashMap<>();
+    ((MapWriter) val).toMap(map);
+    assertTrue(map.size() >= 2);
 
     String key2 = "solr.core.collection1:CACHE.core.fieldCache:entries_count";
     resp = new SolrQueryResponse();
     handler.handleRequestBody(req(CommonParams.QT, "/admin/metrics", CommonParams.WT, "json",
         MetricsHandler.KEY_PARAM, key2), resp);
     values = resp.getValues();
-    val = values.findRecursive("metrics", key2);
+    map = new HashMap<>();
+    values.toMap(map);
+    val = Utils.getObjectByPath(map, true, "metrics/" + key2);
     assertNotNull(val);
     assertTrue(val instanceof Number);
 
@@ -298,7 +306,9 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
     handler.handleRequestBody(req(CommonParams.QT, "/admin/metrics", CommonParams.WT, "json",
         MetricsHandler.KEY_PARAM, key3), resp);
     values = resp.getValues();
-    val = values.findRecursive("metrics", key3);
+    map = new HashMap<>();
+    values.toMap(map);
+    val = Utils.getObjectByPath(map, true, "metrics/" + key3);
     assertNotNull(val);
     assertTrue(val instanceof Number);
     assertEquals(3, ((Number) val).intValue());
@@ -308,11 +318,13 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
     handler.handleRequestBody(req(CommonParams.QT, "/admin/metrics", CommonParams.WT, "json",
         MetricsHandler.KEY_PARAM, key1, MetricsHandler.KEY_PARAM, key2, MetricsHandler.KEY_PARAM, key3), resp);
     values = resp.getValues();
-    val = values.findRecursive("metrics", key1);
+    map = new HashMap<>();
+    values.toMap(map);
+    val = Utils.getObjectByPath(map, false, "metrics/" + key1);
     assertNotNull(val);
-    val = values.findRecursive("metrics", key2);
+    val = Utils.getObjectByPath(map, true, "metrics/" + key2);
     assertNotNull(val);
-    val = values.findRecursive("metrics", key3);
+    val = Utils.getObjectByPath(map, true, "metrics/" + key3);
     assertNotNull(val);
 
     String key4 = "solr.core.collection1:QUERY./select.requestTimes:1minRate";
@@ -320,7 +332,10 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
     handler.handleRequestBody(req(CommonParams.QT, "/admin/metrics", CommonParams.WT, "json",
         MetricsHandler.KEY_PARAM, key4), resp);
     values = resp.getValues();
-    val = values.findRecursive("metrics", key4);
+    map = new HashMap<>();
+    values.toMap(map);
+    // the key contains a slash, need explicit list of path elements
+    val = Utils.getObjectByPath(map, true, Arrays.asList("metrics", key4));
     assertNotNull(val);
     assertTrue(val instanceof Number);
 

--- a/solr/core/src/test/org/apache/solr/handler/admin/MetricsHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/MetricsHandlerTest.java
@@ -286,18 +286,13 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
     Object val = values.findRecursive("metrics", key1);
     assertNotNull(val);
     assertTrue(val instanceof MapWriter);
-    Map<String, Object> map = new HashMap<>();
-    ((MapWriter) val).toMap(map);
-    assertTrue(map.size() >= 2);
+    assertTrue(((MapWriter)val)._size() >= 2);
 
     String key2 = "solr.core.collection1:CACHE.core.fieldCache:entries_count";
     resp = new SolrQueryResponse();
     handler.handleRequestBody(req(CommonParams.QT, "/admin/metrics", CommonParams.WT, "json",
         MetricsHandler.KEY_PARAM, key2), resp);
-    values = resp.getValues();
-    map = new HashMap<>();
-    values.toMap(map);
-    val = Utils.getObjectByPath(map, true, "metrics/" + key2);
+    val = resp.getValues()._get("metrics/" + key2, null);
     assertNotNull(val);
     assertTrue(val instanceof Number);
 
@@ -305,10 +300,8 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
     resp = new SolrQueryResponse();
     handler.handleRequestBody(req(CommonParams.QT, "/admin/metrics", CommonParams.WT, "json",
         MetricsHandler.KEY_PARAM, key3), resp);
-    values = resp.getValues();
-    map = new HashMap<>();
-    values.toMap(map);
-    val = Utils.getObjectByPath(map, true, "metrics/" + key3);
+
+    val = resp.getValues()._get( "metrics/" + key3, null);
     assertNotNull(val);
     assertTrue(val instanceof Number);
     assertEquals(3, ((Number) val).intValue());
@@ -317,25 +310,20 @@ public class MetricsHandlerTest extends SolrTestCaseJ4 {
     resp = new SolrQueryResponse();
     handler.handleRequestBody(req(CommonParams.QT, "/admin/metrics", CommonParams.WT, "json",
         MetricsHandler.KEY_PARAM, key1, MetricsHandler.KEY_PARAM, key2, MetricsHandler.KEY_PARAM, key3), resp);
-    values = resp.getValues();
-    map = new HashMap<>();
-    values.toMap(map);
-    val = Utils.getObjectByPath(map, false, "metrics/" + key1);
+
+    val = resp.getValues()._get( "metrics/" + key1, null);
     assertNotNull(val);
-    val = Utils.getObjectByPath(map, true, "metrics/" + key2);
+    val = resp.getValues()._get( "metrics/" + key2,null);
     assertNotNull(val);
-    val = Utils.getObjectByPath(map, true, "metrics/" + key3);
+    val = resp.getValues()._get( "metrics/" + key3, null);
     assertNotNull(val);
 
     String key4 = "solr.core.collection1:QUERY./select.requestTimes:1minRate";
     resp = new SolrQueryResponse();
     handler.handleRequestBody(req(CommonParams.QT, "/admin/metrics", CommonParams.WT, "json",
         MetricsHandler.KEY_PARAM, key4), resp);
-    values = resp.getValues();
-    map = new HashMap<>();
-    values.toMap(map);
     // the key contains a slash, need explicit list of path elements
-    val = Utils.getObjectByPath(map, true, Arrays.asList("metrics", key4));
+    val = resp.getValues()._get(Arrays.asList("metrics", key4), null);
     assertNotNull(val);
     assertTrue(val instanceof Number);
 

--- a/solr/core/src/test/org/apache/solr/util/stats/MetricUtilsTest.java
+++ b/solr/core/src/test/org/apache/solr/util/stats/MetricUtilsTest.java
@@ -51,7 +51,7 @@ public class MetricUtilsTest extends SolrTestCaseJ4 {
     }
     // obtain timer metrics
     Map<String,Object> map = new HashMap<>();
-    MetricUtils.convertTimer("", timer, MetricUtils.PropertyFilter.ALL, false, false, ".", (k, v) -> {
+    MetricUtils.convertTimer("", timer, MetricUtils.ALL_PROPERTIES, false, false, ".", (k, v) -> {
       ((MapWriter) v).toMap(map);
     });
     @SuppressWarnings({"rawtypes"})
@@ -116,11 +116,11 @@ public class MetricUtilsTest extends SolrTestCaseJ4 {
     });
     registry.register("map", metricsMap);
 
-    SolrMetricManager.GaugeWrapper<MapWriter> gaugeWrapper = new SolrMetricManager.GaugeWrapper(metricsMap, "foo-tag");
+    SolrMetricManager.GaugeWrapper<Map<String,Object>> gaugeWrapper = new SolrMetricManager.GaugeWrapper<>(metricsMap, "foo-tag");
     registry.register("wrappedGauge", gaugeWrapper);
 
     MetricUtils.toMaps(registry, Collections.singletonList(MetricFilter.ALL), MetricFilter.ALL,
-        MetricUtils.PropertyFilter.ALL, false, false, false, false, (k, o) -> {
+        MetricUtils.ALL_PROPERTIES, false, false, false, false, (k, o) -> {
       @SuppressWarnings({"rawtypes"})
       Map<String, Object> v = new HashMap<>();
       if (o != null) {
@@ -167,7 +167,7 @@ public class MetricUtilsTest extends SolrTestCaseJ4 {
     });
     // test compact format
     MetricUtils.toMaps(registry, Collections.singletonList(MetricFilter.ALL), MetricFilter.ALL,
-        MetricUtils.PropertyFilter.ALL, false, false, true, false, (k, o) -> {
+        MetricUtils.ALL_PROPERTIES, false, false, true, false, (k, o) -> {
           if (k.startsWith("counter")) {
             assertTrue(o instanceof Long);
             assertEquals(1L, o);

--- a/solr/core/src/test/org/apache/solr/util/stats/MetricUtilsTest.java
+++ b/solr/core/src/test/org/apache/solr/util/stats/MetricUtilsTest.java
@@ -31,6 +31,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Snapshot;
 import com.codahale.metrics.Timer;
 import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.common.MapWriter;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.metrics.AggregateMetric;
 import org.junit.Test;
@@ -49,7 +50,7 @@ public class MetricUtilsTest extends SolrTestCaseJ4 {
     // obtain timer metrics
     Map<String,Object> map = new HashMap<>();
     MetricUtils.convertTimer("", timer, MetricUtils.PropertyFilter.ALL, false, false, ".", (k, v) -> {
-      map.putAll((Map<String,Object>)v);
+      ((MapWriter) v).toMap(map);
     });
     @SuppressWarnings({"rawtypes"})
     NamedList lst = new NamedList(map);
@@ -106,7 +107,10 @@ public class MetricUtilsTest extends SolrTestCaseJ4 {
     MetricUtils.toMaps(registry, Collections.singletonList(MetricFilter.ALL), MetricFilter.ALL,
         MetricUtils.PropertyFilter.ALL, false, false, false, false, (k, o) -> {
       @SuppressWarnings({"rawtypes"})
-      Map v = (Map)o;
+      Map<String, Object> v = new HashMap<>();
+      if (o != null) {
+        ((MapWriter) o).toMap(v);
+      }
       if (k.startsWith("counter")) {
         assertEquals(1L, v.get("count"));
       } else if (k.startsWith("gauge")) {
@@ -139,7 +143,7 @@ public class MetricUtilsTest extends SolrTestCaseJ4 {
         assertEquals(0D, v.get("max"));
         assertEquals(0D, v.get("mean"));
       } else if (k.startsWith("memory.expected.error")) {
-        assertNull(v);
+        assertTrue(v.isEmpty());
       }
     });
     // test compact format
@@ -152,25 +156,25 @@ public class MetricUtilsTest extends SolrTestCaseJ4 {
             assertTrue(o instanceof String);
             assertEquals("foobar", o);
           } else if (k.startsWith("timer")) {
-            assertTrue(o instanceof Map);
-            @SuppressWarnings({"rawtypes"})
-            Map v = (Map)o;
+            assertTrue(o instanceof MapWriter);
+            Map<String, Object> v = new HashMap<>();
+            ((MapWriter) o).toMap(v);
             assertEquals(1L, v.get("count"));
             assertTrue(((Number)v.get("min_ms")).intValue() > 100);
           } else if (k.startsWith("meter")) {
-            assertTrue(o instanceof Map);
-            @SuppressWarnings({"rawtypes"})
-            Map v = (Map)o;
+            assertTrue(o instanceof MapWriter);
+            Map<String, Object> v = new HashMap<>();
+            ((MapWriter) o).toMap(v);
             assertEquals(1L, v.get("count"));
           } else if (k.startsWith("histogram")) {
-            assertTrue(o instanceof Map);
-            @SuppressWarnings({"rawtypes"})
-            Map v = (Map)o;
+            assertTrue(o instanceof MapWriter);
+            Map<String, Object> v = new HashMap<>();
+            ((MapWriter) o).toMap(v);
             assertEquals(1L, v.get("count"));
           } else if (k.startsWith("aggregate1")) {
-            assertTrue(o instanceof Map);
-            @SuppressWarnings({"rawtypes"})
-            Map v = (Map)o;
+            assertTrue(o instanceof MapWriter);
+            Map<String, Object> v = new HashMap<>();
+            ((MapWriter) o).toMap(v);
             assertEquals(4, v.get("count"));
             Map<String, Object> values = (Map<String, Object>)v.get("values");
             assertNotNull(values);
@@ -182,9 +186,9 @@ public class MetricUtilsTest extends SolrTestCaseJ4 {
             assertEquals(-2, update.get("value"));
             assertEquals(2, update.get("updateCount"));
           } else if (k.startsWith("aggregate2")) {
-            assertTrue(o instanceof Map);
-            @SuppressWarnings({"rawtypes"})
-            Map v = (Map)o;
+            assertTrue(o instanceof MapWriter);
+            Map<String, Object> v = new HashMap<>();
+            ((MapWriter) o).toMap(v);
             assertEquals(2, v.get("count"));
             Map<String, Object> values = (Map<String, Object>)v.get("values");
             assertNotNull(values);
@@ -198,8 +202,9 @@ public class MetricUtilsTest extends SolrTestCaseJ4 {
           } else if (k.startsWith("memory.expected.error")) {
             assertNull(o);
           } else {
-            @SuppressWarnings({"rawtypes"})
-            Map v = (Map)o;
+            assertTrue(o instanceof MapWriter);
+            Map<String, Object> v = new HashMap<>();
+            ((MapWriter) o).toMap(v);
             assertEquals(1L, v.get("count"));
           }
         });

--- a/solr/solrj/src/java/org/apache/solr/common/MapWriter.java
+++ b/solr/solrj/src/java/org/apache/solr/common/MapWriter.java
@@ -115,6 +115,14 @@ public interface MapWriter extends MapSerializable , NavigableObject {
       return this;
     }
 
+    default EntryWriter putIfNotNullNoEx(CharSequence k, Object v) {
+      if (v != null) {
+        putNoEx(k, v);
+      }
+      return this;
+
+    }
+
     default EntryWriter putStringIfNotNull(CharSequence k, Object v) throws IOException {
       if(v != null) put(k,String.valueOf(v));
       return this;

--- a/solr/solrj/src/java/org/apache/solr/common/MapWriterMap.java
+++ b/solr/solrj/src/java/org/apache/solr/common/MapWriterMap.java
@@ -51,6 +51,11 @@ public class MapWriterMap implements MapWriter {
 
 
   @Override
+  public int _size() {
+    return delegate.size();
+  }
+
+  @Override
   @SuppressWarnings("unchecked")
   public Map<String,Object> toMap(Map<String, Object> map) {
     return delegate;

--- a/solr/solrj/src/java/org/apache/solr/common/NavigableObject.java
+++ b/solr/solrj/src/java/org/apache/solr/common/NavigableObject.java
@@ -86,4 +86,10 @@ public interface NavigableObject {
     Object v = Utils.getObjectByPath(this, false, path);
     return v == null ? def : String.valueOf(v);
   }
+
+  default int _size() {
+    int[] size = new int[1];
+    _forEachEntry((k, v) -> size[0]++);
+    return size[0];
+  }
 }

--- a/solr/solrj/src/java/org/apache/solr/common/util/NamedList.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/NamedList.java
@@ -890,6 +890,11 @@ public class NamedList<T> implements Cloneable, Serializable, Iterable<Map.Entry
   }
 
   @Override
+  public int _size() {
+    return size();
+  }
+
+  @Override
   public void forEachEntry(BiConsumer<String, ? super T> fun) {
     forEach(fun);
   }

--- a/solr/solrj/src/java/org/apache/solr/common/util/Utils.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/Utils.java
@@ -227,9 +227,48 @@ public class Utils {
     @Override
     @SuppressWarnings({"rawtypes"})
     public void handleUnknownClass(Object o) {
+      // avoid materializing MapWriter / IteratorWriter to Map / List
+      // instead serialize them directly
       if (o instanceof MapWriter) {
-        Map m = ((MapWriter) o).toMap(new LinkedHashMap<>());
-        write(m);
+        MapWriter mapWriter = (MapWriter) o;
+        startObject();
+        final boolean[] first = new boolean[1];
+        first[0] = true;
+        mapWriter._forEachEntry((k, v) -> {
+          if (first[0]) {
+            first[0] = false;
+          } else {
+            writeValueSeparator();
+          }
+          indent();
+          writeString(k.toString());
+          writeNameSeparator();
+          write(v);
+        });
+        endObject();
+      } else if (o instanceof IteratorWriter) {
+        IteratorWriter iteratorWriter = (IteratorWriter) o;
+        startArray();
+        final boolean[] first = new boolean[1];
+        first[0] = true;
+        try {
+          iteratorWriter.writeIter(new IteratorWriter.ItemWriter() {
+            @Override
+            public IteratorWriter.ItemWriter add(Object o) throws IOException {
+              if (first[0]) {
+                first[0] = false;
+              } else {
+                writeValueSeparator();
+              }
+              indent();
+              write(o);
+              return this;
+            }
+          });
+        } catch (IOException e) {
+          throw new RuntimeException("this should never happen", e);
+        }
+        endArray();
       } else {
         super.handleUnknownClass(o);
       }
@@ -239,13 +278,13 @@ public class Utils {
   public static byte[] toJSON(Object o) {
     if (o == null) return new byte[0];
     CharArr out = new CharArr();
-    if (!(o instanceof List) && !(o instanceof Map)) {
-      if (o instanceof MapWriter) {
-        o = ((MapWriter) o).toMap(new LinkedHashMap<>());
-      } else if (o instanceof IteratorWriter) {
-        o = ((IteratorWriter) o).toList(new ArrayList<>());
-      }
-    }
+//    if (!(o instanceof List) && !(o instanceof Map)) {
+//      if (o instanceof MapWriter) {
+//        o = ((MapWriter) o).toMap(new LinkedHashMap<>());
+//      } else if (o instanceof IteratorWriter) {
+//        o = ((IteratorWriter) o).toList(new ArrayList<>());
+//      }
+//    }
     new MapWriterJSONWriter(out, 2).write(o); // indentation by default
     return toUTF8(out);
   }


### PR DESCRIPTION
This replaces nearly all Map / List usage in `MetricUtils` with `MapWriter` / `IteratorWriter`. The PR includes also changes to `Utils.MapWriterJSONWriter` to similarly avoid creating Map / List instances and instead serialize `MapWriter` / `IteratorWriter` directly.