### PR TITLE
Split the publish_maven step in two TODOs

### DIFF
--- a/dev-tools/scripts/releaseWizard.yaml
+++ b/dev-tools/scripts/releaseWizard.yaml
@@ -974,8 +974,8 @@ groups:
         tee: true
     post_description: 'Note at this point you will see the Jenkins job "Lucene-Solr-SmokeRelease-master" begin to fail, until you run the "Generate Backcompat Indexes" '
   - !Todo
-    id: publish_maven
-    title: Publish maven artifacts
+    id: stage_maven
+    title: Stage the maven artifacts for publishing
     vars:
       dist_folder: lucene-solr-{{ release_version }}-RC{{ rc_number }}-rev{{ build_rc.git_rev | default("<git_rev>", True) }}
     commands: !Commands
@@ -983,15 +983,22 @@ groups:
       confirm_each_command: true
       commands_text: In the source checkout do the following (note that this step will prompt you for your Apache LDAP credentials)
       commands:
-      - !Command
-        cmd: ant clean stage-maven-artifacts  -Dmaven.dist.dir={{ [dist_file_path, dist_folder, 'lucene', 'maven'] | path_join }}  -Dm2.repository.id=apache.releases.https  -Dm2.repository.url={{ m2_repository_url }}
-        logfile: publish_lucene_maven.log
-      - !Command
-        cmd: ant clean stage-maven-artifacts  -Dmaven.dist.dir={{ [dist_file_path, dist_folder, 'solr', 'maven'] | path_join }}  -Dm2.repository.id=apache.releases.https  -Dm2.repository.url={{ m2_repository_url }}
-        logfile: publish_solr_maven.log
-    post_description: |
+        - !Command
+          cmd: ant clean stage-maven-artifacts  -Dmaven.dist.dir={{ [dist_file_path, dist_folder, 'lucene', 'maven'] | path_join }}  -Dm2.repository.id=apache.releases.https  -Dm2.repository.url={{ m2_repository_url }}
+          logfile: publish_lucene_maven.log
+        - !Command
+          cmd: ant clean stage-maven-artifacts  -Dmaven.dist.dir={{ [dist_file_path, dist_folder, 'solr', 'maven'] | path_join }}  -Dm2.repository.id=apache.releases.https  -Dm2.repository.url={{ m2_repository_url }}
+          logfile: publish_solr_maven.log
+    post_description: The artifacts are not published yet, please proceed with the next step to actually publish!
+    links:
+      - https://wiki.apache.org/lucene-java/PublishMavenArtifacts
+  - !Todo
+    id: publish_maven
+    depends: stage_maven
+    title: Publish the staged maven artifacts
+    description: |
       Once you have transferred all maven artifacts to repository.apache.org,
-      you will need to:
+      you will need to do some manual steps to actually release them to Maven Central:
 
       * Close the staging repository
       . Log in to https://repository.apache.org/ with your ASF credentials


### PR DESCRIPTION
During 8.8 release the RM missed some steps when publishing to maven. Turns out the step `release_maven` is a bit larger than wanted. This PR splits the step in two, one `stage_maven` that stages the artifacts using commands, and another `publish_maven` that is about clicking buttons on the repository.apache.org webpage. I have not tested the steps in bash, but here is the AsciiDoc render of the two steps, which looks good:

<img width="797" alt="wizard-split-steps" src="https://user-images.githubusercontent.com/409128/106454726-7c164c80-648b-11eb-9c85-352227ef4833.png">
