### PR TITLE
SOLR-14723: Remove the class attribute for the caches in the _default/example configsets

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -93,6 +93,8 @@ Other Changes
 
 * SOLR-14958: Refactor zkHost config logic to make testing easier and reduce risk of incorrect value being used (hossman)
 
+* SOLR-14723: Remove the class attribute for the caches in the _default/example configsets (Tim Dillon)
+
 ==================  8.7.0 ==================
 
 Consult the lucene/CHANGES.txt file for additional, low level, changes in this release.

--- a/solr/contrib/dataimporthandler-extras/src/test-files/dihextras/solr/collection1/conf/dataimport-solrconfig.xml
+++ b/solr/contrib/dataimporthandler-extras/src/test-files/dihextras/solr/collection1/conf/dataimport-solrconfig.xml
@@ -69,7 +69,6 @@
            and old cache.
          -->
     <filterCache
-      class="solr.LRUCache"
       size="512"
       initialSize="512"
       autowarmCount="256"/>
@@ -78,7 +77,6 @@
          document ids (DocList) based on a query, a sort, and the range
          of documents requested.  -->
     <queryResultCache
-      class="solr.LRUCache"
       size="512"
       initialSize="512"
       autowarmCount="256"/>
@@ -86,7 +84,6 @@
   <!-- documentCache caches Lucene Document objects (the stored fields for each document).
        Since Lucene internal document ids are transient, this cache will not be autowarmed.  -->
     <documentCache
-      class="solr.LRUCache"
       size="512"
       initialSize="512"
       autowarmCount="0"/>
@@ -106,7 +103,6 @@
          of solr.search.CacheRegenerator if autowarming is desired.  -->
     <!--
     <cache name="myUserCache"
-      class="solr.LRUCache"
       size="4096"
       initialSize="1024"
       autowarmCount="1024"
@@ -274,4 +270,3 @@
   </admin>
 
 </config>
-

--- a/solr/contrib/dataimporthandler/src/test-files/dih/solr/collection1/conf/contentstream-solrconfig.xml
+++ b/solr/contrib/dataimporthandler/src/test-files/dih/solr/collection1/conf/contentstream-solrconfig.xml
@@ -69,7 +69,6 @@
            and old cache.
          -->
     <filterCache
-      class="solr.LRUCache"
       size="512"
       initialSize="512"
       autowarmCount="256"/>
@@ -78,7 +77,6 @@
          document ids (DocList) based on a query, a sort, and the range
          of documents requested.  -->
     <queryResultCache
-      class="solr.LRUCache"
       size="512"
       initialSize="512"
       autowarmCount="256"/>
@@ -86,7 +84,6 @@
   <!-- documentCache caches Lucene Document objects (the stored fields for each document).
        Since Lucene internal document ids are transient, this cache will not be autowarmed.  -->
     <documentCache
-      class="solr.LRUCache"
       size="512"
       initialSize="512"
       autowarmCount="0"/>
@@ -106,7 +103,6 @@
          of solr.search.CacheRegenerator if autowarming is desired.  -->
     <!--
     <cache name="myUserCache"
-      class="solr.LRUCache"
       size="4096"
       initialSize="1024"
       autowarmCount="1024"
@@ -284,4 +280,3 @@
   </updateRequestProcessorChain>
 
 </config>
-

--- a/solr/contrib/dataimporthandler/src/test-files/dih/solr/collection1/conf/dataimport-nodatasource-solrconfig.xml
+++ b/solr/contrib/dataimporthandler/src/test-files/dih/solr/collection1/conf/dataimport-nodatasource-solrconfig.xml
@@ -71,7 +71,6 @@
            and old cache.
          -->
     <filterCache
-      class="solr.LRUCache"
       size="512"
       initialSize="512"
       autowarmCount="256"/>
@@ -80,7 +79,6 @@
          document ids (DocList) based on a query, a sort, and the range
          of documents requested.  -->
     <queryResultCache
-      class="solr.LRUCache"
       size="512"
       initialSize="512"
       autowarmCount="256"/>
@@ -88,7 +86,6 @@
   <!-- documentCache caches Lucene Document objects (the stored fields for each document).
        Since Lucene internal document ids are transient, this cache will not be autowarmed.  -->
     <documentCache
-      class="solr.LRUCache"
       size="512"
       initialSize="512"
       autowarmCount="0"/>
@@ -108,7 +105,6 @@
          of solr.search.CacheRegenerator if autowarming is desired.  -->
     <!--
     <cache name="myUserCache"
-      class="solr.LRUCache"
       size="4096"
       initialSize="1024"
       autowarmCount="1024"
@@ -276,4 +272,3 @@
   </admin>
 
 </config>
-

