### PR TITLE
LUCENE-9587: Add '--illegal-access=deny' to test runner

### DIFF
--- a/gradle/testing/defaults-tests.gradle
+++ b/gradle/testing/defaults-tests.gradle
@@ -105,6 +105,7 @@ allprojects {
       ignoreFailures = resolvedTestOption("tests.haltonfailure").toBoolean() == false
 
       jvmArgs Commandline.translateCommandline(resolvedTestOption("tests.jvmargs"))
+      jvmArgs '--illegal-access=deny'
 
       systemProperty 'java.util.logging.config.file', file("${resources}/logging.properties")
       systemProperty 'java.awt.headless', 'true'


### PR DESCRIPTION
This adds back the test runner option, so testing is strict with internal APIs.