### PR TITLE
SOLR-15058: get the correct hostname when hostname contain '_'

### DIFF
--- a/solr/core/src/test/org/apache/solr/cloud/ZkControllerTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ZkControllerTest.java
@@ -106,6 +106,8 @@ public class ZkControllerTest extends SolrTestCaseJ4 {
           zkStateReader.createClusterStateWatchersAndUpdate();
 
           // getBaseUrlForNodeName
+          assertEquals("http://zzz_xxx:1234/solr",
+              zkStateReader.getBaseUrlForNodeName("zzz_xxx:1234_solr"));
           assertEquals("http://zzz.xxx:1234/solr",
               zkStateReader.getBaseUrlForNodeName("zzz.xxx:1234_solr"));
           assertEquals("http://xxx:99",

--- a/solr/solrj/src/java/org/apache/solr/common/util/Utils.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/Utils.java
@@ -758,8 +758,9 @@ public class Utils {
   public static String getBaseUrlForNodeName(final String nodeName, String urlScheme) {
     return getBaseUrlForNodeName(nodeName, urlScheme, false);
   }
+
   public static String getBaseUrlForNodeName(final String nodeName, String urlScheme,  boolean isV2) {
-    final int _offset = nodeName.indexOf("_");
+    final int _offset = nodeName.lastIndexOf("_");
     if (_offset < 0) {
       throw new IllegalArgumentException("nodeName does not contain expected '_' separator: " + nodeName);
     }


### PR DESCRIPTION
<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description


`Utils.getBaseUrlForNodeName` split the nodename by the first '_'

In ZK, Solr add '_solr' to the end of the hostname


# Solution

should split by the last '_'

# Tests

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
