### PR TITLE
LUCENE-9590: Add javadoc for Lucene86PointsFormat class

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene86/Lucene86PointsFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene86/Lucene86PointsFormat.java
@@ -35,8 +35,11 @@ import org.apache.lucene.index.SegmentWriteState;
  *   <li>A .kdm file that records metadata about the fields, such as numbers of dimensions or
  *       numbers of bytes per dimension.
  *   <li>A .kdi file that stores inner nodes of the tree.
- *   <li>A .kdm file that stores leaf nodes, where most of the data lives.
+ *   <li>A .kdd file that stores leaf nodes, where most of the data lives.
  * </ul>
+ *
+ * See <a href="https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=173081898">this
+ * wiki</a> for detailed data structures of the three files.
  *
  * @lucene.experimental
  */

--- a/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java
@@ -66,8 +66,8 @@ final class ReadersAndUpdates {
 
   // Indicates whether this segment is currently being merged. While a segment
   // is merging, all field updates are also registered in the
-  // mergingNumericUpdates map. Also, calls to writeFieldUpdates merge the
-  // updates with mergingNumericUpdates.
+  // mergingDVUpdates map. Also, calls to writeFieldUpdates merge the
+  // updates with mergingDVUpdates.
   // That way, when the segment is done merging, IndexWriter can apply the
   // updates on the merged segment too.
   private boolean isMerging = false;


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/LUCENE-9590

1. since Lucene 4.8.0,  mergingNumericUpdates was replaced by mergingDVUpdates, so we should update some annotation. see detail: https://issues.apache.org/jira/browse/LUCENE-5513
2. add a link on ASF WIKI to introduce the data structure of point value , it make source readers happy and quick to understand point value.
 
