### PR TITLE
LUCENE-9455: ExitableTermsEnum should sample timeout and interruption check before calling next()

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -144,6 +144,9 @@ Improvements
 * LUCENE-9531: Consolidated CharStream and FastCharStream classes: these have been moved
   from each query parser package to org.apache.lucene.queryparser.charstream (Dawid Weiss).
 
+* LUCENE-9455: ExitableTermsEnum should sample timeout and interruption
+  check before calling next(). (Zach Chen)
+
 Bug fixes
 
 * LUCENE-8663: NRTCachingDirectory.slowFileExists may open a file while 

--- a/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ExitableDirectoryReader.java
@@ -496,35 +496,38 @@ public class ExitableDirectoryReader extends FilterDirectoryReader {
    * exitable enumeration of terms.
    */
   public static class ExitableTermsEnum extends FilterTermsEnum {
-
+    private static final int MAX_CALLS_BEFORE_QUERY_TIMEOUT_CHECK = (1 << 4) - 1; // 15
+    private int calls;
     private QueryTimeout queryTimeout;
     
     /** Constructor **/
     public ExitableTermsEnum(TermsEnum termsEnum, QueryTimeout queryTimeout) {
       super(termsEnum);
       this.queryTimeout = queryTimeout;
-      checkAndThrow();
+      checkAndThrowWithSampling();
     }
 
     /**
      * Throws {@link ExitingReaderException} if {@link QueryTimeout#shouldExit()} returns true,
      * or if {@link Thread#interrupted()} returns true.
      */
-    private void checkAndThrow() {
-      if (queryTimeout.shouldExit()) {
-        throw new ExitingReaderException("The request took too long to iterate over terms. Timeout: " 
-            + queryTimeout.toString()
-            + ", TermsEnum=" + in
-        );
-      } else if (Thread.interrupted()) {
-        throw new ExitingReaderException("Interrupted while iterating over terms. TermsEnum=" + in);
+    private void checkAndThrowWithSampling() {
+      if ((calls++ & MAX_CALLS_BEFORE_QUERY_TIMEOUT_CHECK) == 0) {
+        if (queryTimeout.shouldExit()) {
+          throw new ExitingReaderException("The request took too long to iterate over terms. Timeout: "
+              + queryTimeout.toString()
+              + ", TermsEnum=" + in
+          );
+        } else if (Thread.interrupted()) {
+          throw new ExitingReaderException("Interrupted while iterating over terms. TermsEnum=" + in);
+        }
       }
     }
 
     @Override
     public BytesRef next() throws IOException {
       // Before every iteration, check if the iteration should exit
-      checkAndThrow();
+      checkAndThrowWithSampling();
       return in.next();
     }
   }


### PR DESCRIPTION
# Description

ExitableTermsEnum should sample timeout and interruption check before calling next()

# Solution

Add the same sampling logic as in https://github.com/elastic/elasticsearch/blob/4af4eb99e18fdaadac879b1223e986227dd2ee71/server/src/main/java/org/elasticsearch/search/internal/ExitableDirectoryReader.java#L164-L168

# Tests
Updated unit test to test for sampling skipping check

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
