### PR TITLE
LUCENE-9508: Fix DocumentsWriter to block threads until unstalled

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -247,6 +247,14 @@ Optimizations
 * LUCENE-9536: Reduced memory usage for OrdinalMap when a segment has all
   values. (Julie Tibshirani via Adrien Grand)
 
+Bug Fixes
+---------------------
+
+* LUCENE-9508: DocumentsWriter was only stalling threads for 1 second allowing
+  documents to be indexed even the DocumentsWriter wasn't able to keep up flushing.
+  Unless IW can't make progress due to an ill behaving DWPT this issue was barely
+  noticeable. (Simon Willnauer)
+
 Other
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriter.java
@@ -371,19 +371,15 @@ final class DocumentsWriter implements Closeable, Accountable {
   private boolean preUpdate() throws IOException {
     ensureOpen();
     boolean hasEvents = false;
-
-    if (flushControl.anyStalledThreads() || (flushControl.numQueuedFlushes() > 0 && config.checkPendingFlushOnUpdate)) {
+    while (flushControl.anyStalledThreads() || (flushControl.numQueuedFlushes() > 0 && config.checkPendingFlushOnUpdate)) {
       // Help out flushing any queued DWPTs so we can un-stall:
-      do {
-        // Try pick up pending threads here if possible
-        DocumentsWriterPerThread flushingDWPT;
-        while ((flushingDWPT = flushControl.nextPendingFlush()) != null) {
-          // Don't push the delete here since the update could fail!
-          hasEvents |= doFlush(flushingDWPT);
-        }
-        
-        flushControl.waitIfStalled(); // block if stalled
-      } while (flushControl.numQueuedFlushes() != 0); // still queued DWPTs try help flushing
+      // Try pick up pending threads here if possible
+      DocumentsWriterPerThread flushingDWPT;
+      while ((flushingDWPT = flushControl.nextPendingFlush()) != null) {
+        // Don't push the delete here since the update could fail!
+        hasEvents |= doFlush(flushingDWPT);
+      }
+      flushControl.waitIfStalled(); // block if stalled
     }
     return hasEvents;
   }

--- a/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterStallControl.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DocumentsWriterStallControl.java
@@ -103,6 +103,10 @@ final class DocumentsWriterStallControl {
   synchronized boolean hasBlocked() { // for tests
     return numWaiting > 0;
   }
+
+  synchronized int getNumWaiting() { // for tests
+    return numWaiting;
+  }
   
   boolean isHealthy() { // for tests
     return !stalled; // volatile read!


### PR DESCRIPTION
DWStallControl expects the caller to loop on top of the wait call to make
progress with flushing if the DW is stalled. This logic wasn't applied such that
DW only stalled for one second and then released the indexing thread. This can cause
OOM if for instance during a full flush one DWPT gets stuck and other threads keep on
indexing.