### PR TITLE
SOLR-15025: MiniSolrCloudCluster.waitForAllNodes ignores passed timeout value

### DIFF
--- a/solr/contrib/analytics/src/test/org/apache/solr/analytics/SolrAnalyticsTestCase.java
+++ b/solr/contrib/analytics/src/test/org/apache/solr/analytics/SolrAnalyticsTestCase.java
@@ -140,7 +140,7 @@ public class SolrAnalyticsTestCase extends SolrCloudTestCase {
   private Object queryCloudObject(SolrParams params) {
     QueryResponse resp;
     try {
-      cluster.waitForAllNodes(10000);
+      cluster.waitForAllNodes(10);
       QueryRequest qreq = new QueryRequest(params);
       resp = qreq.process(cluster.getSolrClient(), COLLECTIONORALIAS);
     } catch (Exception e) {

--- a/solr/contrib/analytics/src/test/org/apache/solr/analytics/legacy/LegacyAbstractAnalyticsCloudTest.java
+++ b/solr/contrib/analytics/src/test/org/apache/solr/analytics/legacy/LegacyAbstractAnalyticsCloudTest.java
@@ -96,7 +96,7 @@ public class LegacyAbstractAnalyticsCloudTest extends SolrCloudTestCase {
     for (int i = 0; i + 1 < testParams.length;) {
       params.add(testParams[i++], testParams[i++]);
     }
-    cluster.waitForAllNodes(10000);
+    cluster.waitForAllNodes(10);
     QueryRequest qreq = new QueryRequest(params);
     QueryResponse resp = qreq.process(cluster.getSolrClient(), COLLECTIONORALIAS);
     final NamedList<Object> response = resp.getResponse();
@@ -108,7 +108,7 @@ public class LegacyAbstractAnalyticsCloudTest extends SolrCloudTestCase {
   protected void assertRequestTimeout(ModifiableSolrParams params)
       throws IOException, InterruptedException, TimeoutException, SolrServerException {
     params.set("timeAllowed", 0);
-    cluster.waitForAllNodes(10000);
+    cluster.waitForAllNodes(10);
     final QueryResponse maybeTimeout = new QueryRequest(params).process(cluster.getSolrClient(), COLLECTIONORALIAS);
     assertEquals(maybeTimeout.getHeader() + "", 0, maybeTimeout.getStatus());
     final Boolean partial = maybeTimeout.getHeader()

--- a/solr/test-framework/src/java/org/apache/solr/cloud/MiniSolrCloudCluster.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/MiniSolrCloudCluster.java
@@ -90,6 +90,8 @@ public class MiniSolrCloudCluster {
   
   public static final String SOLR_TESTS_SHARDS_WHITELIST = "solr.tests.shardsWhitelist";
 
+  public static final int DEFAULT_TIMEOUT = 30;
+
   public static final String DEFAULT_CLOUD_SOLR_XML = "<solr>\n" +
       "\n" +
       "  <str name=\"shareSchema\">${shareSchema:false}</str>\n" +
@@ -329,7 +331,11 @@ public class MiniSolrCloudCluster {
     log.info("waitForAllNodes: numServers={}", numServers);
     
     int numRunning = 0;
-    TimeOut timeout = new TimeOut(30, TimeUnit.SECONDS, TimeSource.NANO_TIME);
+
+    if (timeoutSeconds == 0) {
+      timeoutSeconds = DEFAULT_TIMEOUT;
+    }
+    TimeOut timeout = new TimeOut(timeoutSeconds, TimeUnit.SECONDS, TimeSource.NANO_TIME);
     
     while (true) {
       if (timeout.hasTimedOut()) {


### PR DESCRIPTION
<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

`MiniSolrCloudCluster.waitForAllNodes` ignores passed timeout value and creates a `TimeOut` with 30 seconds.

# Solution

Pass the provided timeout value to the `TimeOut` 

# Tests

./gradlew check

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
