### PR TITLE
SOLR-14932: Broken "Add replica" button in solr admin UI

### DIFF
--- a/solr/webapp/web/css/angular/collections.css
+++ b/solr/webapp/web/css/angular/collections.css
@@ -125,7 +125,7 @@ limitations under the License.
 
 #content #collections  .chosen-container.chosen-container-single
 {
-	width: 100% !important;
+  width: 100% !important;
 }
 
 #content #collections .actions form .buttons

--- a/solr/webapp/web/css/angular/collections.css
+++ b/solr/webapp/web/css/angular/collections.css
@@ -123,6 +123,11 @@ limitations under the License.
   padding-right: 3px;
 }
 
+#content #collections  .chosen-container.chosen-container-single
+{
+	width: 100% !important;
+}
+
 #content #collections .actions form .buttons
 {
   padding-top: 10px;

--- a/solr/webapp/web/js/angular/controllers/collections.js
+++ b/solr/webapp/web/js/angular/controllers/collections.js
@@ -212,7 +212,7 @@ solrAdminApp.controller('CollectionsController',
             $scope.nodes = [];
             var children = data.tree[0].children;
             for (var child in children) {
-              $scope.nodes.push(children[child].data.title);
+              $scope.nodes.push(children[child].text);
             }
           });
       };
@@ -221,7 +221,7 @@ solrAdminApp.controller('CollectionsController',
           $scope.hideAll();
           replica.showRemove = !replica.showRemove;
       };
-      
+
       $scope.toggleRemoveShard = function(shard) {
           $scope.hideAll();
           shard.showRemove = !shard.showRemove;

--- a/solr/webapp/web/partials/collections.html
+++ b/solr/webapp/web/partials/collections.html
@@ -335,7 +335,7 @@ limitations under the License.
                       <select chosen ng-model="shard.replicaNodeName" ng-options="node for node in nodes" class="other">
                           <option value="">No specified node</option>
                       </select>
-                          node: {{shard.replicaNodeName}}
+						  <span ng-if="shard.replicaNodeName">node: {{shard.replicaNodeName}}</span>
                       </p>
 
                       <p class="clearfix note error" ng-show="createReplicaMessage">

--- a/solr/webapp/web/partials/collections.html
+++ b/solr/webapp/web/partials/collections.html
@@ -335,7 +335,7 @@ limitations under the License.
                       <select chosen ng-model="shard.replicaNodeName" ng-options="node for node in nodes" class="other">
                           <option value="">No specified node</option>
                       </select>
-						  <span ng-if="shard.replicaNodeName">node: {{shard.replicaNodeName}}</span>
+                          <span ng-if="shard.replicaNodeName">node: {{shard.replicaNodeName}}</span>
                       </p>
 
                       <p class="clearfix note error" ng-show="createReplicaMessage">


### PR DESCRIPTION
Earlier with solr 8.6.x drop down button to check live nodes got broken. 
<img width="690" alt="image" src="https://user-images.githubusercontent.com/9280180/96084368-296b5180-0ee9-11eb-8e97-bd481ad53b8d.png">
