### PR TITLE
SOLR Contribs: Assembly was missing READMEs

### DIFF
--- a/gradle/solr/packaging.gradle
+++ b/gradle/solr/packaging.gradle
@@ -66,7 +66,10 @@ configure(allprojects.findAll {project -> project.path.startsWith(":solr:contrib
 
     // An aggregate that configures lib, lucene-libs and test-lib in a temporary location.
     task assemblePackaging(type: Sync) {
-      from "README.txt"
+      from(projectDir, {
+        exclude "src"
+        exclude "build*"
+      })
 
       from ({
         def externalLibs = configurations.runtimeLibs.copyRecursive { dep ->

--- a/solr/contrib/prometheus-exporter/build.gradle
+++ b/solr/contrib/prometheus-exporter/build.gradle
@@ -62,11 +62,6 @@ jar {
 }
 
 assemblePackaging {
-  // Add two folders to default packaging.
-  from(projectDir, {
-    include "bin/**"
-    include "conf/**"
-  })
   // Add all libs except those provided by SolrJ & Logging
   from ({
     def externalLibs = configurations.runtimeLibs.copyRecursive { dep ->


### PR DESCRIPTION
_(9.0/Gradle build)_
I found that `README.md`, `CHANGES.md`, `example/` was not getting in the assembly (the distribution).  I chose to take an excludes-list instead of includes-list approach.  This way, there's a problem in the future, it'll be because we accidentally included stuff (no big deal?) instead of accidentally forgetting stuff (more or a problem).  I tested this manually, and looked at the prometheus one especially.