### PR TITLE
SOLR-14986: Add warning to ref guide that using properties.name is an…

### DIFF
--- a/solr/solr-ref-guide/src/collection-management.adoc
+++ b/solr/solr-ref-guide/src/collection-management.adoc
@@ -90,6 +90,8 @@ Please note that <<realtime-get.adoc#realtime-get,RealTime Get>> or retrieval by
 `property._name_=_value_`::
 Set core property _name_ to _value_. See the section <<defining-core-properties.adoc#defining-core-properties,Defining core.properties>> for details on supported properties and values.
 
+WARNING: The entries in each core.properties file are vital for Solr to function correctly. Incorrect or conflicting entries can result in unusable collections. Altering these entries by specifying `property._name_=_value_` is an expert-level option and should only be used if you have a thorough understanding of the consequences.
+
 `async`::
 Request ID to track this action which will be <<collections-api.adoc#asynchronous-calls,processed asynchronously>>.
 

--- a/solr/solr-ref-guide/src/replica-management.adoc
+++ b/solr/solr-ref-guide/src/replica-management.adoc
@@ -78,6 +78,8 @@ The number of `pull` replicas that should be created (optional, defaults to 1 if
 `property._name_=_value_`::
 Set core property _name_ to _value_. See <<defining-core-properties.adoc#defining-core-properties,Defining core.properties>> for details about supported properties and values.
 
+WARNING: The entries in each core.properties file are vital for Solr to function correctly. Incorrect or conflicting entries can result in unusable collections. Altering these entries by specifying `property._name_=_value_` is an expert-level option and should only be used if you have a thorough understanding of the consequences.
+
 `waitForFinalState`::
 If `true`, the request will complete only when all affected replicas become active. The default is `false`, which means that the API will return the status of the single action, which may be before the new replica is online and active.
 


### PR DESCRIPTION
Changed both CREATE and ADDREPLICA to just add the warning to the docs. The JIRA has a long explanation about why fixing it in the code is too risky/expensive.

gw buildsite succeeds.

I'll commmit this over the weekend absent objections.