### PR TITLE
LUCENE-9624: fix duplicate compute on maxUnpatchedValue

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene84/PForUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene84/PForUtil.java
@@ -71,7 +71,7 @@ final class PForUtil {
     if (numExceptions > 0) {
       int exceptionCount = 0;
       for (int i = 0; i < ForUtil.BLOCK_SIZE; ++i) {
-        if (longs[i] > (1L << patchedBitsRequired) - 1) {
+        if (longs[i] > maxUnpatchedValue) {
           exceptions[exceptionCount*2] = (byte) i;
           exceptions[exceptionCount*2+1] = (byte) (longs[i] >>> patchedBitsRequired);
           longs[i] &= maxUnpatchedValue;


### PR DESCRIPTION
# Description

in [LUCENE-9027](https://github.com/apache/lucene-solr/pull/973) lucene introduced SIMD to decode postings, which leaves a very small problem. since this is a hot way when indexing and searching, so fixing it may make a bit sense. i hope i can fix this problem as my first PR on this amazing project :)

detail:

maxUnpatchedValue has already computed apache.lucene.codecs.lucene84.PForUtil#encode line 64
```
final long maxUnpatchedValue = (1L << patchedBitsRequired) - 1;
```
but this value is computed later again:
apache.lucene.codecs.lucene84.PForUtil#encode line 74
```
if (longs[i] > (1L << patchedBitsRequired) - 1) ...
```

# Solution

convert 
apache.lucene.codecs.lucene84.PForUtil#encode line 74
```
if (longs[i] > (1L << patchedBitsRequired) - 1) ...
```
to 
```
if (longs[i] > maxUnpatchedValue) ...
```

# Tests
this is a really clear change, so tests may not be necessary ?  :)

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