--- a/solr/contrib/dataimporthandler/src/test-files/dih/solr/collection1/conf/dataimport-solrconfig.xml
+++ b/solr/contrib/dataimporthandler/src/test-files/dih/solr/collection1/conf/dataimport-solrconfig.xml
@@ -69,7 +69,6 @@
            and old cache.
          -->
     <filterCache
-      class="solr.LRUCache"
       size="512"
       initialSize="512"
       autowarmCount="256"/>
@@ -78,7 +77,6 @@
          document ids (DocList) based on a query, a sort, and the range
          of documents requested.  -->
     <queryResultCache
-      class="solr.LRUCache"
       size="512"
       initialSize="512"
       autowarmCount="256"/>
@@ -86,7 +84,6 @@
   <!-- documentCache caches Lucene Document objects (the stored fields for each document).
        Since Lucene internal document ids are transient, this cache will not be autowarmed.  -->
     <documentCache
-      class="solr.LRUCache"
       size="512"
       initialSize="512"
       autowarmCount="0"/>
@@ -106,7 +103,6 @@
          of solr.search.CacheRegenerator if autowarming is desired.  -->
     <!--
     <cache name="myUserCache"
-      class="solr.LRUCache"
       size="4096"
       initialSize="1024"
       autowarmCount="1024"
@@ -284,4 +280,3 @@
   </updateRequestProcessorChain>
 
 </config>
-

--- a/solr/contrib/extraction/src/test-files/extraction/solr/collection1/conf/solrconfig.xml
+++ b/solr/contrib/extraction/src/test-files/extraction/solr/collection1/conf/solrconfig.xml
@@ -74,19 +74,16 @@
          that match a particular query.
       -->
     <filterCache
-      class="solr.search.LRUCache"
       size="512"
       initialSize="512"
       autowarmCount="256"/>
 
     <queryResultCache
-      class="solr.search.LRUCache"
       size="512"
       initialSize="512"
       autowarmCount="1024"/>
 
     <documentCache
-      class="solr.search.LRUCache"
       size="512"
       initialSize="512"
       autowarmCount="0"/>
@@ -98,7 +95,6 @@
     <!--
 
     <cache name="myUserCache"
-      class="solr.search.LRUCache"
       size="4096"
       initialSize="1024"
       autowarmCount="1024"

--- a/solr/contrib/ltr/src/test-files/solr/collection1/conf/solrconfig-ltr.xml
+++ b/solr/contrib/ltr/src/test-files/solr/collection1/conf/solrconfig-ltr.xml
@@ -30,9 +30,9 @@
   class="org.apache.solr.ltr.search.LTRQParserPlugin" />
 
  <query>
-  <filterCache class="solr.FastLRUCache" size="4096"
+  <filterCache size="4096"
    initialSize="2048" autowarmCount="0" />
-  <cache name="QUERY_DOC_FV" class="solr.search.LRUCache" size="4096"
+  <cache name="QUERY_DOC_FV" size="4096"
    initialSize="2048" autowarmCount="4096" regenerator="solr.search.NoOpRegenerator" />
  </query>
 

--- a/solr/contrib/ltr/src/test-files/solr/collection1/conf/solrconfig-ltr_Th10_10.xml
+++ b/solr/contrib/ltr/src/test-files/solr/collection1/conf/solrconfig-ltr_Th10_10.xml
@@ -31,9 +31,9 @@
 
 
  <query>
-  <filterCache class="solr.FastLRUCache" size="4096"
+  <filterCache size="4096"
    initialSize="2048" autowarmCount="0" />
-  <cache name="QUERY_DOC_FV" class="solr.search.LRUCache" size="4096"
+  <cache name="QUERY_DOC_FV" size="4096"
    initialSize="2048" autowarmCount="4096" regenerator="solr.search.NoOpRegenerator" />
  </query>
 

--- a/solr/contrib/ltr/src/test-files/solr/collection1/conf/solrconfig-multiseg.xml
+++ b/solr/contrib/ltr/src/test-files/solr/collection1/conf/solrconfig-multiseg.xml
@@ -26,9 +26,9 @@
  <queryParser name="ltr" class="org.apache.solr.ltr.search.LTRQParserPlugin" />
 
  <query>
-  <filterCache class="solr.FastLRUCache" size="4096"
+  <filterCache size="4096"
    initialSize="2048" autowarmCount="0" />
-  <cache name="QUERY_DOC_FV" class="solr.search.LRUCache" size="4096"
+  <cache name="QUERY_DOC_FV" size="4096"
    initialSize="2048" autowarmCount="4096" regenerator="solr.search.NoOpRegenerator" />
  </query>
 

--- a/solr/contrib/prometheus-exporter/src/test-files/solr/collection1/conf/solrconfig.xml
+++ b/solr/contrib/prometheus-exporter/src/test-files/solr/collection1/conf/solrconfig.xml
@@ -55,23 +55,19 @@
 
     <maxBooleanClauses>1024</maxBooleanClauses>
 
