### PR TITLE
LUCENE-9613: Split ordinals into blocks when it saves 10+% space.

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene80/Lucene80DocValuesFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene80/Lucene80DocValuesFormat.java
@@ -53,7 +53,7 @@ import org.apache.lucene.util.packed.DirectWriter;
  *         accumulating the {@link Long#bitCount(long) bit counts} of the visited longs.
  *         Advancing &gt;= 512 documents is performed by skipping to the start of the needed 512 document
  *         sub-block and iterating to the specific document within that block. The index for the
- *         sub-block that is skipped to is retrieved from a rank-table positioned beforethe bit set.
+ *         sub-block that is skipped to is retrieved from a rank-table positioned before the bit set.
  *         The rank-table holds the origo index numbers for all 512 documents sub-blocks, represented
  *         as an unsigned short for each 128 blocks.
  *     <li>ALL: This strategy is used when a block contains exactly 65536 documents, meaning that
@@ -169,6 +169,7 @@ public final class Lucene80DocValuesFormat extends DocValuesFormat {
   static final String META_EXTENSION = "dvm";
   static final int VERSION_START = 0;
   static final int VERSION_BIN_COMPRESSED = 1;  
+  /** This version introduces configurable compression and records ordinals like we record numeric values. */
   static final int VERSION_CONFIGURABLE_COMPRESSION = 2;
   static final int VERSION_CURRENT = VERSION_CONFIGURABLE_COMPRESSION;
 

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene80/Lucene80v1DocValueFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene80/Lucene80v1DocValueFormat.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.lucene80;
+
+import java.io.IOException;
+
+import org.apache.lucene.codecs.DocValuesConsumer;
+import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+
+public class Lucene80v1DocValueFormat extends DocValuesFormat {
+
+  public Lucene80v1DocValueFormat() {
+    super("Lucene80");
+  }
+
+  @Override
+  public DocValuesConsumer fieldsConsumer(SegmentWriteState state) throws IOException {
+    return new Lucene80v1DocValuesConsumer(state,
+        Lucene80DocValuesFormat.DATA_CODEC, Lucene80DocValuesFormat.DATA_EXTENSION,
+        Lucene80DocValuesFormat.META_CODEC, Lucene80DocValuesFormat.META_EXTENSION);
+  }
+
+  @Override
+  public DocValuesProducer fieldsProducer(SegmentReadState state) throws IOException {
+    // Use the actual Lucene80 doc-value format for reading.
+    return DocValuesFormat.forName(getName()).fieldsProducer(state);
+  }
+
+}

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene80/TestLucene80v1DocValuesFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene80/TestLucene80v1DocValuesFormat.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.lucene80;
+
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.util.TestUtil;
+
+/**
+ * Tests Lucene80v1DocValuesFormat.
+ */
+public class TestLucene80v1DocValuesFormat extends BaseLucene80DocValuesFormatTestCase {
+
+  private final Codec codec = TestUtil.alwaysDocValuesFormat(new Lucene80v1DocValueFormat());
+
+  @Override
+  protected Codec getCodec() {
+    return codec;
+  }
+
+}


### PR DESCRIPTION
This changes the way that doc values write ordinals so that Lucene splits into
blocks if it would save more than 10% space, like we do for numeric fields. By
the way, we are now using the same code path to write ordinals and numbers.
