### PR TITLE
LUCENE-9569 Disalbe sort opt on _doc

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/comparators/DocComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/DocComparator.java
@@ -40,8 +40,11 @@ public class DocComparator extends FieldComparator<Integer> {
     /** Creates a new comparator based on document ids for {@code numHits} */
     public DocComparator(int numHits, boolean reverse, int sortPost) {
         this.docIDs = new int[numHits];
+        // Temporarily disable sort optimization for 8.7 release
+        this.enableSkipping = false;
+        // TODO: enable sort optimization after 8.7 release
         // skipping functionality is enabled if we are sorting by _doc in asc order as a primary sort
-        this.enableSkipping = (reverse == false && sortPost == 0);
+        // this.enableSkipping = (reverse == false && sortPost == 0);
     }
 
     @Override

--- a/lucene/core/src/test/org/apache/lucene/search/TestFieldSortOptimizationSkipping.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestFieldSortOptimizationSkipping.java
@@ -321,6 +321,7 @@ public class TestFieldSortOptimizationSkipping extends LuceneTestCase {
     dir.close();
   }
 
+  @AwaitsFix(bugUrl="https://issues.apache.org/jira/browse/LUCENE-9569")
   public void testDocSortOptimizationWithAfter() throws IOException {
     final Directory dir = newDirectory();
     final IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig());
@@ -397,7 +398,7 @@ public class TestFieldSortOptimizationSkipping extends LuceneTestCase {
     dir.close();
   }
 
-
+  @AwaitsFix(bugUrl="https://issues.apache.org/jira/browse/LUCENE-9569")
   public void testDocSortOptimization() throws IOException {
     final Directory dir = newDirectory();
     final IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig());


### PR DESCRIPTION
Sort optimization on _doc was introduced in PR #1856,
but it looks unstable and lead to some recent tests failures.
As the release of 8.7 is very soon, we need to temporarily
disable the sort optimization on _doc for this release
with a plan to stabilize it for later releases.