### PR TITLE
LUCENE-9507 Custom order for leaves in IndexReader and IndexWriter

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/DirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DirectoryReader.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.nio.file.NoSuchFileException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import org.apache.lucene.search.SearcherManager; // javadocs
 import org.apache.lucene.store.Directory;
@@ -56,7 +57,24 @@ public abstract class DirectoryReader extends BaseCompositeReader<LeafReader> {
    * @throws IOException if there is a low-level IO error
    */
   public static DirectoryReader open(final Directory directory) throws IOException {
-    return StandardDirectoryReader.open(directory, null);
+    return StandardDirectoryReader.open(directory, null, null);
+  }
+
+  /**
+   * Returns a IndexReader for the the index in the given Directory
+   *
+   * @param directory the index directory
+   * @param leafSorter a comparator for sorting leaf readers. Providing leafSorter is useful for
+   *     indices on which it is expected to run many queries with particular sort criteria (e.g. for
+   *     time-based indices this is usually a descending sort on timestamp). In this case {@code
+   *     leafSorter} should sort leaves according to this sort criteria. Providing leafSorter allows
+   *     to speed up this particular type of sort queries by early terminating while iterating
+   *     though segments and segments' documents.
+   * @throws IOException if there is a low-level IO error
+   */
+  public static DirectoryReader open(final Directory directory, Comparator<LeafReader> leafSorter)
+      throws IOException {
+    return StandardDirectoryReader.open(directory, null, leafSorter);
   }
 
   /**
@@ -101,7 +119,7 @@ public abstract class DirectoryReader extends BaseCompositeReader<LeafReader> {
    * @throws IOException if there is a low-level IO error
    */
   public static DirectoryReader open(final IndexCommit commit) throws IOException {
-    return StandardDirectoryReader.open(commit.getDirectory(), commit);
+    return StandardDirectoryReader.open(commit.getDirectory(), commit, null);
   }
 
   /**
@@ -118,7 +136,8 @@ public abstract class DirectoryReader extends BaseCompositeReader<LeafReader> {
    */
   public static DirectoryReader open(final IndexCommit commit, int minSupportedMajorVersion)
       throws IOException {
-    return StandardDirectoryReader.open(commit.getDirectory(), minSupportedMajorVersion, commit);
+    return StandardDirectoryReader.open(
+        commit.getDirectory(), minSupportedMajorVersion, commit, null);
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.Deque;
 import java.util.HashMap;
@@ -215,8 +214,6 @@ public class IndexWriter
   static int getActualMaxDocs() {
     return IndexWriter.actualMaxDocs;
   }
-
-  private final Comparator<LeafReader> leafSorter;
 
   /** Used only for testing. */
   private final boolean enableTestPoints;
@@ -936,31 +933,6 @@ public class IndexWriter
    *     low-level IO error
    */
   public IndexWriter(Directory d, IndexWriterConfig conf) throws IOException {
-    this(d, conf, null);
-  }
-
-  /**
-   * Constructs a new IndexWriter per the settings given in <code>conf</code>. If you want to make
-   * "live" changes to this writer instance, use {@link #getConfig()}.
-   *
-   * <p><b>NOTE:</b> after ths writer is created, the given configuration instance cannot be passed
-   * to another writer.
-   *
-   * @param d the index directory. The index is either created or appended according <code>
-   *     conf.getOpenMode()</code>.
-   * @param conf the configuration settings according to which IndexWriter should be initialized.
-   * @param leafSorter a comparator for sorting leaf readers. Providing leafSorter is useful for
-   *     indices on which it is expected to run many queries with particular sort criteria (e.g. for
-   *     time-based indices this is usually a descending sort on timestamp). In this case {@code
-   *     leafSorter} should sort leaves according to this sort criteria. Providing leafSorter allows
-   *     to speed up this particular type of sort queries by early terminating while iterating
-   *     though segments and segments' documents.
-   * @throws IOException if the directory cannot be read/written to, or if it does not exist and
-   *     <code>conf.getOpenMode()</code> is <code>OpenMode.APPEND</code> or if there is any other
-   *     low-level IO error
-   */
-  public IndexWriter(Directory d, IndexWriterConfig conf, Comparator<LeafReader> leafSorter)
-      throws IOException {
     enableTestPoints = isEnableTestPoints();
     conf.setIndexWriter(this); // prevent reuse by other instances
     config = conf;
@@ -969,11 +941,6 @@ public class IndexWriter
     // obtain the write.lock. If the user configured a timeout,
     // we wrap with a sleeper and this might take some time.
     writeLock = d.obtainLock(WRITE_LOCK_NAME);
-    if (config.getIndexSort() != null && leafSorter != null) {
-      throw new IllegalArgumentException(
-          "[IndexWriter] can't use index sort and leaf sorter at the same time!");
-    }
-    this.leafSorter = leafSorter;
 
     boolean success = false;
     try {
@@ -1441,16 +1408,6 @@ public class IndexWriter
   public Analyzer getAnalyzer() {
     ensureOpen();
     return config.getAnalyzer();
-  }
-
-  /**
-   * Returns a comparator for sorting leaf readers. If not {@code null}, this comparator is used to
-   * sort leaf readers within {@code DirectoryReader} opened from this {@code IndexWriter}.
-   *
-   * @return a comparator for sorting leaf readers
-   */
-  public Comparator<LeafReader> getLeafSorter() {
-    return leafSorter;
   }
 
   /**

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriterConfig.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriterConfig.java
@@ -18,6 +18,7 @@ package org.apache.lucene.index;
 
 import java.io.PrintStream;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.stream.Collectors;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
@@ -53,7 +54,7 @@ import org.apache.lucene.util.Version;
 public final class IndexWriterConfig extends LiveIndexWriterConfig {
 
   /** Specifies the open mode for {@link IndexWriter}. */
-  public static enum OpenMode {
+  public enum OpenMode {
     /** Creates a new index or overwrites an existing one. */
     CREATE,
 
@@ -475,6 +476,18 @@ public final class IndexWriterConfig extends LiveIndexWriterConfig {
     this.indexSort = sort;
     this.indexSortFields =
         Arrays.stream(sort.getSort()).map(SortField::getField).collect(Collectors.toSet());
+    return this;
+  }
+
+  /**
+   * Set the comparator for sorting leaf readers. A DirectoryReader opened from a IndexWriter with
+   * this configuration will have its leaf readers sorted with the provided leaf sorter.
+   *
+   * @param leafSorter – a comparator for sorting leaf readers
+   * @return IndexWriterConfig with leafSorter set.
+   */
+  public IndexWriterConfig setLeafSorter(Comparator<LeafReader> leafSorter) {
+    this.leafSorter = leafSorter;
     return this;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/LiveIndexWriterConfig.java
+++ b/lucene/core/src/java/org/apache/lucene/index/LiveIndexWriterConfig.java
@@ -17,6 +17,7 @@
 package org.apache.lucene.index;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Set;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.codecs.Codec;
@@ -90,6 +91,9 @@ public class LiveIndexWriterConfig {
 
   /** The sort order to use to write merged segments. */
   protected Sort indexSort = null;
+
+  /** The comparator for sorting leaf readers. */
+  protected Comparator<LeafReader> leafSorter = null;
 
   /** The field names involved in the index sort */
   protected Set<String> indexSortFields = Collections.emptySet();
@@ -390,6 +394,17 @@ public class LiveIndexWriterConfig {
   }
 
   /**
+   * Returns a comparator for sorting leaf readers. If not {@code null}, this comparator is used to
+   * sort leaf readers within {@code DirectoryReader} opened from the {@code IndexWriter} of this
+   * configuration.
+   *
+   * @return a comparator for sorting leaf readers
+   */
+  public Comparator<LeafReader> getLeafSorter() {
+    return leafSorter;
+  }
+
+  /**
    * Expert: Returns if indexing threads check for pending flushes on update in order to help our
    * flushing indexing buffers to disk
    *
@@ -458,6 +473,7 @@ public class LiveIndexWriterConfig {
     sb.append("checkPendingFlushOnUpdate=").append(isCheckPendingFlushOnUpdate()).append("\n");
     sb.append("softDeletesField=").append(getSoftDeletesField()).append("\n");
     sb.append("maxFullFlushMergeWaitMillis=").append(getMaxFullFlushMergeWaitMillis()).append("\n");
+    sb.append("leafSorter=").append(getLeafSorter()).append("\n");
     return sb.toString();
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/StandardDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/StandardDirectoryReader.java
@@ -158,8 +158,8 @@ public final class StandardDirectoryReader extends DirectoryReader {
 
       writer.incRefDeleter(segmentInfos);
 
-      if (writer.getLeafSorter() != null) {
-        readers.sort(writer.getLeafSorter());
+      if (writer.getConfig().getLeafSorter() != null) {
+        readers.sort(writer.getConfig().getLeafSorter());
       }
 
       StandardDirectoryReader result =
@@ -168,7 +168,7 @@ public final class StandardDirectoryReader extends DirectoryReader {
               readers.toArray(new SegmentReader[readers.size()]),
               writer,
               segmentInfos,
-              writer.getLeafSorter(),
+              writer.getConfig().getLeafSorter(),
               applyAllDeletes,
               writeAllDeletes);
       return result;

--- a/lucene/core/src/java/org/apache/lucene/index/StandardDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/StandardDirectoryReader.java
@@ -44,9 +44,7 @@ public final class StandardDirectoryReader extends DirectoryReader {
   private final boolean applyAllDeletes;
   private final boolean writeAllDeletes;
 
-  /**
-   * package private constructor, called only from static open() methods.
-   */
+  /** package private constructor, called only from static open() methods. */
   StandardDirectoryReader(
       Directory directory,
       LeafReader[] readers,
@@ -64,7 +62,7 @@ public final class StandardDirectoryReader extends DirectoryReader {
     this.writeAllDeletes = writeAllDeletes;
   }
 
-  private static LeafReader[] sortLeaves(LeafReader[] readers,  Comparator<LeafReader> leafSorter) {
+  private static LeafReader[] sortLeaves(LeafReader[] readers, Comparator<LeafReader> leafSorter) {
     if (leafSorter != null) {
       Arrays.sort(readers, leafSorter);
     }

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterReader.java
@@ -1237,7 +1237,9 @@ public class TestIndexWriterReader extends LuceneTestCase {
 
     final int NUM_DOCS = atLeast(30);
     Directory dir = newDirectory();
-    IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig(), leafSorter);
+    IndexWriterConfig iwc = new IndexWriterConfig();
+    iwc.setLeafSorter(leafSorter);
+    IndexWriter writer = new IndexWriter(dir, iwc);
     for (int i = 0; i < NUM_DOCS; ++i) {
       final Document doc = new Document();
       doc.add(new LongPoint(FIELD_NAME, randomLongBetween(1, 99)));
@@ -1245,7 +1247,7 @@ public class TestIndexWriterReader extends LuceneTestCase {
       if (i > 0 && i % 10 == 0) writer.flush();
     }
 
-    // Test1: test that leafReaders are sorted according to leafSorter provided in Writer
+    // Test1: test that leafReaders are sorted according to leafSorter provided in IndexWriterConfig
     {
       try (DirectoryReader reader = open(writer)) {
         List<LeafReader> lrs =

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterReader.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterReader.java
@@ -1249,7 +1249,7 @@ public class TestIndexWriterReader extends LuceneTestCase {
 
     // Test1: test that leafReaders are sorted according to leafSorter provided in IndexWriterConfig
     {
-      try (DirectoryReader reader = open(writer)) {
+      try (DirectoryReader reader = writer.getReader()) {
         List<LeafReader> lrs =
             reader.leaves().stream().map(LeafReaderContext::reader).collect(toList());
         List<LeafReader> expectedSortedlrs =

--- a/lucene/replicator/src/java/org/apache/lucene/replicator/nrt/SegmentInfosSearcherManager.java
+++ b/lucene/replicator/src/java/org/apache/lucene/replicator/nrt/SegmentInfosSearcherManager.java
@@ -60,7 +60,7 @@ class SegmentInfosSearcherManager extends ReferenceManager<IndexSearcher> {
     node.message("SegmentInfosSearcherManager.init: use incoming infos=" + infosIn.toString());
     current =
         SearcherManager.getSearcher(
-            searcherFactory, StandardDirectoryReader.open(dir, currentInfos, null), null);
+            searcherFactory, StandardDirectoryReader.open(dir, currentInfos, null, null), null);
     addReaderClosedListener(current.getIndexReader());
   }
 
@@ -111,7 +111,7 @@ class SegmentInfosSearcherManager extends ReferenceManager<IndexSearcher> {
     }
 
     // Open a new reader, sharing any common segment readers with the old one:
-    DirectoryReader r = StandardDirectoryReader.open(dir, currentInfos, subs);
+    DirectoryReader r = StandardDirectoryReader.open(dir, currentInfos, subs, null);
     addReaderClosedListener(r);
     node.message("refreshed to version=" + currentInfos.getVersion() + " r=" + r);
     return SearcherManager.getSearcher(searcherFactory, r, old.getIndexReader());


### PR DESCRIPTION
1. Add an option to supply a custom leaf sorter for IndexWriter.
A DirectoryReader opened from this IndexWriter will have its leaf
readers sorted with the provided leaf sorter. This is useful for
indices on which it is expected to run many queries with particular
sort criteria (e.g. for time-based indices this is usually a
descending sort on timestamp). Providing leafSorter allows
to speed up early termination for this particular type of
sort queries.

2. Add an option to supply a custom leaf sorter for
StandardDirectoryReader. The leaf readers of this
StandardDirectoryReader will be sorted according the the provided leaf
sorter.