### PR TITLE
UCENE-9346: Support minimumNumberShouldMatch in WANDScorer

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/search/Boolean2ScorerSupplier.java
+++ b/lucene/core/src/java/org/apache/lucene/search/Boolean2ScorerSupplier.java
@@ -68,9 +68,15 @@ final class Boolean2ScorerSupplier extends ScorerSupplier {
       return minRequiredCost.getAsLong();
     } else {
       final Collection<ScorerSupplier> optionalScorers = subs.get(Occur.SHOULD);
-      final long shouldCost = MinShouldMatchSumScorer.cost(
-          optionalScorers.stream().mapToLong(ScorerSupplier::cost),
-          optionalScorers.size(), minShouldMatch);
+      // nocommit The cost calculation here copies that in WANDScorer's constructor, and may need to be adjusted?
+      final long shouldCost = scoreMode == ScoreMode.TOP_SCORES ?
+                              optionalScorers.stream().mapToLong(ScorerSupplier::cost).sum() :
+                              MinShouldMatchSumScorer.cost(
+                                      optionalScorers.stream().mapToLong(ScorerSupplier::cost),
+                                      optionalScorers.size(),
+                                      minShouldMatch);
+
+
       return Math.min(minRequiredCost.orElse(Long.MAX_VALUE), shouldCost);
     }
   }
@@ -195,10 +201,13 @@ final class Boolean2ScorerSupplier extends ScorerSupplier {
       for (ScorerSupplier scorer : optional) {
         optionalScorers.add(scorer.get(leadCost));
       }
-      if (minShouldMatch > 1) {
+
+      if (scoreMode == ScoreMode.TOP_SCORES) {
+        return new WANDScorer(weight, optionalScorers, minShouldMatch);
+      } else if (minShouldMatch > 1) {
+        // nocommit minShouldMath > 1 && scoreMode != ScoreMode.TOP_SCORES still requires MinShouldMatchSumScorer.
+        // Do we want to depcate this entirely now ?
         return new MinShouldMatchSumScorer(weight, optionalScorers, minShouldMatch);
-      } else if (scoreMode == ScoreMode.TOP_SCORES) {
-        return new WANDScorer(weight, optionalScorers);
       } else {
         return new DisjunctionSumScorer(weight, optionalScorers, scoreMode);
       }


### PR DESCRIPTION
# Description
Support minimumNumberShouldMatch in WANDScorer

Currently has a few `nocommit` to keep track of questions

# Solution
Similar to `MinShouldMatchSumScorer`, the logic here keeps track of number of matched scorers for each candidate doc, and compares it with `minShouldMatch` to decide if the minimum number of optional clauses have been matched.

# Tests
Passed existing tests (especially those in `TestBooleanMinShouldMatch` and `TestWANDScorer`), and updated some that check for scores.

`./gradlew check` passed with `nocommit` rule commented out for now.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
