### PR TITLE
SOLR-14987: Reuse HttpSolrClient per node vs. one per Solr core when using CloudSolrStream

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -39,6 +39,8 @@ Improvements
   and solr_metrics_overseer_collectionWorkQueueSize with corresponding entries in the the Prometheus exporter's
   default/stock configuration.  (Saatchi Bhalla, Megan Carey, Andrzej Białecki, David Smiley)
 
+* SOLR-14987: Reuse HttpSolrClient per node vs. one per Solr core when using CloudSolrStream (Timothy Potter)
+
 Optimizations
 ---------------------
 * SOLR-14975: Optimize CoreContainer.getAllCoreNames, getLoadedCoreNames and getCoreDescriptors. (Bruno Roustant)

--- a/solr/core/src/test/org/apache/solr/search/function/AggValueSourceTest.java
+++ b/solr/core/src/test/org/apache/solr/search/function/AggValueSourceTest.java
@@ -44,7 +44,6 @@ public class AggValueSourceTest extends SolrTestCase {
       super("customagg", vs);
     }
 
-    @Override
     public SlotAcc createSlotAcc(FacetContext fcontext, long numDocs, int numSlots) {
       // check we can get access to the request and searcher, via the context
       if (fcontext.getRequest().getCore() != fcontext.getSearcher().getCore()) {

--- a/solr/core/src/test/org/apache/solr/search/function/AggValueSourceTest.java
+++ b/solr/core/src/test/org/apache/solr/search/function/AggValueSourceTest.java
@@ -44,6 +44,7 @@ public class AggValueSourceTest extends SolrTestCase {
       super("customagg", vs);
     }
 
+    @Override
     public SlotAcc createSlotAcc(FacetContext fcontext, long numDocs, int numSlots) {
       // check we can get access to the request and searcher, via the context
       if (fcontext.getRequest().getCore() != fcontext.getSearcher().getCore()) {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/SolrClientCache.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/SolrClientCache.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.lang.invoke.MethodHandles;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -53,6 +54,7 @@ public class SolrClientCache implements Serializable {
   }
 
   public synchronized CloudSolrClient getCloudSolrClient(String zkHost) {
+    Objects.requireNonNull(zkHost, "ZooKeeper host cannot be null!");
     CloudSolrClient client;
     if (solrClients.containsKey(zkHost)) {
       client = (CloudSolrClient) solrClients.get(zkHost);

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/CloudSolrStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/CloudSolrStream.java
@@ -32,6 +32,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.io.Tuple;
@@ -47,8 +48,8 @@ import org.apache.solr.client.solrj.io.stream.expr.StreamExpression;
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionNamedParameter;
 import org.apache.solr.client.solrj.io.stream.expr.StreamExpressionValue;
 import org.apache.solr.client.solrj.io.stream.expr.StreamFactory;
+import org.apache.solr.common.cloud.Aliases;
 import org.apache.solr.common.cloud.ClusterState;
-import org.apache.solr.common.cloud.DocCollection;
 import org.apache.solr.common.cloud.Slice;
 import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.common.params.ModifiableSolrParams;
@@ -152,12 +153,6 @@ public class CloudSolrStream extends TupleStream implements Expressible {
     else if(zkHostExpression.getParameter() instanceof StreamExpressionValue){
       zkHost = ((StreamExpressionValue)zkHostExpression.getParameter()).getValue();
     }
-    /*
-    if(null == zkHost){
-      throw new IOException(String.format(Locale.ROOT,"invalid expression %s - zkHost not found for collection '%s'",expression,collectionName));
-    }
-    */
-    
     // We've got all the required items
     init(collectionName, zkHost, mParams);
   }
@@ -237,7 +232,7 @@ public class CloudSolrStream extends TupleStream implements Expressible {
 
     // If the comparator is null then it was not explicitly set so we will create one using the sort parameter
     // of the query. While doing this we will also take into account any aliases such that if we are sorting on
-    // fieldA but fieldA is aliased to alias.fieldA then the comparater will be against alias.fieldA.
+    // fieldA but fieldA is aliased to alias.fieldA then the comparator will be against alias.fieldA.
 
     if (params.get("q") == null) {
       throw new IOException("q param expected for search function");
@@ -334,60 +329,55 @@ public class CloudSolrStream extends TupleStream implements Expressible {
   public static Slice[] getSlices(String collectionName, ZkStateReader zkStateReader, boolean checkAlias) throws IOException {
     ClusterState clusterState = zkStateReader.getClusterState();
 
-    Map<String, DocCollection> collectionsMap = clusterState.getCollectionsMap();
-
-    //TODO we should probably split collection by comma to query more than one
-    //  which is something already supported in other parts of Solr
-
     // check for alias or collection
 
     List<String> allCollections = new ArrayList<>();
     String[] collectionNames = collectionName.split(",");
+    Aliases aliases = checkAlias ? zkStateReader.getAliases() : null;
+
     for(String col : collectionNames) {
-      List<String> collections = checkAlias
-          ? zkStateReader.getAliases().resolveAliases(col)  // if not an alias, returns collectionName
+      List<String> collections = (aliases != null)
+          ? aliases.resolveAliases(col)  // if not an alias, returns collectionName
           : Collections.singletonList(collectionName);
       allCollections.addAll(collections);
     }
 
     // Lookup all actives slices for these collections
     List<Slice> slices = allCollections.stream()
-        .map(collectionsMap::get)
+        .map(c -> clusterState.getCollectionOrNull(c, true))
         .filter(Objects::nonNull)
         .flatMap(docCol -> Arrays.stream(docCol.getActiveSlicesArr()))
         .collect(Collectors.toList());
     if (!slices.isEmpty()) {
-      return slices.toArray(new Slice[slices.size()]);
-    }
-
-    // Check collection case insensitive
-    for(Entry<String, DocCollection> entry : collectionsMap.entrySet()) {
-      if(entry.getKey().equalsIgnoreCase(collectionName)) {
-        return entry.getValue().getActiveSlicesArr();
-      }
+      return slices.toArray(new Slice[0]);
     }
 
     throw new IOException("Slices not found for " + collectionName);
   }
 
   protected void constructStreams() throws IOException {
+    final ModifiableSolrParams mParams = adjustParams(new ModifiableSolrParams(params));
+    mParams.set(DISTRIB, "false"); // We are the aggregator.
     try {
-
-
-      ModifiableSolrParams mParams = new ModifiableSolrParams(params);
-      mParams = adjustParams(mParams);
-      mParams.set(DISTRIB, "false"); // We are the aggregator.
-
-      List<String> shardUrls = getShards(this.zkHost, this.collection, this.streamContext, mParams);
-
-      for(String shardUrl : shardUrls) {
-        SolrStream solrStream = new SolrStream(shardUrl, mParams);
-        if(streamContext != null) {
-          solrStream.setStreamContext(streamContext);
-        }
-        solrStream.setFieldMappings(this.fieldMappings);
-        solrStreams.add(solrStream);
+      final Stream<SolrStream> streamOfSolrStream;
+      if (streamContext != null && streamContext.get("shards") != null) {
+        // stream of shard url with core
+        streamOfSolrStream = getShards(this.zkHost, this.collection, this.streamContext, mParams).stream()
+            .map(s -> new SolrStream(s, mParams));
+      } else {
+        // stream of replicas to reuse the same SolrHttpClient per baseUrl
+        // avoids re-parsing data we already have in the replicas
+        streamOfSolrStream = getReplicas(this.zkHost, this.collection, this.streamContext, mParams).stream()
+            .map(r -> new SolrStream(r.getBaseUrl(), mParams, r.getCoreName()));
       }
+
+      streamOfSolrStream.forEach(ss -> {
+        if(streamContext != null) {
+          ss.setStreamContext(streamContext);
+        }
+        ss.setFieldMappings(this.fieldMappings);
+        solrStreams.add(ss);
+      });
     } catch (Exception e) {
       throw new IOException(e);
     }
@@ -395,24 +385,17 @@ public class CloudSolrStream extends TupleStream implements Expressible {
 
   private void openStreams() throws IOException {
     ExecutorService service = ExecutorUtil.newMDCAwareCachedThreadPool(new SolrNamedThreadFactory("CloudSolrStream"));
+    List<Future<TupleWrapper>> futures =
+        solrStreams.stream().map(ss -> service.submit(new StreamOpener((SolrStream)ss, comp))).collect(Collectors.toList());
     try {
-      List<Future<TupleWrapper>> futures = new ArrayList<>();
-      for (TupleStream solrStream : solrStreams) {
-        StreamOpener so = new StreamOpener((SolrStream) solrStream, comp);
-        Future<TupleWrapper> future = service.submit(so);
-        futures.add(future);
-      }
-
-      try {
-        for (Future<TupleWrapper> f : futures) {
-          TupleWrapper w = f.get();
-          if (w != null) {
-            tuples.add(w);
-          }
+      for (Future<TupleWrapper> f : futures) {
+        TupleWrapper w = f.get();
+        if (w != null) {
+          tuples.add(w);
         }
-      } catch (Exception e) {
-        throw new IOException(e);
       }
+    } catch (Exception e) {
+      throw new IOException(e);
     } finally {
       service.shutdown();
     }
@@ -462,8 +445,8 @@ public class CloudSolrStream extends TupleStream implements Expressible {
 
   protected class TupleWrapper implements Comparable<TupleWrapper> {
     private Tuple tuple;
-    private SolrStream stream;
-    private StreamComparator comp;
+    private final SolrStream stream;
+    private final StreamComparator comp;
 
     public TupleWrapper(SolrStream stream, StreamComparator comp) {
       this.stream = stream;
@@ -509,8 +492,8 @@ public class CloudSolrStream extends TupleStream implements Expressible {
 
   protected class StreamOpener implements Callable<TupleWrapper> {
 
-    private SolrStream stream;
-    private StreamComparator comp;
+    private final SolrStream stream;
+    private final StreamComparator comp;
 
     public StreamOpener(SolrStream stream, StreamComparator comp) {
       this.stream = stream;

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/SolrStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/SolrStream.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
@@ -264,6 +265,19 @@ public class SolrStream extends TupleStream {
     }
 
     return fields;
+  }
+
+  /**
+   * Do not use as this method will be removed in Solr 9.x.
+   * @param server The SolrClient
+   * @param requestParams Request params
+   * @return A TupleStreamParser
+   * @throws IOException if an I/O related error occurs contacting the remote Solr instance
+   * @throws SolrServerException if an error occurs contacting the remote Solr instance
+   */
+  @Deprecated
+  public TupleStreamParser constructParser(SolrClient server, SolrParams requestParams) throws IOException, SolrServerException {
+    return constructParser(requestParams);
   }
 
   private TupleStreamParser constructParser(SolrParams requestParams) throws IOException, SolrServerException {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/SolrStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/SolrStream.java
@@ -280,6 +280,7 @@ public class SolrStream extends TupleStream {
     return constructParser(requestParams);
   }
 
+  // this method is staying in 9.x
   private TupleStreamParser constructParser(SolrParams requestParams) throws IOException, SolrServerException {
     String p = requestParams.get("qt");
     if (p != null) {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/TupleStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/TupleStream.java
@@ -21,10 +21,13 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.io.SolrClientCache;
@@ -122,70 +125,80 @@ public abstract class TupleStream implements Closeable, Serializable, MapWriter 
     return getShards(zkHost, collection, streamContext, new ModifiableSolrParams());
   }
 
+  static List<Replica> getReplicas(String zkHost,
+                                   String collection,
+                                   StreamContext streamContext,
+                                   SolrParams requestParams)
+      throws IOException {
+    List<Replica> replicas = new LinkedList<>();
+
+    //SolrCloud Sharding
+    SolrClientCache solrClientCache = (streamContext != null ? streamContext.getSolrClientCache() : null);
+    final SolrClientCache localSolrClientCache; // tracks any locally allocated cache that needs to be closed locally
+    if (solrClientCache == null) { // streamContext was null OR streamContext.getSolrClientCache() returned null
+      solrClientCache = localSolrClientCache = new SolrClientCache();
+    } else {
+      localSolrClientCache = null;
+    }
+
+    if (zkHost == null) {
+      throw new IOException(String.format(Locale.ROOT,"invalid expression - zkHost not found for collection '%s'",collection));
+    }
+
+    CloudSolrClient cloudSolrClient = solrClientCache.getCloudSolrClient(zkHost);
+    ZkStateReader zkStateReader = cloudSolrClient.getZkStateReader();
+    ClusterState clusterState = zkStateReader.getClusterState();
+    Slice[] slices = CloudSolrStream.getSlices(collection, zkStateReader, true);
+    Set<String> liveNodes = clusterState.getLiveNodes();
+
+    RequestReplicaListTransformerGenerator requestReplicaListTransformerGenerator;
+    final ModifiableSolrParams solrParams;
+    if (streamContext != null) {
+      solrParams = new ModifiableSolrParams(streamContext.getRequestParams());
+      requestReplicaListTransformerGenerator = streamContext.getRequestReplicaListTransformerGenerator();
+    } else {
+      solrParams = new ModifiableSolrParams();
+      requestReplicaListTransformerGenerator = null;
+    }
+    if (requestReplicaListTransformerGenerator == null) {
+      requestReplicaListTransformerGenerator = new RequestReplicaListTransformerGenerator();
+    }
+    solrParams.add(requestParams);
+
+    ReplicaListTransformer replicaListTransformer = requestReplicaListTransformerGenerator.getReplicaListTransformer(solrParams);
+
+    List<Replica> sortedReplicas = new ArrayList<>();
+    for(Slice slice : slices) {
+      slice.getReplicas().stream().filter(r -> r.isActive(liveNodes)).forEach(sortedReplicas::add);
+      replicaListTransformer.transform(sortedReplicas);
+      if (sortedReplicas.size() > 0) {
+        replicas.add(sortedReplicas.get(0));
+      }
+      sortedReplicas.clear();
+    }
+
+    if (localSolrClientCache != null) {
+      localSolrClientCache.close();
+    }
+
+    return replicas;
+  }
+
   @SuppressWarnings({"unchecked"})
   public static List<String> getShards(String zkHost,
                                        String collection,
                                        StreamContext streamContext,
                                        SolrParams requestParams)
       throws IOException {
-    Map<String, List<String>> shardsMap = null;
-    List<String> shards = new ArrayList<>();
 
-    if(streamContext != null) {
-      shardsMap = (Map<String, List<String>>)streamContext.get("shards");
-    }
-
+    List<String> shards;
+    Map<String, List<String>> shardsMap = streamContext != null ? (Map<String, List<String>>)streamContext.get("shards") : null;
     if(shardsMap != null) {
       //Manual Sharding
       shards = shardsMap.get(collection);
     } else {
-      //SolrCloud Sharding
-      SolrClientCache solrClientCache = (streamContext != null ? streamContext.getSolrClientCache() : null);
-      final SolrClientCache localSolrClientCache; // tracks any locally allocated cache that needs to be closed locally
-      if (solrClientCache == null) { // streamContext was null OR streamContext.getSolrClientCache() returned null
-        solrClientCache = localSolrClientCache = new SolrClientCache();
-      } else {
-        localSolrClientCache = null;
-      }
-      CloudSolrClient cloudSolrClient = solrClientCache.getCloudSolrClient(zkHost);
-      ZkStateReader zkStateReader = cloudSolrClient.getZkStateReader();
-      ClusterState clusterState = zkStateReader.getClusterState();
-      Slice[] slices = CloudSolrStream.getSlices(collection, zkStateReader, true);
-      Set<String> liveNodes = clusterState.getLiveNodes();
-
-
-      RequestReplicaListTransformerGenerator requestReplicaListTransformerGenerator;
-      final ModifiableSolrParams solrParams;
-      if (streamContext != null) {
-        solrParams = new ModifiableSolrParams(streamContext.getRequestParams());
-        requestReplicaListTransformerGenerator = streamContext.getRequestReplicaListTransformerGenerator();
-      } else {
-        solrParams = new ModifiableSolrParams();
-        requestReplicaListTransformerGenerator = null;
-      }
-      if (requestReplicaListTransformerGenerator == null) {
-        requestReplicaListTransformerGenerator = new RequestReplicaListTransformerGenerator();
-      }
-      solrParams.add(requestParams);
-
-      ReplicaListTransformer replicaListTransformer = requestReplicaListTransformerGenerator.getReplicaListTransformer(solrParams);
-
-      for(Slice slice : slices) {
-        List<Replica> sortedReplicas = new ArrayList<>();
-        for(Replica replica : slice.getReplicas()) {
-          if(replica.getState() == Replica.State.ACTIVE && liveNodes.contains(replica.getNodeName())) {
-            sortedReplicas.add(replica);
-          }
-        }
-
-        replicaListTransformer.transform(sortedReplicas);
-        if (sortedReplicas.size() > 0) {
-          shards.add(sortedReplicas.get(0).getCoreUrl());
-        }
-      }
-      if (localSolrClientCache != null) {
-        localSolrClientCache.close();
-      }
+      shards = getReplicas(zkHost, collection, streamContext, requestParams).stream()
+          .map(Replica::getCoreUrl).collect(Collectors.toList());
     }
 
     return shards;


### PR DESCRIPTION
# Description

Backport of #2067 to `branch_8x`; see original PR for detailed description and checklist.