### PR TITLE
LUCENE-9599 Disable sort optim on index sort

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/FieldComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FieldComparator.java
@@ -143,13 +143,20 @@ public abstract class FieldComparator<T> {
   }
 
   /**
-   * For numeric comparators, setting this value, indicates that
-   * the same numeric data has been indexed with two fields: doc values and points and
-   * that these fields have the same name.
-   * This allows to use sort optimization and skip non-competitive documents.
-   * Not applicable for other comparators.
+   * Informs the comparator that the skipping of documents should be disabled.
+   * This function is called in cases when the skipping functionality
+   * should not be applied or not necessary.
+   *
+   * One example for numeric comparators is when we don't know if the same numeric data has
+   * been indexed with docValues and points if these two fields have the same name.
+   * As the skipping functionality relies on these fields to have the same data
+   * and as we don't know if it is true, we have to disable it.
+   *
+   * Another example could be when search sort is a part of the index sort,
+   * and can be already efficiently handled by TopFieldCollector,
+   * and doing extra work for skipping in the comparator is redundant.
    */
-  public void setCanUsePoints() {
+  public void disableSkipping() {
   }
 
   /** Sorts by descending relevance.  NOTE: if you are

--- a/lucene/core/src/java/org/apache/lucene/search/FieldValueHitQueue.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FieldValueHitQueue.java
@@ -136,12 +136,11 @@ public abstract class FieldValueHitQueue<T extends FieldValueHitQueue.Entry> ext
     for (int i = 0; i < numComparators; ++i) {
       SortField field = fields[i];
       reverseMul[i] = field.reverse ? -1 : 1;
-      //TODO: field.getCanUsePoints()
       comparators[i] = field.getComparator(size, i);
     }
-    if (numComparators > 0 && fields[0].getCanUsePoints()) {
-      // inform a numeric comparator that it can use points for sort optimization
-      comparators[0].setCanUsePoints();
+    if (numComparators > 0 && fields[0].getCanUsePoints() == false) {
+      // disable skipping functionality of a numeric comparator if we can't use points
+      comparators[0].disableSkipping();
     }
     if (numComparators == 1) {
       // inform a comparator that sort is based on this single field

--- a/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/comparators/NumericComparator.java
@@ -39,26 +39,25 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
     protected final T missingValue;
     protected final String field;
     protected final boolean reverse;
-    protected final boolean primarySort;
     private final int bytesCount; // how many bytes are used to encode this number
 
-    private boolean canUsePoints;
     protected boolean topValueSet;
     protected boolean singleSort; // singleSort is true, if sort is based on a single sort field.
     protected boolean hitsThresholdReached;
     protected boolean queueFull;
+    private boolean canSkipDocuments;
 
     protected NumericComparator(String field, T missingValue, boolean reverse, int sortPos, int bytesCount) {
         this.field = field;
         this.missingValue = missingValue;
         this.reverse = reverse;
-        this.primarySort = (sortPos == 0);
+        this.canSkipDocuments = (sortPos == 0); // skipping functionality is only relevant for primary sort
         this.bytesCount = bytesCount;
     }
 
     @Override
-    public void setCanUsePoints() {
-        canUsePoints = true;
+    public void disableSkipping() {
+        canSkipDocuments = false;
     }
 
     @Override
@@ -77,7 +76,7 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
     public abstract class NumericLeafComparator implements LeafFieldComparator {
         protected final NumericDocValues docValues;
         private final PointValues pointValues;
-        private final boolean enableSkipping; // if skipping functionality should be enabled
+        private final boolean enableSkipping; // if skipping functionality should be enabled on this segment
         private final int maxDoc;
         private final byte[] minValueAsBytes;
         private final byte[] maxValueAsBytes;
@@ -89,9 +88,9 @@ public abstract class NumericComparator<T extends Number> extends FieldComparato
 
         public NumericLeafComparator(LeafReaderContext context) throws IOException {
             this.docValues = getNumericDocValues(context, field);
-            this.pointValues = (primarySort && canUsePoints) ? context.reader().getPointValues(field) : null;
+            this.pointValues = canSkipDocuments ? context.reader().getPointValues(field) : null;
             if (pointValues != null) {
-                this.enableSkipping = true; // skipping is enabled on primarySort and when points are available
+                this.enableSkipping = true; // skipping is enabled when points are available
                 this.maxDoc = context.reader().maxDoc();
                 this.maxValueAsBytes = reverse == false ? new byte[bytesCount] : topValueSet ? new byte[bytesCount] : null;
                 this.minValueAsBytes = reverse ? new byte[bytesCount] : topValueSet ? new byte[bytesCount] : null;


### PR DESCRIPTION
Disable sort optimization in comparators on index sort.

Currently, if search sort is equal or a part of the index sort, we have
an early termination in TopFieldCollector.
But comparators are not aware of the index sort, and may run
sort optimization even if the search sort is congruent with
the index sort.

This patch:
- adds `disableSkipping` method to `FieldComparator`,
This method is called by `TopFieldCollector`, when the search sort
is congruent with the index sort.
It is also called when we can't use points for sort optimization.
- disables sort optimization in comparators in these cases.

Relates to #1351
Backport for #2075