### PR TITLE
LUCENE-9578: TermRangeQuery empty string lower bound edge case

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/util/automaton/Automata.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/Automata.java
@@ -85,7 +85,15 @@ final public class Automata {
     a.finishState();
     return a;
   }
-  
+
+  /**
+   * Returns a new (deterministic) automaton that accepts all binary terms except
+   * the empty string.
+   */
+  public static Automaton makeAnyBinaryExceptEmpty() {
+    return makeCharRange(0, 255);
+  }
+
   /**
    * Returns a new (deterministic) automaton that accepts any single codepoint.
    */
@@ -255,7 +263,11 @@ final public class Automata {
     } else {
       cmp = -1;
       if (min.length == 0) {
-        return makeAnyBinary();
+        if (minInclusive) {
+          return makeAnyBinary();
+        } else {
+          return makeAnyBinaryExceptEmpty();
+        }
       }
     }
 

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/Automata.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/Automata.java
@@ -90,7 +90,7 @@ final public class Automata {
    * Returns a new (deterministic) automaton that accepts all binary terms except
    * the empty string.
    */
-  public static Automaton makeAnyBinaryExceptEmpty() {
+  public static Automaton makeNonEmptyBinary() {
     Automaton a = new Automaton();
     int s1 = a.createState();
     int s2 = a.createState();
@@ -273,7 +273,7 @@ final public class Automata {
         if (minInclusive) {
           return makeAnyBinary();
         } else {
-          return makeAnyBinaryExceptEmpty();
+          return makeNonEmptyBinary();
         }
       }
     }

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/Automata.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/Automata.java
@@ -254,7 +254,7 @@ final public class Automata {
       cmp = min.compareTo(max);
     } else {
       cmp = -1;
-      if (min.length == 0 && minInclusive) {
+      if (min.length == 0) {
         return makeAnyBinary();
       }
     }
@@ -266,7 +266,7 @@ final public class Automata {
         return makeBinary(min);
       }
     } else if (cmp > 0) {
-      // max > min
+      // max < min
       return makeEmpty();
     }
 

--- a/lucene/core/src/java/org/apache/lucene/util/automaton/Automata.java
+++ b/lucene/core/src/java/org/apache/lucene/util/automaton/Automata.java
@@ -91,7 +91,14 @@ final public class Automata {
    * the empty string.
    */
   public static Automaton makeAnyBinaryExceptEmpty() {
-    return makeCharRange(0, 255);
+    Automaton a = new Automaton();
+    int s1 = a.createState();
+    int s2 = a.createState();
+    a.setAccept(s2, true);
+    a.addTransition(s1, s2, 0, 255);
+    a.addTransition(s2, s2, 0, 255);
+    a.finishState();
+    return a;
   }
 
   /**

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestAutomaton.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestAutomaton.java
@@ -1331,6 +1331,21 @@ public class TestAutomaton extends LuceneTestCase {
     assertFalse(Operations.run(a, intsRef("baq")));
     assertTrue(Operations.run(a, intsRef("bara")));
   }
+  
+  public void testMakeBinaryIntervalLowerBoundEmptyString() throws Exception {
+    Automaton a = Automata.makeBinaryInterval(new BytesRef(""), true, new BytesRef("bar"), true);
+    assertTrue(Operations.run(a, intsRef("a")));
+    assertTrue(Operations.run(a, intsRef("bar")));
+    assertFalse(Operations.run(a, intsRef("bara")));
+    assertFalse(Operations.run(a, intsRef("baz")));
+    
+    
+    a = Automata.makeBinaryInterval(new BytesRef(""), false, new BytesRef("bar"), true);
+    assertTrue(Operations.run(a, intsRef("a")));
+    assertTrue(Operations.run(a, intsRef("bar")));
+    assertFalse(Operations.run(a, intsRef("bara")));
+    assertFalse(Operations.run(a, intsRef("baz")));
+  }
 
   public void testMakeBinaryIntervalEqual() throws Exception {
     Automaton a = Automata.makeBinaryInterval(new BytesRef("bar"), true, new BytesRef("bar"), true);
@@ -1364,6 +1379,15 @@ public class TestAutomaton extends LuceneTestCase {
     assertTrue(Operations.run(a, intsRef("barfop")));
     assertTrue(Operations.run(a, intsRef("barfoop")));
     assertTrue(Operations.run(a, intsRef("zzz")));
+  }
+  
+  public void testMakeBinaryIntervalOpenMaxZeroLengthMin() throws Exception {
+    // when including min, automaton should accept "a"
+    Automaton a = Automata.makeBinaryInterval(new BytesRef(""), true, null, true);
+    assertTrue(Operations.run(a, intsRef("a")));
+    // excluding min should still accept "a"
+    a = Automata.makeBinaryInterval(new BytesRef(""), false, null, true);
+    assertTrue(Operations.run(a, intsRef("a")));
   }
 
   public void testMakeBinaryIntervalOpenMin() throws Exception {

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestAutomaton.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestAutomaton.java
@@ -1334,6 +1334,7 @@ public class TestAutomaton extends LuceneTestCase {
   
   public void testMakeBinaryIntervalLowerBoundEmptyString() throws Exception {
     Automaton a = Automata.makeBinaryInterval(new BytesRef(""), true, new BytesRef("bar"), true);
+    assertTrue(Operations.run(a, intsRef("")));
     assertTrue(Operations.run(a, intsRef("a")));
     assertTrue(Operations.run(a, intsRef("bar")));
     assertFalse(Operations.run(a, intsRef("bara")));
@@ -1341,6 +1342,7 @@ public class TestAutomaton extends LuceneTestCase {
     
     
     a = Automata.makeBinaryInterval(new BytesRef(""), false, new BytesRef("bar"), true);
+    assertFalse(Operations.run(a, intsRef("")));
     assertTrue(Operations.run(a, intsRef("a")));
     assertTrue(Operations.run(a, intsRef("bar")));
     assertFalse(Operations.run(a, intsRef("bara")));
@@ -1384,9 +1386,11 @@ public class TestAutomaton extends LuceneTestCase {
   public void testMakeBinaryIntervalOpenMaxZeroLengthMin() throws Exception {
     // when including min, automaton should accept "a"
     Automaton a = Automata.makeBinaryInterval(new BytesRef(""), true, null, true);
+    assertTrue(Operations.run(a, intsRef("")));
     assertTrue(Operations.run(a, intsRef("a")));
     // excluding min should still accept "a"
     a = Automata.makeBinaryInterval(new BytesRef(""), false, null, true);
+    assertFalse(Operations.run(a, intsRef("")));
     assertTrue(Operations.run(a, intsRef("a")));
   }
 

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestAutomaton.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestAutomaton.java
@@ -1369,6 +1369,12 @@ public class TestAutomaton extends LuceneTestCase {
     assertFalse(Operations.run(a, intsRef("barfoop")));
   }
 
+  public void testMakeBinaryExceptEmpty() throws Exception {
+    Automaton a = Automata.makeAnyBinaryExceptEmpty();
+    assertFalse(Operations.run(a, intsRef("")));
+    assertTrue(Operations.run(a, intsRef(TestUtil.randomRealisticUnicodeString(random(), 1, 10))));
+  }
+
   public void testMakeBinaryIntervalOpenMax() throws Exception {
     Automaton a = Automata.makeBinaryInterval(new BytesRef("bar"), true, null, true);
     assertFalse(Operations.run(a, intsRef("bam")));
@@ -1382,16 +1388,18 @@ public class TestAutomaton extends LuceneTestCase {
     assertTrue(Operations.run(a, intsRef("barfoop")));
     assertTrue(Operations.run(a, intsRef("zzz")));
   }
-  
+
   public void testMakeBinaryIntervalOpenMaxZeroLengthMin() throws Exception {
     // when including min, automaton should accept "a"
     Automaton a = Automata.makeBinaryInterval(new BytesRef(""), true, null, true);
     assertTrue(Operations.run(a, intsRef("")));
     assertTrue(Operations.run(a, intsRef("a")));
+    assertTrue(Operations.run(a, intsRef("aaaaaa")));
     // excluding min should still accept "a"
     a = Automata.makeBinaryInterval(new BytesRef(""), false, null, true);
     assertFalse(Operations.run(a, intsRef("")));
     assertTrue(Operations.run(a, intsRef("a")));
+    assertTrue(Operations.run(a, intsRef("aaaaaa")));
   }
 
   public void testMakeBinaryIntervalOpenMin() throws Exception {

--- a/lucene/core/src/test/org/apache/lucene/util/automaton/TestAutomaton.java
+++ b/lucene/core/src/test/org/apache/lucene/util/automaton/TestAutomaton.java
@@ -1370,7 +1370,7 @@ public class TestAutomaton extends LuceneTestCase {
   }
 
   public void testMakeBinaryExceptEmpty() throws Exception {
-    Automaton a = Automata.makeAnyBinaryExceptEmpty();
+    Automaton a = Automata.makeNonEmptyBinary();
     assertFalse(Operations.run(a, intsRef("")));
     assertTrue(Operations.run(a, intsRef(TestUtil.randomRealisticUnicodeString(random(), 1, 10))));
   }


### PR DESCRIPTION
# Description

Currently a TermRangeQuery with the empty String ("") as lower bound and
includeLower=false leads internally constructs an Automaton that doesn't match
anything. This is unexpected expecially for open upper bounds where any string
should be considered to be "higher" than the empty string.

# Solution

This PR changes "Automata#makeBinaryInterval" so that for an empty string lower
bound and an open upper bound, any String should match the query regardless or
the includeLower flag.

# Tests

Added two new tests to `TestAutomaton`.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `./gradlew check`
- [x] I have added tests for my changes.
