### PR TITLE
LUCENE-9322: Make sure to account for vectors in SortingCodecReader.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
@@ -29,6 +29,7 @@ import org.apache.lucene.codecs.NormsProducer;
 import org.apache.lucene.codecs.PointsReader;
 import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.codecs.TermVectorsReader;
+import org.apache.lucene.codecs.VectorReader;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.util.Bits;
@@ -289,6 +290,32 @@ public final class SortingCodecReader extends FilterCodecReader {
       @Override
       public PointValues getValues(String field) throws IOException {
         return new SortingPointValues(delegate.getValues(field), docMap);
+      }
+
+      @Override
+      public void close() throws IOException {
+        delegate.close();
+      }
+
+      @Override
+      public long ramBytesUsed() {
+        return delegate.ramBytesUsed();
+      }
+    };
+  }
+
+  @Override
+  public VectorReader getVectorReader() {
+    VectorReader delegate = in.getVectorReader();
+    return new VectorReader() {
+      @Override
+      public void checkIntegrity() throws IOException {
+        delegate.checkIntegrity();
+      }
+
+      @Override
+      public VectorValues getVectorValues(String field) throws IOException {
+        return new VectorValuesWriter.SortingVectorValues(delegate.getVectorValues(field), docMap);
       }
 
       @Override

--- a/lucene/core/src/java/org/apache/lucene/index/VectorValuesWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/VectorValuesWriter.java
@@ -98,7 +98,7 @@ class VectorValuesWriter {
     }
   }
 
-  private static class SortingVectorValues extends VectorValues {
+  static class SortingVectorValues extends VectorValues {
 
     private final VectorValues delegate;
     private final VectorValues.RandomAccess randomAccess;


### PR DESCRIPTION
This ensures that vector values are sorted when sorting an index after-the-fact
using `SortingCodecReader`.