### PR TITLE
SOLR-15046: Check if SOLR_SSL_ENABLED strictly equal to true for setting solr.jetty.https.port

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -77,6 +77,8 @@ Bug Fixes
 * SOLR-12182: Don't persist base_url in ZK as the URL scheme is variable, compute from node_name instead when reading
   state back from ZK. (Timothy Potter)
 
+* SOLR-15046: Check if SOLR_SSL_ENABLED strictly equal to true for setting solr.jetty.https.port (Timothy Potter)
+
 
 Other Changes
 ---------------------

--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -2151,7 +2151,7 @@ function start_solr() {
   fi
 
   # If SSL-related system props are set, add them to SOLR_OPTS
-  if [ "$SOLR_SSL_ENABLED" ]; then
+  if [ "$SOLR_SSL_ENABLED" == "true" ]; then
     # If using SSL and solr.jetty.https.port not set explicitly, use the jetty.port
     SSL_PORT_PROP="-Dsolr.jetty.https.port=$SOLR_PORT"
     SOLR_OPTS+=($SOLR_SSL_OPTS "$SSL_PORT_PROP")


### PR DESCRIPTION
# Description

See JIRA: https://issues.apache.org/jira/browse/SOLR-15046

# Solution

Fix bin/solr IF statement. 

# Tests

Manual test using:
```
cd solr
ant server
bin/solr start -c

bin/solr create -c test -s 1 -d _default
WARNING: Using _default configset with data driven schema functionality. NOT RECOMMENDED for production use.
         To turn off: bin/solr config -c test -p 8983 -action set-user-property -property update.autoCreateFields -value false
Created collection 'test' with 1 shard(s), 1 replica(s) with config-set 'test'
```

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have developed this patch against the `master` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
