### PR TITLE
LUCENE-9021 QueryParser: re-use the LookaheadSuccess exception for branch_8x

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -38,6 +38,8 @@ Optimizations
 
 * LUCENE-9536: Reduced memory usage for OrdinalMap when a segment has all
   values. (Julie Tibshirani via Adrien Grand)
+  
+* LUCENE-9021: QueryParser: re-use the LookaheadSuccess exception. (Przemek Bruski via Mikhail Khludnev)
 
 * LUCENE-9636: Faster decoding of postings for some numbers of bits per value.
   (Guo Feng via Adrien Grand)

--- a/lucene/queryparser/build.xml
+++ b/lucene/queryparser/build.xml
@@ -74,6 +74,11 @@
          byline="true"
          match="public QueryParser\(QueryParserTokenManager "
          replace="protected QueryParser(QueryParserTokenManager "/>
+      <!-- change an exception used for signaling to be static -->
+      <replaceregexp file="src/java/org/apache/lucene/queryparser/classic/QueryParser.java"
+         byline="true"
+         match="final private LookaheadSuccess jj_ls ="
+         replace="static final private LookaheadSuccess jj_ls =" />
       <generalReplaces dir="src/java/org/apache/lucene/queryparser/classic"/>
     </sequential>
   </target>

--- a/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParser.java
+++ b/lucene/queryparser/src/java/org/apache/lucene/queryparser/classic/QueryParser.java
@@ -814,7 +814,7 @@ public class QueryParser extends QueryParserBase implements QueryParserConstants
   }
 
   static private final class LookaheadSuccess extends java.lang.Error { }
-  final private LookaheadSuccess jj_ls = new LookaheadSuccess();
+  static final private LookaheadSuccess jj_ls = new LookaheadSuccess();
   private boolean jj_scan_token(int kind) {
     if (jj_scanpos == jj_lastpos) {
       jj_la--;


### PR DESCRIPTION
Same as https://github.com/apache/lucene-solr/pull/962, for branch 8.x

This is basically the same as https://issues.apache.org/jira/browse/SOLR-11242 , but for Lucene QueryParser

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I am authorized to contribute this code to the ASF and have removed any code I do not have a license to distribute.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `ant precommit` and the appropriate test suite.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
