### PR TITLE
SOLR-14933: Ability to add T and P type replica from admin UI

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -132,8 +132,6 @@ Other Changes
 
 * SOLR-14930: Removed rule based replica placement (noble)
 
-* SOLR-14933: Ability to add T and P type replica from admin UI (Sayan Das)
-
 Bug Fixes
 ---------------------
 * SOLR-14546: Fix for a relatively hard to hit issue in OverseerTaskProcessor that could lead to out of order execution
@@ -199,6 +197,8 @@ Improvements
 * SOLR-14905: Update commons-io version to 2.8.0 due to security vulnerability. (Nazerke Seidan via Bruno Roustant)
 
 * SOLR-14691: Metrics reporting should avoid creating objects. (ab, noble)
+
+* SOLR-14933: Ability to add T and P type replica from admin UI (Sayan Das via Eric Pugh)
 
 Optimizations
 ---------------------

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -132,6 +132,8 @@ Other Changes
 
 * SOLR-14930: Removed rule based replica placement (noble)
 
+* SOLR-14933: Ability to add T and P type replica from admin UI (Sayan Das)
+
 Bug Fixes
 ---------------------
 * SOLR-14546: Fix for a relatively hard to hit issue in OverseerTaskProcessor that could lead to out of order execution

--- a/solr/webapp/web/js/angular/controllers/collections.js
+++ b/solr/webapp/web/js/angular/controllers/collections.js
@@ -248,6 +248,7 @@ solrAdminApp.controller('CollectionsController',
         var params = {
           collection: shard.collection,
           shard: shard.name,
+          type: shard.replicaType
         }
         if (shard.replicaNodeName && shard.replicaNodeName != "") {
           params.node = shard.replicaNodeName;

--- a/solr/webapp/web/partials/collections.html
+++ b/solr/webapp/web/partials/collections.html
@@ -331,11 +331,23 @@ limitations under the License.
 
                     <form>
 
-                      <p id="node-name" class="clearfix"><label for="node-name">Node:</label>
-                      <select chosen ng-model="shard.replicaNodeName" ng-options="node for node in nodes" class="other">
-                          <option value="">No specified node</option>
-                      </select>
-                          <span ng-if="shard.replicaNodeName">node: {{shard.replicaNodeName}}</span>
+                      <p id="node-name" class="clearfix">
+                        <p>
+                         <label for="node-name">Node:</label>
+                         <select chosen ng-model="shard.replicaNodeName" ng-options="node for node in nodes" class="other">
+                             <option value="">No specified node</option>
+                         </select>
+                        </p>
+                        <p>
+                            <label for="node-name">Type:</label>
+                            <select chosen ng-model="shard.replicaType" ng-init="shard.replicaType='NRT'" ng-options="node for node in ['NRT', 'TLOG', 'PULL']" class="other">
+
+                            </select>
+                        </p>
+
+
+                        <div ng-if="shard.replicaNodeName">node: {{shard.replicaNodeName}}</div>
+                        <div ng-if="shard.replicaNodeName">node: {{shard.replicaType}}</div>
                       </p>
 
                       <p class="clearfix note error" ng-show="createReplicaMessage">


### PR DESCRIPTION

# Description

As of now we can already add NRT replica from admin UI. Would look to add drop down listing all types of replicas along with the live nodes drop down. With my personal experience replica type, is utmost crucial and it is really annoying to add replica from API every time.

# Solution

Here is how the interface looks like now. let me know if it's looks good or any other adjustment is required.
<img width="370" alt="image" src="https://user-images.githubusercontent.com/9280180/96248336-9bb96000-0fd5-11eb-8880-a5c99db3250c.png">


