### PR TITLE
SOLR-15120 Reduce duplicated core creation work

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -215,6 +215,8 @@ Optimizations
 * SOLR-15079: Block Collapse - Faster collapse code when groups are co-located via Block Join style nested doc indexing.
   Used by default when field=_root_, or explicitly requested for other fields via hint=block.  (Joel Bernstein, hossman)
 
+* SOLR-15120 Reduce duplicated core creation work (Mike Drob, Mark Miller)
+
 Bug Fixes
 ---------------------
 * SOLR-15078: Fix ExpandComponent behavior when expanding on numeric fields to differentiate '0' group from null group (hossman)

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/DeleteCollectionCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/DeleteCollectionCmd.java
@@ -20,7 +20,7 @@ package org.apache.solr.cloud.api.collections;
 
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -59,6 +59,9 @@ import static org.apache.solr.common.params.CommonParams.NAME;
 
 public class DeleteCollectionCmd implements OverseerCollectionMessageHandler.Cmd {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private static final Set<String> okayExceptions = Collections.singleton(NonExistentCoreException.class.getName());
+
   private final OverseerCollectionMessageHandler ocmh;
   private final TimeSource timeSource;
 
@@ -132,8 +135,6 @@ public class DeleteCollectionCmd implements OverseerCollectionMessageHandler.Cmd
 
       String asyncId = message.getStr(ASYNC);
 
-      Set<String> okayExceptions = new HashSet<>(1);
-      okayExceptions.add(NonExistentCoreException.class.getName());
       ZkNodeProps internalMsg = message.plus(NAME, collection);
 
       @SuppressWarnings({"unchecked"})

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/OverseerCollectionMessageHandler.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/OverseerCollectionMessageHandler.java
@@ -297,7 +297,7 @@ public class OverseerCollectionMessageHandler implements OverseerMessageHandler,
     params.set(CoreAdminParams.ACTION, CoreAdminAction.RELOAD.toString());
 
     String asyncId = message.getStr(ASYNC);
-    collectionCmd(message, params, results, Replica.State.ACTIVE, asyncId);
+    collectionCmd(message, params, results, Replica.State.ACTIVE, asyncId, Collections.emptySet());
   }
 
   @SuppressWarnings("unchecked")
@@ -698,11 +698,6 @@ public class OverseerCollectionMessageHandler implements OverseerMessageHandler,
     }
   }
 
