### PR TITLE
LUCENE-9680 - Re-add IndexWriter::getFieldNames

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -7,6 +7,9 @@ http://s.apache.org/luceneversions
 
 New Features
 
+* LUCENE-9680: IndexWriter#getFieldNames() method added to get fields present in index.
+  This method was removed in LUCENE-8909. (Oren Ovadia)
+
 * LUCENE-9322: Vector-valued fields, Lucene90 Codec (Mike Sokolov, Julie Tibshirani, Tomoko Uchida)
 
 * LUCENE-9004: Approximate nearest vector search via NSW graphs

--- a/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FieldInfos.java
@@ -25,6 +25,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.apache.lucene.util.ArrayUtil;
@@ -679,6 +680,10 @@ public class FieldInfos implements Iterable<FieldInfo> {
         // only return true if the field has the same dvType as the requested one
         return dvType == docValuesType.get(fieldName);
       }
+    }
+
+    synchronized Set<String> getFieldNames() {
+      return Set.copyOf(nameToNumber.keySet());
     }
 
     synchronized void clear() {

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -1987,6 +1987,16 @@ public class IndexWriter
     return dvUpdates;
   }
 
+  /**
+   * Return an unmodifiable set of all field names as visible
+   * from this IndexWriter, across all segments of the index.
+   *
+   * @lucene.experimental
+   */
+  public Set<String> getFieldNames() {
+    return globalFieldNumberMap.getFieldNames(); // FieldNumbers#getFieldNames() returns an unmodifiableSet
+  }
+
   // for test purpose
   final synchronized int getSegmentCount() {
     return segmentInfos.size();

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -1988,13 +1988,14 @@ public class IndexWriter
   }
 
   /**
-   * Return an unmodifiable set of all field names as visible
-   * from this IndexWriter, across all segments of the index.
+   * Return an unmodifiable set of all field names as visible from this IndexWriter, across all
+   * segments of the index.
    *
    * @lucene.experimental
    */
   public Set<String> getFieldNames() {
-    return globalFieldNumberMap.getFieldNames(); // FieldNumbers#getFieldNames() returns an unmodifiableSet
+    // FieldNumbers#getFieldNames() returns an unmodifiableSet
+    return globalFieldNumberMap.getFieldNames();
   }
 
   // for test purpose

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
@@ -4619,6 +4619,9 @@ public class TestIndexWriter extends LuceneTestCase {
     addDocWithField(writer, "f2");
     assertEquals(Set.of("f1", "f2"), writer.getFieldNames());
 
+    // set from a previous call is an independent immutable copy, cannot be modified.
+    assertEquals(Set.of("f1"), fieldSet);
+
     // flush should not have an effect on field names
     writer.flush();
     assertEquals(Set.of("f1", "f2"), writer.getFieldNames());

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
@@ -4600,4 +4600,49 @@ public class TestIndexWriter extends LuceneTestCase {
       }
     }
   }
+
+  public void testGetFieldNames() throws IOException {
+    Directory dir = newDirectory();
+
+    IndexWriter writer = new IndexWriter(dir, newIndexWriterConfig(new MockAnalyzer(random())));
+
+    assertEquals(Set.of(), writer.getFieldNames());
+
+    addDocWithField(writer, "f1");
+    assertEquals(Set.of("f1"), writer.getFieldNames());
+
+    // should be unmodifiable:
+    final Set<String> fieldSet = writer.getFieldNames();
+    assertThrows(UnsupportedOperationException.class, () -> fieldSet.add("cannot modify"));
+    assertThrows(UnsupportedOperationException.class, () -> fieldSet.remove("f1"));
+
+    addDocWithField(writer, "f2");
+    assertEquals(Set.of("f1", "f2"), writer.getFieldNames());
+
+    // flush should not have an effect on field names
+    writer.flush();
+    assertEquals(Set.of("f1", "f2"), writer.getFieldNames());
+
+    // commit should not have an effect on field names
+    writer.commit();
+    assertEquals(Set.of("f1", "f2"), writer.getFieldNames());
+
+    writer.close();
+
+    // new writer should identify committed fields
+    writer = new IndexWriter(dir, newIndexWriterConfig(new MockAnalyzer(random())));
+    assertEquals(Set.of("f1", "f2"), writer.getFieldNames());
+
+    writer.deleteAll();
+    assertEquals(Set.of(), writer.getFieldNames());
+
+    writer.close();
+    dir.close();
+  }
+
+  private static void addDocWithField(IndexWriter writer, String field) throws IOException {
+    Document doc = new Document();
+    doc.add(newField(field, "value", storedTextType));
+    writer.addDocument(doc);
+  }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/LUCENE-9680

# Description

As discussed in [this thread](http://mail-archives.apache.org/mod_mbox/lucene-dev/202101.mbox/browser), the `indexWriter::getFieldNames()` method is useful for enforcing soft/hard limits of index usage. 

I simply re-added `getFieldNames()` we recently removed in [LUCENE-8909](https://issues.apache.org/jira/browse/LUCENE-8909).

# Tests

Added a unit test on `IndexWriter`

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
