### PR TITLE
LUCENE-9322: Some fixes to SimpleTextVectorFormat.

### DIFF
--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextTermVectorsWriter.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextTermVectorsWriter.java
@@ -54,7 +54,7 @@ public class SimpleTextTermVectorsWriter extends TermVectorsWriter {
   static final BytesRef STARTOFFSET        = new BytesRef("        startoffset ");
   static final BytesRef ENDOFFSET          = new BytesRef("        endoffset ");
 
-  static final String VECTORS_EXTENSION = "vec";
+  static final String VECTORS_EXTENSION = "tvc";
   
   private IndexOutput out;
   private int numDocsWritten = 0;

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextVectorFormat.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextVectorFormat.java
@@ -43,9 +43,9 @@ public final class SimpleTextVectorFormat extends VectorFormat {
     return new SimpleTextVectorReader(state);
   }
 
-  /** Extension of points data file */
+  /** Extension of vectors data file */
   static final String VECTOR_EXTENSION = "vec";
 
-  /** Extension of points index file */
+  /** Extension of vectors index file */
   static final String META_EXTENSION = "gri";
 }

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextVectorReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextVectorReader.java
@@ -245,8 +245,8 @@ public class SimpleTextVectorReader extends VectorReader {
 
     private void readVector(float[] value) throws IOException {
       SimpleTextUtil.readLine(in, scratch);
-      // skip leading " [" and strip trailing "]"
-      String s = new BytesRef(scratch.bytes(), 2, scratch.length() - 3).utf8ToString();
+      // skip leading "[" and strip trailing "]"
+      String s = new BytesRef(scratch.bytes(), 1, scratch.length() - 2).utf8ToString();
       String[] floatStrings = s.split(",");
       assert floatStrings.length == value.length : " read " + s + " when expecting " + value.length + " floats";
       for (int i = 0; i < floatStrings.length; i++) {

--- a/lucene/core/src/java/org/apache/lucene/index/VectorValuesWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/VectorValuesWriter.java
@@ -152,8 +152,8 @@ class VectorValuesWriter {
     }
 
     @Override
-    public float[] vectorValue() {
-      throw new UnsupportedOperationException();
+    public float[] vectorValue() throws IOException {
+      return randomAccess.vectorValue(docIdOffsets[docId] - 1);
     }
 
     @Override


### PR DESCRIPTION
* Make sure the files are unique by renaming the term vectors extension to `tvc`.
* Fix a bug where reading a vector would drop the leading digit of the first element.