### PR TITLE
SOLR-14869: do not add deleted docs in child doc transformer

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -217,6 +217,8 @@ Optimizations
 Bug Fixes
 ---------------------
 
+* SOLR-14869: ChildDocTransformer omits deleted child documents from query response. (David Smily, Bar Rotstein).
+
 * SOLR-11656: TLOG replication doesn't work properly after rebalancing leaders. (Yuki Yano via
   Erick Erickson)
 

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -217,7 +217,7 @@ Optimizations
 Bug Fixes
 ---------------------
 
-* SOLR-14869: ChildDocTransformer omits deleted child documents from query response. (David Smily, Bar Rotstein).
+* SOLR-14869: ChildDocTransformer omits deleted child documents from query response. (David Smiley, Bar Rotstein).
 
 * SOLR-11656: TLOG replication doesn't work properly after rebalancing leaders. (Yuki Yano via
   Erick Erickson)

--- a/solr/core/src/java/org/apache/solr/response/transform/ChildDocTransformer.java
+++ b/solr/core/src/java/org/apache/solr/response/transform/ChildDocTransformer.java
@@ -119,18 +119,19 @@ class ChildDocTransformer extends DocTransformer {
       int matches = 0;
       // Loop each child ID up to the parent (exclusive).
       for (int docId = firstChildId; docId < rootDocId; ++docId) {
+        final int segDocId = docId - segBaseId;
 
-        // get the path.  (note will default to ANON_CHILD_KEY if schema is not nested or empty string if blank)
-        final String fullDocPath = getPathByDocId(docId - segBaseId, segPathDocValues);
-
-        if (isNestedSchema && !fullDocPath.startsWith(rootDocPath)) {
-          // is not a descendant of the transformed doc; return fast.
+        // check whether doc is "live"
+        if (liveDocs != null && !liveDocs.get(segDocId)) {
+          // doc is not "live"; return fast
           continue;
         }
 
-        // check whether doc is "live"
-        if (liveDocs != null && !liveDocs.get(docId)) {
-          // doc is not "live"; return fast
+        // get the path.  (note will default to ANON_CHILD_KEY if schema is not nested or empty string if blank)
+        final String fullDocPath = getPathByDocId(segDocId, segPathDocValues);
+
+        if (isNestedSchema && !fullDocPath.startsWith(rootDocPath)) {
+          // is not a descendant of the transformed doc; return fast.
           continue;
         }
 

--- a/solr/core/src/test/org/apache/solr/response/transform/TestChildDocTransformerHierarchy.java
+++ b/solr/core/src/test/org/apache/solr/response/transform/TestChildDocTransformerHierarchy.java
@@ -136,6 +136,37 @@ public class TestChildDocTransformerHierarchy extends SolrTestCaseJ4 {
   }
 
   @Test
+  public void testLiveDocs() throws Exception {
+    indexSampleData(numberOfDocsPerNestedTest);
+    // delete toppings path
+    assertU(delQ("_nest_path_:\\/toppings"));
+    assertU(commit());
+
+    try(SolrQueryRequest req = req("q", "type_s:donut", "sort", "id asc", "fl", "id, type_s, toppings, _nest_path_, [child childFilter='_nest_path_:/toppings' limit=1]",
+        "fq", fqToExcludeNonTestedDocs)) {
+      BasicResultContext res = (BasicResultContext) h.queryAndResponse("/select", req).getResponse();
+      Iterator<SolrDocument> docsStreamer = res.getProcessedDocuments();
+      while (docsStreamer.hasNext()) {
+        SolrDocument doc = docsStreamer.next();
+        cleanSolrDocumentFields(doc);
+        assertFalse("root doc should not have anonymous child docs", doc.hasChildDocuments());
+        assertNull("should not include deleted docs", doc.getFieldValues("toppings"));
+      }
+    }
+
+    assertJQ(req("q", "type_s:donut",
+        "sort", "id asc",
+        "fl", "*, [child limit=1]",
+        "fq", fqToExcludeNonTestedDocs),
+        "/response/docs/[0]/type_s==donut",
+        "/response/docs/[0]/lonely/test_s==testing",
+        "/response/docs/[0]/lonely/lonelyGrandChild/test2_s==secondTest",
+        // "!" (negate): don't find toppings.  The "limit" kept us from reaching these, which follow lonely.
+        "!/response/docs/[0]/toppings/[0]/type_s==Regular"
+    );
+  }
+
+  @Test
   public void testChildFilterLimitJSON() throws Exception {
     indexSampleData(numberOfDocsPerNestedTest);
 

--- a/solr/core/src/test/org/apache/solr/response/transform/TestChildDocTransformerHierarchy.java
+++ b/solr/core/src/test/org/apache/solr/response/transform/TestChildDocTransformerHierarchy.java
@@ -136,7 +136,7 @@ public class TestChildDocTransformerHierarchy extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testLiveDocs() throws Exception {
+  public void testWithDeletedChildren() throws Exception {
     indexSampleData(numberOfDocsPerNestedTest);
     // delete toppings path
     assertU(delQ("_nest_path_:\\/toppings"));

--- a/solr/core/src/test/org/apache/solr/response/transform/TestChildDocTransformerHierarchy.java
+++ b/solr/core/src/test/org/apache/solr/response/transform/TestChildDocTransformerHierarchy.java
@@ -137,10 +137,26 @@ public class TestChildDocTransformerHierarchy extends SolrTestCaseJ4 {
 
   @Test
   public void testWithDeletedChildren() throws Exception {
+    // add a doc to create another segment
+    final String addNonTestedDoc =
+        "{\n" +
+          "\"add\": {\n" +
+            "\"doc\": {\n" +
+                "\"id\": " + -1000 + ", \n" +
+                "\"type_s\": \"cake\", \n" +
+            "}\n" +
+          "}\n" +
+        "}";
+
     indexSampleData(numberOfDocsPerNestedTest);
     // delete toppings path
     assertU(delQ("_nest_path_:\\/toppings"));
     assertU(commit());
+
+    if (random().nextBoolean()) {
+      updateJ(addNonTestedDoc, null);
+      assertU(commit());
+    }
 
     try(SolrQueryRequest req = req("q", "type_s:donut", "sort", "id asc", "fl", "id, type_s, toppings, _nest_path_, [child childFilter='_nest_path_:/toppings' limit=1]",
         "fq", fqToExcludeNonTestedDocs)) {

--- a/solr/core/src/test/org/apache/solr/response/transform/TestChildDocTransformerHierarchy.java
+++ b/solr/core/src/test/org/apache/solr/response/transform/TestChildDocTransformerHierarchy.java
@@ -148,15 +148,15 @@ public class TestChildDocTransformerHierarchy extends SolrTestCaseJ4 {
           "}\n" +
         "}";
 
-    indexSampleData(numberOfDocsPerNestedTest);
-    // delete toppings path
-    assertU(delQ("_nest_path_:\\/toppings"));
-    assertU(commit());
-
     if (random().nextBoolean()) {
       updateJ(addNonTestedDoc, null);
       assertU(commit());
     }
+
+    indexSampleData(numberOfDocsPerNestedTest);
+    // delete toppings path
+    assertU(delQ("_nest_path_:\\/toppings"));
+    assertU(commit());
 
     try(SolrQueryRequest req = req("q", "type_s:donut", "sort", "id asc", "fl", "id, type_s, toppings, _nest_path_, [child childFilter='_nest_path_:/toppings' limit=1]",
         "fq", fqToExcludeNonTestedDocs)) {


### PR DESCRIPTION
<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

Fixes [SOLR-14869](https://issues.apache.org/jira/browse/SOLR-14869)

# Solution

Please provide a short description of the approach taken to implement your solution.

# Tests

Please describe the tests you've developed or run to confirm this patch implements the feature or solves the problem.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [x] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
