### PR TITLE
SOLR-15129: Use Solr distribution TGZ as docker context

### DIFF
--- a/solr/docker/Dockerfile
+++ b/solr/docker/Dockerfile
@@ -47,7 +47,7 @@ RUN set -ex; \
 COPY --from=input /opt/solr /opt/solr
 
 RUN set -ex; \
-  export SOLR_VERSION="$(cat /opt/solr/VERSION)"; \
+  export SOLR_VERSION="$(cat /opt/solr/VERSION.txt)"; \
   (cd /opt; ln -s solr "solr-$SOLR_VERSION"); \
   mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d; \
   cp /opt/solr/bin/solr.in.sh /etc/default/solr.in.sh; \

--- a/solr/docker/Dockerfile
+++ b/solr/docker/Dockerfile
@@ -1,18 +1,16 @@
 ARG BASE_IMAGE=openjdk:11-jre-slim
 
 FROM $BASE_IMAGE as input
-ARG SOLR_VERSION
 
-# ADD extracts tgz !
-COPY . /opt/solr-$SOLR_VERSION
+COPY /solr-* /opt/solr
 
 # remove what we don't want; ensure permissions are right
 #  TODO; arguably these permissions should have been set correctly previously in the TAR
 RUN set -ex; \
-  rm -Rf /opt/solr-$SOLR_VERSION/docs /opt/solr-$SOLR_VERSION/dist/{solr-solrj-$SOLR_VERSION.jar,solrj-lib,solr-test-framework-$SOLR_VERSION.jar,test-framework}; \
-  find "/opt/solr-$SOLR_VERSION" -type d -print0 | xargs -0 chmod 0755; \
-  find "/opt/solr-$SOLR_VERSION" -type f -print0 | xargs -0 chmod 0644; \
-  chmod -R 0755 "/opt/solr-$SOLR_VERSION/docker" "/opt/solr-$SOLR_VERSION/bin" "/opt/solr-$SOLR_VERSION/contrib/prometheus-exporter/bin/solr-exporter" "/opt/solr-$SOLR_VERSION/server/scripts/cloud-scripts"
+  rm -Rf /opt/solr/docs /opt/solr/dist/{solr-solrj-*.jar,solrj-lib,solr-test-framework-*.jar,test-framework}; \
+  find "/opt/solr" -type d -print0 | xargs -0 chmod 0755; \
+  find "/opt/solr" -type f -print0 | xargs -0 chmod 0644; \
+  chmod -R 0755 "/opt/solr/docker" "/opt/solr/bin" "/opt/solr/contrib/prometheus-exporter/bin/solr-exporter" "/opt/solr/server/scripts/cloud-scripts"
 
 FROM $BASE_IMAGE
 
@@ -46,15 +44,11 @@ RUN set -ex; \
   groupadd -r --gid "$SOLR_GID" "$SOLR_GROUP"; \
   useradd -r --uid "$SOLR_UID" --gid "$SOLR_GID" "$SOLR_USER"
 
-ARG SOLR_VERSION
-
-# Used by solr-fg
-ENV SOLR_VERSION $SOLR_VERSION
-
-COPY --from=input /opt/solr-$SOLR_VERSION /opt/solr-$SOLR_VERSION
+COPY --from=input /opt/solr /opt/solr
 
 RUN set -ex; \
-  (cd /opt; ln -s "solr-$SOLR_VERSION" solr); \
+  export SOLR_VERSION="$(cat /opt/solr/VERSION)"; \
+  (cd /opt; ln -s solr "solr-$SOLR_VERSION"); \
   mkdir -p /opt/solr/server/solr/lib /docker-entrypoint-initdb.d; \
   cp /opt/solr/bin/solr.in.sh /etc/default/solr.in.sh; \
   mv /opt/solr/bin/solr.in.sh /opt/solr/bin/solr.in.sh.orig; \

--- a/solr/docker/Dockerfile
+++ b/solr/docker/Dockerfile
@@ -4,8 +4,7 @@ FROM $BASE_IMAGE as input
 ARG SOLR_VERSION
 
 # ADD extracts tgz !
-ADD /releases/solr-$SOLR_VERSION.tgz /opt/
-COPY /scripts /scripts
+COPY . /opt/solr-$SOLR_VERSION
 
 # remove what we don't want; ensure permissions are right
 #  TODO; arguably these permissions should have been set correctly previously in the TAR
