### PR TITLE
LUCENE-9721: Hunspell: disallow ONLYINCOMPOUND suffixes at the very end of compound words

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/Stemmer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/Stemmer.java
@@ -568,6 +568,12 @@ final class Stemmer {
       if (context != allowed && !dictionary.hasFlag(append, dictionary.compoundPermit, scratch)) {
         return false;
       }
+      if (context == WordContext.COMPOUND_END
+          && !isPrefix
+          && !previousWasPrefix
+          && dictionary.hasFlag(append, dictionary.onlyincompound, scratch)) {
+        return false;
+      }
     }
 
     if (recursionDepth == 0) {

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/SpellCheckerTest.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/SpellCheckerTest.java
@@ -152,6 +152,10 @@ public class SpellCheckerTest extends StemmerTestBase {
     doTest("compoundrule8");
   }
 
+  public void testDisallowCompoundOnlySuffixesAtTheVeryEnd() throws Exception {
+    doTest("onlyincompound2");
+  }
+
   public void testGermanCompounding() throws Exception {
     doTest("germancompounding");
   }

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/onlyincompound2.aff
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/onlyincompound2.aff
@@ -1,0 +1,12 @@
+# affixes only in compounds (see also fogemorpheme example)
+ONLYINCOMPOUND O
+COMPOUNDFLAG A
+COMPOUNDPERMITFLAG P
+
+SFX B Y 1
+SFX B 0 s/OP .
+
+# obligate fogemorpheme by forbidding the stem (0) in compounds
+
+CHECKCOMPOUNDPATTERN 1
+CHECKCOMPOUNDPATTERN 0/B /A

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/onlyincompound2.dic
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/onlyincompound2.dic
@@ -1,0 +1,3 @@
+2
+foo/A
+pseudo/AB

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/onlyincompound2.good
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/onlyincompound2.good
@@ -1,0 +1,3 @@
+foo
+foopseudo
+pseudosfoo

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/onlyincompound2.wrong
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/onlyincompound2.wrong
@@ -1,0 +1,3 @@
+pseudos
+foopseudos
+pseudofoo


### PR DESCRIPTION
<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

Hunspell has some special logic for these suffixes, which are only allowed depending on prefix presence

# Solution

Replicate this logic

# Tests

`onlyincompound2` from Hunspell repo

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
