### PR TITLE
SOLR-15081: Metrics for core: isLeader, status

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -201,13 +201,12 @@ New Features
 
 Improvements
 ---------------------
-
-* SOLR-15079: Block Collapse - Faster collapse code when groups are co-located via Block Join style nested doc indexing.
-  Used by default when field=_root_, or explicitly requsted for other fields via hint=block.  (Joel Bernstein, hossman)
+* SOLR-15081: Metrics for a core: add SolrCloud "isLeader" and "replicaState".  (David Smiley)
 
 Optimizations
 ---------------------
-(No changes)
+* SOLR-15079: Block Collapse - Faster collapse code when groups are co-located via Block Join style nested doc indexing.
+  Used by default when field=_root_, or explicitly requested for other fields via hint=block.  (Joel Bernstein, hossman)
 
 Bug Fixes
 ---------------------

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -1203,26 +1203,19 @@ public final class SolrCore implements SolrInfoBean, Closeable {
     parentContext.gauge(() -> isClosed() ? parentContext.nullString() : getIndexDir(), true, "indexDir", Category.CORE.toString());
     parentContext.gauge(() -> isClosed() ? parentContext.nullNumber() : getIndexSize(), true, "sizeInBytes", Category.INDEX.toString());
     parentContext.gauge(() -> isClosed() ? parentContext.nullString() : NumberUtils.readableSize(getIndexSize()), true, "size", Category.INDEX.toString());
-    if (coreContainer != null) {
-      final CloudDescriptor cd = getCoreDescriptor().getCloudDescriptor();
-      if (cd != null) {
-        parentContext.gauge(() -> {
-          if (cd.getCollectionName() != null) {
-            return cd.getCollectionName();
-          } else {
-            return parentContext.nullString();
-          }
-        }, true, "collection", Category.CORE.toString());
 
-        parentContext.gauge(() -> {
-          if (cd.getShardId() != null) {
-            return cd.getShardId();
-          } else {
-            return parentContext.nullString();
-          }
-        }, true, "shard", Category.CORE.toString());
-      }
+    final CloudDescriptor cd = getCoreDescriptor().getCloudDescriptor();
+    if (cd != null) {
+      parentContext.gauge(cd::getCollectionName, true, "collection", Category.CORE.toString());
+      parentContext.gauge(cd::getShardId, true, "shard", Category.CORE.toString());
+      parentContext.gauge(cd::isLeader, true, "isLeader", Category.CORE.toString());
+      parentContext.gauge(
+          () -> String.valueOf(cd.getLastPublished()),
+          true,
+          "replicaState",
+          Category.CORE.toString());
     }
+
     // initialize disk total / free metrics
     Path dataDirPath = Paths.get(dataDir);
     File dataDirFile = dataDirPath.toFile();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15081
Copying the description: 

> The core level metrics hold some interesting information, but I don't see information pertaining to the SolrCloud status of the core.  In particular, I'd like to see the leader status here, and also the replica state.  The use-case I have in mind is enabling the Prometheus Exporter to get the doc count (and maybe other basics) of only the leader replicas, thereby counting unique documents instead of a fully replicated figure.  This is an approximation to doing a match-all-docs query on all collections, but is a more sound approach when one has orders of magnitude more collections than nodes.