### PR TITLE
SOLR-14851 Http2SolrClient doesn't handle keystore type

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -208,6 +208,8 @@ Bug Fixes
 
 * SOLR-14993: Unable to download zookeeper files of 1byte in size (Erick Erickson, Allen Sooredoo)
 
+* SOLR-14851: Http2SolrClient doesn't handle keystore type correctly (Andras Salamon via janhoy)
+
 Other Changes
 ---------------------
 

--- a/solr/solr-ref-guide/src/enabling-ssl.adoc
+++ b/solr/solr-ref-guide/src/enabling-ssl.adoc
@@ -401,8 +401,10 @@ From a java client using SolrJ, index a document. In the code below, the `javax.
 ----
 System.setProperty("javax.net.ssl.keyStore", "/path/to/solr-ssl.keystore.p12");
 System.setProperty("javax.net.ssl.keyStorePassword", "secret");
+System.setProperty("javax.net.ssl.keyStoreType", "pkcs12");
 System.setProperty("javax.net.ssl.trustStore", "/path/to/solr-ssl.keystore.p12");
 System.setProperty("javax.net.ssl.trustStorePassword", "secret");
+System.setProperty("javax.net.ssl.trustStoreType", "pkcs12");
 String zkHost = "127.0.0.1:2181";
 CloudSolrClient client = new CloudSolrClient.Builder(Collections.singletonList(zkHost),Optional.empty()).build();
 client.setDefaultCollection("mycollection");

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -967,6 +967,10 @@ public class Http2SolrClient extends SolrClient {
       sslContextFactory.setKeyStorePassword
           (System.getProperty("javax.net.ssl.keyStorePassword"));
     }
+    if (null != System.getProperty("javax.net.ssl.keyStoreType")) {
+      sslContextFactory.setKeyStoreType
+              (System.getProperty("javax.net.ssl.keyStoreType"));
+    }
     if (null != System.getProperty("javax.net.ssl.trustStore")) {
       sslContextFactory.setTrustStorePath
           (System.getProperty("javax.net.ssl.trustStore"));
@@ -974,6 +978,10 @@ public class Http2SolrClient extends SolrClient {
     if (null != System.getProperty("javax.net.ssl.trustStorePassword")) {
       sslContextFactory.setTrustStorePassword
           (System.getProperty("javax.net.ssl.trustStorePassword"));
+    }
+    if (null != System.getProperty("javax.net.ssl.trustStoreType")) {
+      sslContextFactory.setTrustStoreType
+              (System.getProperty("javax.net.ssl.trustStoreType"));
     }
 
     sslContextFactory.setEndpointIdentificationAlgorithm(System.getProperty("solr.jetty.ssl.verifyClientHostName"));

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/Http2SolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/Http2SolrClientTest.java
@@ -605,9 +605,15 @@ public class Http2SolrClientTest extends SolrJettyTestBase {
     assertNull(Http2SolrClient.getDefaultSslContextFactory().getEndpointIdentificationAlgorithm());
 
     System.setProperty("solr.jetty.ssl.verifyClientHostName", "HTTPS");
+    System.setProperty("javax.net.ssl.keyStoreType", "foo");
+    System.setProperty("javax.net.ssl.trustStoreType", "bar");
     SslContextFactory.Client sslContextFactory = Http2SolrClient.getDefaultSslContextFactory();
     assertEquals("HTTPS", sslContextFactory.getEndpointIdentificationAlgorithm());
+    assertEquals("foo", sslContextFactory.getKeyStoreType());
+    assertEquals("bar", sslContextFactory.getTrustStoreType());
     System.clearProperty("solr.jetty.ssl.verifyClientHostName");
+    System.clearProperty("javax.net.ssl.keyStoreType");
+    System.clearProperty("javax.net.ssl.trustStoreType");
   }
 
   /**


### PR DESCRIPTION
Based on patch by Andras Salamon in https://issues.apache.org/jira/browse/SOLR-14851

Signed-off-by: Jan Høydahl <janhoy@apache.org>


# Description

Make truststore and keystore type configurable in Http2SolrClient 

# Tests

Extended the existing test case
