### PR TITLE
LUCENE-9617: Reset lowestUnassignedFieldNumber in FieldNumbers.clear()

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -184,8 +184,8 @@ Bug fixes
 * LUCENE-9365: FuzzyQuery was missing matches when prefix length was equal to the term length
   (Mark Harwood, Mike Drob)
 
-* LUCENE-9617: Reset lowestUnassignedFieldNumber on FieldNumbers.clear(), to avoid leaking
-  field numbers on IndexWriter.deleteAll(). (Michael Froh)
+* LUCENE-9617: Fix per-field memory leak in IndexWriter.deleteAll(). Reset next available internal
+  field number to 0 on FieldInfos.clear(), to avoid wasting FieldInfo references. (Michael Froh)
 
 Other
 

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -184,6 +184,9 @@ Bug fixes
 * LUCENE-9365: FuzzyQuery was missing matches when prefix length was equal to the term length
   (Mark Harwood, Mike Drob)
 
+* LUCENE-9617: Reset lowestUnassignedFieldNumber on FieldNumbers.clear(), to avoid leaking
+  field numbers on IndexWriter.deleteAll(). (Michael Froh)
+
 Other
 
 * LUCENE-9312: Allow gradle builds against arbitrary JVMs. (Tomoko Uchida, Dawid Weiss)

--- a/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
@@ -481,6 +481,7 @@ public class FieldInfos implements Iterable<FieldInfo> {
       indexOptions.clear();
       docValuesType.clear();
       dimensions.clear();
+      lowestUnassignedFieldNumber = -1;
     }
 
     synchronized void setIndexOptions(int number, String name, IndexOptions indexOptions) {

--- a/lucene/core/src/test/org/apache/lucene/index/TestFieldInfos.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestFieldInfos.java
@@ -187,4 +187,23 @@ public class TestFieldInfos extends LuceneTestCase {
     writer.close();
     dir.close();
   }
+
+  public void testFieldNumbersAutoIncrement() {
+    FieldInfos.FieldNumbers fieldNumbers = new FieldInfos.FieldNumbers("softDeletes");
+    for (int i = 0; i < 10; i++) {
+      fieldNumbers.addOrGet("field" + i, -1, IndexOptions.NONE, DocValuesType.NONE,
+          0, 0, 0, 0,
+          VectorValues.SearchStrategy.NONE, false);
+    }
+    int idx = fieldNumbers.addOrGet("EleventhField", -1, IndexOptions.NONE, DocValuesType.NONE,
+        0, 0, 0, 0,
+        VectorValues.SearchStrategy.NONE, false);
+    assertEquals("Field numbers 0 through 9 were allocated", 10, idx);
+
+    fieldNumbers.clear();
+    idx = fieldNumbers.addOrGet("PostClearField", -1, IndexOptions.NONE, DocValuesType.NONE,
+        0, 0, 0, 0,
+        VectorValues.SearchStrategy.NONE, false);
+    assertEquals("Field numbers should reset after clear()", 0, idx);
+  }
 }


### PR DESCRIPTION
FieldNumbers.clear() is called from IndexWriter.deleteAll(), which is
supposed to completely reset the state of the index. This includes
clearing all known fields.

Prior to this change, it would allocate progressively higher field
numbers, which results in larger and  larger arrays for
FieldInfos.byNumber, effectively "leaking" field numbers every time
deleteAll() is called.

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

If you run a loop that repeatedly adds documents to an IndexWriter and calls deleteAll, new fields will be given progressively higher index numbers. Since these index numbers are reflected in the size of the FieldInfos.byNumber array, this is effectively a memory leak.

# Solution

Reset lowestUnassignedFieldNumber to -1 when FieldNumbers.clear() is called (resetting the state to that of a newly-created FieldNumbers instance).

# Tests

Added a unit test to confirm that after calling clear(), the next field is given number 0.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
