### PR TITLE
LUCENE-9722: Close merged readers on abort

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -5020,7 +5020,6 @@ public class IndexWriter
         // all the 0-doc segments that we "merged":
         assert merge.info.info.maxDoc() == 0;
         success = commitMerge(merge, mergeState);
-        success = true;
         return 0;
       }
 

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -5019,7 +5019,7 @@ public class IndexWriter
         // Merge would produce a 0-doc segment, so we do nothing except commit the merge to remove
         // all the 0-doc segments that we "merged":
         assert merge.info.info.maxDoc() == 0;
-        commitMerge(merge, mergeState);
+        success = commitMerge(merge, mergeState);
         success = true;
         return 0;
       }

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriter.java
@@ -3847,6 +3847,37 @@ public class TestIndexWriter extends LuceneTestCase {
     IOUtils.close(writer, dir);
   }
 
+  public void testAbortFullyDeletedSegment() throws Exception {
+    AtomicBoolean abortMergeBeforeCommit = new AtomicBoolean();
+    OneMergeWrappingMergePolicy mergePolicy = new OneMergeWrappingMergePolicy(newMergePolicy(),
+        toWrap -> new MergePolicy.OneMerge(toWrap.segments) {
+          @Override
+          void onMergeComplete() throws IOException {
+            super.onMergeComplete();
+            if (abortMergeBeforeCommit.get()) {
+              setAborted();
+            }
+          }
+        }) {
+      @Override
+      public boolean keepFullyDeletedSegment(IOSupplier<CodecReader> readerIOSupplier) {
+        return true;
+      }
+    };
+
+    Directory dir = newDirectory();
+    IndexWriterConfig indexWriterConfig = newIndexWriterConfig().setMergePolicy(mergePolicy).setCommitOnClose(false);
+    IndexWriter writer = new IndexWriter(dir, indexWriterConfig);
+    writer.addDocument(Collections.singletonList(new StringField("id", "1", Field.Store.YES)));
+    writer.flush();
+
+    writer.deleteDocuments(new Term("id", "1"));
+    abortMergeBeforeCommit.set(true);
+    writer.flush();
+    writer.forceMerge(1);
+    IOUtils.close(writer, dir);
+  }
+
   private void assertHardLiveDocs(IndexWriter writer, Set<Integer> uniqueDocs) throws IOException {
     try (DirectoryReader reader = DirectoryReader.open(writer)) {
       assertEquals(uniqueDocs.size(), reader.numDocs());


### PR DESCRIPTION
We fail to close the merged readers of an aborted merge if its output segment contains no document.

This bug was discovered by a test in Elasticsearch (https://github.com/elastic/elasticsearch/issues/67884).