### PR TITLE
SOLR-15060: Introduce DelegatingDirectoryFactory.

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -228,6 +228,8 @@ Improvements
 
 * SOLR-14413: Allow timeAllowed and cursorMark parameters together. (John Gallagher via Mike Drob)
 
+* SOLR-15060: Introduce DelegatingDirectoryFactory. (Bruno Roustant)
+
 Optimizations
 ---------------------
 * SOLR-14975: Optimize CoreContainer.getAllCoreNames, getLoadedCoreNames and getCoreDescriptors. (Bruno Roustant)

--- a/solr/core/src/java/org/apache/solr/core/DelegatingDirectoryFactory.java
+++ b/solr/core/src/java/org/apache/solr/core/DelegatingDirectoryFactory.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.core;
+
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.LockFactory;
+import org.apache.solr.common.params.SolrParams;
+import org.apache.solr.common.util.NamedList;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+/**
+ * Delegates to a {@link DirectoryFactory} defined by the {@code delegateFactory} parameter.
+ * <p>
+ * Configured with the {@code delegateFactory} parameter which defines the full class name of the delegate
+ * {@link DirectoryFactory}, plus any additional parameter for the delegate factory.</p>
+ */
+public class DelegatingDirectoryFactory extends DirectoryFactory {
+
+    protected DirectoryFactory delegateFactory;
+
+    public DirectoryFactory getDelegate() {
+        return delegateFactory;
+    }
+
+    @Override
+    public void initCoreContainer(CoreContainer cc) {
+        super.initCoreContainer(cc);
+        if (delegateFactory != null) {
+            delegateFactory.initCoreContainer(cc);
+        }
+    }
+
+    @Override
+    public void init(@SuppressWarnings("rawtypes") NamedList args) {
+        SolrParams params = args.toSolrParams();
+        String delegateFactoryClass = params.get("delegateFactory");
+        if (delegateFactoryClass == null) {
+            throw new IllegalArgumentException("delegateFactory class is required");
+        }
+        DirectoryFactory delegateFactory = coreContainer.getResourceLoader().newInstance(delegateFactoryClass, DirectoryFactory.class);
+        delegateFactory.initCoreContainer(coreContainer);
+        delegateFactory.init(args);
+        this.delegateFactory = delegateFactory;
+    }
+
+    @Override
+    public void doneWithDirectory(Directory directory) throws IOException {
+        delegateFactory.doneWithDirectory(directory);
+    }
+
+    @Override
+    public void addCloseListener(Directory dir, CachingDirectoryFactory.CloseListener closeListener) {
+        delegateFactory.addCloseListener(dir, closeListener);
+    }
+
+    @Override
+    public void close() throws IOException {
+        delegateFactory.close();
+    }
+
+    @Override
+    protected Directory create(String path, LockFactory lockFactory, DirContext dirContext) throws IOException {
+        return delegateFactory.create(path, lockFactory, dirContext);
+    }
+
+    @Override
+    protected LockFactory createLockFactory(String rawLockType) throws IOException {
+        return delegateFactory.createLockFactory(rawLockType);
+    }
+
+    @Override
+    public boolean exists(String path) throws IOException {
+        return delegateFactory.exists(path);
+    }
+
+    @Override
+    public void remove(Directory dir) throws IOException {
+        delegateFactory.remove(dir);
+    }
+
+    @Override
+    public void remove(Directory dir, boolean afterCoreClose) throws IOException {
+        delegateFactory.remove(dir, afterCoreClose);
+    }
+
+    @Override
+    public void remove(String path, boolean afterCoreClose) throws IOException {
+        delegateFactory.remove(path, afterCoreClose);
+    }
+
+    @Override
+    public void remove(String path) throws IOException {
+        delegateFactory.remove(path);
+    }
+
+    @Override
+    public long size(Directory directory) throws IOException {
+        return delegateFactory.size(directory);
+    }
+
+    @Override
+    public long size(String path) throws IOException {
+        return delegateFactory.size(path);
+    }
+
+    @Override
+    public void move(Directory fromDir, Directory toDir, String fileName, IOContext ioContext) throws IOException {
+        delegateFactory.move(fromDir, toDir, fileName, ioContext);
+    }
+
+    @Override
+    public void renameWithOverwrite(Directory dir, String fileName, String toName) throws IOException {
+        delegateFactory.renameWithOverwrite(dir, fileName, toName);
+    }
+
+    @Override
+    public Directory get(String path, DirContext dirContext, String rawLockType, Function<Directory, Directory> wrappingFunction)
+            throws IOException {
+        return delegateFactory.get(path, dirContext, rawLockType, wrappingFunction);
+    }
+
+    @Override
+    public void incRef(Directory directory) {
+        delegateFactory.incRef(directory);
+    }
+
+    @Override
+    public boolean isPersistent() {
+        return delegateFactory.isPersistent();
+    }
+
+    @Override
+    public boolean isSharedStorage() {
+        return delegateFactory.isSharedStorage();
+    }
+
+    @Override
+    public void release(Directory directory) throws IOException {
+        delegateFactory.release(directory);
+    }
+
+    @Override
+    public String normalize(String path) throws IOException {
+        return delegateFactory.normalize(path);
+    }
+
+    @Override
+    public boolean isAbsolute(String path) {
+        return delegateFactory.isAbsolute(path);
+    }
+
+    @Override
+    public boolean searchersReserveCommitPoints() {
+        return delegateFactory.searchersReserveCommitPoints();
+    }
+
+    @Override
+    public String getDataHome(CoreDescriptor cd) throws IOException {
+        return delegateFactory.getDataHome(cd);
+    }
+
+    @Override
+    public void cleanupOldIndexDirectories(String dataDirPath, String currentIndexDirPath, boolean afterCoreReload) {
+        delegateFactory.cleanupOldIndexDirectories(dataDirPath, currentIndexDirPath, afterCoreReload);
+    }
+
+    @Override
+    protected boolean deleteOldIndexDirectory(String oldDirPath) throws IOException {
+        return delegateFactory.deleteOldIndexDirectory(oldDirPath);
+    }
+
+    @Override
+    protected Directory getBaseDir(Directory dir) {
+        return delegateFactory.getBaseDir(dir);
+    }
+}

