### PR TITLE
LUCENE-9669: Add an expert API to allow opening indices created < N-1

### DIFF
--- a/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/TestBackwardsCompatibility.java
+++ b/lucene/backward-codecs/src/test/org/apache/lucene/backward_index/TestBackwardsCompatibility.java
@@ -62,6 +62,7 @@ import org.apache.lucene.index.CheckIndex;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.Fields;
+import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.IndexFormatTooOldException;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexReader;
@@ -82,11 +83,13 @@ import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.RandomIndexWriter;
 import org.apache.lucene.index.SegmentCommitInfo;
+import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.index.SegmentReader;
 import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.index.StandardDirectoryReader;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
@@ -1985,5 +1988,17 @@ public class TestBackwardsCompatibility extends LuceneTestCase {
     }
     bytes.bytes[bytes.length++] = (byte) value;
     return bytes;
+  }
+
+  public void testFailOpenOldIndex() throws IOException {
+    for (String name : oldNames) {
+      Directory directory = oldIndexDirs.get(name);
+      IndexCommit commit = DirectoryReader.listCommits(directory).get(0);
+      IllegalArgumentException iae = expectThrows(IllegalArgumentException.class, () ->
+        StandardDirectoryReader.open(commit, Version.LATEST.major));
+      iae.getMessage().startsWith("\"createdVersionMajor must be >= " + Version.LATEST.major);
+      // now open with allowed min version
+      StandardDirectoryReader.open(commit, Version.LATEST.major-1).close();
+    }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/DirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DirectoryReader.java
@@ -105,6 +105,17 @@ public abstract class DirectoryReader extends BaseCompositeReader<LeafReader> {
   }
 
   /**
+   * Expert: returns an IndexReader reading the index in the given {@link IndexCommit}.
+   *
+   * @param commit the commit point to open
+   * @param minIndexVersionCreated the minimum index version created to check before opening the index
+   * @throws IOException if there is a low-level IO error
+   */
+  public static DirectoryReader open(final IndexCommit commit, int minIndexVersionCreated) throws IOException {
+    return StandardDirectoryReader.open(commit.getDirectory(), minIndexVersionCreated, commit);
+  }
+
+  /**
    * If the index has changed since the provided reader was opened, open and return a new reader;
    * else, return null. The new reader, if not null, will be the same type of reader as the previous
    * one, ie an NRT reader will open a new NRT reader, a MultiReader will open a new MultiReader,

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -1009,6 +1009,11 @@ public class IndexWriter
         changed();
 
       } else if (reader != null) {
+        if (reader.segmentInfos.getIndexCreatedVersionMajor() < Version.MIN_SUPPORTED_MAJOR) {
+          // second line of defence in the case somebody tries to trick us.
+          throw new IllegalArgumentException("createdVersionMajor must be >= " + Version.MIN_SUPPORTED_MAJOR
+                          + ", got: " + reader.segmentInfos.getIndexCreatedVersionMajor());
+        }
         // Init from an existing already opened NRT or non-NRT reader:
 
         if (reader.directory() != commit.getDirectory()) {

--- a/lucene/core/src/java/org/apache/lucene/index/LeafMetaData.java
+++ b/lucene/core/src/java/org/apache/lucene/index/LeafMetaData.java
@@ -31,15 +31,19 @@ public final class LeafMetaData {
   private final Sort sort;
 
   /** Expert: Sole constructor. Public for use by custom {@link LeafReader} impls. */
-  public LeafMetaData(int createdVersionMajor, Version minVersion, Sort sort) {
+  public LeafMetaData(int createdVersionMajor, Version minVersion, int minVersionSupported, Sort sort) {
     this.createdVersionMajor = createdVersionMajor;
+    if (minVersionSupported > Version.LATEST.major || minVersionSupported < 0) {
+      throw new IllegalArgumentException("minVersionSupported must be positive and <= "
+              + Version.LATEST.major + " but was: " + minVersionSupported);
+    }
     if (createdVersionMajor > Version.LATEST.major) {
       throw new IllegalArgumentException(
           "createdVersionMajor is in the future: " + createdVersionMajor);
     }
-    if (createdVersionMajor < 6) {
+    if (createdVersionMajor < minVersionSupported) {
       throw new IllegalArgumentException(
-          "createdVersionMajor must be >= 6, got: " + createdVersionMajor);
+          "createdVersionMajor must be >= " + minVersionSupported + ", got: " + createdVersionMajor);
     }
     if (createdVersionMajor >= 7 && minVersion == null) {
       throw new IllegalArgumentException("minVersion must be set when createdVersionMajor is >= 7");

--- a/lucene/core/src/java/org/apache/lucene/index/ParallelLeafReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ParallelLeafReader.java
@@ -170,6 +170,7 @@ public class ParallelLeafReader extends LeafReader {
     Version minVersion = Version.LATEST;
     for (final LeafReader reader : this.parallelReaders) {
       Version leafVersion = reader.getMetaData().getMinVersion();
+
       if (leafVersion == null) {
         minVersion = null;
         break;
@@ -179,7 +180,7 @@ public class ParallelLeafReader extends LeafReader {
     }
 
     fieldInfos = builder.finish();
-    this.metaData = new LeafMetaData(createdVersionMajor, minVersion, indexSort);
+    this.metaData = new LeafMetaData(createdVersionMajor, minVersion, createdVersionMajor, indexSort);
 
     // do this finally so any Exceptions occurred before don't affect refcounts:
     for (LeafReader reader : completeReaderSet) {

--- a/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ReadersAndUpdates.java
@@ -42,6 +42,7 @@ import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.InfoStream;
+import org.apache.lucene.util.Version;
 
 // Used by IndexWriter to hold open SegmentReaders (for
 // searching or merging), plus pending deletes and updates,
@@ -176,7 +177,7 @@ final class ReadersAndUpdates {
   public synchronized SegmentReader getReader(IOContext context) throws IOException {
     if (reader == null) {
       // We steal returned ref:
-      reader = new SegmentReader(info, indexCreatedVersionMajor, context);
+      reader = new SegmentReader(info, indexCreatedVersionMajor, Version.MIN_SUPPORTED_MAJOR, context);
       pendingDeletes.onNewReader(reader, info);
     }
 
@@ -581,7 +582,7 @@ final class ReadersAndUpdates {
       // IndexWriter.commitMergedDeletes).
       final SegmentReader reader;
       if (this.reader == null) {
-        reader = new SegmentReader(info, indexCreatedVersionMajor, IOContext.READONCE);
+        reader = new SegmentReader(info, indexCreatedVersionMajor, Version.MIN_SUPPORTED_MAJOR, IOContext.READONCE);
         pendingDeletes.onNewReader(reader, info);
       } else {
         reader = this.reader;

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentReader.java
@@ -33,6 +33,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.IOUtils;
+import org.apache.lucene.util.Version;
 
 /**
  * IndexReader implementation over a single segment.
@@ -76,12 +77,12 @@ public final class SegmentReader extends CodecReader {
    * @throws CorruptIndexException if the index is corrupt
    * @throws IOException if there is a low-level IO error
    */
-  SegmentReader(SegmentCommitInfo si, int createdVersionMajor, IOContext context)
+  SegmentReader(SegmentCommitInfo si, int createdVersionMajor, int minSupportedMajor, IOContext context)
       throws IOException {
     this.si = si.clone();
     this.originalSi = si;
     this.metaData =
-        new LeafMetaData(createdVersionMajor, si.info.getMinVersion(), si.info.getIndexSort());
+        new LeafMetaData(createdVersionMajor, si.info.getMinVersion(), minSupportedMajor, si.info.getIndexSort());
 
     // We pull liveDocs/DV updates from disk:
     this.isNRT = false;

--- a/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SortingCodecReader.java
@@ -24,6 +24,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Optional;
+
 import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.codecs.FieldsProducer;
 import org.apache.lucene.codecs.NormsProducer;
@@ -36,6 +38,7 @@ import org.apache.lucene.search.SortField;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.IOSupplier;
+import org.apache.lucene.util.Version;
 import org.apache.lucene.util.packed.PackedInts;
 
 /**
@@ -157,7 +160,7 @@ public final class SortingCodecReader extends FilterCodecReader {
   static CodecReader wrap(CodecReader reader, Sorter.DocMap docMap, Sort sort) {
     LeafMetaData metaData = reader.getMetaData();
     LeafMetaData newMetaData =
-        new LeafMetaData(metaData.getCreatedVersionMajor(), metaData.getMinVersion(), sort);
+        new LeafMetaData(metaData.getCreatedVersionMajor(), metaData.getMinVersion(), metaData.getCreatedVersionMajor(), sort);
     if (docMap == null) {
       // the reader is already sorted
       return new FilterCodecReader(reader) {

--- a/lucene/core/src/java/org/apache/lucene/util/Version.java
+++ b/lucene/core/src/java/org/apache/lucene/util/Version.java
@@ -164,6 +164,12 @@ public final class Version {
   @Deprecated public static final Version LUCENE_CURRENT = LATEST;
 
   /**
+   * Constant for the minimal supported major version of an index. This
+   * version is defined by the version that initially created the index.
+   */
+  public static final int MIN_SUPPORTED_MAJOR = Version.LATEST.major-1;
+
+  /**
    * Parse a version number of the form {@code "major.minor.bugfix.prerelease"}.
    *
    * <p>Part {@code ".bugfix"} and part {@code ".prerelease"} are optional. Note that this is

--- a/lucene/core/src/test/org/apache/lucene/index/TestDemoParallelLeafReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDemoParallelLeafReader.java
@@ -498,7 +498,7 @@ public class TestDemoParallelLeafReader extends LuceneTestCase {
             SegmentInfos infos = SegmentInfos.readLatestCommit(dir);
             assert infos.size() == 1;
             final LeafReader parLeafReader =
-                new SegmentReader(infos.info(0), Version.LATEST.major, IOContext.DEFAULT);
+                new SegmentReader(infos.info(0), Version.LATEST.major, Version.MIN_SUPPORTED_MAJOR, IOContext.DEFAULT);
 
             // checkParallelReader(leaf, parLeafReader, schemaGen);
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestDirectoryReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDirectoryReader.java
@@ -46,6 +46,7 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.TestUtil;
+import org.apache.lucene.util.Version;
 import org.junit.Assume;
 
 @LuceneTestCase.SuppressCodecs("SimpleText")
@@ -1095,5 +1096,20 @@ public class TestDirectoryReader extends LuceneTestCase {
     Directory dir = newFSDirectory(tempDir);
     assertFalse(DirectoryReader.indexExists(dir));
     dir.close();
+  }
+
+  public void testOpenWithInvalidMinCompatVersion() throws IOException {
+    try (Directory dir = newDirectory();
+          IndexWriter writer = new IndexWriter(dir, newIndexWriterConfig())) {
+      Document doc = new Document();
+      doc.add(newStringField("field1", "foobar", Field.Store.YES));
+      doc.add(newStringField("field2", "foobaz", Field.Store.YES));
+      writer.addDocument(doc);
+      writer.commit();
+      IndexCommit commit = DirectoryReader.listCommits(dir).get(0);
+      expectThrows(IllegalArgumentException.class, () -> DirectoryReader.open(commit, Version.LATEST.major+1));
+      expectThrows(IllegalArgumentException.class, () -> DirectoryReader.open(commit, -1));
+      DirectoryReader.open(commit, random().nextInt(Version.LATEST.major+1)).close();
+    }
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/index/TestDoc.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDoc.java
@@ -210,8 +210,8 @@ public class TestDoc extends LuceneTestCase {
       boolean useCompoundFile)
       throws Exception {
     IOContext context = newIOContext(random(), new IOContext(new MergeInfo(-1, -1, false, -1)));
-    SegmentReader r1 = new SegmentReader(si1, Version.LATEST.major, context);
-    SegmentReader r2 = new SegmentReader(si2, Version.LATEST.major, context);
+    SegmentReader r1 = new SegmentReader(si1, Version.LATEST.major, Version.MIN_SUPPORTED_MAJOR, context);
+    SegmentReader r2 = new SegmentReader(si2, Version.LATEST.major, Version.MIN_SUPPORTED_MAJOR, context);
 
     final Codec codec = Codec.getDefault();
     TrackingDirectoryWrapper trackingDir = new TrackingDirectoryWrapper(si1.info.dir);
@@ -256,7 +256,7 @@ public class TestDoc extends LuceneTestCase {
   }
 
   private void printSegment(PrintWriter out, SegmentCommitInfo si) throws Exception {
-    SegmentReader reader = new SegmentReader(si, Version.LATEST.major, newIOContext(random()));
+    SegmentReader reader = new SegmentReader(si, Version.LATEST.major, Version.MIN_SUPPORTED_MAJOR, newIOContext(random()));
 
     for (int i = 0; i < reader.numDocs(); i++) out.println(reader.document(i));
 

--- a/lucene/core/src/test/org/apache/lucene/index/TestDocumentWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestDocumentWriter.java
@@ -61,7 +61,7 @@ public class TestDocumentWriter extends LuceneTestCase {
     SegmentCommitInfo info = writer.newestSegment();
     writer.close();
     // After adding the document, we should be able to read it back in
-    SegmentReader reader = new SegmentReader(info, Version.LATEST.major, newIOContext(random()));
+    SegmentReader reader = new SegmentReader(info, Version.LATEST.major, Version.MIN_SUPPORTED_MAJOR, newIOContext(random()));
     assertTrue(reader != null);
     Document doc = reader.document(0);
     assertTrue(doc != null);
@@ -123,7 +123,7 @@ public class TestDocumentWriter extends LuceneTestCase {
     writer.commit();
     SegmentCommitInfo info = writer.newestSegment();
     writer.close();
-    SegmentReader reader = new SegmentReader(info, Version.LATEST.major, newIOContext(random()));
+    SegmentReader reader = new SegmentReader(info, Version.LATEST.major, Version.MIN_SUPPORTED_MAJOR, newIOContext(random()));
 
     PostingsEnum termPositions =
         MultiTerms.getTermPostingsEnum(reader, "repeated", new BytesRef("repeated"));
@@ -198,7 +198,7 @@ public class TestDocumentWriter extends LuceneTestCase {
     writer.commit();
     SegmentCommitInfo info = writer.newestSegment();
     writer.close();
-    SegmentReader reader = new SegmentReader(info, Version.LATEST.major, newIOContext(random()));
+    SegmentReader reader = new SegmentReader(info, Version.LATEST.major, Version.MIN_SUPPORTED_MAJOR, newIOContext(random()));
 
     PostingsEnum termPositions = MultiTerms.getTermPostingsEnum(reader, "f1", new BytesRef("a"));
     assertTrue(termPositions.nextDoc() != DocIdSetIterator.NO_MORE_DOCS);
@@ -242,7 +242,7 @@ public class TestDocumentWriter extends LuceneTestCase {
     writer.commit();
     SegmentCommitInfo info = writer.newestSegment();
     writer.close();
-    SegmentReader reader = new SegmentReader(info, Version.LATEST.major, newIOContext(random()));
+    SegmentReader reader = new SegmentReader(info, Version.LATEST.major, Version.MIN_SUPPORTED_MAJOR, newIOContext(random()));
 
     PostingsEnum termPositions =
         reader.postings(new Term("preanalyzed", "term1"), PostingsEnum.ALL);

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterThreadsToSegments.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterThreadsToSegments.java
@@ -365,7 +365,7 @@ public class TestIndexWriterThreadsToSegments extends LuceneTestCase {
               si.setCodec(codec);
               SegmentCommitInfo sci =
                   new SegmentCommitInfo(si, 0, 0, -1, -1, -1, StringHelper.randomId());
-              SegmentReader sr = new SegmentReader(sci, Version.LATEST.major, IOContext.DEFAULT);
+              SegmentReader sr = new SegmentReader(sci, Version.LATEST.major, Version.MIN_SUPPORTED_MAJOR, IOContext.DEFAULT);
               try {
                 thread0Count += sr.docFreq(new Term("field", "threadID0"));
                 thread1Count += sr.docFreq(new Term("field", "threadID1"));

--- a/lucene/core/src/test/org/apache/lucene/index/TestSegmentMerger.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSegmentMerger.java
@@ -58,8 +58,8 @@ public class TestSegmentMerger extends LuceneTestCase {
     SegmentCommitInfo info1 = DocHelper.writeDoc(random(), merge1Dir, doc1);
     DocHelper.setupDoc(doc2);
     SegmentCommitInfo info2 = DocHelper.writeDoc(random(), merge2Dir, doc2);
-    reader1 = new SegmentReader(info1, Version.LATEST.major, newIOContext(random()));
-    reader2 = new SegmentReader(info2, Version.LATEST.major, newIOContext(random()));
+    reader1 = new SegmentReader(info1, Version.LATEST.major, Version.MIN_SUPPORTED_MAJOR, newIOContext(random()));
+    reader2 = new SegmentReader(info2, Version.LATEST.major, Version.MIN_SUPPORTED_MAJOR, newIOContext(random()));
   }
 
   @Override
@@ -113,7 +113,7 @@ public class TestSegmentMerger extends LuceneTestCase {
             new SegmentCommitInfo(
                 mergeState.segmentInfo, 0, 0, -1L, -1L, -1L, StringHelper.randomId()),
             Version.LATEST.major,
-            newIOContext(random()));
+                Version.MIN_SUPPORTED_MAJOR, newIOContext(random()));
     assertTrue(mergedReader != null);
     assertTrue(mergedReader.numDocs() == 2);
     Document newDoc1 = mergedReader.document(0);

--- a/lucene/core/src/test/org/apache/lucene/index/TestSegmentReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSegmentReader.java
@@ -41,7 +41,7 @@ public class TestSegmentReader extends LuceneTestCase {
     dir = newDirectory();
     DocHelper.setupDoc(testDoc);
     SegmentCommitInfo info = DocHelper.writeDoc(random(), dir, testDoc);
-    reader = new SegmentReader(info, Version.LATEST.major, IOContext.READ);
+    reader = new SegmentReader(info, Version.LATEST.major, Version.MIN_SUPPORTED_MAJOR, IOContext.READ);
   }
 
   @Override

--- a/lucene/core/src/test/org/apache/lucene/index/TestSegmentTermDocs.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSegmentTermDocs.java
@@ -52,7 +52,7 @@ public class TestSegmentTermDocs extends LuceneTestCase {
 
   public void testTermDocs() throws IOException {
     // After adding the document, we should be able to read it back in
-    SegmentReader reader = new SegmentReader(info, Version.LATEST.major, newIOContext(random()));
+    SegmentReader reader = new SegmentReader(info, Version.LATEST.major, Version.MIN_SUPPORTED_MAJOR, newIOContext(random()));
     assertTrue(reader != null);
 
     TermsEnum terms = reader.terms(DocHelper.TEXT_FIELD_2_KEY).iterator();
@@ -70,7 +70,7 @@ public class TestSegmentTermDocs extends LuceneTestCase {
   public void testBadSeek() throws IOException {
     {
       // After adding the document, we should be able to read it back in
-      SegmentReader reader = new SegmentReader(info, Version.LATEST.major, newIOContext(random()));
+      SegmentReader reader = new SegmentReader(info, Version.LATEST.major, Version.MIN_SUPPORTED_MAJOR, newIOContext(random()));
       assertTrue(reader != null);
       PostingsEnum termDocs =
           TestUtil.docs(random(), reader, "textField2", new BytesRef("bad"), null, 0);
@@ -80,7 +80,7 @@ public class TestSegmentTermDocs extends LuceneTestCase {
     }
     {
       // After adding the document, we should be able to read it back in
-      SegmentReader reader = new SegmentReader(info, Version.LATEST.major, newIOContext(random()));
+      SegmentReader reader = new SegmentReader(info, Version.LATEST.major, Version.MIN_SUPPORTED_MAJOR, newIOContext(random()));
       assertTrue(reader != null);
       PostingsEnum termDocs = TestUtil.docs(random(), reader, "junk", new BytesRef("bad"), null, 0);
       assertNull(termDocs);

--- a/lucene/core/src/test/org/apache/lucene/index/TestSegmentToThreadMapping.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestSegmentToThreadMapping.java
@@ -120,7 +120,7 @@ public class TestSegmentToThreadMapping extends LuceneTestCase {
 
       @Override
       public LeafMetaData getMetaData() {
-        return new LeafMetaData(Version.LATEST.major, Version.LATEST, null);
+        return new LeafMetaData(Version.LATEST.major, Version.LATEST, Version.MIN_SUPPORTED_MAJOR, null);
       }
 
       @Override

--- a/lucene/highlighter/src/java/org/apache/lucene/search/highlight/TermVectorLeafReader.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/highlight/TermVectorLeafReader.java
@@ -184,7 +184,7 @@ public class TermVectorLeafReader extends LeafReader {
 
   @Override
   public LeafMetaData getMetaData() {
-    return new LeafMetaData(Version.LATEST.major, null, null);
+    return new LeafMetaData(Version.LATEST.major, null, Version.MIN_SUPPORTED_MAJOR, null);
   }
 
   @Override

--- a/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
+++ b/lucene/memory/src/java/org/apache/lucene/index/memory/MemoryIndex.java
@@ -1728,7 +1728,7 @@ public class MemoryIndex {
 
     @Override
     public LeafMetaData getMetaData() {
-      return new LeafMetaData(Version.LATEST.major, Version.LATEST, null);
+      return new LeafMetaData(Version.LATEST.major, Version.LATEST, Version.MIN_SUPPORTED_MAJOR, null);
     }
 
     @Override

--- a/lucene/replicator/src/java/org/apache/lucene/replicator/nrt/SegmentInfosSearcherManager.java
+++ b/lucene/replicator/src/java/org/apache/lucene/replicator/nrt/SegmentInfosSearcherManager.java
@@ -33,6 +33,7 @@ import org.apache.lucene.search.ReferenceManager;
 import org.apache.lucene.search.SearcherFactory;
 import org.apache.lucene.search.SearcherManager;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.Version;
 
 /**
  * A SearcherManager that refreshes via an externally provided (NRT) SegmentInfos, either from
@@ -60,7 +61,7 @@ class SegmentInfosSearcherManager extends ReferenceManager<IndexSearcher> {
     node.message("SegmentInfosSearcherManager.init: use incoming infos=" + infosIn.toString());
     current =
         SearcherManager.getSearcher(
-            searcherFactory, StandardDirectoryReader.open(dir, currentInfos, null), null);
+            searcherFactory, StandardDirectoryReader.open(dir, currentInfos, Version.MIN_SUPPORTED_MAJOR, null), null);
     addReaderClosedListener(current.getIndexReader());
   }
 
@@ -111,7 +112,7 @@ class SegmentInfosSearcherManager extends ReferenceManager<IndexSearcher> {
     }
 
     // Open a new reader, sharing any common segment readers with the old one:
-    DirectoryReader r = StandardDirectoryReader.open(dir, currentInfos, subs);
+    DirectoryReader r = StandardDirectoryReader.open(dir, currentInfos, Version.MIN_SUPPORTED_MAJOR, subs);
     addReaderClosedListener(r);
     node.message("refreshed to version=" + currentInfos.getVersion() + " r=" + r);
     return SearcherManager.getSearcher(searcherFactory, r, old.getIndexReader());

--- a/lucene/test-framework/src/java/org/apache/lucene/search/QueryUtils.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/search/QueryUtils.java
@@ -258,7 +258,7 @@ public class QueryUtils {
 
       @Override
       public LeafMetaData getMetaData() {
-        return new LeafMetaData(Version.LATEST.major, Version.LATEST, null);
+        return new LeafMetaData(Version.LATEST.major, Version.LATEST, Version.MIN_SUPPORTED_MAJOR, null);
       }
 
       @Override

--- a/solr/core/src/java/org/apache/solr/index/SlowCompositeReaderWrapper.java
+++ b/solr/core/src/java/org/apache/solr/index/SlowCompositeReaderWrapper.java
@@ -76,7 +76,7 @@ public final class SlowCompositeReaderWrapper extends LeafReader {
     in = reader;
     in.registerParentReader(this);
     if (reader.leaves().isEmpty()) {
-      metaData = new LeafMetaData(Version.LATEST.major, Version.LATEST, null);
+      metaData = new LeafMetaData(Version.LATEST.major, Version.LATEST, Version.MIN_SUPPORTED_MAJOR, null);
     } else {
       Version minVersion = Version.LATEST;
       for (LeafReaderContext leafReaderContext : reader.leaves()) {
@@ -88,7 +88,8 @@ public final class SlowCompositeReaderWrapper extends LeafReader {
           minVersion = leafVersion;
         }
       }
-      metaData = new LeafMetaData(reader.leaves().get(0).reader().getMetaData().getCreatedVersionMajor(), minVersion, null);
+      int createdVersionMajor = reader.leaves().get(0).reader().getMetaData().getCreatedVersionMajor();
+      metaData = new LeafMetaData(createdVersionMajor, minVersion, createdVersionMajor, null);
     }
     fieldInfos = FieldInfos.getMergedFieldInfos(in);
   }

--- a/solr/core/src/test/org/apache/solr/search/TestDocSet.java
+++ b/solr/core/src/test/org/apache/solr/search/TestDocSet.java
@@ -363,7 +363,7 @@ public class TestDocSet extends SolrTestCase {
 
       @Override
       public LeafMetaData getMetaData() {
-        return new LeafMetaData(Version.LATEST.major, Version.LATEST, null);
+        return new LeafMetaData(Version.LATEST.major, Version.LATEST, Version.MIN_SUPPORTED_MAJOR, null);
       }
 
       @Override


### PR DESCRIPTION
Today we force indices that were created with N-2 and older versions of lucene
to fail on open. This check doesn't even check if the codecs are available. In order
to allow users to open older indices and for us to support N-2 versions this change
adds an API on DirectoryReader to specify a mininum index version on a per reader basis.
This doesn't apply for the IndexWriter which will fail on opening older indices.