-    <filterCache class="solr.FastLRUCache"
-                 size="512"
+    <filterCache size="512"
                  initialSize="512"
                  autowarmCount="0"/>
 
-    <queryResultCache class="solr.LRUCache"
-                      size="512"
+    <queryResultCache size="512"
                       initialSize="512"
                       autowarmCount="0"/>
 
-    <documentCache class="solr.LRUCache"
-                   size="512"
+    <documentCache size="512"
                    initialSize="512"
                    autowarmCount="0"/>
 
     <cache name="perSegFilter"
-           class="solr.search.LRUCache"
            size="10"
            initialSize="0"
            autowarmCount="10"

--- a/solr/core/src/java/org/apache/solr/core/SolrConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrConfig.java
@@ -335,7 +335,7 @@ public class SolrConfig extends XmlConfigFile implements MapSerializable {
       .add(new SolrPluginInfo(TransformerFactory.class, "transformer", REQUIRE_NAME, REQUIRE_CLASS, MULTI_OK))
       .add(new SolrPluginInfo(SearchComponent.class, "searchComponent", REQUIRE_NAME, REQUIRE_CLASS, MULTI_OK))
       .add(new SolrPluginInfo(UpdateRequestProcessorFactory.class, "updateProcessor", REQUIRE_NAME, REQUIRE_CLASS, MULTI_OK))
-      .add(new SolrPluginInfo(SolrCache.class, "cache", REQUIRE_NAME, REQUIRE_CLASS, MULTI_OK))
+      .add(new SolrPluginInfo(SolrCache.class, "cache", REQUIRE_NAME, MULTI_OK))
           // TODO: WTF is up with queryConverter???
           // it apparently *only* works as a singleton? - SOLR-4304
           // and even then -- only if there is a single SpellCheckComponent

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-analytics-query.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-analytics-query.xml
@@ -83,25 +83,21 @@
          that match a particular query.
       -->
     <filterCache
-        class="solr.search.FastLRUCache"
         size="512"
         initialSize="512"
         autowarmCount="2"/>
 
     <queryResultCache
-        class="solr.search.LRUCache"
         size="512"
         initialSize="512"
         autowarmCount="2"/>
 
     <documentCache
-        class="solr.search.LRUCache"
         size="512"
         initialSize="512"
         autowarmCount="0"/>
 
     <cache name="perSegFilter"
-           class="solr.search.LRUCache"
            size="10"
            initialSize="0"
            autowarmCount="10" />
@@ -113,7 +109,6 @@
     <!--
 
     <cache name="myUserCache"
-      class="solr.search.LRUCache"
       size="4096"
       initialSize="1024"
       autowarmCount="1024"
@@ -313,4 +308,3 @@ based HashBitset. -->
   </updateRequestProcessorChain>
 
 </config>
-

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-cache-enable-disable.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-cache-enable-disable.xml
@@ -37,21 +37,18 @@
       -->
     <filterCache
       enabled="${filterCache.enabled}"
-      class="solr.search.FastLRUCache"
       size="512"
       initialSize="512"
       autowarmCount="2"/>
 
     <queryResultCache
       enabled="${queryResultCache.enabled}"
-      class="solr.search.LRUCache"
       size="512"
       initialSize="512"
       autowarmCount="2"/>
 
     <documentCache
       enabled="${documentCache.enabled}"
-      class="solr.search.LRUCache"
       size="512"
       initialSize="512"
       autowarmCount="0"/>
@@ -88,6 +85,3 @@
   </initParams>
 
 </config>
-
-
-

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-caching.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-caching.xml
@@ -21,16 +21,19 @@
   <schemaFactory class="ClassicIndexSchemaFactory"/>
   <query>
     <cache name="lfuCacheDecayFalse"
+           class="solr.search.LFUCache"
            size="10"
            initialSize="9"
            timeDecay="false" />
 
     <cache name="lfuCacheDecayTrue"
+           class="solr.search.LFUCache"
            size="10"
            initialSize="9"
            timeDecay="true" />
 
     <cache name="lfuCacheDecayDefault"
+           class="solr.search.LFUCache"
            size="10"
            initialSize="9" />
   </query>

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-caching.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-caching.xml
@@ -21,19 +21,16 @@
   <schemaFactory class="ClassicIndexSchemaFactory"/>
   <query>
     <cache name="lfuCacheDecayFalse"
-           class="solr.search.LFUCache"
            size="10"
            initialSize="9"
            timeDecay="false" />
 
     <cache name="lfuCacheDecayTrue"
-           class="solr.search.LFUCache"
            size="10"
            initialSize="9"
            timeDecay="true" />
 
     <cache name="lfuCacheDecayDefault"
-           class="solr.search.LFUCache"
            size="10"
            initialSize="9" />
   </query>

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-collapseqparser.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-collapseqparser.xml
@@ -83,25 +83,21 @@
          that match a particular query.
       -->
     <filterCache
-        class="solr.search.FastLRUCache"
         size="512"
         initialSize="512"
         autowarmCount="2"/>
 
     <queryResultCache
-        class="solr.search.LRUCache"
         size="512"
         initialSize="512"
         autowarmCount="2"/>
 
     <documentCache
-        class="solr.search.LRUCache"
         size="512"
         initialSize="512"
         autowarmCount="0"/>
 
     <cache name="perSegFilter"
-           class="solr.search.LRUCache"
            size="10"
            initialSize="0"
            autowarmCount="10" />
@@ -113,7 +109,6 @@
     <!--
 
     <cache name="myUserCache"
-      class="solr.search.LRUCache"
       size="4096"
       initialSize="1024"
       autowarmCount="1024"
@@ -320,4 +315,3 @@ based HashBitset. -->
     </lst>
   </initParams>
 </config>
-

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-deeppaging.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-deeppaging.xml
@@ -39,8 +39,8 @@
   <!-- deep paging better play nice with caching -->
   <query>
     <!-- no wautowarming, it screws up our ability to sanity check cache stats in tests -->
-    <filterCache class="solr.FastLRUCache" size="50" initialSize="50" autowarmCount="0"/>
-    <queryResultCache class="solr.LRUCache" size="50" initialSize="50" autowarmCount="0"/>
+    <filterCache size="50" initialSize="50" autowarmCount="0"/>
+    <queryResultCache size="50" initialSize="50" autowarmCount="0"/>
     <queryResultWindowSize>50</queryResultWindowSize>
     <queryResultMaxDocsCached>500</queryResultMaxDocsCached>
     <!-- randomized so we excersize cursors using various paths in SolrIndexSearcher -->
@@ -49,4 +49,3 @@
 
   <requestHandler name="/select" class="solr.SearchHandler" default="true" />
 </config>
-

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-elevate.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-elevate.xml
@@ -56,19 +56,16 @@
          that match a particular query.
       -->
     <filterCache
-      class="solr.search.FastLRUCache"
       size="512"
       initialSize="512"
       autowarmCount="256"/>
 
     <queryResultCache
-      class="solr.search.LRUCache"
       size="512"
       initialSize="512"
       autowarmCount="1024"/>
 
     <documentCache
-      class="solr.search.LRUCache"
       size="512"
       initialSize="512"
       autowarmCount="0"/>

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-managed-schema.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-managed-schema.xml
@@ -37,21 +37,18 @@
   <query>
     <filterCache
         enabled="${filterCache.enabled:false}"
-        class="solr.search.FastLRUCache"
         size="512"
         initialSize="512"
         autowarmCount="2"/>
 
     <queryResultCache
         enabled="${queryResultCache.enabled:false}"
-        class="solr.search.LRUCache"
         size="512"
         initialSize="512"
         autowarmCount="2"/>
 
     <documentCache
         enabled="${documentCache.enabled:false}"
-        class="solr.search.LRUCache"
         size="512"
         initialSize="512"
         autowarmCount="0"/>

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-minhash.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-minhash.xml
@@ -95,25 +95,21 @@
          that match a particular query.
       -->
     <filterCache
-      class="solr.search.FastLRUCache"
       size="512"
       initialSize="512"
       autowarmCount="2"/>
 
     <queryResultCache
-      class="solr.search.LRUCache"
       size="512"
       initialSize="512"
       autowarmCount="2"/>
 
     <documentCache
-      class="solr.search.LRUCache"
       size="512"
       initialSize="512"
       autowarmCount="0"/>
 
     <cache name="perSegFilter"
-      class="solr.search.LRUCache"
       size="10"
       initialSize="0"
       autowarmCount="10" />
@@ -125,7 +121,6 @@
     <!--
 
     <cache name="myUserCache"
-      class="solr.search.LRUCache"
       size="4096"
       initialSize="1024"
       autowarmCount="1024"
@@ -561,4 +556,3 @@
   <queryParser name="minhash" class="org.apache.solr.search.MinHashQParserPlugin" />
 
 </config>
-

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-noopregen.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-noopregen.xml
@@ -26,8 +26,7 @@
   <schemaFactory class="ClassicIndexSchemaFactory"/>
   <requestHandler name="/select" class="solr.SearchHandler" />
   <query>
-    <cache name="myPerSegmentCache" 
-           class="solr.LRUCache"
+    <cache name="myPerSegmentCache"
            size="3"
            initialSize="0"
            autowarmCount="100%"

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-plugcollector.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-plugcollector.xml
@@ -82,25 +82,21 @@
          that match a particular query.
       -->
     <filterCache
-        class="solr.search.FastLRUCache"
         size="512"
         initialSize="512"
         autowarmCount="2"/>
 
     <queryResultCache
-        class="solr.search.LRUCache"
         size="512"
         initialSize="512"
         autowarmCount="2"/>
 
     <documentCache
-        class="solr.search.LRUCache"
         size="512"
         initialSize="512"
         autowarmCount="0"/>
 
     <cache name="perSegFilter"
-           class="solr.search.LRUCache"
            size="10"
            initialSize="0"
            autowarmCount="10" />
@@ -112,7 +108,6 @@
     <!--
 
     <cache name="myUserCache"
-      class="solr.search.LRUCache"
       size="4096"
       initialSize="1024"
       autowarmCount="1024"
@@ -537,4 +532,3 @@ based HashBitset. -->
   </initParams>
 
 </config>
-

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-sortingresponse.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-sortingresponse.xml
@@ -35,8 +35,7 @@
 
     <queryResultMaxDocsCached>200</queryResultMaxDocsCached>
 
-    <documentCache class="solr.LRUCache"
-                   size="512"
+    <documentCache size="512"
                    initialSize="512"
                    autowarmCount="0"/>
   </query>

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-spatial.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-spatial.xml
@@ -27,13 +27,11 @@
   <requestHandler name="/select" class="solr.SearchHandler" />
   <query>
     <cache name="perSegSpatialFieldCache_srptgeom"
-           class="solr.LRUCache"
            size="3"
            initialSize="0"
            autowarmCount="100%"
            regenerator="solr.NoOpRegenerator"/>
     <cache name="perSegSpatialFieldCache_srptgeom_geo3d"
-           class="solr.LRUCache"
            size="3"
            initialSize="0"
            autowarmCount="100%"

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-tlog.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-tlog.xml
@@ -136,23 +136,19 @@
 
 
   <query>
-    <filterCache class="solr.FastLRUCache"
-      size="512"
+    <filterCache size="512"
       initialSize="512"
       autowarmCount="0" />
 
-    <queryResultCache class="solr.LRUCache"
-      size="512"
+    <queryResultCache size="512"
       initialSize="512"
       autowarmCount="0" />
 
-    <documentCache class="solr.LRUCache"
-      size="512"
+    <documentCache size="512"
       initialSize="512"
       autowarmCount="0" />
 
     <cache name="perSegFilter"
-      class="solr.search.LRUCache"
       size="10"
       initialSize="0"
       autowarmCount="10"

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig.xml
@@ -95,25 +95,21 @@
          that match a particular query.
       -->
     <filterCache
-      class="solr.search.FastLRUCache"
       size="512"
       initialSize="512"
       autowarmCount="2"/>
 
     <queryResultCache
-      class="solr.search.LRUCache"
       size="512"
       initialSize="512"
       autowarmCount="2"/>
 
     <documentCache
-      class="solr.search.LRUCache"
       size="512"
       initialSize="512"
       autowarmCount="0"/>
 
     <cache name="perSegFilter"
-      class="solr.search.LRUCache"
       size="10"
       initialSize="0"
       autowarmCount="10" />
@@ -125,7 +121,6 @@
     <!--
 
     <cache name="myUserCache"
-      class="solr.search.LRUCache"
       size="4096"
       initialSize="1024"
       autowarmCount="1024"
@@ -567,4 +562,3 @@
   </transformer>
 
 </config>
-

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig_perf.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig_perf.xml
@@ -36,19 +36,16 @@
   
   <query>
     <filterCache
-      class="solr.FastLRUCache"
       size="512"
       initialSize="512"
       autowarmCount="0"/>
 
     <queryResultCache
-      class="solr.LRUCache"
       size="512"
       initialSize="512"
       autowarmCount="0"/>
 
     <documentCache
-      class="solr.LRUCache"
       size="512"
       initialSize="512"
       autowarmCount="0"/>

--- a/solr/core/src/test-files/solr/configsets/ccjoin/conf/solrconfig.xml
+++ b/solr/core/src/test-files/solr/configsets/ccjoin/conf/solrconfig.xml
@@ -26,24 +26,20 @@
   <requestHandler name="/select" class="solr.SearchHandler" />
 
   <query>
-    <filterCache class="solr.CaffeineCache"
-      size="512"
+    <filterCache size="512"
       initialSize="512"
       autowarmCount="0" />
 
-    <queryResultCache class="solr.CaffeineCache"
-      size="512"
+    <queryResultCache size="512"
       initialSize="512"
       autowarmCount="0" />
 
-    <documentCache class="solr.CaffeineCache"
-      size="512"
+    <documentCache size="512"
       initialSize="512"
       autowarmCount="0" />
   </query>
 
   <cache name="hash_product_id_s"
-         class="solr.CaffeineCache"
          size="128"
          initialSize="0"
          regenerator="solr.NoOpRegenerator"/>

--- a/solr/core/src/test-files/solr/configsets/exitable-directory/conf/solrconfig.xml
+++ b/solr/core/src/test-files/solr/configsets/exitable-directory/conf/solrconfig.xml
@@ -56,20 +56,16 @@
   </updateHandler>
 
   <query>
-         <filterCache class="solr.FastLRUCache"
-                 size="0"
+         <filterCache size="0"
                  initialSize="0"
                  autowarmCount="0"/>
-         <queryResultCache class="solr.LRUCache"
-                  size="0"
+         <queryResultCache size="0"
                   initialSize="0"
                   autowarmCount="0"/>
-         <documentCache class="solr.LRUCache"
-                   size="0"
+         <documentCache size="0"
                    initialSize="0"
                    autowarmCount="0"/>
-         <fieldValueCache class="solr.FastLRUCache"
-                size="0"
+         <fieldValueCache size="0"
                 autowarmCount="0"
                 showItems="0" />         
   </query>

--- a/solr/core/src/test/org/apache/solr/search/TestSolr4Spatial2.java
+++ b/solr/core/src/test/org/apache/solr/search/TestSolr4Spatial2.java
@@ -315,8 +315,11 @@ public class TestSolr4Spatial2 extends SolrTestCaseJ4 {
       assertJQ(sameReq, "/response/numFound==1", "/response/docs/[0]/id=='1'");
 
       // When there are new segments, we accumulate another hit. This tests the cache was not blown away on commit.
+      // (i.e. the cache instance is new but it should've been regenerated from the old one).
       // Checking equality for the first reader's cache key indicates whether the cache should still be valid.
       Object leafKey2 = getFirstLeafReaderKey();
+      // get the current instance of metrics - the old one may not represent the current cache instance
+      cacheMetrics = (MetricsMap) ((SolrMetricManager.GaugeWrapper)h.getCore().getCoreMetricManager().getRegistry().getMetrics().get("CACHE.searcher.perSegSpatialFieldCache_" + fieldName)).getGauge();
       assertEquals(leafKey1.equals(leafKey2) ? "2" : "1", cacheMetrics.getValue().get("cumulative_hits").toString());
     }
 

--- a/solr/core/src/test/org/apache/solr/search/json/TestJsonRequest.java
+++ b/solr/core/src/test/org/apache/solr/search/json/TestJsonRequest.java
@@ -26,8 +26,8 @@ import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.search.CaffeineCache;
 import org.apache.solr.search.DocSet;
-import org.apache.solr.search.FastLRUCache;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -448,7 +448,7 @@ public class TestJsonRequest extends SolrTestCaseHS {
     if(client.getClientProvider()==null) {
       final SolrQueryRequest request = req();
       try {
-        final FastLRUCache<Query,DocSet> filterCache = (FastLRUCache<Query,DocSet>) request.getSearcher().getFilterCache();
+        final CaffeineCache<Query,DocSet> filterCache = (CaffeineCache<Query,DocSet>) request.getSearcher().getFilterCache();
         filterCache.clear();
         final TermQuery catA = new TermQuery(new Term("cat_s", "A"));
         assertNull("cache is empty",filterCache.get(catA));

--- a/solr/example/example-DIH/solr/db/conf/solrconfig.xml
+++ b/solr/example/example-DIH/solr/db/conf/solrconfig.xml
@@ -406,8 +406,7 @@
            autowarmCount - the number of entries to prepopulate from
                and old cache.
       -->
-    <filterCache class="solr.FastLRUCache"
-                 size="512"
+    <filterCache size="512"
                  initialSize="512"
                  autowarmCount="0"/>
 
@@ -416,8 +415,7 @@
          Caches results of searches - ordered lists of document ids
          (DocList) based on a query, a sort, and the range of documents requested.
       -->
-    <queryResultCache class="solr.LRUCache"
-                     size="512"
+    <queryResultCache size="512"
                      initialSize="512"
                      autowarmCount="0"/>
 
@@ -427,14 +425,12 @@
          document).  Since Lucene internal document ids are transient,
          this cache will not be autowarmed.
       -->
-    <documentCache class="solr.LRUCache"
-                   size="512"
+    <documentCache size="512"
                    initialSize="512"
                    autowarmCount="0"/>
 
     <!-- custom cache currently used by block join -->
     <cache name="perSegFilter"
-      class="solr.search.LRUCache"
       size="10"
       initialSize="0"
       autowarmCount="10"
@@ -447,8 +443,7 @@
          even if not configured here.
       -->
     <!--
-       <fieldValueCache class="solr.FastLRUCache"
-                        size="512"
+       <fieldValueCache size="512"
                         autowarmCount="128"
                         showItems="32" />
       -->
@@ -464,7 +459,6 @@
       -->
     <!--
        <cache name="myUserCache"
-              class="solr.LRUCache"
               size="4096"
               initialSize="1024"
               autowarmCount="1024"

--- a/solr/example/example-DIH/solr/mail/conf/solrconfig.xml
+++ b/solr/example/example-DIH/solr/mail/conf/solrconfig.xml
@@ -409,8 +409,7 @@
            autowarmCount - the number of entries to prepopulate from
                and old cache.
       -->
-    <filterCache class="solr.FastLRUCache"
-                 size="512"
+    <filterCache size="512"
                  initialSize="512"
                  autowarmCount="0"/>
 
@@ -419,8 +418,7 @@
          Caches results of searches - ordered lists of document ids
          (DocList) based on a query, a sort, and the range of documents requested.
       -->
-    <queryResultCache class="solr.LRUCache"
-                     size="512"
+    <queryResultCache size="512"
                      initialSize="512"
                      autowarmCount="0"/>
 
@@ -430,14 +428,12 @@
          document).  Since Lucene internal document ids are transient,
          this cache will not be autowarmed.
       -->
-    <documentCache class="solr.LRUCache"
-                   size="512"
+    <documentCache size="512"
                    initialSize="512"
                    autowarmCount="0"/>
 
     <!-- custom cache currently used by block join -->
     <cache name="perSegFilter"
-      class="solr.search.LRUCache"
       size="10"
       initialSize="0"
       autowarmCount="10"
@@ -450,8 +446,7 @@
          even if not configured here.
       -->
     <!--
-       <fieldValueCache class="solr.FastLRUCache"
-                        size="512"
+       <fieldValueCache size="512"
                         autowarmCount="128"
                         showItems="32" />
       -->
@@ -467,7 +462,6 @@
       -->
     <!--
        <cache name="myUserCache"
-              class="solr.LRUCache"
               size="4096"
               initialSize="1024"
               autowarmCount="1024"

--- a/solr/example/example-DIH/solr/solr/conf/solrconfig.xml
+++ b/solr/example/example-DIH/solr/solr/conf/solrconfig.xml
@@ -406,8 +406,7 @@
            autowarmCount - the number of entries to prepopulate from
                and old cache.
       -->
-    <filterCache class="solr.FastLRUCache"
-                 size="512"
+    <filterCache size="512"
                  initialSize="512"
                  autowarmCount="0"/>
 
@@ -416,8 +415,7 @@
          Caches results of searches - ordered lists of document ids
          (DocList) based on a query, a sort, and the range of documents requested.
       -->
-    <queryResultCache class="solr.LRUCache"
-                     size="512"
+    <queryResultCache size="512"
                      initialSize="512"
                      autowarmCount="0"/>
 
@@ -427,14 +425,12 @@
          document).  Since Lucene internal document ids are transient,
          this cache will not be autowarmed.
       -->
-    <documentCache class="solr.LRUCache"
-                   size="512"
+    <documentCache size="512"
                    initialSize="512"
                    autowarmCount="0"/>
 
     <!-- custom cache currently used by block join -->
     <cache name="perSegFilter"
-      class="solr.search.LRUCache"
       size="10"
       initialSize="0"
       autowarmCount="10"
@@ -447,8 +443,7 @@
          even if not configured here.
       -->
     <!--
-       <fieldValueCache class="solr.FastLRUCache"
-                        size="512"
+       <fieldValueCache size="512"
                         autowarmCount="128"
                         showItems="32" />
       -->
@@ -464,7 +459,6 @@
       -->
     <!--
        <cache name="myUserCache"
-              class="solr.LRUCache"
               size="4096"
               initialSize="1024"
               autowarmCount="1024"

--- a/solr/example/files/conf/solrconfig.xml
+++ b/solr/example/files/conf/solrconfig.xml
@@ -404,8 +404,7 @@
            autowarmCount - the number of entries to prepopulate from
                and old cache.
       -->
-    <filterCache class="solr.FastLRUCache"
-                 size="512"
+    <filterCache size="512"
                  initialSize="512"
                  autowarmCount="0"/>
 
@@ -417,8 +416,7 @@
             maxRamMB - the maximum amount of RAM (in MB) that this cache is allowed
                        to occupy
       -->
-    <queryResultCache class="solr.LRUCache"
-                      size="512"
+    <queryResultCache size="512"
                       initialSize="512"
                       autowarmCount="0"/>
 
@@ -428,8 +426,7 @@
          document).  Since Lucene internal document ids are transient,
          this cache will not be autowarmed.
       -->
