### PR TITLE
WIP: LUCENE-9476 Add basic functionality, basic tests

### DIFF
--- a/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/directory/TestDirectoryTaxonomyReader.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/taxonomy/directory/TestDirectoryTaxonomyReader.java
@@ -16,11 +16,6 @@
  */
 package org.apache.lucene.facet.taxonomy.directory;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Random;
-import java.util.Set;
 import org.apache.lucene.analysis.MockAnalyzer;
 import org.apache.lucene.facet.FacetTestCase;
 import org.apache.lucene.facet.taxonomy.FacetLabel;
@@ -37,6 +32,12 @@ import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.IOUtils;
 import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
 
 public class TestDirectoryTaxonomyReader extends FacetTestCase {
 
@@ -568,5 +569,32 @@ public class TestDirectoryTaxonomyReader extends FacetTestCase {
     assertTrue(taxoReader.getChildResources().size() > 0);
     taxoReader.close();
     dir.close();
+  }
+
+  public void testBulkPath() throws Exception {
+    Directory src = newDirectory();
+    DirectoryTaxonomyWriter w = new DirectoryTaxonomyWriter(src);
+    String arr[] = new String[]{"a", "b", "c", "d", "e"};
+
+    FacetLabel allpaths[] = new FacetLabel[arr.length];
+    int allords[] = new int[arr.length];
+
+    for (int i=0;i<arr.length;i++) {
+      allpaths[i] = new FacetLabel(arr[i]);
+      w.addCategory(allpaths[i]);
+    }
+    w.commit();
+    w.close();
+
+    DirectoryTaxonomyReader r1 = new DirectoryTaxonomyReader(src);
+
+    for (int i=0;i<allpaths.length;i++) {
+      allords[i] = r1.getOrdinal(allpaths[i]);
+    }
+
+    FacetLabel allBulkpath[] = r1.getBulkPath(allords);
+    assertArrayEquals(allpaths, allBulkpath);
+    r1.close();
+    src.close();
   }
 }


### PR DESCRIPTION
<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

In [LUCENE-9450](https://issues.apache.org/jira/browse/LUCENE-9450) we switched the Taxonomy index from Stored Fields to `BinaryDocValues.` In the resulting implementation of the `getPath` code, we create a new `BinaryDocValues`'s values instance for each ordinal. 
It may happen that we may traverse over the same nodes over and over again if the `getPath` API is called multiple times for ordinals in the same segment/with the same `readerIndex`.

This PR takes advantage of that fact by sorting ordinals and then trying to find out if some of the ordinals are present in the same segment/have the same `readerIndex` (by trying to `advanceExact` to the correct position and not failing) thereby allowing us to reuse the previous `BinaryDocValues` object. 


# Solution

Steps:
1. Sort all ordinals and remember their position so as to store the path in the correct position
2. Try to `advanceExact` to the correct position with the previously calculated `readerIndex`. If the operation fails, try to find the correct segment for the ordinal and then `advanceExact` to the desired position.
3. Store this position for future ordinals.

# Tests

Added a new test for the API that compares the individual `getPath` results from ordinals with the bulk FacetLabels returned by the `getBulkPath` API

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
