### PR TITLE
LUCENE-9599 Disable sort optim on index sort

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/FieldComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FieldComparator.java
@@ -143,11 +143,14 @@ public abstract class FieldComparator<T> {
   }
 
   /**
-   * Informs the comparator that the search sort is congruent with the index sort.
-   * Some comparators provide skipping functionality, that can be disabled on index sort,
-   * as in this case early termination is already handled in TopFieldCollector.
+   * Informs the comparator that the skipping of documents should be disabled.
+   * This function is called by TopFieldCollector in cases when the skipping functionality
+   * should not be applied or not necessary. An example could be when
+   * search sort is a part of the index sort, and can be already efficiently
+   * handled by TopFieldCollector, and doing extra work for skipping in the comparator
+   * is redundant.
    */
-  public void usesIndexSort() {
+  public void disableSkipping() {
   }
 
   /** Sorts by descending relevance.  NOTE: if you are

--- a/lucene/core/src/java/org/apache/lucene/search/FieldComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FieldComparator.java
@@ -142,6 +142,14 @@ public abstract class FieldComparator<T> {
   public void setSingleSort() {
   }
 
+  /**
+   * Informs the comparator that the search sort is congruent with the index sort.
+   * Some comparators provide skipping functionality, that can be disabled on index sort,
+   * as in this case early termination is already handled in TopFieldCollector.
+   */
+  public void usesIndexSort() {
+  }
+
   /** Sorts by descending relevance.  NOTE: if you are
    *  sorting only by descending relevance and then
    *  secondarily by ascending docID, performance is faster

--- a/lucene/core/src/java/org/apache/lucene/search/FieldValueHitQueue.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FieldValueHitQueue.java
@@ -178,10 +178,13 @@ public abstract class FieldValueHitQueue<T extends FieldValueHitQueue.Entry> ext
     return reverseMul;
   }
 
-  public LeafFieldComparator[] getComparators(LeafReaderContext context) throws IOException {
+  public LeafFieldComparator[] getComparators(LeafReaderContext context, boolean indexSort) throws IOException {
     LeafFieldComparator[] comparators = new LeafFieldComparator[this.comparators.length];
     for (int i = 0; i < comparators.length; ++i) {
       comparators[i] = this.comparators[i].getLeafComparator(context);
+      if (indexSort) {
+        comparators[i].usesIndexSort();
+      }
     }
     return comparators;
   }

--- a/lucene/core/src/java/org/apache/lucene/search/FieldValueHitQueue.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FieldValueHitQueue.java
@@ -178,13 +178,10 @@ public abstract class FieldValueHitQueue<T extends FieldValueHitQueue.Entry> ext
     return reverseMul;
   }
 
-  public LeafFieldComparator[] getComparators(LeafReaderContext context, boolean indexSort) throws IOException {
+  public LeafFieldComparator[] getComparators(LeafReaderContext context) throws IOException {
     LeafFieldComparator[] comparators = new LeafFieldComparator[this.comparators.length];
     for (int i = 0; i < comparators.length; ++i) {
       comparators[i] = this.comparators[i].getLeafComparator(context);
-      if (indexSort) {
-        comparators[i].usesIndexSort();
-      }
     }
     return comparators;
   }

--- a/lucene/core/src/java/org/apache/lucene/search/LeafFieldComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/LeafFieldComparator.java
@@ -131,11 +131,5 @@ public interface LeafFieldComparator {
    */
   default void setHitsThresholdReached() throws IOException{
   }
-
-  /**
-   * Informs this leaf comparator that the search sort is congruent with the index sort.
-   */
-  default void usesIndexSort() {
-  }
-
+  
 }

--- a/lucene/core/src/java/org/apache/lucene/search/LeafFieldComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/LeafFieldComparator.java
@@ -132,4 +132,10 @@ public interface LeafFieldComparator {
   default void setHitsThresholdReached() throws IOException{
   }
 
+  /**
+   * Informs this leaf comparator that the search sort is congruent with the index sort.
+   */
+  default void usesIndexSort() {
+  }
+
 }

--- a/lucene/core/src/java/org/apache/lucene/search/TopFieldCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TopFieldCollector.java
@@ -353,7 +353,7 @@ public abstract class TopFieldCollector extends TopDocsCollector<Entry> {
           && queueFull
           && hitsThresholdChecker.isThresholdReached()) {
       assert bottom != null;
-      float minScore = ((FieldComparator.RelevanceComparator) firstComparator).value(bottom.slot);
+      float minScore = (float) firstComparator.value(bottom.slot);
       if (minScore > minCompetitiveScore) {
         scorer.setMinCompetitiveScore(minScore);
         minCompetitiveScore = minScore;

--- a/lucene/core/src/java/org/apache/lucene/search/TopFieldCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/TopFieldCollector.java
@@ -59,7 +59,7 @@ public abstract class TopFieldCollector extends TopDocsCollector<Entry> {
         final Sort indexSort = context.reader().getMetaData().getSort();
         searchSortPartOfIndexSort = canEarlyTerminate(sort, indexSort);
         if (searchSortPartOfIndexSort) {
-          firstComparator.usesIndexSort();
+          firstComparator.disableSkipping();
         }
       }
       LeafFieldComparator[] comparators = queue.getComparators(context);

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
@@ -71,11 +71,11 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
     public abstract class NumericLeafComparator implements LeafFieldComparator {
         protected final NumericDocValues docValues;
         private final PointValues pointValues;
-        private final boolean enableSkipping; // if skipping functionality should be enabled
         private final int maxDoc;
         private final byte[] minValueAsBytes;
         private final byte[] maxValueAsBytes;
 
+        private boolean enableSkipping; // if skipping functionality should be enabled
         private DocIdSetIterator competitiveIterator;
         private long iteratorCost;
         private int maxDocVisited = 0;
@@ -102,6 +102,12 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
         /** Retrieves the NumericDocValues for the field in this segment */
         protected NumericDocValues getNumericDocValues(LeafReaderContext context, String field) throws IOException {
             return DocValues.getNumeric(context.reader(), field);
+        }
+
+        @Override
+        public void usesIndexSort() {
+            // disable skipping functionality on index sort, as early termination in this case is handled in TopFieldCollector
+            this.enableSkipping = false;
         }
 
         @Override


### PR DESCRIPTION
Disable sort optimization in comparators on index sort.

Currently, if search sort is equal or a part of the index sort, we have
an early termination in TopFieldCollector.
But comparators are not aware of the index sort, and may run
sort optimization even if the search sort is congruent with
the index sort.

This patch:
- make leaf comparators aware that search sort is congruent
with the index sort.
- disables sort optimization in comparators in this case.
- removes a private  MultiComparatorLeafCollector class as the only
class that extended that class was TopFieldLeafCollector that
now incorporates the logic of the deleted class.

Relates to #1351