-    <documentCache class="solr.LRUCache"
-                   size="512"
+    <documentCache size="512"
                    initialSize="512"
                    autowarmCount="0"/>
 
@@ -440,8 +437,7 @@
          even if not configured here.
       -->
     <!--
-       <fieldValueCache class="solr.FastLRUCache"
-                        size="512"
+       <fieldValueCache size="512"
                         autowarmCount="128"
                         showItems="32" />
       -->
@@ -457,7 +453,6 @@
       -->
     <!--
        <cache name="myUserCache"
-              class="solr.LRUCache"
               size="4096"
               initialSize="1024"
               autowarmCount="1024"

--- a/solr/server/solr/configsets/_default/conf/solrconfig.xml
+++ b/solr/server/solr/configsets/_default/conf/solrconfig.xml
@@ -416,8 +416,7 @@
                       to occupy. Note that when this option is specified, the size
                       and initialSize parameters are ignored.
       -->
-    <filterCache class="solr.FastLRUCache"
-                 size="512"
+    <filterCache size="512"
                  initialSize="512"
                  autowarmCount="0"/>
 
@@ -429,8 +428,7 @@
             maxRamMB - the maximum amount of RAM (in MB) that this cache is allowed
                        to occupy
       -->
-    <queryResultCache class="solr.LRUCache"
-                      size="512"
+    <queryResultCache size="512"
                       initialSize="512"
                       autowarmCount="0"/>
 
