### PR TITLE
Add example for ConfigSet create with properties map.

### DIFF
--- a/solr/solr-ref-guide/src/configsets-api.adoc
+++ b/solr/solr-ref-guide/src/configsets-api.adoc
@@ -178,6 +178,18 @@ curl -X POST -H 'Content-type: application/json' -d '{
   "create":{
     "name": "myConfigSet",
     "baseConfigSet": "predefinedTemplate",
+    "configSetProp.immutable": "false"}}'
+    http://localhost:8983/api/cluster/configs?omitHeader=true
+----
+
+With the v2 API, ConfigSet properties can also be provided via the `properties` map:
+
+[source,bash]
+----
+curl -X POST -H 'Content-type: application/json' -d '{
+  "create":{
+    "name": "myConfigSet",
+    "baseConfigSet": "predefinedTemplate",
     "properties": {
       "immutable": "false"
     }}}'

--- a/solr/solr-ref-guide/src/configsets-api.adoc
+++ b/solr/solr-ref-guide/src/configsets-api.adoc
@@ -178,7 +178,9 @@ curl -X POST -H 'Content-type: application/json' -d '{
   "create":{
     "name": "myConfigSet",
     "baseConfigSet": "predefinedTemplate",
-    "configSetProp.immutable": "false"}}'
+    "properties": {
+      "immutable": "false"
+    }}}'
     http://localhost:8983/api/cluster/configs?omitHeader=true
 ----
 ====


### PR DESCRIPTION
The previous example in the documentation only used the less-user-friendly `configSetProp.<name>` option.