--- a/solr/core/src/java/org/apache/solr/core/DirectoryFactory.java
+++ b/solr/core/src/java/org/apache/solr/core/DirectoryFactory.java
@@ -27,6 +27,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.lucene.store.Directory;
@@ -215,11 +216,22 @@ public abstract class DirectoryFactory implements NamedListInitializedPlugin,
    * Returns the Directory for a given path, using the specified rawLockType.
    * Will return the same Directory instance for the same path.
    * 
-   * 
    * @throws IOException If there is a low-level I/O error.
    */
-  public abstract Directory get(String path, DirContext dirContext, String rawLockType)
-      throws IOException;
+  public Directory get(String path, DirContext dirContext, String rawLockType) throws IOException {
+    return get(path, dirContext, rawLockType, Function.identity());
+  }
+
+  /**
+   * Returns the Directory for a given path, using the specified rawLockType.
+   * Will return the same Directory instance for the same path.
+   *
+   * @param wrappingFunction A function called to wrap the internally {@link #create(String, LockFactory, DirContext) created}
+   *                         {@link Directory} with another {@link Directory}. Use {@link Function#identity()} for no wrapping.
+   * @throws IOException If there is a low-level I/O error.
+   */
+  public abstract Directory get(String path, DirContext dirContext, String rawLockType, Function<Directory, Directory> wrappingFunction)
+          throws IOException;
   
   /**
    * Increment the number of references to the given Directory. You must call

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-delegatingdirectory.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-delegatingdirectory.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" ?>
+
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<config>
+  <luceneMatchVersion>${tests.luceneMatchVersion:LATEST}</luceneMatchVersion>
+  <directoryFactory name="DirectoryFactory" class="org.apache.solr.core.TestDelegatingDirectoryFactory$DelegatingDirectoryFactoryForTest">
+    <str name="delegateFactory">solr.MMapDirectoryFactory</str>
+    <str name="maxChunkSize">524288</str>
+  </directoryFactory>
+  <schemaFactory class="ClassicIndexSchemaFactory"/>
+</config>

--- a/solr/core/src/test/org/apache/solr/core/TestDelegatingDirectoryFactory.java
+++ b/solr/core/src/test/org/apache/solr/core/TestDelegatingDirectoryFactory.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.core;
+
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FilterDirectory;
+import org.apache.lucene.store.MMapDirectory;
+import org.apache.solr.SolrTestCaseJ4;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.MatcherAssert.*;
+
+/**
+ * Tests {@link DelegatingDirectoryFactory}.
+ */
+public class TestDelegatingDirectoryFactory extends SolrTestCaseJ4 {
+
+    private DirectoryFactory directoryFactory;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        initCore("solrconfig-delegatingdirectory.xml", "schema.xml");
+    }
+
+    @Before
+    public void before() {
+        directoryFactory = DirectoryFactory.loadDirectoryFactory(solrConfig, h.getCoreContainer(), null);
+    }
+
+    @After
+    public void after() throws Exception {
+        if (directoryFactory != null) {
+            directoryFactory.close();
+        }
+    }
+
+    @Test
+    public void testDelegation() throws Exception {
+        // Verify config.
+        assertThat(directoryFactory, is(instanceOf(DelegatingDirectoryFactoryForTest.class)));
+        assertThat(((DelegatingDirectoryFactoryForTest) directoryFactory).getDelegate(), is(instanceOf(MMapDirectoryFactory.class)));
+
+        Directory directory = directoryFactory.get(h.getCore().getIndexDir(), DirectoryFactory.DirContext.DEFAULT, DirectoryFactory.LOCK_TYPE_NATIVE);
+        try {
+            // Verify the created Directory is a custom one wrapping a MMapDirectory because we use a wrapping function
+            // in DelegatingDirectoryFactoryForTest.
+            assertThat(directory, is(instanceOf(DelegatingDirectoryForTest.class)));
+            Directory delegateDirectory = ((DelegatingDirectoryForTest) directory).getDelegate();
+            assertThat(delegateDirectory, is(instanceOf(MMapDirectory.class)));
+            // Verify config params are passed to the delegate factory.
+            assertThat(((MMapDirectory) delegateDirectory).getMaxChunkSize(), is(524288));
+        } finally {
+            directoryFactory.release(directory);
+        }
+
+        // Verify the delegation works with CachingDirectoryFactory: the cached Directory is the same instance.
+        Directory directory2 = directoryFactory.get(h.getCore().getIndexDir(), DirectoryFactory.DirContext.DEFAULT, DirectoryFactory.LOCK_TYPE_NATIVE);
+        try {
+            assertThat(directory2, sameInstance(directory));
+        } finally {
+            directoryFactory.release(directory2);
+            directoryFactory.doneWithDirectory(directory2);
+        }
+    }
+
+    public static class DelegatingDirectoryFactoryForTest extends DelegatingDirectoryFactory {
+
+        @Override
+        public Directory get(String path, DirContext dirContext, String rawLockType, Function<Directory, Directory> wrappingFunction)
+                throws IOException {
+            return delegateFactory.get(path, dirContext, rawLockType, (dir) -> wrappingFunction.apply(new DelegatingDirectoryForTest(dir)));
+        }
+    }
+
+    private static class DelegatingDirectoryForTest extends FilterDirectory {
+
+        DelegatingDirectoryForTest(Directory delegate) {
+            super(delegate);
+        }
+    }
+}


### PR DESCRIPTION
For the description, see https://issues.apache.org/jira/browse/SOLR-15060

This PR adds a new method get(String path, DirContext dirContext, String rawLockType, Function<Directory, Directory> wrappingFunction) in DirectoryFactory, with a new wrappingFunction parameter. The existing get(String path, DirContext dirContext, String rawLockType) calls the new one with Function.identity().

I wonder if this change should be 8x or 9x.