@@ -440,14 +438,12 @@
          document).  Since Lucene internal document ids are transient,
          this cache will not be autowarmed.
       -->
-    <documentCache class="solr.LRUCache"
-                   size="512"
+    <documentCache size="512"
                    initialSize="512"
                    autowarmCount="0"/>
 
     <!-- custom cache currently used by block join -->
     <cache name="perSegFilter"
-           class="solr.search.LRUCache"
            size="10"
            initialSize="0"
            autowarmCount="10"
@@ -460,8 +456,7 @@
          even if not configured here.
       -->
     <!--
-       <fieldValueCache class="solr.FastLRUCache"
-                        size="512"
+       <fieldValueCache size="512"
                         autowarmCount="128"
                         showItems="32" />
       -->
@@ -477,7 +472,6 @@
       -->
     <!--
        <cache name="myUserCache"
-              class="solr.LRUCache"
               size="4096"
               initialSize="1024"
               autowarmCount="1024"

--- a/solr/server/solr/configsets/_default/conf/solrconfig.xml
+++ b/solr/server/solr/configsets/_default/conf/solrconfig.xml
@@ -392,6 +392,7 @@
          threaded operation and thus is generally faster than LRUCache
          when the hit ratio of the cache is high (> 75%), and may be
          faster under other scenarios on multi-cpu systems.
