### PR TITLE
SOLR-14980: Added explanations on how facet methods are picked

### DIFF
--- a/solr/solr-ref-guide/src/json-facet-api.adoc
+++ b/solr/solr-ref-guide/src/json-facet-api.adoc
@@ -217,9 +217,9 @@ The default of `-1` causes a hueristic to be applied based on other options spec
 This parameter indicates the facet algorithm to use:
 
 * "dv" DocValues, collect into ordinal array
-* "uif" UnInvertedField, collect into ordinal array
-* "dvhash" DocValues, collect into hash - improves efficiency over high cardinality fields
-* "enum" TermsEnum then intersect DocSet (stream-able)
+* "uif" UnInvertedField, collect into ordinal array. Used if the field doesn't have DocValues
+* "dvhash" DocValues, collect into hash - improves efficiency over high cardinality fields. Works on point fields and single-valued string fields
+* "enum" TermsEnum then intersect DocSet (stream-able). Works on indexed fields sorted by `index asc`
 * "stream" Presently equivalent to "enum"
 * "smart" Pick the best method for the field type (this is the default)
 


### PR DESCRIPTION
To explain why, for example, `dvhash` doesn't work on multi-valued string fields.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [x] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