-  private List<Replica> collectionCmd(ZkNodeProps message, ModifiableSolrParams params,
-                             NamedList<Object> results, Replica.State stateMatcher, String asyncId) {
-    return collectionCmd( message, params, results, stateMatcher, asyncId, Collections.emptySet());
-  }
-
   /**
    * Send request to all replicas of a collection
    * @return List of replicas which is not live for receiving the request
@@ -711,7 +706,6 @@ public class OverseerCollectionMessageHandler implements OverseerMessageHandler,
                      NamedList<Object> results, Replica.State stateMatcher, String asyncId, Set<String> okayExceptions) {
     log.info("Executing Collection Cmd={}, asyncId={}", params, asyncId);
     String collectionName = message.getStr(NAME);
-    @SuppressWarnings("deprecation")
     ShardHandler shardHandler = shardHandlerFactory.getShardHandler();
 
     ClusterState clusterState = zkStateReader.getClusterState();

--- a/solr/core/src/java/org/apache/solr/core/ConfigOverlay.java
+++ b/solr/core/src/java/org/apache/solr/core/ConfigOverlay.java
@@ -223,7 +223,7 @@ public class ConfigOverlay implements MapSerializable {
   public Map<String, String> getEditableSubProperties(String xpath) {
     Object o = Utils.getObjectByPath(props, false, StrUtils.splitSmart(xpath, '/'));
     if (o instanceof Map) {
-      return (Map) o;
+      return (Map<String,String>) o;
     } else {
       return null;
     }

--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -29,7 +29,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;

--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -1268,7 +1268,7 @@ public class CoreContainer {
     return create(coreName, cfg.getCoreRootDirectory().resolve(coreName), parameters, false);
   }
 
-  Set<String> inFlightCreations = new HashSet<>(); // See SOLR-14969
+  final Set<String> inFlightCreations = ConcurrentHashMap.newKeySet(); // See SOLR-14969
   /**
    * Creates a new core in a specified instance directory, publishing the core state to the cluster
    *
@@ -1278,17 +1278,13 @@ public class CoreContainer {
    * @return the newly created core
    */
   public SolrCore create(String coreName, Path instancePath, Map<String, String> parameters, boolean newCollection) {
-    SolrCore core = null;
     boolean iAdded = false;
     try {
-      synchronized (inFlightCreations) {
-        if (inFlightCreations.add(coreName)) {
-          iAdded = true;
-        } else {
-          String msg = "Already creating a core with name '" + coreName + "', call aborted '";
-          log.warn(msg);
-          throw new SolrException(ErrorCode.CONFLICT, msg);
-        }
+      iAdded = inFlightCreations.add(coreName);
+      if (! iAdded) {
+        String msg = "Already creating a core with name '" + coreName + "', call aborted '";
+        log.warn(msg);
+        throw new SolrException(ErrorCode.CONFLICT, msg);
       }
       CoreDescriptor cd = new CoreDescriptor(coreName, instancePath, parameters, getContainerProperties(), getZkController());
 
@@ -1316,6 +1312,7 @@ public class CoreContainer {
         // first and clean it up if there's an error.
         coresLocator.create(this, cd);
 
+        SolrCore core;
         try {
           solrCores.waitAddPendingCoreOps(cd.getName());
           core = createFromDescriptor(cd, true, newCollection);
@@ -1360,10 +1357,8 @@ public class CoreContainer {
             "Error CREATEing SolrCore '" + coreName + "': " + ex.getMessage() + rootMsg, ex);
       }
     } finally {
-      synchronized (inFlightCreations) {
-        if (iAdded) {
-          inFlightCreations.remove(coreName);
-        }
+      if (iAdded) {
+        inFlightCreations.remove(coreName);
       }
     }
   }

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -176,7 +176,6 @@ import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.solr.common.params.CommonParams.NAME;
 import static org.apache.solr.common.params.CommonParams.PATH;
 
 /**
@@ -3187,20 +3186,29 @@ public final class SolrCore implements SolrInfoBean, Closeable {
     }
   }
 
-  @SuppressWarnings({"rawtypes"})
-  private static final Map implicitPluginsInfo = (Map) Utils.fromJSONResource("ImplicitPlugins.json");
+  private static final class ImplicitHolder {
+    private ImplicitHolder() { }
 
-  @SuppressWarnings({"unchecked", "rawtypes"})
-  public List<PluginInfo> getImplicitHandlers() {
-    List<PluginInfo> implicits = new ArrayList<>();
-    Map requestHandlers = (Map) implicitPluginsInfo.get(SolrRequestHandler.TYPE);
-    for (Object o : requestHandlers.entrySet()) {
-      Map.Entry<String, Map> entry = (Map.Entry<String, Map>) o;
-      Map info = Utils.getDeepCopy(entry.getValue(), 4);
-      info.put(NAME, entry.getKey());
-      implicits.add(new PluginInfo(SolrRequestHandler.TYPE, info));
+    private static final List<PluginInfo> INSTANCE;
+
+    static {
+      @SuppressWarnings("unchecked")
+      Map<String,?> implicitPluginsInfo = (Map<String,?>) Utils.fromJSONResource("ImplicitPlugins.json");
+      @SuppressWarnings("unchecked")
+      Map<String, Map<String,Object>> requestHandlers = (Map<String, Map<String, Object>>) implicitPluginsInfo.get(SolrRequestHandler.TYPE);
+
+      List<PluginInfo> implicits = new ArrayList<>(requestHandlers.size());
+      for (Map.Entry<String, Map<String,Object>> entry : requestHandlers.entrySet()) {
+        Map<String,Object> info = entry.getValue();
+        info.put(CommonParams.NAME, entry.getKey());
+        implicits.add(new PluginInfo(SolrRequestHandler.TYPE, info));
+      }
+      INSTANCE = Collections.unmodifiableList(implicits);
     }
-    return implicits;
+  }
+
+  public List<PluginInfo> getImplicitHandlers() {
+    return ImplicitHolder.INSTANCE;
   }
 
   /**

--- a/solr/core/src/java/org/apache/solr/metrics/SolrMetricManager.java
+++ b/solr/core/src/java/org/apache/solr/metrics/SolrMetricManager.java
@@ -1144,8 +1144,8 @@ public class SolrMetricManager {
       log.warn("Interrupted while trying to obtain lock to modify reporters registry: {}", registry);
       return Collections.emptySet();
     }
-    log.info("Closing metric reporters for registry={} tag={}", registry, tag);
     try {
+      log.info("Closing metric reporters for registry={} tag={}", registry, tag);
       Map<String, SolrMetricReporter> perRegistry = reporters.get(registry);
       if (perRegistry != null) {
         Set<String> names = new HashSet<>(perRegistry.keySet());
@@ -1171,6 +1171,9 @@ public class SolrMetricManager {
       }
     } finally {
       reportersLock.unlock();
+      if (log.isDebugEnabled()) {
+        log.debug("Finished closing registry={}, tag={}", registry, tag);
+      }
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/metrics/reporters/jmx/JmxMetricsReporter.java
+++ b/solr/core/src/java/org/apache/solr/metrics/reporters/jmx/JmxMetricsReporter.java
@@ -527,7 +527,7 @@ public class JmxMetricsReporter implements Reporter, Closeable {
           }
           for (ObjectInstance inst : objects) {
             if (log.isDebugEnabled()) {
-              log.debug("## - tag={}{}", mBeanServer.getAttribute(inst.getObjectName(), INSTANCE_TAG));
+              log.debug("## - tag={}", mBeanServer.getAttribute(inst.getObjectName(), INSTANCE_TAG));
             }
           }
         }
@@ -567,8 +567,8 @@ public class JmxMetricsReporter implements Reporter, Closeable {
         if (filter.matches(name, gauge)) {
           final ObjectName objectName = createName("gauges", name);
           if (gauge instanceof SolrMetricManager.GaugeWrapper &&
-              ((SolrMetricManager.GaugeWrapper)gauge).getGauge() instanceof MetricsMap) {
-            MetricsMap mm = (MetricsMap)((SolrMetricManager.GaugeWrapper)gauge).getGauge();
+              ((SolrMetricManager.GaugeWrapper<?>)gauge).getGauge() instanceof MetricsMap) {
+            MetricsMap mm = (MetricsMap)((SolrMetricManager.GaugeWrapper<?>)gauge).getGauge();
             mm.setAttribute(new Attribute(INSTANCE_TAG, tag));
             // don't wrap it in a JmxGauge, it already supports all necessary JMX attributes
             registerMBean(mm, objectName);
@@ -746,7 +746,7 @@ public class JmxMetricsReporter implements Reporter, Closeable {
       } else if (v instanceof Timer) {
         listener.onTimerAdded(k, (Timer)v);
       } else if (v instanceof Gauge) {
-        listener.onGaugeAdded(k, (Gauge)v);
+        listener.onGaugeAdded(k, (Gauge<?>)v);
       } else {
         log.warn("Unknown metric type {} for metric '{}', ignoring", v.getClass().getName(), k);
       }

--- a/solr/core/src/test/org/apache/solr/HelloWorldSolrCloudTestCase.java
+++ b/solr/core/src/test/org/apache/solr/HelloWorldSolrCloudTestCase.java
@@ -31,7 +31,7 @@ import org.junit.Test;
  * How to use this test class:
  * #1 Run the test, e.g.
  *    in Eclipse 'Run As JUnit Test' or
- *    on the command line:  cd solr/core ; ant test -Dtestcase=HelloWorldSolrCloudTestCase
+ *    on the command line:  ./gradlew -p solr/core test --tests HelloWorldSolrCloudTestCase
  * #2 Modify the test, e.g.
  *    in setupCluster add further documents and then re-run the test.
  */

--- a/solr/core/src/test/org/apache/solr/core/TestCoreContainer.java
+++ b/solr/core/src/test/org/apache/solr/core/TestCoreContainer.java
@@ -219,7 +219,7 @@ public class TestCoreContainer extends SolrTestCaseJ4 {
       // time around. The final unload in the loop should delete the core and
       // allow the next time around to succeed.
       // This also checks the bookkeeping in CoreContainer.create
-      // that prevents muliple simulatneous creations,
+      // that prevents multiple simultaneous creations,
       // currently "inFlightCreations"
       String testName = "coreToTest";
       for (int thread = 0; thread < NUM_THREADS; ++thread) {

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/ZkCmdExecutor.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/ZkCmdExecutor.java
@@ -28,7 +28,7 @@ import java.lang.invoke.MethodHandles;
 
 
 public class ZkCmdExecutor {
-  public static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   private long retryDelay = 1500L; // 1 second would match timeout, so 500 ms over for padding
   private int retryCount;

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/ZkOperation.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/ZkOperation.java
@@ -21,7 +21,7 @@ import org.apache.zookeeper.KeeperException;
 /**
  * A callback object which can be used for implementing retry-able operations.
  */
-public interface ZkOperation {
+public interface ZkOperation<T> {
 
     /**
      * Performs the operation - which may be involved multiple times if the connection
@@ -29,5 +29,5 @@ public interface ZkOperation {
      *
      * @return the result of the operation or null
      */
-    Object execute() throws KeeperException, InterruptedException;
+    T execute() throws KeeperException, InterruptedException;
 }

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/ZkStateReader.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/ZkStateReader.java
@@ -1709,7 +1709,9 @@ public class ZkStateReader implements SolrCloseable {
    */
   public void waitForState(final String collection, long wait, TimeUnit unit, Predicate<DocCollection> predicate)
       throws InterruptedException, TimeoutException {
-
+    if (log.isDebugEnabled()) {
+      log.debug("Waiting up to {}ms for state {}", unit.toMillis(wait), predicate);
+    }
     if (closed) {
       throw new AlreadyClosedException();
     }
@@ -1735,6 +1737,9 @@ public class ZkStateReader implements SolrCloseable {
     } finally {
       removeDocCollectionWatcher(collection, watcher);
       waitLatches.remove(latch);
+      if (log.isDebugEnabled()) {
+        log.debug("Completed wait for {}", predicate);
+      }
     }
   }
 

--- a/solr/solrj/src/java/org/apache/solr/common/util/ValidatingJsonMap.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/ValidatingJsonMap.java
@@ -279,9 +279,8 @@ public class ValidatingJsonMap implements Map<String, Object>, NavigableObject {
       map.putAll(includedMap);
     }
     if (maxDepth > 0) {
-      map.entrySet().stream()
-          .filter(e -> e.getValue() instanceof Map)
-          .map(Map.Entry::getValue)
+      map.values().stream()
+          .filter(o -> o instanceof Map)
           .forEach(m -> handleIncludes((ValidatingJsonMap) m, loc, maxDepth - 1));
     }
   }


### PR DESCRIPTION
Use j.u.c collections instead of sync block
Rework how we load implicit handlers
Additional debug and trace logging for zookeeper comms