### PR TITLE
LUCENE-9567: JPOSSFF loads built-in stop tags by default

### DIFF
--- a/lucene/MIGRATE.md
+++ b/lucene/MIGRATE.md
@@ -1,5 +1,11 @@
 # Apache Lucene Migration Guide
 
+## JapanesePartOfSpeechStopFilterFactory loads default stop tags if "tags" argument not specified (LUCENE-9567)
+
+Previously, JapanesePartOfSpeechStopFilterFactory added no filter if `args` didn't include "tags". Now, it will load 
+the default stop tags returned by `JapaneseAnalyzer.getDefaultStopTags()` (i.e. the tags from`stoptags.txt` in the 
+`lucene-analyzers-kuromoji` jar.)
+
 ## ICUCollationKeyAnalyzer is renamed (LUCENE-9558)
 
 o.a.l.collation.ICUCollationAnalyzer is renamed to o.a.l.a.icu.ICUCollationKeyAnalyzer.

--- a/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/JapanesePartOfSpeechStopFilterFactory.java
+++ b/lucene/analysis/kuromoji/src/java/org/apache/lucene/analysis/ja/JapanesePartOfSpeechStopFilterFactory.java
@@ -53,6 +53,9 @@ public class JapanesePartOfSpeechStopFilterFactory extends TokenFilterFactory im
   public JapanesePartOfSpeechStopFilterFactory(Map<String,String> args) {
     super(args);
     stopTagFiles = get(args, "tags");
+    if (stopTagFiles == null) {
+      stopTags = JapaneseAnalyzer.getDefaultStopTags();
+    }
     if (!args.isEmpty()) {
       throw new IllegalArgumentException("Unknown parameters: " + args);
     }
@@ -65,13 +68,15 @@ public class JapanesePartOfSpeechStopFilterFactory extends TokenFilterFactory im
 
   @Override
   public void inform(ResourceLoader loader) throws IOException {
-    stopTags = null;
-    CharArraySet cas = getWordSet(loader, stopTagFiles, false);
-    if (cas != null) {
-      stopTags = new HashSet<>();
-      for (Object element : cas) {
-        char chars[] = (char[]) element;
-        stopTags.add(new String(chars));
+    if (stopTagFiles != null) {
+      stopTags = null;
+      CharArraySet cas = getWordSet(loader, stopTagFiles, false);
+      if (cas != null) {
+        stopTags = new HashSet<>();
+        for (Object element : cas) {
+          char chars[] = (char[]) element;
+          stopTags.add(new String(chars));
+        }
       }
     }
   }

--- a/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/TestJapanesePartOfSpeechStopFilterFactory.java
+++ b/lucene/analysis/kuromoji/src/test/org/apache/lucene/analysis/ja/TestJapanesePartOfSpeechStopFilterFactory.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.apache.lucene.analysis.BaseTokenStreamTestCase;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.util.ClasspathResourceLoader;
 import org.apache.lucene.util.Version;
 
 /**
@@ -48,6 +49,22 @@ public class TestJapanesePartOfSpeechStopFilterFactory extends BaseTokenStreamTe
     ts = factory.create(ts);
     assertTokenStreamContents(ts,
         new String[] { "私", "は", "制限", "スピード", "を" }
+    );
+  }
+
+  /** If we don't specify "tags", then load the default stop tags. */
+  public void testNoTagsSpecified() throws IOException {
+    JapaneseTokenizerFactory tokenizerFactory = new JapaneseTokenizerFactory(new HashMap<String,String>());
+    tokenizerFactory.inform(new StringMockResourceLoader(""));
+    TokenStream ts = tokenizerFactory.create();
+    ((Tokenizer)ts).setReader(new StringReader("私は制限スピードを超える。"));
+    Map<String,String> args = new HashMap<>();
+    args.put("luceneMatchVersion", Version.LATEST.toString());
+    JapanesePartOfSpeechStopFilterFactory factory = new JapanesePartOfSpeechStopFilterFactory(args);
+    factory.inform(new ClasspathResourceLoader(JapaneseAnalyzer.class));
+    ts = factory.create(ts);
+    assertTokenStreamContents(ts,
+            new String[] { "私", "制限", "スピード", "超える" }
     );
   }
   


### PR DESCRIPTION
If a user does not specify the "tags" argument for
JapanesePartOfSpeechStopFilterFactory, it is unlikely that their
intention was to omit the filter. (Why would they use
JapanesePartOfSpeechStopFilterFactory at all in that case?)

This change loads the stoptags.txt that ships in the Kuromoji
analysis jar if no tags argument is specified.

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

Loading default stop tags if "tags" argument is not specified in JapanesePartOfSpeechStopFilterFactory.

# Solution

If the "tags" argument is not specified. then we load the default stop tags (as defined by `JapaneseAnalyzer.getDefaultStopTags()`) in the constructor (rather than waiting for the call to `inform`).

This implementation was chosen to be consistent with KoreanPartOfSpeechStopFilterFactory.

I added a note to MIGRATE.md, in case anyone is currently using JapanesePartOfSpeechStopFilterFactory with no arguments, to let them know that it will begin having an effect due to this change.

# Tests

Added a unit test to verify the behavior without specifying the "tags" argument.

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [X] I have developed this patch against the `master` branch.
- [X] I have run `./gradlew check`.
- [X] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
