### PR TITLE
LUCENE-9582: rename VectorValues.ScoreFunction to SearchStrategy

### DIFF
--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextFieldInfosFormat.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextFieldInfosFormat.java
@@ -69,7 +69,7 @@ public class SimpleTextFieldInfosFormat extends FieldInfosFormat {
   static final BytesRef INDEX_DIM_COUNT =  new BytesRef("  index dimensional count ");
   static final BytesRef DIM_NUM_BYTES   =  new BytesRef("  dimensional num bytes ");
   static final BytesRef VECTOR_NUM_DIMS =  new BytesRef("  vector number of dimensions ");
-  static final BytesRef VECTOR_SCORE_FUNC = new BytesRef("  vector score function ");
+  static final BytesRef VECTOR_SEARCH_STRATEGY = new BytesRef("  vector search strategy ");
   static final BytesRef SOFT_DELETES    =  new BytesRef("  soft-deletes ");
   
   @Override
@@ -154,9 +154,9 @@ public class SimpleTextFieldInfosFormat extends FieldInfosFormat {
         int vectorNumDimensions = Integer.parseInt(readString(VECTOR_NUM_DIMS.length, scratch));
 
         SimpleTextUtil.readLine(input, scratch);
-        assert StringHelper.startsWith(scratch.get(), VECTOR_SCORE_FUNC);
-        String scoreFunction = readString(VECTOR_SCORE_FUNC.length, scratch);
-        VectorValues.ScoreFunction vectorDistFunc = distanceFunction(scoreFunction);
+        assert StringHelper.startsWith(scratch.get(), VECTOR_SEARCH_STRATEGY);
+        String scoreFunction = readString(VECTOR_SEARCH_STRATEGY.length, scratch);
+        VectorValues.SearchStrategy vectorDistFunc = distanceFunction(scoreFunction);
 
         SimpleTextUtil.readLine(input, scratch);
         assert StringHelper.startsWith(scratch.get(), SOFT_DELETES);
@@ -186,8 +186,8 @@ public class SimpleTextFieldInfosFormat extends FieldInfosFormat {
     return DocValuesType.valueOf(dvType);
   }
 
-  public VectorValues.ScoreFunction distanceFunction(String scoreFunction) {
-    return VectorValues.ScoreFunction.valueOf(scoreFunction);
+  public VectorValues.SearchStrategy distanceFunction(String scoreFunction) {
+    return VectorValues.SearchStrategy.valueOf(scoreFunction);
   }
   
   private String readString(int offset, BytesRefBuilder scratch) {
@@ -274,8 +274,8 @@ public class SimpleTextFieldInfosFormat extends FieldInfosFormat {
         SimpleTextUtil.write(out, Integer.toString(fi.getVectorDimension()), scratch);
         SimpleTextUtil.writeNewline(out);
 
-        SimpleTextUtil.write(out, VECTOR_SCORE_FUNC);
-        SimpleTextUtil.write(out, fi.getVectorScoreFunction().name(), scratch);
+        SimpleTextUtil.write(out, VECTOR_SEARCH_STRATEGY);
+        SimpleTextUtil.write(out, fi.getVectorSearchStrategy().name(), scratch);
         SimpleTextUtil.writeNewline(out);
 
         SimpleTextUtil.write(out, SOFT_DELETES);

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextVectorReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextVectorReader.java
@@ -63,7 +63,7 @@ public class SimpleTextVectorReader extends VectorReader {
       while (fieldNumber != -1) {
         String fieldName = readString(in, FIELD_NAME);
         String scoreFunctionName = readString(in, SCORE_FUNCTION);
-        VectorValues.ScoreFunction scoreFunction = VectorValues.ScoreFunction.valueOf(scoreFunctionName);
+        VectorValues.SearchStrategy searchStrategy = VectorValues.SearchStrategy.valueOf(scoreFunctionName);
         long vectorDataOffset = readLong(in, VECTOR_DATA_OFFSET);
         long vectorDataLength = readLong(in, VECTOR_DATA_LENGTH);
         int dimension = readInt(in, VECTOR_DIMENSION);
@@ -73,7 +73,7 @@ public class SimpleTextVectorReader extends VectorReader {
           docIds[i] = readInt(in, EMPTY);
         }
         assert fieldEntries.containsKey(fieldName) == false;
-        fieldEntries.put(fieldName, new FieldEntry(dimension, scoreFunction, vectorDataOffset, vectorDataLength, docIds));
+        fieldEntries.put(fieldName, new FieldEntry(dimension, searchStrategy, vectorDataOffset, vectorDataLength, docIds));
         fieldNumber = readInt(in, FIELD_NUMBER);
       }
       SimpleTextUtil.checkFooter(in);
@@ -138,16 +138,16 @@ public class SimpleTextVectorReader extends VectorReader {
   private static class FieldEntry {
 
     final int dimension;
-    final VectorValues.ScoreFunction scoreFunction;
+    final VectorValues.SearchStrategy searchStrategy;
 
     final long vectorDataOffset;
     final long vectorDataLength;
     final int[] ordToDoc;
 
-    FieldEntry(int dimension, VectorValues.ScoreFunction scoreFunction,
+    FieldEntry(int dimension, VectorValues.SearchStrategy searchStrategy,
                long vectorDataOffset, long vectorDataLength, int[] ordToDoc) {
       this.dimension = dimension;
-      this.scoreFunction = scoreFunction;
+      this.searchStrategy = searchStrategy;
       this.vectorDataOffset = vectorDataOffset;
       this.vectorDataLength = vectorDataLength;
       this.ordToDoc = ordToDoc;
@@ -189,8 +189,8 @@ public class SimpleTextVectorReader extends VectorReader {
     }
 
     @Override
-    public ScoreFunction scoreFunction() {
-      return entry.scoreFunction;
+    public SearchStrategy searchStrategy() {
+      return entry.searchStrategy;
     }
 
     @Override

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextVectorWriter.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextVectorWriter.java
@@ -84,7 +84,7 @@ public class SimpleTextVectorWriter extends VectorWriter {
   private void writeMeta(FieldInfo field, long vectorDataOffset, long vectorDataLength, List<Integer> docIds) throws IOException {
     writeField(meta, FIELD_NUMBER, field.number);
     writeField(meta, FIELD_NAME, field.name);
-    writeField(meta, SCORE_FUNCTION, field.getVectorScoreFunction().name());
+    writeField(meta, SCORE_FUNCTION, field.getVectorSearchStrategy().name());
     writeField(meta, VECTOR_DATA_OFFSET, vectorDataOffset);
     writeField(meta, VECTOR_DATA_LENGTH, vectorDataLength);
     writeField(meta, VECTOR_DIMENSION, field.getVectorDimension());

--- a/lucene/codecs/src/test/org/apache/lucene/codecs/uniformsplit/TestBlockWriter.java
+++ b/lucene/codecs/src/test/org/apache/lucene/codecs/uniformsplit/TestBlockWriter.java
@@ -122,7 +122,7 @@ public class TestBlockWriter extends LuceneTestCase {
         0,
         0,
         0,
-        VectorValues.ScoreFunction.NONE,
+        VectorValues.SearchStrategy.NONE,
         true
     );
   }

--- a/lucene/codecs/src/test/org/apache/lucene/codecs/uniformsplit/sharedterms/TestSTBlockReader.java
+++ b/lucene/codecs/src/test/org/apache/lucene/codecs/uniformsplit/sharedterms/TestSTBlockReader.java
@@ -205,7 +205,7 @@ public class TestSTBlockReader extends LuceneTestCase {
         0,
         0,
         0,
-        VectorValues.ScoreFunction.NONE,
+        VectorValues.SearchStrategy.NONE,
         false
     );
   }

--- a/lucene/core/src/java/org/apache/lucene/codecs/VectorWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/VectorWriter.java
@@ -69,23 +69,23 @@ public abstract class VectorWriter implements Closeable {
     }
     List<VectorValuesSub> subs = new ArrayList<>();
     int dimension = -1;
-    VectorValues.ScoreFunction scoreFunction = null;
+    VectorValues.SearchStrategy searchStrategy = null;
     int nonEmptySegmentIndex = 0;
     for (int i = 0; i < mergeState.vectorReaders.length; i++) {
       VectorReader vectorReader = mergeState.vectorReaders[i];
       if (vectorReader != null) {
         if (mergeFieldInfo != null && mergeFieldInfo.hasVectorValues()) {
           int segmentDimension = mergeFieldInfo.getVectorDimension();
-          VectorValues.ScoreFunction segmentScoreFunction = mergeFieldInfo.getVectorScoreFunction();
+          VectorValues.SearchStrategy segmentSearchStrategy = mergeFieldInfo.getVectorSearchStrategy();
           if (dimension == -1) {
             dimension = segmentDimension;
-            scoreFunction = mergeFieldInfo.getVectorScoreFunction();
+            searchStrategy = mergeFieldInfo.getVectorSearchStrategy();
           } else if (dimension != segmentDimension) {
             throw new IllegalStateException("Varying dimensions for vector-valued field " + mergeFieldInfo.name
                 + ": " + dimension + "!=" + segmentDimension);
-          } else if (scoreFunction != segmentScoreFunction) {
-            throw new IllegalStateException("Varying score functions for vector-valued field " + mergeFieldInfo.name
-                + ": " + scoreFunction + "!=" + segmentScoreFunction);
+          } else if (searchStrategy != segmentSearchStrategy) {
+            throw new IllegalStateException("Varying search strategys for vector-valued field " + mergeFieldInfo.name
+                + ": " + searchStrategy + "!=" + segmentSearchStrategy);
           }
           VectorValues values = vectorReader.getVectorValues(mergeFieldInfo.name);
           if (values != null) {
@@ -223,8 +223,8 @@ public abstract class VectorWriter implements Closeable {
     }
 
     @Override
-    public VectorValues.ScoreFunction scoreFunction() {
-      return subs.get(0).values.scoreFunction();
+    public SearchStrategy searchStrategy() {
+      return subs.get(0).values.searchStrategy();
     }
 
     class MergerRandomAccess implements VectorValues.RandomAccess {
@@ -249,8 +249,8 @@ public abstract class VectorWriter implements Closeable {
       }
 
       @Override
-      public ScoreFunction scoreFunction() {
-        return VectorValuesMerger.this.scoreFunction();
+      public SearchStrategy searchStrategy() {
+        return VectorValuesMerger.this.searchStrategy();
       }
 
       @Override

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene50/Lucene50FieldInfosFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene50/Lucene50FieldInfosFormat.java
@@ -150,7 +150,7 @@ public final class Lucene50FieldInfosFormat extends FieldInfosFormat {
           try {
             infos[i] = new FieldInfo(name, fieldNumber, storeTermVector, omitNorms, storePayloads, 
                                      indexOptions, docValuesType, dvGen, attributes, 0, 0, 0,
-                                     0, VectorValues.ScoreFunction.NONE, false);
+                                     0, VectorValues.SearchStrategy.NONE, false);
           } catch (IllegalStateException e) {
             throw new CorruptIndexException("invalid fieldinfo for field: " + name + ", fieldNumber=" + fieldNumber, input, e);
           }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene60/Lucene60FieldInfosFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene60/Lucene60FieldInfosFormat.java
@@ -166,7 +166,7 @@ public final class Lucene60FieldInfosFormat extends FieldInfosFormat {
             infos[i] = new FieldInfo(name, fieldNumber, storeTermVector, omitNorms, storePayloads, 
                                      indexOptions, docValuesType, dvGen, attributes,
                                      pointDataDimensionCount, pointIndexDimensionCount, pointNumBytes,
-                                     0, VectorValues.ScoreFunction.NONE, isSoftDeletesField);
+                                     0, VectorValues.SearchStrategy.NONE, isSoftDeletesField);
           } catch (IllegalStateException e) {
             throw new CorruptIndexException("invalid fieldinfo for field: " + name + ", fieldNumber=" + fieldNumber, input, e);
           }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90VectorReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90VectorReader.java
@@ -102,11 +102,11 @@ public final class Lucene90VectorReader extends VectorReader {
       if (info == null) {
         throw new CorruptIndexException("Invalid field number: " + fieldNumber, meta);
       }
-      int scoreFunctionId = meta.readInt();
-      if (scoreFunctionId < 0 || scoreFunctionId >= VectorValues.ScoreFunction.values().length) {
-        throw new CorruptIndexException("Invalid score function id: " + scoreFunctionId, meta);
+      int searchStrategyId = meta.readInt();
+      if (searchStrategyId < 0 || searchStrategyId >= VectorValues.SearchStrategy.values().length) {
+        throw new CorruptIndexException("Invalid search strategy id: " + searchStrategyId, meta);
       }
-      VectorValues.ScoreFunction scoreFunction = VectorValues.ScoreFunction.values()[scoreFunctionId];
+      VectorValues.SearchStrategy searchStrategy = VectorValues.SearchStrategy.values()[searchStrategyId];
       long vectorDataOffset = meta.readVLong();
       long vectorDataLength = meta.readVLong();
       int dimension = meta.readInt();
@@ -116,7 +116,7 @@ public final class Lucene90VectorReader extends VectorReader {
         int doc = meta.readVInt();
         ordToDoc[i] = doc;
       }
-      FieldEntry fieldEntry = new FieldEntry(dimension, scoreFunction, maxDoc, vectorDataOffset, vectorDataLength,
+      FieldEntry fieldEntry = new FieldEntry(dimension, searchStrategy, maxDoc, vectorDataOffset, vectorDataLength,
                                               ordToDoc);
       fields.put(info.name, fieldEntry);
     }
@@ -173,17 +173,17 @@ public final class Lucene90VectorReader extends VectorReader {
   private static class FieldEntry {
 
     final int dimension;
-    final VectorValues.ScoreFunction scoreFunction;
+    final VectorValues.SearchStrategy searchStrategy;
     final int maxDoc;
 
     final long vectorDataOffset;
     final long vectorDataLength;
     final int[] ordToDoc;
 
-    FieldEntry(int dimension, VectorValues.ScoreFunction scoreFunction, int maxDoc,
+    FieldEntry(int dimension, VectorValues.SearchStrategy searchStrategy, int maxDoc,
                long vectorDataOffset, long vectorDataLength, int[] ordToDoc) {
       this.dimension = dimension;
-      this.scoreFunction = scoreFunction;
+      this.searchStrategy = searchStrategy;
       this.maxDoc = maxDoc;
       this.vectorDataOffset = vectorDataOffset;
       this.vectorDataLength = vectorDataLength;
@@ -231,8 +231,8 @@ public final class Lucene90VectorReader extends VectorReader {
     }
 
     @Override
-    public ScoreFunction scoreFunction() {
-      return fieldEntry.scoreFunction;
+    public SearchStrategy searchStrategy() {
+      return fieldEntry.searchStrategy;
     }
 
     @Override
@@ -312,8 +312,8 @@ public final class Lucene90VectorReader extends VectorReader {
       }
 
       @Override
-      public VectorValues.ScoreFunction scoreFunction() {
-        return fieldEntry.scoreFunction;
+      public SearchStrategy searchStrategy() {
+        return fieldEntry.searchStrategy;
       }
 
       @Override

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90VectorWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90VectorWriter.java
@@ -92,7 +92,7 @@ public final class Lucene90VectorWriter extends VectorWriter {
 
   private void writeMeta(FieldInfo field, long vectorDataOffset, long vectorDataLength, List<Integer> docIds) throws IOException {
     meta.writeInt(field.number);
-    meta.writeInt(field.getVectorScoreFunction().ordinal());
+    meta.writeInt(field.getVectorSearchStrategy().ordinal());
     meta.writeVLong(vectorDataOffset);
     meta.writeVLong(vectorDataLength);
     meta.writeInt(field.getVectorDimension());

--- a/lucene/core/src/java/org/apache/lucene/document/FieldType.java
+++ b/lucene/core/src/java/org/apache/lucene/document/FieldType.java
@@ -46,7 +46,7 @@ public class FieldType implements IndexableFieldType  {
   private int indexDimensionCount;
   private int dimensionNumBytes;
   private int vectorDimension;
-  private VectorValues.ScoreFunction vectorScoreFunction = VectorValues.ScoreFunction.NONE;
+  private VectorValues.SearchStrategy vectorSearchStrategy = VectorValues.SearchStrategy.NONE;
   private Map<String, String> attributes;
 
   /**
@@ -66,7 +66,7 @@ public class FieldType implements IndexableFieldType  {
     this.indexDimensionCount = ref.pointIndexDimensionCount();
     this.dimensionNumBytes = ref.pointNumBytes();
     this.vectorDimension = ref.vectorDimension();
-    this.vectorScoreFunction = ref.vectorScoreFunction();
+    this.vectorSearchStrategy = ref.vectorSearchStrategy();
     if (ref.getAttributes() != null) {
       this.attributes = new HashMap<>(ref.getAttributes());
     }
@@ -357,7 +357,7 @@ public class FieldType implements IndexableFieldType  {
     return dimensionNumBytes;
   }
 
-  void setVectorDimensionsAndScoreFunction(int numDimensions, VectorValues.ScoreFunction distFunc) {
+  void setVectorDimensionsAndSearchStrategy(int numDimensions, VectorValues.SearchStrategy distFunc) {
     checkIfFrozen();
     if (numDimensions <= 0) {
       throw new IllegalArgumentException("vector numDimensions must be > 0; got " + numDimensions);
@@ -366,7 +366,7 @@ public class FieldType implements IndexableFieldType  {
       throw new IllegalArgumentException("vector numDimensions must be <= VectorValues.MAX_DIMENSIONS (=" + VectorValues.MAX_DIMENSIONS + "); got " + numDimensions);
     }
     this.vectorDimension = numDimensions;
-    this.vectorScoreFunction = distFunc;
+    this.vectorSearchStrategy = distFunc;
   }
 
   @Override
@@ -375,8 +375,8 @@ public class FieldType implements IndexableFieldType  {
   }
 
   @Override
-  public VectorValues.ScoreFunction vectorScoreFunction() {
-    return vectorScoreFunction;
+  public VectorValues.SearchStrategy vectorSearchStrategy() {
+    return vectorSearchStrategy;
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/document/VectorField.java
+++ b/lucene/core/src/java/org/apache/lucene/document/VectorField.java
@@ -23,15 +23,15 @@ import org.apache.lucene.index.VectorValues;
  * Vectors are dense - that is, every dimension of a vector contains an explicit value, stored
  * packed into an array (of type float[]) whose length is the vector dimension. Values can be
  * retrieved using {@link VectorValues}, which is a forward-only docID-based iterator and also
- * offers random-access by dense ordinal (not docId). VectorValues.ScoreFunctions may be
+ * offers random-access by dense ordinal (not docId). VectorValues.SearchStrategys may be
  * used to compare vectors at query time (for example as part of result ranking). A VectorField may
- * be associated with a score function that defines the metric used for nearest-neighbor search
+ * be associated with a search strategy that defines the metric used for nearest-neighbor search
  * among vectors of that field, but at the moment this association is purely nominal: it is intended
  * for future use by the to-be-implemented nearest neighbors search.
  */
 public class VectorField extends Field {
 
-  private static FieldType getType(float[] v, VectorValues.ScoreFunction scoreFunction) {
+  private static FieldType getType(float[] v, VectorValues.SearchStrategy searchStrategy) {
     if (v == null) {
       throw new IllegalArgumentException("vector value must not be null");
     }
@@ -42,38 +42,38 @@ public class VectorField extends Field {
     if (dimension > VectorValues.MAX_DIMENSIONS) {
       throw new IllegalArgumentException("cannot index vectors with dimension greater than " + VectorValues.MAX_DIMENSIONS);
     }
-    if (scoreFunction == null) {
-      throw new IllegalArgumentException("score function must not be null");
+    if (searchStrategy == null) {
+      throw new IllegalArgumentException("search strategy must not be null");
     }
     FieldType type = new FieldType();
-    type.setVectorDimensionsAndScoreFunction(dimension, scoreFunction);
+    type.setVectorDimensionsAndSearchStrategy(dimension, searchStrategy);
     type.freeze();
     return type;
   }
 
   /** Creates a numeric vector field. Fields are single-valued: each document has either one value
-   * or no value. Vectors of a single field share the same dimension and score function.
+   * or no value. Vectors of a single field share the same dimension and search strategy.
    *
    *  @param name field name
    *  @param vector value
-   *  @param scoreFunction a function defining vector proximity.
+   *  @param searchStrategy a function defining vector proximity.
    *  @throws IllegalArgumentException if any parameter is null, or the vector is empty or has dimension &gt; 1024.
    */
-  public VectorField(String name, float[] vector, VectorValues.ScoreFunction scoreFunction) {
-    super(name, getType(vector, scoreFunction));
+  public VectorField(String name, float[] vector, VectorValues.SearchStrategy searchStrategy) {
+    super(name, getType(vector, searchStrategy));
     fieldsData = vector;
   }
 
-  /** Creates a numeric vector field with the default EUCLIDEAN (L2) score function. Fields are
+  /** Creates a numeric vector field with the default EUCLIDEAN_HNSW (L2) search strategy. Fields are
    * single-valued: each document has either one value or no value. Vectors of a single field share
-   * the same dimension and score function.
+   * the same dimension and search strategy.
    *
    *  @param name field name
    *  @param vector value
    *  @throws IllegalArgumentException if any parameter is null, or the vector is empty or has dimension &gt; 1024.
    */
   public VectorField(String name, float[] vector) {
-    this(name, vector, VectorValues.ScoreFunction.EUCLIDEAN);
+    this(name, vector, VectorValues.SearchStrategy.EUCLIDEAN_HNSW);
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/index/FieldInfo.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FieldInfo.java
@@ -55,7 +55,7 @@ public final class FieldInfo {
   private int pointNumBytes;
 
   private int vectorDimension;  // if it is a positive value, it means this field indexes vectors
-  private VectorValues.ScoreFunction vectorScoreFunction = VectorValues.ScoreFunction.NONE;
+  private VectorValues.SearchStrategy vectorSearchStrategy = VectorValues.SearchStrategy.NONE;
 
   // whether this field is used as the soft-deletes field
   private final boolean softDeletesField;
@@ -68,7 +68,7 @@ public final class FieldInfo {
   public FieldInfo(String name, int number, boolean storeTermVector, boolean omitNorms, boolean storePayloads,
                    IndexOptions indexOptions, DocValuesType docValues, long dvGen, Map<String,String> attributes,
                    int pointDimensionCount, int pointIndexDimensionCount, int pointNumBytes,
-                   int vectorDimension, VectorValues.ScoreFunction vectorScoreFunction, boolean softDeletesField) {
+                   int vectorDimension, VectorValues.SearchStrategy vectorSearchStrategy, boolean softDeletesField) {
     this.name = Objects.requireNonNull(name);
     this.number = number;
     this.docValuesType = Objects.requireNonNull(docValues, "DocValuesType must not be null (field: \"" + name + "\")");
@@ -88,7 +88,7 @@ public final class FieldInfo {
     this.pointIndexDimensionCount = pointIndexDimensionCount;
     this.pointNumBytes = pointNumBytes;
     this.vectorDimension = vectorDimension;
-    this.vectorScoreFunction = vectorScoreFunction;
+    this.vectorSearchStrategy = vectorSearchStrategy;
     this.softDeletesField = softDeletesField;
     this.checkConsistency();
   }
@@ -147,8 +147,8 @@ public final class FieldInfo {
       throw new IllegalStateException("vectorDimension must be >=0; got " + vectorDimension);
     }
 
-    if (vectorDimension == 0 && vectorScoreFunction != VectorValues.ScoreFunction.NONE) {
-      throw new IllegalStateException("vector score function must be NONE when dimension = 0; got " + vectorScoreFunction);
+    if (vectorDimension == 0 && vectorSearchStrategy != VectorValues.SearchStrategy.NONE) {
+      throw new IllegalStateException("vector search strategy must be NONE when dimension = 0; got " + vectorSearchStrategy);
     }
 
     return true;
@@ -247,25 +247,25 @@ public final class FieldInfo {
   }
 
   /** Record that this field is indexed with vectors, with the specified num of dimensions and distance function */
-  public void setVectorDimensionAndScoreFunction(int dimension, VectorValues.ScoreFunction scoreFunction) {
+  public void setVectorDimensionAndSearchStrategy(int dimension, VectorValues.SearchStrategy searchStrategy) {
     if (dimension < 0) {
       throw new IllegalArgumentException("vector dimension must be >= 0; got " + dimension);
     }
     if (dimension > VectorValues.MAX_DIMENSIONS) {
       throw new IllegalArgumentException("vector dimension must be <= VectorValues.MAX_DIMENSIONS (=" + VectorValues.MAX_DIMENSIONS + "); got " + dimension);
     }
-    if (dimension == 0 && scoreFunction != VectorValues.ScoreFunction.NONE) {
-      throw new IllegalArgumentException("vector score function must be NONE when the vector dimension = 0; got " + scoreFunction);
+    if (dimension == 0 && searchStrategy != VectorValues.SearchStrategy.NONE) {
+      throw new IllegalArgumentException("vector search strategy must be NONE when the vector dimension = 0; got " + searchStrategy);
     }
     if (vectorDimension != 0 && vectorDimension != dimension) {
       throw new IllegalArgumentException("cannot change vector dimension from " + vectorDimension + " to " + dimension + " for field=\"" + name + "\"");
     }
-    if (vectorScoreFunction != VectorValues.ScoreFunction.NONE && vectorScoreFunction != scoreFunction) {
-      throw new IllegalArgumentException("cannot change vector score function from " + vectorScoreFunction + " to " + scoreFunction + " for field=\"" + name + "\"");
+    if (vectorSearchStrategy != VectorValues.SearchStrategy.NONE && vectorSearchStrategy != searchStrategy) {
+      throw new IllegalArgumentException("cannot change vector search strategy from " + vectorSearchStrategy + " to " + searchStrategy + " for field=\"" + name + "\"");
     }
 
     this.vectorDimension = dimension;
-    this.vectorScoreFunction = scoreFunction;
+    this.vectorSearchStrategy = searchStrategy;
 
     assert checkConsistency();
   }
@@ -275,9 +275,9 @@ public final class FieldInfo {
     return vectorDimension;
   }
 
-  /** Returns {@link org.apache.lucene.index.VectorValues.ScoreFunction} for the field */
-  public VectorValues.ScoreFunction getVectorScoreFunction() {
-    return vectorScoreFunction;
+  /** Returns {@link VectorValues.SearchStrategy} for the field */
+  public VectorValues.SearchStrategy getVectorSearchStrategy() {
+    return vectorSearchStrategy;
   }
 
   /** Record that this field is indexed with docvalues, with the specified type */

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -1185,7 +1185,7 @@ public class IndexWriter implements Closeable, TwoPhaseCommit, Accountable,
       FieldInfos fis = readFieldInfos(info);
       for(FieldInfo fi : fis) {
         map.addOrGet(fi.name, fi.number, fi.getIndexOptions(), fi.getDocValuesType(), fi.getPointDimensionCount(), fi.getPointIndexDimensionCount(), fi.getPointNumBytes(),
-                     fi.getVectorDimension(), fi.getVectorScoreFunction(), fi.isSoftDeletesField());
+                     fi.getVectorDimension(), fi.getVectorSearchStrategy(), fi.isSoftDeletesField());
       }
     }
 
@@ -1922,7 +1922,7 @@ public class IndexWriter implements Closeable, TwoPhaseCommit, Accountable,
       if (globalFieldNumberMap.contains(f.name(), dvType) == false) {
         // if this field doesn't exists we try to add it. if it exists and the DV type doesn't match we
         // get a consistent error message as if you try to do that during an indexing operation.
-        globalFieldNumberMap.addOrGet(f.name(), -1, IndexOptions.NONE, dvType, 0, 0, 0, 0, VectorValues.ScoreFunction.NONE, f.name().equals(config.softDeletesField));
+        globalFieldNumberMap.addOrGet(f.name(), -1, IndexOptions.NONE, dvType, 0, 0, 0, 0, VectorValues.SearchStrategy.NONE, f.name().equals(config.softDeletesField));
         assert globalFieldNumberMap.contains(f.name(), dvType);
       }
       if (config.getIndexSortFields().contains(f.name())) {
@@ -2969,7 +2969,7 @@ public class IndexWriter implements Closeable, TwoPhaseCommit, Accountable,
               // This will throw exceptions if any of the incoming fields have an illegal schema change:
               globalFieldNumberMap.addOrGet(fi.name, fi.number, fi.getIndexOptions(), fi.getDocValuesType(),
                                             fi.getPointDimensionCount(), fi.getPointIndexDimensionCount(), fi.getPointNumBytes(),
-                                            fi.getVectorDimension(), fi.getVectorScoreFunction(), fi.isSoftDeletesField());
+                                            fi.getVectorDimension(), fi.getVectorSearchStrategy(), fi.isSoftDeletesField());
             }
             infos.add(copySegmentAsIs(info, newSegName, context));
           }

--- a/lucene/core/src/java/org/apache/lucene/index/IndexableFieldType.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexableFieldType.java
@@ -120,9 +120,9 @@ public interface IndexableFieldType {
   public int vectorDimension();
 
   /**
-   * The {@link org.apache.lucene.index.VectorValues.ScoreFunction} of the field's vector value
+   * The {@link VectorValues.SearchStrategy} of the field's vector value
    */
-  public VectorValues.ScoreFunction vectorScoreFunction();
+  public VectorValues.SearchStrategy vectorSearchStrategy();
 
   /**
    * Attributes for the field type.

--- a/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java
@@ -783,14 +783,14 @@ final class IndexingChain implements Accountable {
   /** Called from processDocument to index one field's vector value */
   private void indexVector(int docID, PerField fp, IndexableField field) {
     int dimension = field.fieldType().vectorDimension();
-    VectorValues.ScoreFunction scoreFunction = field.fieldType().vectorScoreFunction();
+    VectorValues.SearchStrategy searchStrategy = field.fieldType().vectorSearchStrategy();
 
     // Record dimensions and distance function for this field; this setter will throw IllegalArgExc if
     // the dimensions or distance function were already set to something different:
     if (fp.fieldInfo.getVectorDimension() == 0) {
-      fieldInfos.globalFieldNumbers.setVectorDimensionsAndScoreFunction(fp.fieldInfo.number, fp.fieldInfo.name, dimension, scoreFunction);
+      fieldInfos.globalFieldNumbers.setVectorDimensionsAndSearchStrategy(fp.fieldInfo.number, fp.fieldInfo.name, dimension, searchStrategy);
     }
-    fp.fieldInfo.setVectorDimensionAndScoreFunction(dimension, scoreFunction);
+    fp.fieldInfo.setVectorDimensionAndSearchStrategy(dimension, searchStrategy);
 
     if (fp.vectorValuesWriter == null) {
       fp.vectorValuesWriter = new VectorValuesWriter(fp.fieldInfo, bytesUsed);

--- a/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java
@@ -658,7 +658,7 @@ final class ReadersAndUpdates {
     return new FieldInfo(fi.name, fieldNumber, fi.hasVectors(), fi.omitsNorms(), fi.hasPayloads(),
         fi.getIndexOptions(), fi.getDocValuesType(), fi.getDocValuesGen(), new HashMap<>(fi.attributes()),
         fi.getPointDimensionCount(), fi.getPointIndexDimensionCount(), fi.getPointNumBytes(),
-        fi.getVectorDimension(), fi.getVectorScoreFunction(), fi.isSoftDeletesField());
+        fi.getVectorDimension(), fi.getVectorSearchStrategy(), fi.isSoftDeletesField());
   }
 
   private SegmentReader createNewReaderWithLatestLiveDocs(SegmentReader reader) throws IOException {

--- a/lucene/core/src/java/org/apache/lucene/index/VectorValuesWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/VectorValuesWriter.java
@@ -90,7 +90,7 @@ class VectorValuesWriter {
    * @throws IOException if there is an error writing the field and its values
    */
   public void flush(Sorter.DocMap sortMap, VectorWriter vectorWriter) throws IOException {
-    VectorValues vectorValues = new BufferedVectorValues(docsWithField, vectors, fieldInfo.getVectorDimension(), fieldInfo.getVectorScoreFunction());
+    VectorValues vectorValues = new BufferedVectorValues(docsWithField, vectors, fieldInfo.getVectorDimension(), fieldInfo.getVectorSearchStrategy());
     if (sortMap != null) {
       vectorWriter.writeField(fieldInfo, new SortingVectorValues(vectorValues, sortMap));
     } else {
@@ -167,8 +167,8 @@ class VectorValuesWriter {
     }
 
     @Override
-    public ScoreFunction scoreFunction() {
-      return delegate.scoreFunction();
+    public SearchStrategy searchStrategy() {
+      return delegate.searchStrategy();
     }
 
     @Override
@@ -197,8 +197,8 @@ class VectorValuesWriter {
         }
 
         @Override
-        public ScoreFunction scoreFunction() {
-          return delegate.scoreFunction();
+        public SearchStrategy searchStrategy() {
+          return delegate.searchStrategy();
         }
 
         @Override
@@ -225,7 +225,7 @@ class VectorValuesWriter {
 
     // These are always the vectors of a VectorValuesWriter, which are copied when added to it
     final List<float[]> vectors;
-    final VectorValues.ScoreFunction scoreFunction;
+    final SearchStrategy searchStrategy;
     final int dimension;
 
     final ByteBuffer buffer;
@@ -236,11 +236,11 @@ class VectorValuesWriter {
     DocIdSetIterator docsWithFieldIter;
     int ord = -1;
 
-    BufferedVectorValues(DocsWithFieldSet docsWithField, List<float[]> vectors, int dimension, VectorValues.ScoreFunction scoreFunction) {
+    BufferedVectorValues(DocsWithFieldSet docsWithField, List<float[]> vectors, int dimension, SearchStrategy searchStrategy) {
       this.docsWithField = docsWithField;
       this.vectors = vectors;
       this.dimension = dimension;
-      this.scoreFunction = scoreFunction;
+      this.searchStrategy = searchStrategy;
       buffer = ByteBuffer.allocate(dimension * Float.BYTES);
       binaryValue = new BytesRef(buffer.array());
       raBuffer = ByteBuffer.allocate(dimension * Float.BYTES);
@@ -264,8 +264,8 @@ class VectorValuesWriter {
     }
 
     @Override
-    public VectorValues.ScoreFunction scoreFunction() {
-      return scoreFunction;
+    public SearchStrategy searchStrategy() {
+      return searchStrategy;
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
@@ -60,7 +60,7 @@ public final class VectorUtil {
     return res;
   }
 
-  public static float squareSum(float[] v1, float[] v2) {
+  public static float squareDistance(float[] v1, float[] v2) {
     assert v1.length == v2.length;
     float squareSum = 0.0f;
     int dim = v1.length;

--- a/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/util/VectorUtil.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.lucene.util;
+ 
+/**
+ * Utilities for computations with numeric arrays
+ */
+public final class VectorUtil {
+
+  private VectorUtil() {
+  }
+
+  public static float dotProduct(float[] a, float[] b) {
+    float res = 0f;
+    /*
+     * If length of vector is larger than 8, we use unrolled dot product to accelerate the
+     * calculation.
+     */
+    int i;
+    for (i = 0; i < a.length % 8; i++) {
+      res += b[i] * a[i];
+    }
+    if (a.length < 8) {
+      return res;
+    }
+    float s0 = 0f;
+    float s1 = 0f;
+    float s2 = 0f;
+    float s3 = 0f;
+    float s4 = 0f;
+    float s5 = 0f;
+    float s6 = 0f;
+    float s7 = 0f;
+    for (; i + 7 < a.length; i += 8) {
+      s0 += b[i] * a[i];
+      s1 += b[i + 1] * a[i + 1];
+      s2 += b[i + 2] * a[i + 2];
+      s3 += b[i + 3] * a[i + 3];
+      s4 += b[i + 4] * a[i + 4];
+      s5 += b[i + 5] * a[i + 5];
+      s6 += b[i + 6] * a[i + 6];
+      s7 += b[i + 7] * a[i + 7];
+    }
+    res += s0 + s1 + s2 + s3 + s4 + s5 + s6 + s7;
+    return res;
+  }
+
+  public static float squareSum(float[] v1, float[] v2) {
+    assert v1.length == v2.length;
+    float squareSum = 0.0f;
+    int dim = v1.length;
+    for (int i = 0; i < dim; i++) {
+      float diff = v1[i] - v2[i];
+      squareSum += diff * diff;
+    }
+    return squareSum;
+  }
+
+}

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexableField.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexableField.java
@@ -112,8 +112,8 @@ public class TestIndexableField extends LuceneTestCase {
       }
 
       @Override
-      public VectorValues.ScoreFunction vectorScoreFunction() {
-        return VectorValues.ScoreFunction.NONE;
+      public VectorValues.SearchStrategy vectorSearchStrategy() {
+        return VectorValues.SearchStrategy.NONE;
       }
 
       @Override

--- a/lucene/core/src/test/org/apache/lucene/index/TestPendingSoftDeletes.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestPendingSoftDeletes.java
@@ -37,7 +37,7 @@ import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.StringHelper;
 import org.apache.lucene.util.Version;
 
-import static org.apache.lucene.index.VectorValues.ScoreFunction.NONE;
+import static org.apache.lucene.index.VectorValues.SearchStrategy.NONE;
 
 public class TestPendingSoftDeletes extends TestPendingDeletes {
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestVectorValues.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestVectorValues.java
@@ -27,7 +27,7 @@ import org.apache.lucene.document.Field.Store;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.document.VectorField;
-import org.apache.lucene.index.VectorValues.ScoreFunction;
+import org.apache.lucene.index.VectorValues.SearchStrategy;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.store.Directory;
@@ -57,7 +57,7 @@ public class TestVectorValues extends LuceneTestCase {
       }
       try (IndexWriter w = new IndexWriter(dir, createIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new VectorField("f", new float[4], ScoreFunction.DOT_PRODUCT));
+        doc.add(new VectorField("f", new float[4], VectorValues.SearchStrategy.DOT_PRODUCT_HNSW));
         w.addDocument(doc);
       }
     }
@@ -67,7 +67,7 @@ public class TestVectorValues extends LuceneTestCase {
     float[] v = new float[1];
     VectorField field = new VectorField("f", v);
     assertEquals(1, field.fieldType().vectorDimension());
-    assertEquals(ScoreFunction.EUCLIDEAN, field.fieldType().vectorScoreFunction());
+    assertEquals(VectorValues.SearchStrategy.EUCLIDEAN_HNSW, field.fieldType().vectorSearchStrategy());
     assertSame(v, field.vectorValue());
   }
 
@@ -94,7 +94,7 @@ public class TestVectorValues extends LuceneTestCase {
     try (Directory dir = newDirectory();
          IndexWriter w = new IndexWriter(dir, createIndexWriterConfig())) {
       Document doc = new Document();
-      doc.add(new VectorField("f", new float[4], ScoreFunction.DOT_PRODUCT));
+      doc.add(new VectorField("f", new float[4], VectorValues.SearchStrategy.DOT_PRODUCT_HNSW));
       w.addDocument(doc);
       if (random().nextBoolean()) {
         // sometimes test with two segments
@@ -102,18 +102,18 @@ public class TestVectorValues extends LuceneTestCase {
       }
 
       Document doc2 = new Document();
-      doc2.add(new VectorField("f", new float[3], ScoreFunction.DOT_PRODUCT));
+      doc2.add(new VectorField("f", new float[3], VectorValues.SearchStrategy.DOT_PRODUCT_HNSW));
       IllegalArgumentException expected = expectThrows(IllegalArgumentException.class,
           () -> w.addDocument(doc2));
       assertEquals("cannot change vector dimension from 4 to 3 for field=\"f\"", expected.getMessage());
     }
   }
 
-  public void testIllegalScoreFunctionChange() throws Exception {
+  public void testIllegalSearchStrategyChange() throws Exception {
     try (Directory dir = newDirectory();
          IndexWriter w = new IndexWriter(dir, createIndexWriterConfig())) {
       Document doc = new Document();
-      doc.add(new VectorField("f", new float[4], ScoreFunction.DOT_PRODUCT));
+      doc.add(new VectorField("f", new float[4], VectorValues.SearchStrategy.DOT_PRODUCT_HNSW));
       w.addDocument(doc);
       if (random().nextBoolean()) {
         // sometimes test with two segments
@@ -121,10 +121,10 @@ public class TestVectorValues extends LuceneTestCase {
       }
 
       Document doc2 = new Document();
-      doc2.add(new VectorField("f", new float[4], ScoreFunction.EUCLIDEAN));
+      doc2.add(new VectorField("f", new float[4], VectorValues.SearchStrategy.EUCLIDEAN_HNSW));
       IllegalArgumentException expected = expectThrows(IllegalArgumentException.class,
           () -> w.addDocument(doc2));
-      assertEquals("cannot change vector score function from DOT_PRODUCT to EUCLIDEAN for field=\"f\"", expected.getMessage());
+      assertEquals("cannot change vector search strategy from DOT_PRODUCT_HNSW to EUCLIDEAN_HNSW for field=\"f\"", expected.getMessage());
     }
   }
 
@@ -132,13 +132,13 @@ public class TestVectorValues extends LuceneTestCase {
     try (Directory dir = newDirectory()) {
       try (IndexWriter w = new IndexWriter(dir, createIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new VectorField("f", new float[4], ScoreFunction.DOT_PRODUCT));
+        doc.add(new VectorField("f", new float[4], VectorValues.SearchStrategy.DOT_PRODUCT_HNSW));
         w.addDocument(doc);
       }
 
       try (IndexWriter w2 = new IndexWriter(dir, createIndexWriterConfig())) {
         Document doc2 = new Document();
-        doc2.add(new VectorField("f", new float[1], ScoreFunction.DOT_PRODUCT));
+        doc2.add(new VectorField("f", new float[1], VectorValues.SearchStrategy.DOT_PRODUCT_HNSW));
         IllegalArgumentException expected = expectThrows(IllegalArgumentException.class,
             () -> w2.addDocument(doc2));
         assertEquals("cannot change vector dimension from 4 to 1 for field=\"f\"", expected.getMessage());
@@ -146,20 +146,20 @@ public class TestVectorValues extends LuceneTestCase {
     }
   }
 
-  public void testIllegalScoreFunctionChangeTwoWriters() throws Exception {
+  public void testIllegalSearchStrategyChangeTwoWriters() throws Exception {
     try (Directory dir = newDirectory()) {
       try (IndexWriter w = new IndexWriter(dir, createIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new VectorField("f", new float[4], ScoreFunction.DOT_PRODUCT));
+        doc.add(new VectorField("f", new float[4], VectorValues.SearchStrategy.DOT_PRODUCT_HNSW));
         w.addDocument(doc);
       }
 
       try (IndexWriter w2 = new IndexWriter(dir, createIndexWriterConfig())) {
         Document doc2 = new Document();
-        doc2.add(new VectorField("f", new float[4], ScoreFunction.EUCLIDEAN));
+        doc2.add(new VectorField("f", new float[4], VectorValues.SearchStrategy.EUCLIDEAN_HNSW));
         IllegalArgumentException expected = expectThrows(IllegalArgumentException.class,
             () -> w2.addDocument(doc2));
-        assertEquals("cannot change vector score function from DOT_PRODUCT to EUCLIDEAN for field=\"f\"", expected.getMessage());
+        assertEquals("cannot change vector search strategy from DOT_PRODUCT_HNSW to EUCLIDEAN_HNSW for field=\"f\"", expected.getMessage());
       }
     }
   }
@@ -167,7 +167,7 @@ public class TestVectorValues extends LuceneTestCase {
   public void testAddIndexesDirectory0() throws Exception {
     String fieldName = "field";
     Document doc = new Document();
-    doc.add(new VectorField(fieldName, new float[4], ScoreFunction.DOT_PRODUCT));
+    doc.add(new VectorField(fieldName, new float[4], VectorValues.SearchStrategy.DOT_PRODUCT_HNSW));
     try (Directory dir = newDirectory();
          Directory dir2 = newDirectory()) {
       try (IndexWriter w = new IndexWriter(dir, createIndexWriterConfig())) {
@@ -194,7 +194,7 @@ public class TestVectorValues extends LuceneTestCase {
       try (IndexWriter w = new IndexWriter(dir, createIndexWriterConfig())) {
         w.addDocument(doc);
       }
-      doc.add(new VectorField(fieldName, new float[4], ScoreFunction.DOT_PRODUCT)); 
+      doc.add(new VectorField(fieldName, new float[4], VectorValues.SearchStrategy.DOT_PRODUCT_HNSW));
       try (IndexWriter w2 = new IndexWriter(dir2, createIndexWriterConfig())) {
         w2.addDocument(doc);
         w2.addIndexes(new Directory[]{dir});
@@ -213,7 +213,7 @@ public class TestVectorValues extends LuceneTestCase {
     String fieldName = "field";
     float[] vector = new float[1];
     Document doc = new Document();
-    doc.add(new VectorField(fieldName, vector, ScoreFunction.DOT_PRODUCT));
+    doc.add(new VectorField(fieldName, vector, VectorValues.SearchStrategy.DOT_PRODUCT_HNSW));
     try (Directory dir = newDirectory();
          Directory dir2 = newDirectory()) {
       try (IndexWriter w = new IndexWriter(dir, createIndexWriterConfig())) {
@@ -244,12 +244,12 @@ public class TestVectorValues extends LuceneTestCase {
          Directory dir2 = newDirectory()) {
       try (IndexWriter w = new IndexWriter(dir, createIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new VectorField("f", new float[4], ScoreFunction.DOT_PRODUCT));
+        doc.add(new VectorField("f", new float[4], SearchStrategy.DOT_PRODUCT_HNSW));
         w.addDocument(doc);
       }
       try (IndexWriter w2 = new IndexWriter(dir2, createIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new VectorField("f", new float[5], ScoreFunction.DOT_PRODUCT));
+        doc.add(new VectorField("f", new float[5], VectorValues.SearchStrategy.DOT_PRODUCT_HNSW));
         w2.addDocument(doc);
         IllegalArgumentException expected = expectThrows(IllegalArgumentException.class,
             () -> w2.addIndexes(new Directory[]{dir}));
@@ -258,21 +258,21 @@ public class TestVectorValues extends LuceneTestCase {
     }
   }
 
-  public void testIllegalScoreFunctionChangeViaAddIndexesDirectory() throws Exception {
+  public void testIllegalSearchStrategyChangeViaAddIndexesDirectory() throws Exception {
     try (Directory dir = newDirectory();
          Directory dir2 = newDirectory()) {
       try (IndexWriter w = new IndexWriter(dir, createIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new VectorField("f", new float[4], ScoreFunction.DOT_PRODUCT));
+        doc.add(new VectorField("f", new float[4], VectorValues.SearchStrategy.DOT_PRODUCT_HNSW));
         w.addDocument(doc);
       }
       try (IndexWriter w2 = new IndexWriter(dir2, createIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new VectorField("f", new float[4], ScoreFunction.EUCLIDEAN));
+        doc.add(new VectorField("f", new float[4], VectorValues.SearchStrategy.EUCLIDEAN_HNSW));
         w2.addDocument(doc);
         IllegalArgumentException expected = expectThrows(IllegalArgumentException.class,
             () -> w2.addIndexes(dir));
-        assertEquals("cannot change vector score function from EUCLIDEAN to DOT_PRODUCT for field=\"f\"", expected.getMessage());
+        assertEquals("cannot change vector search strategy from EUCLIDEAN_HNSW to DOT_PRODUCT_HNSW for field=\"f\"", expected.getMessage());
       }
     }
   }
@@ -282,12 +282,12 @@ public class TestVectorValues extends LuceneTestCase {
          Directory dir2 = newDirectory()) {
       try (IndexWriter w = new IndexWriter(dir, createIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new VectorField("f", new float[4], ScoreFunction.DOT_PRODUCT));
+        doc.add(new VectorField("f", new float[4], SearchStrategy.DOT_PRODUCT_HNSW));
         w.addDocument(doc);
       }
       try (IndexWriter w2 = new IndexWriter(dir2, createIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new VectorField("f", new float[5], ScoreFunction.DOT_PRODUCT));
+        doc.add(new VectorField("f", new float[5], VectorValues.SearchStrategy.DOT_PRODUCT_HNSW));
         w2.addDocument(doc);
         try (DirectoryReader r = DirectoryReader.open(dir)) {
           IllegalArgumentException expected = expectThrows(IllegalArgumentException.class,
@@ -298,22 +298,22 @@ public class TestVectorValues extends LuceneTestCase {
     }
   }
 
-  public void testIllegalScoreFunctionChangeViaAddIndexesCodecReader() throws Exception {
+  public void testIllegalSearchStrategyChangeViaAddIndexesCodecReader() throws Exception {
     try (Directory dir = newDirectory();
          Directory dir2 = newDirectory()) {
       try (IndexWriter w = new IndexWriter(dir, createIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new VectorField("f", new float[4], ScoreFunction.DOT_PRODUCT));
+        doc.add(new VectorField("f", new float[4], VectorValues.SearchStrategy.DOT_PRODUCT_HNSW));
         w.addDocument(doc);
       }
       try (IndexWriter w2 = new IndexWriter(dir2, createIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new VectorField("f", new float[4], ScoreFunction.EUCLIDEAN));
+        doc.add(new VectorField("f", new float[4], VectorValues.SearchStrategy.EUCLIDEAN_HNSW));
         w2.addDocument(doc);
         try (DirectoryReader r = DirectoryReader.open(dir)) {
           IllegalArgumentException expected = expectThrows(IllegalArgumentException.class,
               () -> w2.addIndexes(new CodecReader[]{(CodecReader) getOnlyLeafReader(r)}));
-          assertEquals("cannot change vector score function from EUCLIDEAN to DOT_PRODUCT for field=\"f\"", expected.getMessage());
+          assertEquals("cannot change vector search strategy from EUCLIDEAN_HNSW to DOT_PRODUCT_HNSW for field=\"f\"", expected.getMessage());
         }
       }
     }
@@ -324,12 +324,12 @@ public class TestVectorValues extends LuceneTestCase {
          Directory dir2 = newDirectory()) {
       try (IndexWriter w = new IndexWriter(dir, createIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new VectorField("f", new float[4], ScoreFunction.DOT_PRODUCT));
+        doc.add(new VectorField("f", new float[4], VectorValues.SearchStrategy.DOT_PRODUCT_HNSW));
         w.addDocument(doc);
       }
       try (IndexWriter w2 = new IndexWriter(dir2, createIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new VectorField("f", new float[5], ScoreFunction.DOT_PRODUCT));
+        doc.add(new VectorField("f", new float[5], VectorValues.SearchStrategy.DOT_PRODUCT_HNSW));
         w2.addDocument(doc);
         try (DirectoryReader r = DirectoryReader.open(dir)) {
           IllegalArgumentException expected = expectThrows(IllegalArgumentException.class,
@@ -340,22 +340,22 @@ public class TestVectorValues extends LuceneTestCase {
     }
   }
 
-  public void testIllegalScoreFunctionChangeViaAddIndexesSlowCodecReader() throws Exception {
+  public void testIllegalSearchStrategyChangeViaAddIndexesSlowCodecReader() throws Exception {
     try (Directory dir = newDirectory();
          Directory dir2 = newDirectory()) {
       try (IndexWriter w = new IndexWriter(dir, createIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new VectorField("f", new float[4], ScoreFunction.DOT_PRODUCT));
+        doc.add(new VectorField("f", new float[4], VectorValues.SearchStrategy.DOT_PRODUCT_HNSW));
         w.addDocument(doc);
       }
       try (IndexWriter w2 = new IndexWriter(dir2, createIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new VectorField("f", new float[4], ScoreFunction.EUCLIDEAN));
+        doc.add(new VectorField("f", new float[4], SearchStrategy.EUCLIDEAN_HNSW));
         w2.addDocument(doc);
         try (DirectoryReader r = DirectoryReader.open(dir)) {
           IllegalArgumentException expected = expectThrows(IllegalArgumentException.class,
               () -> TestUtil.addIndexesSlowly(w2, r));
-          assertEquals("cannot change vector score function from EUCLIDEAN to DOT_PRODUCT for field=\"f\"", expected.getMessage());
+          assertEquals("cannot change vector search strategy from EUCLIDEAN_HNSW to DOT_PRODUCT_HNSW for field=\"f\"", expected.getMessage());
         }
       }
     }
@@ -365,8 +365,8 @@ public class TestVectorValues extends LuceneTestCase {
     try (Directory dir = newDirectory();
          IndexWriter w = new IndexWriter(dir, createIndexWriterConfig())) {
       Document doc = new Document();
-      doc.add(new VectorField("f", new float[4], ScoreFunction.DOT_PRODUCT));
-      doc.add(new VectorField("f", new float[4], ScoreFunction.DOT_PRODUCT));
+      doc.add(new VectorField("f", new float[4], VectorValues.SearchStrategy.DOT_PRODUCT_HNSW));
+      doc.add(new VectorField("f", new float[4], VectorValues.SearchStrategy.DOT_PRODUCT_HNSW));
       IllegalArgumentException expected = expectThrows(IllegalArgumentException.class,
           () -> w.addDocument(doc));
       assertEquals("VectorValuesField \"f\" appears more than once in this document (only one value is allowed per field)",
@@ -379,10 +379,10 @@ public class TestVectorValues extends LuceneTestCase {
          IndexWriter w = new IndexWriter(dir, createIndexWriterConfig())) {
       Document doc = new Document();
       expectThrows(IllegalArgumentException.class,
-          () -> doc.add(new VectorField("f", new float[VectorValues.MAX_DIMENSIONS + 1], ScoreFunction.DOT_PRODUCT)));
+          () -> doc.add(new VectorField("f", new float[VectorValues.MAX_DIMENSIONS + 1], VectorValues.SearchStrategy.DOT_PRODUCT_HNSW)));
 
       Document doc2 = new Document();
-      doc2.add(new VectorField("f", new float[1], ScoreFunction.EUCLIDEAN));
+      doc2.add(new VectorField("f", new float[1], VectorValues.SearchStrategy.EUCLIDEAN_HNSW));
       w.addDocument(doc2);
     }
   }
@@ -392,11 +392,11 @@ public class TestVectorValues extends LuceneTestCase {
          IndexWriter w = new IndexWriter(dir, createIndexWriterConfig())) {
       Document doc = new Document();
       Exception e = expectThrows(IllegalArgumentException.class,
-          () -> doc.add(new VectorField("f", new float[0], ScoreFunction.NONE)));
+          () -> doc.add(new VectorField("f", new float[0], SearchStrategy.NONE)));
       assertEquals("cannot index an empty vector", e.getMessage());
 
       Document doc2 = new Document();
-      doc2.add(new VectorField("f", new float[1], ScoreFunction.NONE));
+      doc2.add(new VectorField("f", new float[1], VectorValues.SearchStrategy.NONE));
       w.addDocument(doc2);
     }
   }
@@ -406,14 +406,14 @@ public class TestVectorValues extends LuceneTestCase {
     try (Directory dir = newDirectory()) {
       try (IndexWriter w = new IndexWriter(dir, createIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new VectorField("f", new float[4], ScoreFunction.DOT_PRODUCT));
+        doc.add(new VectorField("f", new float[4], VectorValues.SearchStrategy.DOT_PRODUCT_HNSW));
         w.addDocument(doc);
       }
       IndexWriterConfig iwc = newIndexWriterConfig();
       iwc.setCodec(Codec.forName("SimpleText"));
       try (IndexWriter w = new IndexWriter(dir, iwc)) {
         Document doc = new Document();
-        doc.add(new VectorField("f", new float[4], ScoreFunction.DOT_PRODUCT));
+        doc.add(new VectorField("f", new float[4], VectorValues.SearchStrategy.DOT_PRODUCT_HNSW));
         w.addDocument(doc);
         w.forceMerge(1);
       }
@@ -427,12 +427,12 @@ public class TestVectorValues extends LuceneTestCase {
     try (Directory dir = newDirectory()) {
       try (IndexWriter w = new IndexWriter(dir, iwc)) {
         Document doc = new Document();
-        doc.add(new VectorField("f", new float[4], ScoreFunction.DOT_PRODUCT));
+        doc.add(new VectorField("f", new float[4], VectorValues.SearchStrategy.DOT_PRODUCT_HNSW));
         w.addDocument(doc);
       }
       try (IndexWriter w = new IndexWriter(dir, createIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new VectorField("f", new float[4], ScoreFunction.DOT_PRODUCT));
+        doc.add(new VectorField("f", new float[4], VectorValues.SearchStrategy.DOT_PRODUCT_HNSW));
         w.addDocument(doc);
         w.forceMerge(1);
       }
@@ -440,7 +440,7 @@ public class TestVectorValues extends LuceneTestCase {
   }
 
   public void testInvalidVectorFieldUsage() {
-    VectorField field = new VectorField("field", new float[2], ScoreFunction.NONE);
+    VectorField field = new VectorField("field", new float[2], VectorValues.SearchStrategy.NONE);
 
     expectThrows(IllegalArgumentException.class, () -> field.setIntValue(14));
 
@@ -454,7 +454,7 @@ public class TestVectorValues extends LuceneTestCase {
          IndexWriter w = new IndexWriter(dir, createIndexWriterConfig())) {
       Document doc = new Document();
       doc.add(new StringField("id", "0", Store.NO));
-      doc.add(new VectorField("v", new float[]{2, 3, 5}, ScoreFunction.DOT_PRODUCT));
+      doc.add(new VectorField("v", new float[]{2, 3, 5}, VectorValues.SearchStrategy.DOT_PRODUCT_HNSW));
       w.addDocument(doc);
       w.addDocument(new Document());
       w.commit();
@@ -475,12 +475,12 @@ public class TestVectorValues extends LuceneTestCase {
          IndexWriter w = new IndexWriter(dir, createIndexWriterConfig())) {
       Document doc = new Document();
       doc.add(new StringField("id", "0", Store.NO));
-      doc.add(new VectorField("v0", new float[]{2, 3, 5}, ScoreFunction.DOT_PRODUCT));
+      doc.add(new VectorField("v0", new float[]{2, 3, 5}, VectorValues.SearchStrategy.DOT_PRODUCT_HNSW));
       w.addDocument(doc);
       w.commit();
 
       doc = new Document();
-      doc.add(new VectorField("v1", new float[]{2, 3, 5}, ScoreFunction.DOT_PRODUCT));
+      doc.add(new VectorField("v1", new float[]{2, 3, 5}, VectorValues.SearchStrategy.DOT_PRODUCT_HNSW));
       w.addDocument(doc);
       w.forceMerge(1);
     }
@@ -492,10 +492,10 @@ public class TestVectorValues extends LuceneTestCase {
     int[] fieldDocCounts = new int[numFields];
     float[] fieldTotals= new float[numFields];
     int[] fieldDims = new int[numFields];
-    ScoreFunction[] fieldScoreFunctions = new ScoreFunction[numFields];
+    VectorValues.SearchStrategy[] fieldSearchStrategies = new VectorValues.SearchStrategy[numFields];
     for (int i = 0; i < numFields; i++) {
       fieldDims[i] = random().nextInt(20) + 1;
-      fieldScoreFunctions[i] = ScoreFunction.values()[random().nextInt(ScoreFunction.values().length)];
+      fieldSearchStrategies[i] = VectorValues.SearchStrategy.values()[random().nextInt(VectorValues.SearchStrategy.values().length)];
     }
     try (Directory dir = newDirectory();
          RandomIndexWriter w = new RandomIndexWriter(random(), dir, createIndexWriterConfig())) {
@@ -505,7 +505,7 @@ public class TestVectorValues extends LuceneTestCase {
           String fieldName = "int" + field;
           if (random().nextInt(100) == 17) {
             float[] v = randomVector(fieldDims[field]);
-            doc.add(new VectorField(fieldName, v, fieldScoreFunctions[field]));
+            doc.add(new VectorField(fieldName, v, fieldSearchStrategies[field]));
             fieldDocCounts[field]++;
             fieldTotals[field] += v[0];
           }
@@ -542,15 +542,15 @@ public class TestVectorValues extends LuceneTestCase {
     try (Directory dir = newDirectory();
          IndexWriter iw = new IndexWriter(dir, createIndexWriterConfig())) {
       Document doc1 = new Document();
-      doc1.add(new VectorField(fieldName, v, VectorValues.ScoreFunction.EUCLIDEAN));
+      doc1.add(new VectorField(fieldName, v, VectorValues.SearchStrategy.EUCLIDEAN_HNSW));
       v[0] = 1;
       Document doc2 = new Document();
-      doc2.add(new VectorField(fieldName, v, VectorValues.ScoreFunction.EUCLIDEAN));
+      doc2.add(new VectorField(fieldName, v, VectorValues.SearchStrategy.EUCLIDEAN_HNSW));
       iw.addDocument(doc1);
       iw.addDocument(doc2);
       v[0] = 2;
       Document doc3 = new Document();
-      doc3.add(new VectorField(fieldName, v, VectorValues.ScoreFunction.EUCLIDEAN));
+      doc3.add(new VectorField(fieldName, v, VectorValues.SearchStrategy.EUCLIDEAN_HNSW));
       iw.addDocument(doc3);
       try (IndexReader reader = iw.getReader()) {
         LeafReader r = reader.leaves().get(0).reader();
@@ -693,10 +693,10 @@ public class TestVectorValues extends LuceneTestCase {
     try (Directory dir = newDirectory()) {
       try (IndexWriter w = new IndexWriter(dir, createIndexWriterConfig())) {
         Document doc = new Document();
-        doc.add(new VectorField("v1", randomVector(3), ScoreFunction.NONE));
+        doc.add(new VectorField("v1", randomVector(3), VectorValues.SearchStrategy.NONE));
         w.addDocument(doc);
 
-        doc.add(new VectorField("v2", randomVector(3), ScoreFunction.NONE));
+        doc.add(new VectorField("v2", randomVector(3), VectorValues.SearchStrategy.NONE));
         w.addDocument(doc);
       }
 
@@ -714,12 +714,12 @@ public class TestVectorValues extends LuceneTestCase {
     }
   }
 
-  public void testScoreFunctionIdentifiers() throws Exception {
-    // make sure we don't accidentally mess up score function identifiers by re-ordering their enumerators
-    assertEquals(0, ScoreFunction.NONE.ordinal());
-    assertEquals(1, ScoreFunction.EUCLIDEAN.ordinal());
-    assertEquals(2, ScoreFunction.DOT_PRODUCT.ordinal());
-    assertEquals(3, ScoreFunction.values().length);
+  public void testSearchStrategyIdentifiers() throws Exception {
+    // make sure we don't accidentally mess up search strategy identifiers by re-ordering their enumerators
+    assertEquals(0, VectorValues.SearchStrategy.NONE.ordinal());
+    assertEquals(1, VectorValues.SearchStrategy.EUCLIDEAN_HNSW.ordinal());
+    assertEquals(2, VectorValues.SearchStrategy.DOT_PRODUCT_HNSW.ordinal());
+    assertEquals(3, VectorValues.SearchStrategy.values().length);
   }
 
 }

--- a/lucene/core/src/test/org/apache/lucene/util/TestVectorUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestVectorUtil.java
@@ -39,21 +39,21 @@ public class TestVectorUtil extends LuceneTestCase {
     assertEquals(0, VectorUtil.dotProduct(u, v), 1e-5);
   }
 
-  public void testSelfSquareSum() {
+  public void testSelfSquareDistance() {
     // the l2 distance of a vector with itself is zero
     float[] v = randomVector();
-    assertEquals(0, VectorUtil.squareSum(v, v), 1e-5);
+    assertEquals(0, VectorUtil.squareDistance(v, v), 1e-5);
   }
 
-  public void testBasicSquareSum() {
-    assertEquals(12, VectorUtil.squareSum(new float[]{1, 2, 3}, new float[]{-1, 0, 5}), 0);
+  public void testBasicSquareDistance() {
+    assertEquals(12, VectorUtil.squareDistance(new float[]{1, 2, 3}, new float[]{-1, 0, 5}), 0);
   }
 
-  public void testRandomSquareSum() {
-    // the square sum of a vector with its inverse is equal to four times the sum of squares of its components
+  public void testRandomSquareDistance() {
+    // the square distance of a vector with its inverse is equal to four times the sum of squares of its components
     float[] v = randomVector();
     float[] u = negative(v);
-    assertEquals(4 * l2(v), VectorUtil.squareSum(u, v), 1e-5);
+    assertEquals(4 * l2(v), VectorUtil.squareDistance(u, v), 1e-5);
   }
 
   private float l2(float[] v) {

--- a/lucene/core/src/test/org/apache/lucene/util/TestVectorUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestVectorUtil.java
@@ -50,7 +50,7 @@ public class TestVectorUtil extends LuceneTestCase {
   }
 
   public void testRandomSquareSum() {
-    // the MSE of a vector with its inverse is equal to four times the sum of squares of its components
+    // the square sum of a vector with its inverse is equal to four times the sum of squares of its components
     float[] v = randomVector();
     float[] u = negative(v);
     assertEquals(4 * l2(v), VectorUtil.squareSum(u, v), 1e-5);

--- a/lucene/core/src/test/org/apache/lucene/util/TestVectorUtil.java
+++ b/lucene/core/src/test/org/apache/lucene/util/TestVectorUtil.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.util;
+
+public class TestVectorUtil extends LuceneTestCase {
+
+  public void testBasicDotProduct() {
+    assertEquals(5, VectorUtil.dotProduct(new float[]{1, 2, 3}, new float[]{-10, 0, 5}), 0);
+  }
+
+  public void testSelfDotProduct() {
+    // the dot product of a vector with itself is equal to the sum of the squares of its components
+    float[] v = randomVector();
+    assertEquals(l2(v), VectorUtil.dotProduct(v, v), 1e-5);
+  }
+
+  public void testOrthogonalDotProduct() {
+    // the dot product of two perpendicular vectors is 0
+    float[] v = new float[2];
+    v[0] = random().nextInt(100);
+    v[1] = random().nextInt(100);
+    float[] u = new float[2];
+    u[0] = v[1];
+    u[1] = -v[0];
+    assertEquals(0, VectorUtil.dotProduct(u, v), 1e-5);
+  }
+
+  public void testSelfSquareSum() {
+    // the l2 distance of a vector with itself is zero
+    float[] v = randomVector();
+    assertEquals(0, VectorUtil.squareSum(v, v), 1e-5);
+  }
+
+  public void testBasicSquareSum() {
+    assertEquals(12, VectorUtil.squareSum(new float[]{1, 2, 3}, new float[]{-1, 0, 5}), 0);
+  }
+
+  public void testRandomSquareSum() {
+    // the MSE of a vector with its inverse is equal to four times the sum of squares of its components
+    float[] v = randomVector();
+    float[] u = negative(v);
+    assertEquals(4 * l2(v), VectorUtil.squareSum(u, v), 1e-5);
+  }
+
+  private float l2(float[] v) {
+    float l2 = 0;
+    for (float x : v) {
+      l2 += x * x;
+    }
+    return l2;
+  }
+
+  private float[] negative(float[] v) {
+    float[] u = new float[v.length];
+    for (int i = 0; i < v.length; i++) {
+      u[i] = - v[i];
+    }
+    return u;
+  }
+
+  private float[] randomVector() {
+    float[] v = new float[random().nextInt(100) + 1];
+    for (int i = 0; i < v.length; i++) {
+      v[i] = random().nextFloat();
+    }
+    return v;
+  }
+
+}

--- a/lucene/highlighter/src/java/org/apache/lucene/search/highlight/TermVectorLeafReader.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/highlight/TermVectorLeafReader.java
@@ -82,7 +82,7 @@ public class TermVectorLeafReader extends LeafReader {
     }
     FieldInfo fieldInfo = new FieldInfo(field, 0,
                                         true, true, terms.hasPayloads(),
-                                        indexOptions, DocValuesType.NONE, -1, Collections.emptyMap(), 0, 0, 0, 0, VectorValues.ScoreFunction.NONE, false);
+                                        indexOptions, DocValuesType.NONE, -1, Collections.emptyMap(), 0, 0, 0, 0, VectorValues.SearchStrategy.NONE, false);
     fieldInfos = new FieldInfos(new FieldInfo[]{fieldInfo});
   }
 

--- a/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
+++ b/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
@@ -502,7 +502,7 @@ public class MemoryIndex {
     return new FieldInfo(fieldName, ord, fieldType.storeTermVectors(), fieldType.omitNorms(), storePayloads,
         indexOptions, fieldType.docValuesType(), -1, Collections.emptyMap(),
         fieldType.pointDimensionCount(), fieldType.pointIndexDimensionCount(), fieldType.pointNumBytes(),
-        fieldType.vectorDimension(), fieldType.vectorScoreFunction(), false);
+        fieldType.vectorDimension(), fieldType.vectorSearchStrategy(), false);
   }
 
   private void storePointValues(Info info, BytesRef pointValue) {
@@ -522,7 +522,7 @@ public class MemoryIndex {
           info.fieldInfo.name, info.fieldInfo.number, info.fieldInfo.hasVectors(), info.fieldInfo.hasPayloads(),
           info.fieldInfo.hasPayloads(), info.fieldInfo.getIndexOptions(), docValuesType, -1, info.fieldInfo.attributes(),
           info.fieldInfo.getPointDimensionCount(), info.fieldInfo.getPointIndexDimensionCount(), info.fieldInfo.getPointNumBytes(),
-          info.fieldInfo.getVectorDimension(), info.fieldInfo.getVectorScoreFunction(),
+          info.fieldInfo.getVectorDimension(), info.fieldInfo.getVectorSearchStrategy(),
           info.fieldInfo.isSoftDeletesField()
       );
     } else if (existingDocValuesType != docValuesType) {

--- a/lucene/queries/src/java/org/apache/lucene/queries/intervals/IntervalQuery.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/intervals/IntervalQuery.java
@@ -99,7 +99,7 @@ public final class IntervalQuery extends Query {
   private IntervalQuery(String field, IntervalsSource intervalsSource, IntervalScoreFunction scoreFunction) {
     Objects.requireNonNull(field, "null field aren't accepted");
     Objects.requireNonNull(intervalsSource, "null intervalsSource aren't accepted");
-    Objects.requireNonNull(scoreFunction, "null scoreFunction aren't accepted");
+    Objects.requireNonNull(scoreFunction, "null searchStrategy aren't accepted");
     this.field = field;
     this.intervalsSource = intervalsSource;
     this.scoreFunction = scoreFunction;

--- a/lucene/queries/src/java/org/apache/lucene/queries/intervals/IntervalQuery.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/intervals/IntervalQuery.java
@@ -99,7 +99,7 @@ public final class IntervalQuery extends Query {
   private IntervalQuery(String field, IntervalsSource intervalsSource, IntervalScoreFunction scoreFunction) {
     Objects.requireNonNull(field, "null field aren't accepted");
     Objects.requireNonNull(intervalsSource, "null intervalsSource aren't accepted");
-    Objects.requireNonNull(scoreFunction, "null searchStrategy aren't accepted");
+    Objects.requireNonNull(scoreFunction, "null scoreFunction aren't accepted");
     this.field = field;
     this.intervalsSource = intervalsSource;
     this.scoreFunction = scoreFunction;

--- a/lucene/test-framework/src/java/org/apache/lucene/index/BaseIndexFileFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/index/BaseIndexFileFormatTestCase.java
@@ -355,7 +355,7 @@ abstract class BaseIndexFileFormatTestCase extends LuceneTestCase {
     FieldInfo field = new FieldInfo(proto.name, proto.number, proto.hasVectors(), proto.omitsNorms(), proto.hasPayloads(), 
                                     proto.getIndexOptions(), proto.getDocValuesType(), proto.getDocValuesGen(), new HashMap<>(),
                                     proto.getPointDimensionCount(), proto.getPointIndexDimensionCount(), proto.getPointNumBytes(),
-                                    proto.getVectorDimension(), proto.getVectorScoreFunction(), proto.isSoftDeletesField());
+                                    proto.getVectorDimension(), proto.getVectorSearchStrategy(), proto.isSoftDeletesField());
 
     FieldInfos fieldInfos = new FieldInfos(new FieldInfo[] { field } );
 

--- a/lucene/test-framework/src/java/org/apache/lucene/index/MismatchedLeafReader.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/index/MismatchedLeafReader.java
@@ -81,7 +81,7 @@ public class MismatchedLeafReader extends FilterLeafReader {
                                         oldInfo.getPointIndexDimensionCount(),      // index dimension count
                                         oldInfo.getPointNumBytes(),  // dimension numBytes
                                         oldInfo.getVectorDimension(), // number of dimensions of the field's vector
-                                        oldInfo.getVectorScoreFunction(),      // distance function for calculating similarity of the field's vector
+                                        oldInfo.getVectorSearchStrategy(),      // distance function for calculating similarity of the field's vector
                                         oldInfo.isSoftDeletesField()); // used as soft-deletes field
       shuffled.set(i, newInfo);
     }

--- a/lucene/test-framework/src/java/org/apache/lucene/index/RandomPostingsTester.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/index/RandomPostingsTester.java
@@ -130,7 +130,7 @@ public class RandomPostingsTester {
       fieldInfoArray[fieldUpto] = new FieldInfo(field, fieldUpto, false, false, true,
                                                 IndexOptions.DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS,
                                                 DocValuesType.NONE, -1, new HashMap<>(),
-                                                0, 0, 0, 0, VectorValues.ScoreFunction.NONE, false);
+                                                0, 0, 0, 0, VectorValues.SearchStrategy.NONE, false);
       fieldUpto++;
 
       SortedMap<BytesRef,SeedAndOrd> postings = new TreeMap<>();
@@ -651,7 +651,7 @@ public class RandomPostingsTester {
                                                    DocValuesType.NONE,
                                                    -1,
                                                    new HashMap<>(),
-                                                   0, 0, 0, 0, VectorValues.ScoreFunction.NONE, false);
+                                                   0, 0, 0, 0, VectorValues.SearchStrategy.NONE, false);
     }
 
     FieldInfos newFieldInfos = new FieldInfos(newFieldInfoArray);

--- a/solr/core/src/java/org/apache/solr/schema/SchemaField.java
+++ b/solr/core/src/java/org/apache/solr/schema/SchemaField.java
@@ -454,8 +454,8 @@ public final class SchemaField extends FieldProperties implements IndexableField
   }
 
   @Override
-  public VectorValues.ScoreFunction vectorScoreFunction() {
-    return VectorValues.ScoreFunction.NONE;
+  public VectorValues.SearchStrategy vectorSearchStrategy() {
+    return VectorValues.SearchStrategy.NONE;
   }
 
   @Override

--- a/solr/core/src/java/org/apache/solr/search/CollapsingQParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/search/CollapsingQParserPlugin.java
@@ -494,7 +494,7 @@ public class CollapsingQParserPlugin extends QParserPlugin {
               fieldInfo.getPointIndexDimensionCount(),
               fieldInfo.getPointNumBytes(),
               fieldInfo.getVectorDimension(),
-              fieldInfo.getVectorScoreFunction(),
+              fieldInfo.getVectorSearchStrategy(),
               fieldInfo.isSoftDeletesField());
           newInfos.add(f);
         } else {

--- a/solr/core/src/java/org/apache/solr/search/Insanity.java
+++ b/solr/core/src/java/org/apache/solr/search/Insanity.java
@@ -68,7 +68,7 @@ public class Insanity {
           filteredInfos.add(new FieldInfo(fi.name, fi.number, fi.hasVectors(), fi.omitsNorms(),
                                           fi.hasPayloads(), fi.getIndexOptions(), DocValuesType.NONE, -1, Collections.emptyMap(),
                                           fi.getPointDimensionCount(), fi.getPointIndexDimensionCount(), fi.getPointNumBytes(),
-                                          fi.getVectorDimension(), fi.getVectorScoreFunction(), fi.isSoftDeletesField()));
+                                          fi.getVectorDimension(), fi.getVectorSearchStrategy(), fi.isSoftDeletesField()));
         } else {
           filteredInfos.add(fi);
         }

--- a/solr/core/src/java/org/apache/solr/uninverting/UninvertingReader.java
+++ b/solr/core/src/java/org/apache/solr/uninverting/UninvertingReader.java
@@ -285,7 +285,7 @@ public class UninvertingReader extends FilterLeafReader {
         newFieldInfos.add(new FieldInfo(fi.name, fi.number, fi.hasVectors(), fi.omitsNorms(),
             fi.hasPayloads(), fi.getIndexOptions(), type, fi.getDocValuesGen(), fi.attributes(),
             fi.getPointDimensionCount(), fi.getPointIndexDimensionCount(), fi.getPointNumBytes(),
-            fi.getVectorDimension(), fi.getVectorScoreFunction(), fi.isSoftDeletesField()));
+            fi.getVectorDimension(), fi.getVectorSearchStrategy(), fi.isSoftDeletesField()));
       } else {
         newFieldInfos.add(fi);
       }


### PR DESCRIPTION
This is - renaming as the title says, plus a light refactoring, and adding `o.a.l.util.VectorUtil` to house the score function implementations.