@@ -13,7 +12,7 @@ RUN set -ex; \
   rm -Rf /opt/solr-$SOLR_VERSION/docs /opt/solr-$SOLR_VERSION/dist/{solr-solrj-$SOLR_VERSION.jar,solrj-lib,solr-test-framework-$SOLR_VERSION.jar,test-framework}; \
   find "/opt/solr-$SOLR_VERSION" -type d -print0 | xargs -0 chmod 0755; \
   find "/opt/solr-$SOLR_VERSION" -type f -print0 | xargs -0 chmod 0644; \
-  chmod -R 0755 /scripts "/opt/solr-$SOLR_VERSION/bin" "/opt/solr-$SOLR_VERSION/contrib/prometheus-exporter/bin/solr-exporter" "/opt/solr-$SOLR_VERSION/server/scripts/cloud-scripts"
+  chmod -R 0755 "/opt/solr-$SOLR_VERSION/docker" "/opt/solr-$SOLR_VERSION/bin" "/opt/solr-$SOLR_VERSION/contrib/prometheus-exporter/bin/solr-exporter" "/opt/solr-$SOLR_VERSION/server/scripts/cloud-scripts"
 
 FROM $BASE_IMAGE
 
@@ -35,7 +34,7 @@ ENV SOLR_USER="solr" \
     SOLR_UID="8983" \
     SOLR_GROUP="solr" \
     SOLR_GID="8983" \
-    PATH="/opt/solr/bin:/opt/docker-solr/scripts:/opt/solr/contrib/prometheus-exporter/bin:$PATH" \
+    PATH="/opt/solr/bin:/opt/solr/docker:/opt/solr/contrib/prometheus-exporter/bin:$PATH" \
     SOLR_INCLUDE=/etc/default/solr.in.sh \
     SOLR_HOME=/var/solr/data \
     SOLR_PID_DIR=/var/solr \
@@ -46,8 +45,6 @@ ENV SOLR_USER="solr" \
 RUN set -ex; \
   groupadd -r --gid "$SOLR_GID" "$SOLR_GROUP"; \
   useradd -r --uid "$SOLR_UID" --gid "$SOLR_GID" "$SOLR_USER"
-
-COPY --from=input scripts /opt/docker-solr/scripts
 
 ARG SOLR_VERSION
 

--- a/solr/docker/build.gradle
+++ b/solr/docker/build.gradle
@@ -37,57 +37,59 @@ configurations {
   packaging {
     canBeResolved = true
   }
+  dockerContext {
+    canBeResolved = true
+  }
   dockerImage {
     canBeResolved = true
   }
 }
 
+ext {
+  packagingDir = file("${buildDir}/packaging")
+}
+
+
 dependencies {
-  packaging project(path: ":solr:packaging", configuration: 'archives')
+  packaging files(packagingDir) {
+    builtBy 'assemblePackaging'
+  }
+
+  dockerContext project(path: ":solr:packaging", configuration: 'archives')
 
   dockerImage files(imageIdFile) {
     builtBy 'dockerBuild'
   }
 }
 
