### PR TITLE
SOLR-15114: WAND does not work correctly on multiple segments in Solr 8.6.3

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/MaxScoreCollector.java
+++ b/solr/core/src/java/org/apache/solr/search/MaxScoreCollector.java
@@ -41,7 +41,12 @@ public class MaxScoreCollector extends SimpleCollector {
   }
 
   @Override
-  public void setScorer(Scorable scorer) {
+  public void setScorer(Scorable scorer) throws IOException {
+    if (maxScore == Float.MIN_VALUE) {
+      scorer.setMinCompetitiveScore(0f);
+    } else {
+      scorer.setMinCompetitiveScore(Math.nextUp(maxScore));
+    }
     this.scorer = scorer;
   }
 


### PR DESCRIPTION
## Description

In Solr 8.6.3, minCompetitiveScore of WANDScorer resets to zero for each index segment and remain zero until maxScore is updated.
There are two causes of this problem:

- MaxScoreCollector does not set minCompetitiveScore of MinCompetitiveScoreAwareScorable newly generated for another index segment.
- MaxScoreCollector updates minCompetitiveScore only if maxScore is updated. This behavior is correct considering the purpose of MaxScoreCollector.

For details, see the attached pdf https://issues.apache.org/jira/secure/attachment/13019548/wand.pdf.

Fixed https://issues.apache.org/jira/browse/SOLR-15114