### PR TITLE
LUCENE-9688: Hunspell: consider prefix's continuation flags when applying suffix

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/Stemmer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/Stemmer.java
@@ -249,8 +249,8 @@ final class Stemmer {
    * @param previous previous affix that was removed (so we dont remove same one twice)
    * @param prevFlag Flag from a previous stemming step that need to be cross-checked with any
    *     affixes in this recursive step
-   * @param prefixFlag flag of the most inner removed prefix, so that when removing a suffix, it's
-   *     also checked against the word
+   * @param prefixId ID of the most inner removed prefix, so that when removing a suffix, it's also
+   *     checked against the word
    * @param recursionDepth current recursiondepth
    * @param doPrefix true if we should remove prefixes
    * @param doSuffix true if we should remove suffixes
@@ -268,7 +268,7 @@ final class Stemmer {
       int length,
       int previous,
       int prevFlag,
-      int prefixFlag,
+      int prefixId,
       int recursionDepth,
       boolean doPrefix,
       boolean doSuffix,
@@ -396,7 +396,7 @@ final class Stemmer {
                     strippedWord,
                     strippedWord.length,
                     suffix,
-                    prefixFlag,
+                    prefixId,
                     recursionDepth,
                     false,
                     circumfix,
@@ -472,9 +472,9 @@ final class Stemmer {
    * @param strippedWord Word the affix has been removed and the strip added
    * @param length valid length of stripped word
    * @param affix HunspellAffix representing the affix rule itself
-   * @param prefixFlag when we already stripped a prefix, we cant simply recurse and check the
-   *     suffix, unless both are compatible so we must check dictionary form against both to add it
-   *     as a stem!
+   * @param prefixId when we already stripped a prefix, we cant simply recurse and check the suffix,
+   *     unless both are compatible so we must check dictionary form against both to add it as a
+   *     stem!
    * @param recursionDepth current recursion depth
    * @param prefix true if we are removing a prefix (false if it's a suffix)
    * @return List of stems for the word, or an empty list if none are found
@@ -483,14 +483,13 @@ final class Stemmer {
       char[] strippedWord,
       int length,
       int affix,
-      int prefixFlag,
+      int prefixId,
       int recursionDepth,
       boolean prefix,
       boolean circumfix,
       boolean caseVariant)
       throws IOException {
     char flag = dictionary.affixData(affix, Dictionary.AFFIX_FLAG);
-    char append = dictionary.affixData(affix, Dictionary.AFFIX_APPEND);
 
     List<CharsRef> stems = new ArrayList<>();
 
@@ -498,16 +497,15 @@ final class Stemmer {
     if (forms != null) {
       for (int i = 0; i < forms.length; i += formStep) {
         char[] wordFlags = dictionary.decodeFlags(forms.ints[forms.offset + i], scratch);
-        if (Dictionary.hasFlag(wordFlags, flag)) {
+        if (Dictionary.hasFlag(wordFlags, flag) || isFlagAppendedByAffix(prefixId, flag)) {
           // confusing: in this one exception, we already chained the first prefix against the
           // second,
           // so it doesnt need to be checked against the word
           boolean chainedPrefix = dictionary.complexPrefixes && recursionDepth == 1 && prefix;
-          if (!chainedPrefix
-              && prefixFlag >= 0
-              && !Dictionary.hasFlag(wordFlags, (char) prefixFlag)) {
-            // see if we can chain prefix thru the suffix continuation class (only if it has any!)
-            if (!dictionary.hasFlag(append, (char) prefixFlag, scratch)) {
+          if (!chainedPrefix && prefixId >= 0) {
+            char prefixFlag = dictionary.affixData(prefixId, Dictionary.AFFIX_FLAG);
+            if (!Dictionary.hasFlag(wordFlags, prefixFlag)
+                && !isFlagAppendedByAffix(affix, prefixFlag)) {
               continue;
             }
           }
@@ -515,8 +513,7 @@ final class Stemmer {
           // if circumfix was previously set by a prefix, we must check this suffix,
           // to ensure it has it, and vice versa
           if (dictionary.circumfix != -1) {
-            boolean suffixCircumfix =
-                dictionary.hasFlag(append, (char) dictionary.circumfix, scratch);
+            boolean suffixCircumfix = isFlagAppendedByAffix(affix, (char) dictionary.circumfix);
             if (circumfix != suffixCircumfix) {
               continue;
             }
@@ -539,14 +536,14 @@ final class Stemmer {
     // if a circumfix flag is defined in the dictionary, and we are a prefix, we need to check if we
     // have that flag
     if (dictionary.circumfix != -1 && !circumfix && prefix) {
-      circumfix = dictionary.hasFlag(append, (char) dictionary.circumfix, scratch);
+      circumfix = isFlagAppendedByAffix(affix, (char) dictionary.circumfix);
     }
 
     if (isCrossProduct(affix) && recursionDepth <= 1) {
       boolean doPrefix;
       if (recursionDepth == 0) {
         if (prefix) {
-          prefixFlag = flag;
+          prefixId = affix;
           doPrefix = dictionary.complexPrefixes && dictionary.twoStageAffix;
           // we took away the first prefix.
           // COMPLEXPREFIXES = true:  combine with a second prefix and another suffix
@@ -562,7 +559,7 @@ final class Stemmer {
       } else {
         doPrefix = false;
         if (prefix && dictionary.complexPrefixes) {
-          prefixFlag = flag;
+          prefixId = affix;
           // we took away the second prefix: go look for another suffix
         } else if (prefix || dictionary.complexPrefixes || !dictionary.twoStageAffix) {
           return stems;
@@ -576,7 +573,7 @@ final class Stemmer {
               length,
               affix,
               flag,
-              prefixFlag,
+              prefixId,
               recursionDepth + 1,
               doPrefix,
               true,
@@ -586,6 +583,12 @@ final class Stemmer {
     }
 
     return stems;
+  }
+
+  private boolean isFlagAppendedByAffix(int affixId, char flag) {
+    if (affixId < 0) return false;
+    int appendId = dictionary.affixData(affixId, Dictionary.AFFIX_APPEND);
+    return dictionary.hasFlag(appendId, flag, scratch);
   }
 
   private boolean isCrossProduct(int affix) {

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestDependencies.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestDependencies.java
@@ -38,5 +38,8 @@ public class TestDependencies extends StemmerTestBase {
     assertStemsTo("hydration", "hydrate");
     assertStemsTo("dehydrate", "hydrate");
     assertStemsTo("dehydration", "hydrate");
+
+    assertStemsTo("calorie", "calorie", "calorie");
+    assertStemsTo("calories", "calorie");
   }
 }

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/dependencies.aff
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/dependencies.aff
@@ -17,3 +17,10 @@ PFX h 0 de .
 
 SFX A Y 1
 SFX A te tion/S .
+
+SFX s Y 1
+SFX s 0 s .
+
+PFX p Y 1
+PFX p 0 0/s .
+

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/dependencies.dic
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/dependencies.dic
@@ -1,4 +1,5 @@
-2
+4
 drink/RQ	[verb]
 drink/S	[noun]
 hydrate/hA
+calorie/p


### PR DESCRIPTION
<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

aff:
SFX s Y 1
SFX s 0 s .

PFX p Y 1
PFX p 0 0/s .

dic:
calorie/p

"calories" should be accepted

# Solution

When applying suffix "s" (which expects "s" flag to be set), check not only the word itself (which only has "p") flag, but the continuation flags of the just applied prefix "p" which has "s" as its continuation.

# Tests

`TestDependencies` updated

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