-task dockerTar(type: Tar) {
-  group = 'Docker'
-  description = 'Package docker context to prepare for docker build'
+task assemblePackaging(type: Sync) {
+  description = 'Assemble docker scripts and Dockerfile for Solr Packaging'
 
-  dependsOn configurations.packaging
-  into('scripts') {
-    from file('scripts')
-    fileMode 755
-  }
-  into('releases') {
-    from configurations.packaging
-    include '*.tgz'
-  }
-  from file('Dockerfile')
-  destinationDirectory = file(dockerBuildDistribution)
-  extension 'tgz'
-  compression = Compression.GZIP
+  from(projectDir, {
+    include "Dockerfile"
+  })
+  from("$projectDir/scripts")
+
+  into packagingDir
 }
 
-task dockerBuild(dependsOn: tasks.dockerTar) {
+task dockerBuild(dependsOn: configurations.dockerContext) {
   group = 'Docker'
   description = 'Build Solr docker image'
 
   // Ensure that the docker image is rebuilt on build-arg changes or changes in the docker context
   inputs.properties([
           baseDockerImage: baseDockerImage,
-          githubUrlOrMirror: githubUrlOrMirror,
-          version: version
+          githubUrlOrMirror: githubUrlOrMirror
   ])
-  inputs.dir(dockerBuildDistribution)
+  //inputs.files(configurations.dockerContext.files)
 
   doLast {
     exec {
-      standardInput = tasks.dockerTar.outputs.files.singleFile.newDataInputStream()
+      standardInput = configurations.dockerContext.files.
       commandLine "docker", "build",
               "--iidfile", imageIdFile,
               "--build-arg", "BASE_IMAGE=${inputs.properties.baseDockerImage}",
-              "--build-arg", "SOLR_VERSION=${version}",
               "--build-arg", "GITHUB_URL=${inputs.properties.githubUrlOrMirror}",
               "-"
     }

--- a/solr/docker/build.gradle
+++ b/solr/docker/build.gradle
@@ -30,11 +30,13 @@ def baseDockerImage = propertyOrEnvOrDefault("solr.docker.baseImage", "SOLR_DOCK
 def githubUrlOrMirror = propertyOrEnvOrDefault("solr.docker.githubUrl", "SOLR_DOCKER_GITHUB_URL", 'github.com')
 
 // Build directory locations
-def dockerBuildDistribution = "$buildDir/distributions"
 def imageIdFile = "$buildDir/image-id"
 
 configurations {
   packaging {
+    canBeResolved = true
+  }
+  solrArtifacts {
     canBeResolved = true
   }
   dockerContext {
@@ -47,15 +49,21 @@ configurations {
 
 ext {
   packagingDir = file("${buildDir}/packaging")
+  dockerContextDir = "${buildDir}/docker"
+  dockerContextFile = "context.tgz"
+  dockerContextPath = "${dockerContextDir}/${dockerContextFile}"
 }
-
 
 dependencies {
   packaging files(packagingDir) {
     builtBy 'assemblePackaging'
   }
 
-  dockerContext project(path: ":solr:packaging", configuration: 'archives')
+  solrArtifacts project(path: ":solr:packaging", configuration: 'archives')
+
+  dockerContext files(dockerContextPath) {
+    builtBy 'dockerContext'
+  }
 
   dockerImage files(imageIdFile) {
     builtBy 'dockerBuild'
@@ -73,6 +81,18 @@ task assemblePackaging(type: Sync) {
   into packagingDir
 }
 
+task dockerContext(type: Sync) {
+  group = 'Docker'
+  description = 'Sync Solr tgz to become docker context'
+
+  from(configurations.solrArtifacts, {
+    include "*.tgz"
+    rename { file -> dockerContextFile }
+  })
+
+  into dockerContextDir
+}
+
 task dockerBuild(dependsOn: configurations.dockerContext) {
   group = 'Docker'
   description = 'Build Solr docker image'
@@ -82,12 +102,13 @@ task dockerBuild(dependsOn: configurations.dockerContext) {
           baseDockerImage: baseDockerImage,
           githubUrlOrMirror: githubUrlOrMirror
   ])
-  //inputs.files(configurations.dockerContext.files)
+  inputs.files(dockerContextPath)
 
   doLast {
     exec {
-      standardInput = configurations.dockerContext.files.
+      standardInput = configurations.dockerContext.singleFile.newDataInputStream()
       commandLine "docker", "build",
+              "-f", "solr-${version}/Dockerfile",
               "--iidfile", imageIdFile,
               "--build-arg", "BASE_IMAGE=${inputs.properties.baseDockerImage}",
               "--build-arg", "GITHUB_URL=${inputs.properties.githubUrlOrMirror}",

--- a/solr/docker/scripts/docker-entrypoint.sh
+++ b/solr/docker/scripts/docker-entrypoint.sh
@@ -18,7 +18,7 @@ if ! [[ ${SOLR_PORT:-} =~ ^[0-9]+$ ]]; then
 fi
 
 # Essential for running Solr
-/opt/docker-solr/scripts/init-var-solr
+init-var-solr
 
 # when invoked with e.g.: docker run solr -help
 if [ "${1:0:1}" == '-' ]; then
@@ -27,7 +27,7 @@ fi
 
 # execute command passed in as arguments.
 # The Dockerfile has specified the PATH to include
-# /opt/solr/bin (for Solr) and /opt/docker-solr/scripts (for our scripts
+# /opt/solr/bin (for Solr) and /opt/solr/docker (for docker-specific scripts
 # like solr-foreground, solr-create, solr-precreate, solr-demo).
 # Note: if you specify "solr", you'll typically want to add -f to run it in
 # the foreground.

--- a/solr/docker/scripts/solr-create
+++ b/solr/docker/scripts/solr-create
@@ -15,7 +15,7 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
     set -x
 fi
 
-. /opt/docker-solr/scripts/run-initdb
+run-initdb
 
 # solr uses "-c corename". Parse the arguments to determine the core name.
 CORE_NAME="$(

--- a/solr/docker/scripts/solr-demo
+++ b/solr/docker/scripts/solr-demo
@@ -8,7 +8,7 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
     set -x
 fi
 
-. /opt/docker-solr/scripts/run-initdb
+run-initdb
 
 CORE=demo
 

--- a/solr/docker/scripts/solr-foreground
+++ b/solr/docker/scripts/solr-foreground
@@ -7,6 +7,6 @@ if [[ "$VERBOSE" == "yes" ]]; then
     set -x
 fi
 
-. /opt/docker-solr/scripts/run-initdb
+run-initdb
 
 exec solr-fg "$@"

--- a/solr/docker/scripts/solr-precreate
+++ b/solr/docker/scripts/solr-precreate
@@ -17,8 +17,8 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
     set -x
 fi
 
-. /opt/docker-solr/scripts/run-initdb
+run-initdb
 
-/opt/docker-solr/scripts/precreate-core "$@"
+precreate-core "$@"
 
 exec solr-fg

--- a/solr/docker/scripts/start-local-solr
+++ b/solr/docker/scripts/start-local-solr
@@ -11,7 +11,7 @@ echo "Running solr in the background. Logs are in /var/solr/logs"
 SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost}" solr start
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
-if ! /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"; then
+if ! wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"; then
     echo "Could not start Solr."
     if [ -f "/var/solr/logs/solr.log" ]; then
         echo "Here is the log:"

--- a/solr/docker/tests/shared.sh
+++ b/solr/docker/tests/shared.sh
@@ -25,7 +25,7 @@ function wait_for_container_and_solr {
 
   printf '\nWaiting for Solr...\n'
   local status
-  status=$(docker exec "$container_name" /opt/docker-solr/scripts/wait-for-solr.sh --max-attempts 60 --wait-seconds 1)
+  status=$(docker exec "$container_name" wait-for-solr.sh --max-attempts 60 --wait-seconds 1)
 #  echo "Got status from Solr: $status"
   if ! grep -E -i -q 'Solr is running' <<<"$status"; then
     echo "Solr did not start"

--- a/solr/packaging/build.gradle
+++ b/solr/packaging/build.gradle
@@ -28,6 +28,7 @@ description = 'Solr distribution packaging'
 ext {
   distDir = file("$buildDir/solr-${version}")
   devDir = file("$buildDir/dev")
+  versionFile = "$buildDir/VERSION.txt"
 }
 
 configurations {
@@ -70,6 +71,15 @@ dependencies {
   docs project(path: ':solr:documentation', configuration: 'minimalSite')
 
   docker project(path: ':solr:docker', configuration: 'packaging')
+}
+
+task constructVersionFile() {
+  outputs.file(versionFile)
+  inputs.property('version', project.version)
+
+  doLast {
+    project.file(versionFile) << project.version
+  }
 }
 
 distributions {
@@ -139,8 +149,7 @@ distributions {
         include "Dockerfile"
       })
 
-      file('VERSION').text = version
-      from(file('VERSION'))
+      from(tasks.constructVersionFile.outputs)
     }
   }
 }

--- a/solr/packaging/build.gradle
+++ b/solr/packaging/build.gradle
@@ -138,6 +138,9 @@ distributions {
       from(configurations.docker, {
         include "Dockerfile"
       })
+
+      file('VERSION').text = version
+      from(file('VERSION'))
     }
   }
 }

--- a/solr/packaging/build.gradle
+++ b/solr/packaging/build.gradle
@@ -39,6 +39,7 @@ configurations {
   example
   server
   docs
+  docker
 }
 
 dependencies {
@@ -67,6 +68,8 @@ dependencies {
 
   // Copy files from documentation output
   docs project(path: ':solr:documentation', configuration: 'minimalSite')
+
+  docker project(path: ':solr:docker', configuration: 'packaging')
 }
 
 distributions {
@@ -83,6 +86,7 @@ distributions {
           "**/bin/solr",
           "**/bin/init.d/solr",
           "**/bin/solr-exporter",
+          "**/docker/*",
       ]) { copy ->
         copy.setMode(0755)
       }
@@ -124,6 +128,15 @@ distributions {
 
       from(configurations.docs, {
         into "docs"
+      })
+
+      from(configurations.docker, {
+        exclude "Dockerfile"
+        into "docker"
+      })
+
+      from(configurations.docker, {
+        include "Dockerfile"
       })
     }
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15102

This should work, but there is still cleanup needed with the gradle changes.

Also we might want to infer the Solr version another way.

Backwards incompatibility that needs to be added back in: `/opt/docker-solr`

Changes in the image:
- `/opt/docker-solr` -> `/opt/solr/docker`
- `/opt/solr` is no longer a sym link, `/opt/solr-<version>` is.