### PR TITLE
Reconcile upgrade notes in master

### DIFF
--- a/solr/solr-ref-guide/src/solr-upgrade-notes.adoc
+++ b/solr/solr-ref-guide/src/solr-upgrade-notes.adoc
@@ -66,8 +66,8 @@ The Solr community is working on pluggable API to replace this functionality, wi
 * Similarly, rule-based replica placement strategy has been deprecated and will be replaced
   in Solr 9.0 by APIs for replica placement and cluster events, with plugin-based implementations.
 
-* Support for detecting spinning disks will be removed in Lucene 9.0 (LUCENE-9576). Corresponding
-`spins` metrics in Solr are deprecated and will be removed in Solr 9.0.
+* Support for detecting spinning disks has been removed in LUCENE-9576. Corresponding
+`spins` metrics in Solr still exist but now they always return `false` and will be removed in Solr 9.0.
 
 *Legacy Scaling (non-SolrCloud) Terminology Updated*
 

--- a/solr/solr-ref-guide/src/solr-upgrade-notes.adoc
+++ b/solr/solr-ref-guide/src/solr-upgrade-notes.adoc
@@ -24,7 +24,7 @@ These notes highlight the biggest changes that may impact the largest number of
 implementations. It is not a comprehensive list of all changes to Solr in any release.
 
 When planning your Solr upgrade, consider the customizations you have made to
-your system and review the {solr-javadocs}/changes//Changes.html[`CHANGES.txt`]
+your system and review the {solr-javadocs}/changes/Changes.html[`CHANGES.txt`]
 file found in your Solr package. That file includes all the changes and updates
 that may effect your existing implementation.
 
@@ -38,12 +38,20 @@ Detailed steps for upgrading a Solr cluster are in the section <<upgrading-a-sol
 
 If you are upgrading from 7.x, see the section <<Upgrading from 7.x Releases>> below.
 
+=== Solr 8.8
+
+*Removed Contribs*
+
+* The search results clustering contrib has been removed from 8.x Solr line due to lack
+  of Java 1.8 compatibility in the dependency providing on-line clustering of search results.
+  See SOLR-14981 for more details.
+
 === Solr 8.7
 
 See the https://cwiki.apache.org/confluence/display/SOLR/ReleaseNote87[8.7 Release Notes^]
 for an overview of the main new features of Solr 8.7.
 
-When upgrading to 8.7 users, should be aware of the following major changes from 8.6.
+When upgrading to 8.7.x users should be aware of the following major changes from 8.6.
 
 *Autoscaling*
 
@@ -58,8 +66,8 @@ The Solr community is working on pluggable API to replace this functionality, wi
 * Similarly, rule-based replica placement strategy has been deprecated and will be replaced
   in Solr 9.0 by APIs for replica placement and cluster events, with plugin-based implementations.
 
-* Support for detecting spinning disks has been removed in LUCENE-9576. Corresponding
-`spins` metrics in Solr still exist but now they always return `false` and will be removed in Solr 9.0.
+* Support for detecting spinning disks will be removed in Lucene 9.0 (LUCENE-9576). Corresponding
+`spins` metrics in Solr are deprecated and will be removed in Solr 9.0.
 
 *Legacy Scaling (non-SolrCloud) Terminology Updated*
 
@@ -128,9 +136,10 @@ If your cluster is running 8.6.0 and *not using an explicit autoscaling policy*,
 +
 Replace `localhost:8983` with your Solr endpoint.
 +
-```
+[source,text]
 curl -X POST -H 'Content-type:application/json'  -d '{set-cluster-policy : [], set-cluster-preferences : []}' http://localhost:8983/api/cluster/autoscaling
-```
++
+For more details on autoscaling policies, see the section <<solrcloud-autoscaling-overview.adoc#cluster-policy,Cluster Policy>>.
 +
 This information is only relevant for users upgrading from 8.6.0. If upgrading from an earlier version to 8.6.1+, this warning can be ignored.
 
@@ -160,10 +169,14 @@ More information about this new feature is available in the section <<common-que
 
 *Autoscaling*
 
-* Solr now includes a default autoscaling policy.
+* **NOTE: The default autoscaling policy has been removed as of 8.6.1**
++
+Solr now includes a default autoscaling policy.
 This policy can be overridden with your custom rules or by specifying an empty policy to replace the default.
++
+For details of the default policy, see the section <<solrcloud-autoscaling-overview.adoc#cluster-policy,Cluster Policy>>.
 
