### PR TITLE
SOLR-14251 Add option skipFreeSpaceCheck to skip checking for availble disk space before splitting shards. Useful with shared file systems like HDFS

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/SplitShardCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/SplitShardCmd.java
@@ -58,6 +58,7 @@ import static org.apache.solr.common.params.CollectionAdminParams.FOLLOW_ALIASES
 import static org.apache.solr.common.params.CollectionParams.CollectionAction.*;
 import static org.apache.solr.common.params.CommonAdminParams.ASYNC;
 import static org.apache.solr.common.params.CommonAdminParams.NUM_SUB_SHARDS;
+import static org.apache.solr.common.params.CommonAdminParams.SKIP_FREE_SPACE_CHECK;
 
 
 public class SplitShardCmd implements OverseerCollectionMessageHandler.Cmd {
@@ -129,10 +130,16 @@ public class SplitShardCmd implements OverseerCollectionMessageHandler.Cmd {
       throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "Interrupted.");
     }
 
+
     RTimerTree t;
     if (ocmh.overseer.getCoreContainer().getNodeConfig().getMetricsConfig().isEnabled()) {
       t = timings.sub("checkDiskSpace");
-      checkDiskSpace(collectionName, slice.get(), parentShardLeader, splitMethod, ocmh.cloudManager);
+      boolean skipFreeSpaceCheck = message.getBool(SKIP_FREE_SPACE_CHECK, false);
+      if(skipFreeSpaceCheck) {
+        log.debug("Skipping check for sufficient disk space", message);
+      } else {
+        checkDiskSpace(collectionName, slice.get(), parentShardLeader, splitMethod, ocmh.cloudManager);
+      }
       t.stop();
     }
 

--- a/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
@@ -144,6 +144,7 @@ import static org.apache.solr.common.params.CommonAdminParams.SPLIT_BY_PREFIX;
 import static org.apache.solr.common.params.CommonAdminParams.SPLIT_FUZZ;
 import static org.apache.solr.common.params.CommonAdminParams.SPLIT_METHOD;
 import static org.apache.solr.common.params.CommonAdminParams.WAIT_FOR_FINAL_STATE;
+import static org.apache.solr.common.params.CommonAdminParams.SKIP_FREE_SPACE_CHECK;
 import static org.apache.solr.common.params.CommonParams.NAME;
 import static org.apache.solr.common.params.CommonParams.TIMING;
 import static org.apache.solr.common.params.CommonParams.VALUE_LONG;
@@ -744,7 +745,8 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
           NUM_SUB_SHARDS,
           SPLIT_FUZZ,
           SPLIT_BY_PREFIX,
-          FOLLOW_ALIASES);
+          FOLLOW_ALIASES,
+          SKIP_FREE_SPACE_CHECK);
       return copyPropertiesWithPrefix(req.getParams(), map, COLL_PROP_PREFIX);
     }),
     DELETESHARD_OP(DELETESHARD, (req, rsp, h) -> {

--- a/solr/solr-ref-guide/src/shard-management.adoc
+++ b/solr/solr-ref-guide/src/shard-management.adoc
@@ -80,6 +80,9 @@ copies don't occupy additional disk space on the leader node, unless hard-linkin
 A float value (default is 0.0f, must be smaller than 0.5f) that allows to vary the sub-shard ranges
 by this percentage of total shard range, odd shards being larger and even shards being smaller.
 
+`skipFreeSpaceCheck`::
+A boolean value to skip checking for free disk space before shard splitting. Can be useful in case of shared file systems like HDFS. Defaults to `false`.
+
 `property._name_=_value_`::
 Set core property _name_ to _value_. See the section <<defining-core-properties.adoc#defining-core-properties,Defining core.properties>> for details on supported properties and values.
 

--- a/solr/solrj/src/java/org/apache/solr/common/params/CommonAdminParams.java
+++ b/solr/solrj/src/java/org/apache/solr/common/params/CommonAdminParams.java
@@ -35,4 +35,6 @@ public interface CommonAdminParams
   String TIMEOUT = "timeout";
   /** Inexact shard splitting factor. */
   String SPLIT_FUZZ = "splitFuzz";
+  /** Skip free space checking before shard splitting. **/
+  String SKIP_FREE_SPACE_CHECK = "skipFreeSpaceCheck";
 }


### PR DESCRIPTION
# Description

The Shard split operation is checking available disk space on local disks of the host Solr is running on even if the index is on a shared storage (e.g. HDFS). 

# Solution

I'm adding option skipFreeSpaceCheck as a workaround so shards can be split until there is a proper solution implemented.

# Tests

Tested only manually.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ x I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
