### PR TITLE
Added support to download index folders from gcs url

### DIFF
--- a/gradle/documentation/render-javadoc/java11/package-list
+++ b/gradle/documentation/render-javadoc/java11/package-list
@@ -280,3 +280,4 @@ org.w3c.dom.html
 org.w3c.dom.stylesheets
 org.w3c.dom.xpath
 module:jdk.zipfs
+com.google.cloud.storage

--- a/lucene/luke/build.gradle
+++ b/lucene/luke/build.gradle
@@ -28,6 +28,7 @@ dependencies {
   api project(':lucene:core')
 
   implementation 'org.apache.logging.log4j:log4j-core'
+  implementation 'com.google.cloud:google-cloud-storage:1.113.4'
 
   implementation project(':lucene:codecs')
   implementation project(':lucene:backward-codecs')

--- a/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/menubar/OpenIndexDialogFactory.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/app/desktop/components/dialog/menubar/OpenIndexDialogFactory.java
@@ -17,19 +17,7 @@
 
 package org.apache.lucene.luke.app.desktop.components.dialog.menubar;
 
-import javax.swing.BorderFactory;
-import javax.swing.BoxLayout;
-import javax.swing.ButtonGroup;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
-import javax.swing.JDialog;
-import javax.swing.JFileChooser;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JRadioButton;
-import javax.swing.JSeparator;
+import javax.swing.*;
 import java.awt.Dialog;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
@@ -65,6 +53,8 @@ import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.util.NamedThreadFactory;
 import org.apache.lucene.util.SuppressForbidden;
 
+import org.apache.lucene.luke.util.GoogleCloudReader;
+
 /** Factory of open index dialog */
 public final class OpenIndexDialogFactory implements DialogOpener.DialogFactory {
 
@@ -81,6 +71,8 @@ public final class OpenIndexDialogFactory implements DialogOpener.DialogFactory 
   private final JComboBox<String> idxPathCombo = new JComboBox<>();
 
   private final JButton browseBtn = new JButton();
+
+  private final JTextField gsURITxtField = new JTextField();
 
   private final JCheckBox readOnlyCB = new JCheckBox();
 
@@ -180,7 +172,7 @@ public final class OpenIndexDialogFactory implements DialogOpener.DialogFactory 
   }
 
   private JPanel basicSettings() {
-    JPanel panel = new JPanel(new GridLayout(2, 1));
+    JPanel panel = new JPanel(new GridLayout(5, 1));
     panel.setOpaque(false);
 
     JPanel idxPath = new JPanel(new FlowLayout(FlowLayout.LEADING));
@@ -202,6 +194,8 @@ public final class OpenIndexDialogFactory implements DialogOpener.DialogFactory 
     readOnly.add(readOnlyCB);
     JLabel roIconLB = new JLabel(FontUtils.elegantIconHtml("&#xe06c;"));
     readOnly.add(roIconLB);
+    panel.add(new JLabel("Enter URL here"));
+    panel.add(gsURITxtField);
     panel.add(readOnly);
 
     return panel;
@@ -330,8 +324,13 @@ public final class OpenIndexDialogFactory implements DialogOpener.DialogFactory 
         if (indexHandler.indexOpened()) {
           indexHandler.close();
         }
-
+//
         String selectedPath = (String) idxPathCombo.getSelectedItem();
+//        We can reassign this to be url if URL is not empty
+        if(!gsURITxtField.getText().trim().isEmpty()){
+          selectedPath = GoogleCloudReader.readFromGoogleCloud(gsURITxtField.getText().trim());
+        }
+
         String dirImplClazz = (String) dirImplCombo.getSelectedItem();
         if (selectedPath == null || selectedPath.length() == 0) {
           String message = MessageUtils.getLocalizedMessage("openindex.message.index_path_not_selected");

--- a/lucene/luke/src/java/org/apache/lucene/luke/util/GoogleCloudReader.java
+++ b/lucene/luke/src/java/org/apache/lucene/luke/util/GoogleCloudReader.java
@@ -1,0 +1,59 @@
+ package org.apache.lucene.luke.util;
+ import com.google.api.gax.paging.Page;
+ import com.google.cloud.ReadChannel;
+ import com.google.cloud.storage.Blob;
+ import com.google.cloud.storage.Bucket;
+ import com.google.cloud.storage.Storage;
+ import com.google.cloud.storage.StorageOptions;
+
+ import java.io.File;
+ import java.io.FileOutputStream;
+ import java.io.IOException;
+ import java.nio.file.Path;
+ import java.nio.file.Paths;
+ import java.util.Arrays;
+ import java.util.List;
+ import java.util.stream.Collectors;
+
+ public class GoogleCloudReader {
+   final static String PROJECT_ID = "shopify-cloud-es";
+   final static String BUCKET_NAME = "elasticsearch-hq-wang";
+
+     public static String readFromGoogleCloud(String uri) throws IOException {
+
+         String[] folderStructure = uri.substring(uri.indexOf(BUCKET_NAME) + BUCKET_NAME.length()).split("/");
+
+         StorageOptions options = StorageOptions.newBuilder()
+                 .setProjectId(PROJECT_ID).build();
+         List<String> paths = Arrays.asList(folderStructure);
+         paths = paths.stream().filter(x -> x != null && !x.isEmpty()).collect(Collectors.toList());
+
+         Storage storage = options.getService();
+         Bucket bucket = storage.get(BUCKET_NAME);
+         String prefix = String.join("/", paths);
+
+         String[] structure = uri.substring(uri.indexOf(BUCKET_NAME)).split("/");
+         StringBuilder folders = new StringBuilder();
+
+         for (String s: structure){
+             folders.append(s);
+             folders.append("/");
+             File directory = new File(folders.toString());
+             directory.mkdir();
+         }
+
+         Page<Blob> blobs = bucket.list(Storage.BlobListOption.prefix(prefix));
+         for (Blob blob : blobs.iterateAll()) {
+             String path = BUCKET_NAME + "/" + blob.getName();
+             if (!(new File(path)).isDirectory()){
+                 ReadChannel readChannel = blob.reader();
+                 FileOutputStream fileOutputStream = new FileOutputStream(path);
+                 fileOutputStream.getChannel().transferFrom(readChannel, 0, Long.MAX_VALUE);
+                 fileOutputStream.close();
+             }
+         }
+         Path currentPath = Paths.get(System.getProperty("user.dir"));
+         Path filePath = Paths.get(currentPath.toString(), folders.toString());
+         return filePath.toString();
+     }
+ }


### PR DESCRIPTION
Added support in luke to read from GCS URI. Downloads the file/folder locally and points the resulting browse path that location. 

To use: verify that BUCKET_NAME and project_id are properly set.

Run `./gradlew lucene:luke:assemble`
Run the last `java -jar [..]` command that was written to console