-* The ComputePlan action now supports a collection selector to identify collections based on collection properties to determine which collections should be operated on.
+* The <<solrcloud-autoscaling-trigger-actions.adoc#compute-plan-action,ComputePlan action>> now supports a collection selector to identify collections based on collection properties to determine which collections should be operated on.
 
 *Security*
 
@@ -343,6 +356,7 @@ The system is currently considered experimental, so use with caution. It must
 be enabled with a system parameter passed at start up before it can be used.
 For details, please see the section <<package-manager.adoc#package-manager,Package Management>>.
 
+With this feature Solr's Blob Store functionality is now deprecated and will likely be removed in 9.0.
 
 *Security*
 
@@ -573,7 +587,7 @@ If you run in SolrCloud mode, you must be on Solr version 7.3 or higher in order
 
 == Upgrading from Pre-7.x Versions
 
-Users upgrading from versions of Solr prior to 7.x are strongly encouraged to consult {solr-javadocs}/changes//Changes.html[`CHANGES.txt`] for the details of _all_ changes since the version they are upgrading from.
+Users upgrading from versions of Solr prior to 7.x are strongly encouraged to consult {solr-javadocs}/changes/Changes.html[`CHANGES.txt`] for the details of _all_ changes since the version they are upgrading from.
 
 The upgrade from Solr 6.x to Solr 7.0 introduced several *major* changes that you should be aware of before upgrading. Please do a thorough review of the section <<major-changes-in-solr-7.adoc#major-changes-in-solr-7,Major Changes in Solr 7>> before starting your upgrade.
 

--- a/solr/solr-ref-guide/src/solr-upgrade-notes.adoc
+++ b/solr/solr-ref-guide/src/solr-upgrade-notes.adoc
@@ -139,8 +139,6 @@ Replace `localhost:8983` with your Solr endpoint.
 [source,text]
 curl -X POST -H 'Content-type:application/json'  -d '{set-cluster-policy : [], set-cluster-preferences : []}' http://localhost:8983/api/cluster/autoscaling
 +
-For more details on autoscaling policies, see the section <<solrcloud-autoscaling-overview.adoc#cluster-policy,Cluster Policy>>.
-+
 This information is only relevant for users upgrading from 8.6.0. If upgrading from an earlier version to 8.6.1+, this warning can be ignored.
 
 === Solr 8.6
@@ -176,7 +174,7 @@ This policy can be overridden with your custom rules or by specifying an empty p
 +
 For details of the default policy, see the section <<solrcloud-autoscaling-overview.adoc#cluster-policy,Cluster Policy>>.
 
-* The <<solrcloud-autoscaling-trigger-actions.adoc#compute-plan-action,ComputePlan action>> now supports a collection selector to identify collections based on collection properties to determine which collections should be operated on.
+* The ComputePlan action now supports a collection selector to identify collections based on collection properties to determine which collections should be operated on.
 
 *Security*
 

--- a/solr/solr-ref-guide/src/solr-upgrade-notes.adoc
+++ b/solr/solr-ref-guide/src/solr-upgrade-notes.adoc
@@ -171,8 +171,6 @@ More information about this new feature is available in the section <<common-que
 +
 Solr now includes a default autoscaling policy.
 This policy can be overridden with your custom rules or by specifying an empty policy to replace the default.
-+
-For details of the default policy, see the section <<solrcloud-autoscaling-overview.adoc#cluster-policy,Cluster Policy>>.
 
 * The ComputePlan action now supports a collection selector to identify collections based on collection properties to determine which collections should be operated on.
 

--- a/solr/solr-ref-guide/src/solr-upgrade-notes.adoc
+++ b/solr/solr-ref-guide/src/solr-upgrade-notes.adoc
@@ -43,7 +43,7 @@ If you are upgrading from 7.x, see the section <<Upgrading from 7.x Releases>> b
 See the https://cwiki.apache.org/confluence/display/SOLR/ReleaseNote87[8.7 Release Notes^]
 for an overview of the main new features of Solr 8.7.
 
-When upgrading to 8.6.x users should be aware of the following major changes from 8.6.
+When upgrading to 8.7 users, should be aware of the following major changes from 8.6.
 
 *Autoscaling*
 


### PR DESCRIPTION
The upgrade notes in ref-guide tends to sometimes be updated in 8.x branches only and not synced to master branch.
This is an attempt, (inspired by and fixes #2102). I diffed the `branch_8x` version with master and saw that the 8x wording in most cases was more up to date. I tried to make sure that the updates are valid for 9.x, and skipped a few refguide links that I I believe may have been since removed, but have not tried to compile the refguide to detect its validity.