### PR TITLE
SOLR-15097: Supply base_url in replica data returned to Admin UI

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/admin/ZookeeperInfoHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/ZookeeperInfoHandler.java
@@ -674,10 +674,10 @@ public final class ZookeeperInfoHandler extends RequestHandlerBase {
                 // verify this collection matches the status filter
                 if (page.matchesStatusFilter((Map<String, Object>) collectionState, liveNodes)) {
                   matchesStatusFilter.add(collection);
-                  collectionStates.put(collection, collectionState);
+                  collectionStates.put(collection, ClusterStatus.postProcessCollectionJSON((Map<String, Object>) collectionState));
                 }
               } else {
-                collectionStates.put(collection, collectionState);
+                collectionStates.put(collection, ClusterStatus.postProcessCollectionJSON((Map<String, Object>) collectionState));
               }
             } else {
               // looks like an external collection ...
@@ -702,10 +702,10 @@ public final class ZookeeperInfoHandler extends RequestHandlerBase {
                   // verify this collection matches the filtered state
                   if (page.matchesStatusFilter((Map<String, Object>) collectionState, liveNodes)) {
                     matchesStatusFilter.add(collection);
-                    collectionStates.put(collection, collectionState);
+                    collectionStates.put(collection, ClusterStatus.postProcessCollectionJSON((Map<String, Object>) collectionState));
                   }
                 } else {
-                  collectionStates.put(collection, collectionState);
+                  collectionStates.put(collection, ClusterStatus.postProcessCollectionJSON((Map<String, Object>) collectionState));
                 }
               }
             }


### PR DESCRIPTION
Looks like a bad backport from master for SOLR-12182.

Fix here is to pass the collection metadata through `ClusterStatus#postProcessCollectionJSON` to supply `base_url` from `node_name` as it's required by the UI.

There is no unit test for `ZookeeperInfoHandler` unfortunately, so requires manual testing:
```
cd solr
ant server
bin/solr -c
bin/solr create -c test
```
Visit the Admin UI and click on the Graph View for Cloud. Ensure you see the test collection in the graph.