### PR TITLE
SOLR-10732: short circuit calls to searcher#numDocs when base is empty

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/PivotFacetProcessor.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/PivotFacetProcessor.java
@@ -16,28 +16,6 @@
  */
 package org.apache.solr.handler.component;
 
-import org.apache.lucene.util.BytesRefBuilder;
-import org.apache.solr.common.StringUtils;
-import org.apache.solr.common.params.RequiredSolrParams;
-import org.apache.solr.schema.SchemaField;
-import org.apache.solr.schema.FieldType;
-import org.apache.solr.search.SolrIndexSearcher;
-import org.apache.solr.search.DocSet;
-import org.apache.solr.search.SyntaxError;
-import org.apache.solr.util.PivotListEntry;
-import org.apache.solr.common.SolrException;
-import org.apache.solr.common.util.NamedList;
-import org.apache.solr.common.util.SimpleOrderedMap;
-import org.apache.solr.common.util.StrUtils;
-import org.apache.solr.common.SolrException.ErrorCode;
-import org.apache.solr.common.params.SolrParams;
-import org.apache.solr.common.params.ShardParams;
-import org.apache.solr.common.params.FacetParams;
-import org.apache.solr.common.params.StatsParams;
-import org.apache.solr.request.SimpleFacets;
-import org.apache.solr.request.SolrQueryRequest;
-import org.apache.lucene.search.Query;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -46,6 +24,28 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRefBuilder;
+import org.apache.solr.common.SolrException;
+import org.apache.solr.common.SolrException.ErrorCode;
+import org.apache.solr.common.StringUtils;
+import org.apache.solr.common.params.FacetParams;
+import org.apache.solr.common.params.RequiredSolrParams;
+import org.apache.solr.common.params.ShardParams;
+import org.apache.solr.common.params.SolrParams;
+import org.apache.solr.common.params.StatsParams;
+import org.apache.solr.common.util.NamedList;
+import org.apache.solr.common.util.SimpleOrderedMap;
+import org.apache.solr.common.util.StrUtils;
+import org.apache.solr.request.SimpleFacets;
+import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.schema.FieldType;
+import org.apache.solr.schema.SchemaField;
+import org.apache.solr.search.DocSet;
+import org.apache.solr.search.SolrIndexSearcher;
+import org.apache.solr.search.SyntaxError;
+import org.apache.solr.util.PivotListEntry;
 
 /**
  * Processes all Pivot facet logic for a single node -- both non-distrib, and per-shard
@@ -345,6 +345,9 @@ public class PivotFacetProcessor extends SimpleFacets
    * @param pivotValue String representation of the value, may be null (ie: "missing")
    */
   private int getSubsetSize(DocSet base, SchemaField field, String pivotValue) throws IOException {
+    if (base.size() == 0) {
+      return 0;
+    }
     FieldType ft = field.getType();
     if ( null == pivotValue ) {
       Query query = ft.getRangeQuery(null, field, null, null, false, false);

--- a/solr/core/src/java/org/apache/solr/handler/component/RangeFacetProcessor.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/RangeFacetProcessor.java
@@ -258,6 +258,9 @@ public class RangeFacetProcessor extends SimpleFacets {
    * @see org.apache.lucene.search.TermRangeQuery
    */
   protected int rangeCount(DocSet subset, RangeFacetRequest rfr, RangeFacetRequest.FacetRange fr) throws IOException, SyntaxError {
+    if (subset.size() == 0) {
+      return 0;
+    }
     SchemaField schemaField = rfr.getSchemaField();
     Query rangeQ = schemaField.getType().getRangeQuery(null, schemaField, fr.lower, fr.upper, fr.includeLower, fr.includeUpper);
     if (rfr.isGroupFacet()) {

--- a/solr/core/src/java/org/apache/solr/request/SimpleFacets.java
+++ b/solr/core/src/java/org/apache/solr/request/SimpleFacets.java
@@ -287,7 +287,7 @@ public class SimpleFacets {
     NamedList<Integer> res = new SimpleOrderedMap<>();
 
     /* Ignore CommonParams.DF - could have init param facet.query assuming
-     * the schema default with query param DF intented to only affect Q.
+     * the schema default with query param DF intended to only affect Q.
      * If user doesn't want schema default for facet.query, they should be
      * explicit.
      */
@@ -306,6 +306,10 @@ public class SimpleFacets {
   }
 
   public void getFacetQueryCount(ParsedParams parsed, NamedList<Integer> res) throws SyntaxError, IOException {
+    if (parsed.docs.size() == 0) {
+      res.add(parsed.key, 0);
+      return;
+    }
     // TODO: slight optimization would prevent double-parsing of any localParams
     // TODO: SOLR-7753
     Query qobj = QParser.getParser(parsed.facetValue, req).getQuery();
@@ -325,6 +329,9 @@ public class SimpleFacets {
    * @see FacetParams#FACET_QUERY
    */
   public int getGroupedFacetQueryCount(Query facetQuery, DocSet docSet) throws IOException {
+    if (docSet.size() == 0) {
+      return 0;
+    }
     // It is okay to retrieve group.field from global because it is never a local param
     String groupField = global.get(GroupParams.GROUP_FIELD);
     if (groupField == null) {
@@ -423,7 +430,7 @@ public class SimpleFacets {
   }
 
   /**
-   * Term counts for use in field faceting that resepcts the specified mincount - 
+   * Term counts for use in field faceting that respects the specified mincount -
    * if mincount is null, the "zeros" param is consulted for the appropriate backcompat 
    * default
    *
@@ -893,7 +900,7 @@ public class SimpleFacets {
       inputStream = inputStream.sorted();
     }
     Stream<SimpleImmutableEntry<String,Integer>> termCountEntries = inputStream
-        .map((term) -> new SimpleImmutableEntry<>(term, numDocs(term, sf, ft, baseDocset)));
+        .map((term) -> new SimpleImmutableEntry<>(term, baseDocset.size() == 0 ? 0 : numDocs(term, sf, ft, baseDocset)));
     if (sort.equals(FacetParams.FACET_SORT_COUNT)) {
       termCountEntries = termCountEntries.sorted(Collections.reverseOrder(Map.Entry.comparingByValue()));
     }
@@ -903,7 +910,7 @@ public class SimpleFacets {
 
   private int numDocs(String term, final SchemaField sf, final FieldType ft, final DocSet baseDocset) {
     try {
-      return searcher.numDocs(ft.getFieldQuery(null, sf, term), baseDocset);
+      return baseDocset.size() == 0? 0: searcher.numDocs(ft.getFieldQuery(null, sf, term), baseDocset);
     } catch (IOException e1) {
       throw new RuntimeException(e1);
     }

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetProcessor.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetProcessor.java
@@ -419,7 +419,7 @@ public abstract class FacetProcessor<FacetRequestT extends FacetRequest>  {
       }
       count = result.size();  // don't really need this if we are skipping, but it's free.
     } else {
-      if (q == null) {
+      if (q == null || fcontext.base.size() == 0) {
         count = fcontext.base.size();
       } else {
         count = fcontext.searcher.numDocs(q, fcontext.base);


### PR DESCRIPTION
This avoids constructing redundant queries