+         Starting with Solr 9.0 the default cache implementation used is CaffeineCache.
     -->
 
     <!-- Filter Cache

--- a/solr/server/solr/configsets/sample_techproducts_configs/conf/solrconfig.xml
+++ b/solr/server/solr/configsets/sample_techproducts_configs/conf/solrconfig.xml
@@ -439,8 +439,7 @@
                       to occupy. Note that when this option is specified, the size
                       and initialSize parameters are ignored.
       -->
-    <filterCache class="solr.FastLRUCache"
-                 size="512"
+    <filterCache size="512"
                  initialSize="512"
                  autowarmCount="0"/>
 
@@ -452,8 +451,7 @@
            maxRamMB - the maximum amount of RAM (in MB) that this cache is allowed
                       to occupy
      -->
-    <queryResultCache class="solr.LRUCache"
-                     size="512"
+    <queryResultCache size="512"
                      initialSize="512"
                      autowarmCount="0"/>
 
@@ -463,14 +461,12 @@
          document).  Since Lucene internal document ids are transient,
          this cache will not be autowarmed.
       -->
-    <documentCache class="solr.LRUCache"
-                   size="512"
+    <documentCache size="512"
                    initialSize="512"
                    autowarmCount="0"/>
 
     <!-- custom cache currently used by block join -->
     <cache name="perSegFilter"
-      class="solr.search.LRUCache"
       size="10"
       initialSize="0"
       autowarmCount="10"
@@ -483,8 +479,7 @@
          even if not configured here.
       -->
     <!--
-       <fieldValueCache class="solr.FastLRUCache"
-                        size="512"
+       <fieldValueCache size="512"
                         autowarmCount="128"
                         showItems="32" />
       -->
@@ -500,7 +495,6 @@
          https://lucene.apache.org/solr/guide/learning-to-rank.html
       -->
     <cache enable="${solr.ltr.enabled:false}" name="QUERY_DOC_FV"
-           class="solr.search.LRUCache"
            size="4096"
            initialSize="2048"
            autowarmCount="4096"
@@ -517,7 +511,6 @@
       -->
     <!--
        <cache name="myUserCache"
-              class="solr.LRUCache"
               size="4096"
               initialSize="1024"
               autowarmCount="1024"


### PR DESCRIPTION
<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

In 8.x branch, the default and example configsets include LRUCache and FastLRUCache as the implementation for the various caches. Those implementations are deprecated.

# Solution

Remove the attribute completely and let the default take over (as it's in master), this should make upgrading configsets easier.

# Tests

_ant test_

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have developed this patch against the `master` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
