### PR TITLE
LUCENE-9686: Fix read past EOF handling in DirectIODirectory

### DIFF
--- a/lucene/misc/src/java/org/apache/lucene/misc/store/DirectIODirectory.java
+++ b/lucene/misc/src/java/org/apache/lucene/misc/store/DirectIODirectory.java
@@ -359,12 +359,8 @@ public class DirectIODirectory extends FilterDirectory {
         filePos = alignedPos - buffer.capacity();
 
         final int delta = (int) (pos - alignedPos);
-        refill();
-        try {
-          buffer.position(delta);
-        } catch (IllegalArgumentException iae) {
-          throw new EOFException("read past EOF: " + this);
-        }
+        refill(delta);
+        buffer.position(delta);
       }
       assert pos == getFilePointer();
     }
@@ -381,23 +377,18 @@ public class DirectIODirectory extends FilterDirectory {
     @Override
     public byte readByte() throws IOException {
       if (!buffer.hasRemaining()) {
-        refill();
-
-        // refill may not actually fill buffer if it reaches EOF
-        if (buffer.limit() == 0) {
-          throw new EOFException("read past EOF: " + this);
-        }
+        refill(1);
       }
 
       return buffer.get();
     }
 
-    private void refill() throws IOException {
+    private void refill(int byteToRead) throws IOException {
       filePos += buffer.capacity();
 
       // BaseDirectoryTestCase#testSeekPastEOF test for consecutive read past EOF,
       // hence throwing EOFException early to maintain buffer state (position in particular)
-      if (filePos > channel.size()) {
+      if (filePos > channel.size() || (channel.size() - filePos < byteToRead)) {
         throw new EOFException("read past EOF: " + this);
       }
 
@@ -423,9 +414,7 @@ public class DirectIODirectory extends FilterDirectory {
           buffer.get(dst, offset, left);
           toRead -= left;
           offset += left;
-          // when reading past EOF, this method will keep increasing filePos in the loop to
-          // eventually throw EOFException
-          refill();
+          refill(toRead);
         } else {
           buffer.get(dst, offset, toRead);
           break;

--- a/lucene/misc/src/java/org/apache/lucene/misc/store/DirectIODirectory.java
+++ b/lucene/misc/src/java/org/apache/lucene/misc/store/DirectIODirectory.java
@@ -382,7 +382,13 @@ public class DirectIODirectory extends FilterDirectory {
     public byte readByte() throws IOException {
       if (!buffer.hasRemaining()) {
         refill();
+
+        // refill may not actually fill buffer if it reaches EOF
+        if (buffer.limit() == 0) {
+          throw new EOFException("read past EOF: " + this);
+        }
       }
+
       return buffer.get();
     }
 
@@ -417,6 +423,8 @@ public class DirectIODirectory extends FilterDirectory {
           buffer.get(dst, offset, left);
           toRead -= left;
           offset += left;
+          // when reading past EOF, this method will keep increasing filePos in the loop to
+          // eventually throw EOFException
           refill();
         } else {
           buffer.get(dst, offset, toRead);

--- a/lucene/misc/src/java/org/apache/lucene/misc/store/DirectIODirectory.java
+++ b/lucene/misc/src/java/org/apache/lucene/misc/store/DirectIODirectory.java
@@ -383,12 +383,12 @@ public class DirectIODirectory extends FilterDirectory {
       return buffer.get();
     }
 
-    private void refill(int byteToRead) throws IOException {
+    private void refill(int bytesToRead) throws IOException {
       filePos += buffer.capacity();
 
       // BaseDirectoryTestCase#testSeekPastEOF test for consecutive read past EOF,
       // hence throwing EOFException early to maintain buffer state (position in particular)
-      if (filePos > channel.size() || (channel.size() - filePos < byteToRead)) {
+      if (filePos > channel.size() || (channel.size() - filePos < bytesToRead)) {
         throw new EOFException("read past EOF: " + this);
       }
 

--- a/lucene/misc/src/test/org/apache/lucene/misc/store/TestDirectIODirectory.java
+++ b/lucene/misc/src/test/org/apache/lucene/misc/store/TestDirectIODirectory.java
@@ -16,6 +16,7 @@
  */
 package org.apache.lucene.misc.store;
 
+import com.carrotsearch.randomizedtesting.RandomizedTest;
 import java.io.EOFException;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -78,6 +79,13 @@ public class TestDirectIODirectory extends BaseDirectoryTestCase {
       o.close();
       IndexInput i = dir.openInput("out", newIOContext(random()));
       i.seek(fileSize);
+
+      // Seeking past EOF should always throw EOFException
+      expectThrows(
+          EOFException.class, () -> i.seek(fileSize + RandomizedTest.randomIntBetween(1, 2048)));
+
+      // Reading immediately after seeking past EOF should throw EOFException
+      expectThrows(EOFException.class, () -> i.readByte());
       i.close();
     }
   }
@@ -97,11 +105,38 @@ public class TestDirectIODirectory extends BaseDirectoryTestCase {
       }
 
       try (IndexInput i = dir.openInput("out", newIOContext(random()))) {
+        expectThrows(
+            EOFException.class, () -> i.seek(fileSize + RandomizedTest.randomIntBetween(1, 2048)));
+        expectThrows(EOFException.class, () -> i.readByte());
+        expectThrows(EOFException.class, () -> i.readBytes(new byte[1], 0, 1));
+      }
+
+      try (IndexInput i = dir.openInput("out", newIOContext(random()))) {
         expectThrows(EOFException.class, () -> i.readByte());
       }
 
       try (IndexInput i = dir.openInput("out", newIOContext(random()))) {
         expectThrows(EOFException.class, () -> i.readBytes(new byte[1], 0, 1));
+      }
+    }
+  }
+
+  public void testSeekPastEOFAndRead() throws Exception {
+    try (Directory dir = getDirectory(createTempDir("testSeekPastEOF"))) {
+      final int len = random().nextInt(2048);
+
+      try (IndexOutput o = dir.createOutput("out", newIOContext(random()))) {
+        byte[] b = new byte[len];
+        o.writeBytes(b, 0, len);
+      }
+
+      try (IndexInput i = dir.openInput("out", newIOContext(random()))) {
+        // Seeking past EOF should always throw EOFException
+        expectThrows(
+            EOFException.class, () -> i.seek(len + RandomizedTest.randomIntBetween(1, 2048)));
+
+        // Reading immediately after seeking past EOF should throw EOFException
+        expectThrows(EOFException.class, () -> i.readByte());
       }
     }
   }

--- a/lucene/misc/src/test/org/apache/lucene/misc/store/TestDirectIODirectory.java
+++ b/lucene/misc/src/test/org/apache/lucene/misc/store/TestDirectIODirectory.java
@@ -95,6 +95,14 @@ public class TestDirectIODirectory extends BaseDirectoryTestCase {
         expectThrows(EOFException.class, () -> i.readByte());
         expectThrows(EOFException.class, () -> i.readBytes(new byte[1], 0, 1));
       }
+
+      try (IndexInput i = dir.openInput("out", newIOContext(random()))) {
+        expectThrows(EOFException.class, () -> i.readByte());
+      }
+
+      try (IndexInput i = dir.openInput("out", newIOContext(random()))) {
+        expectThrows(EOFException.class, () -> i.readBytes(new byte[1], 0, 1));
+      }
     }
   }
 

--- a/lucene/misc/src/test/org/apache/lucene/misc/store/TestDirectIODirectory.java
+++ b/lucene/misc/src/test/org/apache/lucene/misc/store/TestDirectIODirectory.java
@@ -82,8 +82,9 @@ public class TestDirectIODirectory extends BaseDirectoryTestCase {
     }
   }
 
-  public void testReadPastEOFShouldThrowEOFException() throws Exception {
-    final int fileSize = random().nextInt(100);
+  public void testReadPastEOFShouldThrowEOFExceptionWithEmptyFile() throws Exception {
+    // fileSize needs to be 0 to test this condition. Do not randomized.
+    final int fileSize = 0;
     try (Directory dir = getDirectory(createTempDir("testReadPastEOF"))) {
       try (IndexOutput o = dir.createOutput("out", newIOContext(random()))) {
         o.writeBytes(new byte[fileSize], 0, fileSize);


### PR DESCRIPTION
# Description

Explicitly handle read past EOF case in DirectIODirectory#readByte to throw EOFException

# Solution

In DirectIODirectory.readByte, checks for `buffer.limit() == 0” after DirectIODirectory#refill was called.

# Tests

* Add a new test to for read past EOF scenario
* Passed reported randomized test with `./gradlew test —tests TestDirectIODirectory.testFloatsUnderflow -Dtests.seed=73B56EAB13269C91 -Dtests.slow=true -Dtests.badapples=true -Dtests.locale=haw-US -Dtests.timezone=America/Inuvik -Dtests.asserts=true -Dtests.file.encoding=UTF-8`
* Passed `./gradlew check`

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
