### PR TITLE
[LUCENE-9410] German/French stemmers fail for common forms maux, gegrüßt, grüßend, schlummert

### DIFF
--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/de/TestGermanLightStemFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/de/TestGermanLightStemFilter.java
@@ -70,6 +70,10 @@ public class TestGermanLightStemFilter extends BaseTokenStreamTestCase {
       }
     };
     checkOneTerm(a, "sängerinnen", "sängerinnen");
+    //LUCENE-9410
+    checkOneTerm(analyzer, "schlummert", "schlummern");
+    checkOneTerm(analyzer, "grüßend", "grüßen");
+    checkOneTerm(analyzer, "gegrüßt", "grüßen");
     a.close();
   }
   

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/de/TestGermanLightStemFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/de/TestGermanLightStemFilter.java
@@ -70,11 +70,14 @@ public class TestGermanLightStemFilter extends BaseTokenStreamTestCase {
       }
     };
     checkOneTerm(a, "sängerinnen", "sängerinnen");
+    a.close();
+  }
+
+  public void testExamples() throws IOException {
     //LUCENE-9410
     checkOneTerm(analyzer, "schlummert", "schlummern");
     checkOneTerm(analyzer, "grüßend", "grüßen");
     checkOneTerm(analyzer, "gegrüßt", "grüßen");
-    a.close();
   }
   
   /** blast some random strings through the analyzer */

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/de/TestGermanMinimalStemFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/de/TestGermanMinimalStemFilter.java
@@ -64,6 +64,10 @@ public class TestGermanMinimalStemFilter extends BaseTokenStreamTestCase {
     checkOneTerm(analyzer, "boote", "boot");
     checkOneTerm(analyzer, "götter", "gott");
     checkOneTerm(analyzer, "äpfel", "apfel");
+    //LUCENE-9410
+    checkOneTerm(analyzer, "schlummert", "schlummern");
+    checkOneTerm(analyzer, "grüßend", "grüßen");
+    checkOneTerm(analyzer, "gegrüßt", "grüßen");
   }
   
   public void testKeyword() throws IOException {

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/fr/TestFrenchLightStemFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/fr/TestFrenchLightStemFilter.java
@@ -167,6 +167,9 @@ public class TestFrenchLightStemFilter extends BaseTokenStreamTestCase {
     checkOneTerm(analyzer, "disposition", "dispos");
     checkOneTerm(analyzer, "dispose", "dispos");
 
+    //LUCENE-9410
+    checkOneTerm(analyzer, "maux", "mal");
+
     // SOLR-3463 : abusive compression of repeated characters in numbers
     // Trailing repeated char elision :
     checkOneTerm(analyzer, "1234555", "1234555");

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/fr/TestFrenchMinimalStemFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/fr/TestFrenchMinimalStemFilter.java
@@ -58,6 +58,7 @@ public class TestFrenchMinimalStemFilter extends BaseTokenStreamTestCase {
   public void testExamples() throws IOException {
     checkOneTerm(analyzer, "chevaux", "cheval");
     checkOneTerm(analyzer, "hiboux", "hibou");
+    checkOneTerm(analyzer, "maux", "mal");
     
     checkOneTerm(analyzer, "chantés", "chant");
     checkOneTerm(analyzer, "chanter", "chant");
@@ -66,6 +67,7 @@ public class TestFrenchMinimalStemFilter extends BaseTokenStreamTestCase {
     checkOneTerm(analyzer, "baronnes", "baron");
     checkOneTerm(analyzer, "barons", "baron");
     checkOneTerm(analyzer, "baron", "baron");
+
   }
   
   public void testKeyword() throws IOException {

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/fr/TestFrenchMinimalStemFilter.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/fr/TestFrenchMinimalStemFilter.java
@@ -58,6 +58,8 @@ public class TestFrenchMinimalStemFilter extends BaseTokenStreamTestCase {
   public void testExamples() throws IOException {
     checkOneTerm(analyzer, "chevaux", "cheval");
     checkOneTerm(analyzer, "hiboux", "hibou");
+
+    //LUCENE-9410
     checkOneTerm(analyzer, "maux", "mal");
     
     checkOneTerm(analyzer, "chantés", "chant");


### PR DESCRIPTION
https://issues.apache.org/jira/browse/LUCENE-9410

I don't know if it's just an acceptable exception or something serious? I wrote test cases for these words.
Should them be mapped by hand to simple forms?