### PR TITLE
LUCENE-9565 Fix competitive iteration

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/Weight.java
+++ b/lucene/core/src/java/org/apache/lucene/search/Weight.java
@@ -204,9 +204,14 @@ public abstract class Weight implements SegmentCacheable {
       collector.setScorer(scorer);
       DocIdSetIterator scorerIterator = twoPhase == null ? iterator : twoPhase.approximation();
       DocIdSetIterator collectorIterator = collector.competitiveIterator();
-      // if possible filter scorerIterator to keep only competitive docs as defined by collector
-      DocIdSetIterator filteredIterator = collectorIterator == null ? scorerIterator :
-          ConjunctionDISI.intersectIterators(Arrays.asList(scorerIterator, collectorIterator));
+      DocIdSetIterator filteredIterator = scorerIterator;
+      if (collectorIterator != null) {
+        if (scorerIterator.docID() != -1) {
+          collectorIterator.advance(scorerIterator.docID());
+        }
+        // filter scorerIterator to keep only competitive docs as defined by collector
+        filteredIterator = ConjunctionDISI.intersectIterators(Arrays.asList(scorerIterator, collectorIterator));
+      }
       if (filteredIterator.docID() == -1 && min == 0 && max == DocIdSetIterator.NO_MORE_DOCS) {
         scoreAll(collector, filteredIterator, twoPhase, acceptDocs);
         return DocIdSetIterator.NO_MORE_DOCS;

--- a/lucene/core/src/java/org/apache/lucene/search/Weight.java
+++ b/lucene/core/src/java/org/apache/lucene/search/Weight.java
@@ -210,7 +210,7 @@ public abstract class Weight implements SegmentCacheable {
       } else {
         if (scorerIterator.docID() != -1) {
           // Wrap ScorerIterator to start from -1 for conjunction 
-          scorerIterator = new RangeDISIWrapper(scorerIterator, scorerIterator.docID(), max);
+          scorerIterator = new RangeDISIWrapper(scorerIterator, max);
         }
         // filter scorerIterator to keep only competitive docs as defined by collector
         filteredIterator = ConjunctionDISI.intersectIterators(Arrays.asList(scorerIterator, collectorIterator));
@@ -283,9 +283,9 @@ public abstract class Weight implements SegmentCacheable {
     private final int max;
     private int docID = -1;
 
-    public RangeDISIWrapper(DocIdSetIterator in, int min, int max) {
+    public RangeDISIWrapper(DocIdSetIterator in, int max) {
       this.in = in;
-      this.min = min;
+      this.min = in.docID();
       this.max = max;
     }
 

--- a/lucene/core/src/java/org/apache/lucene/search/Weight.java
+++ b/lucene/core/src/java/org/apache/lucene/search/Weight.java
@@ -204,10 +204,13 @@ public abstract class Weight implements SegmentCacheable {
       collector.setScorer(scorer);
       DocIdSetIterator scorerIterator = twoPhase == null ? iterator : twoPhase.approximation();
       DocIdSetIterator collectorIterator = collector.competitiveIterator();
-      DocIdSetIterator filteredIterator = scorerIterator;
-      if (collectorIterator != null) {
+      DocIdSetIterator filteredIterator;
+      if (collectorIterator == null) {
+        filteredIterator = scorerIterator;
+      } else {
         if (scorerIterator.docID() != -1) {
-          collectorIterator.advance(scorerIterator.docID());
+          // Wrap ScorerIterator to start from -1 for conjunction 
+          scorerIterator = new RangeDISIWrapper(scorerIterator, scorerIterator.docID(), max);
         }
         // filter scorerIterator to keep only competitive docs as defined by collector
         filteredIterator = ConjunctionDISI.intersectIterators(Arrays.asList(scorerIterator, collectorIterator));
@@ -269,6 +272,47 @@ public abstract class Weight implements SegmentCacheable {
         }
       }
     }
+  }
+
+  /**
+   * Wraps an internal docIdSetIterator for it to start with docID = -1
+   */
+  protected static class RangeDISIWrapper extends DocIdSetIterator {
+    private final DocIdSetIterator in;
+    private final int min;
+    private final int max;
+    private int docID = -1;
+
+    public RangeDISIWrapper(DocIdSetIterator in, int min, int max) {
+      this.in = in;
+      this.min = min;
+      this.max = max;
+    }
+
+    @Override
+    public int docID() {
+      return docID;
+    }
+
+    @Override
+    public int nextDoc() throws IOException {
+      return advance(docID + 1);
+    }
+
+    @Override
+    public int advance(int target) throws IOException {
+      target = Math.max(min, target);
+      if (target >= max) {
+        return docID = NO_MORE_DOCS;
+      }
+      return docID = in.advance(target);
+    }
+
+    @Override
+    public long cost() {
+      return Math.min(max - min, in.cost());
+    }
+
   }
 
 }

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/DocComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/DocComparator.java
@@ -133,14 +133,16 @@ public class DocComparator extends FieldComparator<Integer> {
                 return null;
             } else {
                 return new DocIdSetIterator() {
+                    private int docID = -1;
+
                     @Override
                     public int nextDoc() throws IOException {
-                        return competitiveIterator.nextDoc();
+                        return advance(docID + 1);
                     }
 
                     @Override
                     public int docID() {
-                        return competitiveIterator.docID();
+                        return docID;
                     }
 
                     @Override
@@ -150,7 +152,7 @@ public class DocComparator extends FieldComparator<Integer> {
 
                     @Override
                     public int advance(int target) throws IOException {
-                        return competitiveIterator.advance(target);
+                        return docID = competitiveIterator.advance(target);
                     }
                 };
             }

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
@@ -220,14 +220,16 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
         public DocIdSetIterator competitiveIterator() {
             if (enableSkipping == false) return null;
             return new DocIdSetIterator() {
+                private int docID = -1;
+
                 @Override
                 public int nextDoc() throws IOException {
-                    return competitiveIterator.nextDoc();
+                    return advance(docID + 1);
                 }
 
                 @Override
                 public int docID() {
-                    return competitiveIterator.docID();
+                    return docID;
                 }
 
                 @Override
@@ -237,7 +239,7 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
 
                 @Override
                 public int advance(int target) throws IOException {
-                    return competitiveIterator.advance(target);
+                    return docID = competitiveIterator.advance(target);
                 }
             };
         }


### PR DESCRIPTION
PR #1351 introduced a sort optimization where documents can be skipped.
But iteration over competitive iterators was not properly organized,
as they were not storing the current docID, and
when competitive iterator was updated, the current doc ID was lost.

This patch fixes it.

Relates to #1351