### PR TITLE
Set pinentry-mode to loopback for artifact signing.

### DIFF
--- a/lucene/common-build.xml
+++ b/lucene/common-build.xml
@@ -2410,6 +2410,8 @@ ${ant.project.name}.test.dependencies=${test.classpath.list}
         <arg value="--output"/>
         <targetfile/>
         <arg value="--detach-sig"/>
+        <arg value="--pinentry-mode"/>
+        <arg value="loopback"/>
         <srcfile/>
 
         <fileset dir="@{artifacts.dir}">


### PR DESCRIPTION
On my GPG version, not doing so makes `ant sign-artifacts` fail as the
default pinentry mode is `ask`, which wants to create a dialog that asks
for the GPG password.