### PR TITLE
SOLR-14977: Fix typo in solr-upgrade-notes.adoc

### DIFF
--- a/solr/solr-ref-guide/src/solr-upgrade-notes.adoc
+++ b/solr/solr-ref-guide/src/solr-upgrade-notes.adoc
@@ -43,7 +43,7 @@ If you are upgrading from 7.x, see the section <<Upgrading from 7.x Releases>> b
 See the https://cwiki.apache.org/confluence/display/SOLR/ReleaseNote87[8.7 Release Notes^]
 for an overview of the main new features of Solr 8.7.
 
-When upgrading to 8.6.x users should be aware of the following major changes from 8.6.
+When upgrading to 8.7 users, should be aware of the following major changes from 8.6.
 
 *Autoscaling*
 


### PR DESCRIPTION
# Description

Fixed small typo in release notes. Should refer to 8.7, not 8.6.x.

