### PR TITLE
LUCENE-9726: Hunspell: speed up spellchecking by stopping at a single…

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/SpellChecker.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/SpellChecker.java
@@ -165,8 +165,8 @@ public class SpellChecker {
         length,
         originalCase,
         context,
-        (buffer, offset1, length1, forms, formID) -> {
-          result[0] = new CharsRef(buffer, offset1, length1);
+        (stem, forms, formID) -> {
+          result[0] = stem;
           return false;
         });
     return result[0];

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/Stemmer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/Stemmer.java
@@ -100,24 +100,41 @@ final class Stemmer {
       return Collections.emptyList();
     }
 
+    List<CharsRef> list = new ArrayList<>();
+    RootProcessor processor =
+        (buffer, offset, length1, forms, formID) -> {
+          list.add(newStem(buffer, offset, length1, forms, formID));
+          return true;
+        };
+
+    if (!doStem(word, 0, length, null, WordContext.SIMPLE_WORD, processor)) {
+      return list;
+    }
+
     WordCase wordCase = caseOf(word, length);
-    List<CharsRef> list = doStem(word, 0, length, null, WordContext.SIMPLE_WORD);
     if (wordCase == WordCase.UPPER || wordCase == WordCase.TITLE) {
-      addCaseVariations(word, length, wordCase, list);
+      addCaseVariations(word, length, wordCase, processor);
     }
     return list;
   }
 
-  private void addCaseVariations(char[] word, int length, WordCase wordCase, List<CharsRef> list) {
+  private void addCaseVariations(
+      char[] word, int length, WordCase wordCase, RootProcessor processor) {
     if (wordCase == WordCase.UPPER) {
       caseFoldTitle(word, length);
       char[] aposCase = capitalizeAfterApostrophe(titleBuffer, length);
       if (aposCase != null) {
-        list.addAll(doStem(aposCase, 0, length, wordCase, WordContext.SIMPLE_WORD));
+        if (!doStem(aposCase, 0, length, wordCase, WordContext.SIMPLE_WORD, processor)) {
+          return;
+        }
       }
-      list.addAll(doStem(titleBuffer, 0, length, wordCase, WordContext.SIMPLE_WORD));
+      if (!doStem(titleBuffer, 0, length, wordCase, WordContext.SIMPLE_WORD, processor)) {
+        return;
+      }
       for (char[] variation : sharpSVariations(titleBuffer, length)) {
-        list.addAll(doStem(variation, 0, variation.length, null, WordContext.SIMPLE_WORD));
+        if (!doStem(variation, 0, variation.length, null, WordContext.SIMPLE_WORD, processor)) {
+          return;
+        }
       }
     }
 
@@ -126,10 +143,14 @@ final class Stemmer {
     }
 
     caseFoldLower(wordCase == WordCase.UPPER ? titleBuffer : word, length);
-    list.addAll(doStem(lowerBuffer, 0, length, wordCase, WordContext.SIMPLE_WORD));
+    if (!doStem(lowerBuffer, 0, length, wordCase, WordContext.SIMPLE_WORD, processor)) {
+      return;
+    }
     if (wordCase == WordCase.UPPER) {
       for (char[] variation : sharpSVariations(lowerBuffer, length)) {
-        list.addAll(doStem(variation, 0, variation.length, null, WordContext.SIMPLE_WORD));
+        if (!doStem(variation, 0, variation.length, null, WordContext.SIMPLE_WORD, processor)) {
+          return;
+        }
       }
     }
   }
@@ -220,9 +241,13 @@ final class Stemmer {
     return result.filter(s -> !s.equals(src)).map(String::toCharArray).collect(Collectors.toList());
   }
 
-  List<CharsRef> doStem(
-      char[] word, int offset, int length, WordCase originalCase, WordContext context) {
-    List<CharsRef> stems = new ArrayList<>();
+  boolean doStem(
+      char[] word,
+      int offset,
+      int length,
+      WordCase originalCase,
+      WordContext context,
+      RootProcessor processor) {
     IntsRef forms = dictionary.lookupWord(word, offset, length);
     if (forms != null) {
       for (int i = 0; i < forms.length; i += formStep) {
@@ -241,36 +266,37 @@ final class Stemmer {
         if (context.isCompound()) {
           if (context != WordContext.COMPOUND_END
               && Dictionary.hasFlag(wordFlags, dictionary.compoundForbid)) {
-            return new ArrayList<>();
+            return false;
           }
           if (!Dictionary.hasFlag(wordFlags, dictionary.compoundFlag)
               && !Dictionary.hasFlag(wordFlags, context.requiredFlag(dictionary))) {
             continue;
           }
         }
-        stems.add(newStem(word, offset, length, forms, i));
+        if (!processor.processRoot(word, offset, length, forms, i)) {
+          return false;
+        }
       }
     }
     try {
-      stems.addAll(
-          stem(
-              word,
-              offset,
-              length,
-              context,
-              -1,
-              Dictionary.FLAG_UNSET,
-              -1,
-              0,
-              true,
-              true,
-              false,
-              false,
-              originalCase));
+      return stem(
+          word,
+          offset,
+          length,
+          context,
+          -1,
+          Dictionary.FLAG_UNSET,
+          -1,
+          0,
+          true,
+          true,
+          false,
+          false,
+          originalCase,
+          processor);
     } catch (IOException bogus) {
       throw new RuntimeException(bogus);
     }
-    return stems;
   }
 
   private boolean acceptCase(
@@ -317,6 +343,11 @@ final class Stemmer {
       }
     }
     return deduped;
+  }
+
+  interface RootProcessor {
+    /** @return whether the processing should be continued */
+    boolean processRoot(char[] buffer, int offset, int length, IntsRef forms, int formID);
   }
 
   private CharsRef newStem(char[] buffer, int offset, int length, IntsRef forms, int formID) {
@@ -385,9 +416,9 @@ final class Stemmer {
    *     most suffix must also contain circumfix flag.
    * @param originalCase if non-null, represents original word case to disallow case variations of
    *     word with KEEPCASE flags
-   * @return List of stems, or empty list if no stems are found
+   * @return whether the processing should be continued
    */
-  private List<CharsRef> stem(
+  private boolean stem(
       char[] word,
       int offset,
       int length,
@@ -400,12 +431,9 @@ final class Stemmer {
       boolean doSuffix,
       boolean previousWasPrefix,
       boolean circumfix,
-      WordCase originalCase)
+      WordCase originalCase,
+      RootProcessor processor)
       throws IOException {
-
-    // TODO: allow this stuff to be reused by tokenfilter
-    List<CharsRef> stems = new ArrayList<>();
-
     if (doPrefix && dictionary.prefixes != null) {
       FST<IntsRef> fst = dictionary.prefixes;
       FST.Arc<IntsRef> arc = prefixArcs[recursionDepth];
@@ -440,19 +468,21 @@ final class Stemmer {
             }
 
             boolean pureAffix = strippedWord == word;
-            stems.addAll(
-                applyAffix(
-                    strippedWord,
-                    pureAffix ? offset + i : 0,
-                    pureAffix ? length - i : strippedWord.length,
-                    context,
-                    prefix,
-                    previous,
-                    -1,
-                    recursionDepth,
-                    true,
-                    circumfix,
-                    originalCase));
+            if (!applyAffix(
+                strippedWord,
+                pureAffix ? offset + i : 0,
+                pureAffix ? length - i : strippedWord.length,
+                context,
+                prefix,
+                previous,
+                -1,
+                recursionDepth,
+                true,
+                circumfix,
+                originalCase,
+                processor)) {
+              return false;
+            }
           }
         }
       }
@@ -493,25 +523,27 @@ final class Stemmer {
             }
 
             boolean pureAffix = strippedWord == word;
-            stems.addAll(
-                applyAffix(
-                    strippedWord,
-                    pureAffix ? offset : 0,
-                    pureAffix ? i : strippedWord.length,
-                    context,
-                    suffix,
-                    previous,
-                    prefixId,
-                    recursionDepth,
-                    false,
-                    circumfix,
-                    originalCase));
+            if (!applyAffix(
+                strippedWord,
+                pureAffix ? offset : 0,
+                pureAffix ? i : strippedWord.length,
+                context,
+                suffix,
+                previous,
+                prefixId,
+                recursionDepth,
+                false,
+                circumfix,
+                originalCase,
+                processor)) {
+              return false;
+            }
           }
         }
       }
     }
 
-    return stems;
+    return true;
   }
 
   /**
@@ -626,9 +658,9 @@ final class Stemmer {
    *     as a stem!
    * @param recursionDepth current recursion depth
    * @param prefix true if we are removing a prefix (false if it's a suffix)
-   * @return List of stems for the word, or an empty list if none are found
+   * @return whether the processing should be continued
    */
-  private List<CharsRef> applyAffix(
+  private boolean applyAffix(
       char[] strippedWord,
       int offset,
       int length,
@@ -639,11 +671,10 @@ final class Stemmer {
       int recursionDepth,
       boolean prefix,
       boolean circumfix,
-      WordCase originalCase)
+      WordCase originalCase,
+      RootProcessor processor)
       throws IOException {
     char flag = dictionary.affixData(affix, Dictionary.AFFIX_FLAG);
-
-    List<CharsRef> stems = new ArrayList<>();
 
     boolean skipLookup = needsAnotherAffix(affix, previousAffix, !prefix);
     IntsRef forms = skipLookup ? null : dictionary.lookupWord(strippedWord, offset, length);
@@ -688,7 +719,9 @@ final class Stemmer {
               continue;
             }
           }
-          stems.add(newStem(strippedWord, offset, length, forms, i));
+          if (!processor.processRoot(strippedWord, offset, length, forms, i)) {
+            return false;
+          }
         }
       }
     }
@@ -714,7 +747,7 @@ final class Stemmer {
           // COMPLEXPREFIXES = true: we don't recurse! only one suffix allowed
           // COMPLEXPREFIXES = false: combine with another suffix
         } else {
-          return stems;
+          return true;
         }
       } else {
         doPrefix = false;
@@ -722,29 +755,29 @@ final class Stemmer {
           prefixId = affix;
           // we took away the second prefix: go look for another suffix
         } else if (prefix || dictionary.complexPrefixes || !dictionary.twoStageAffix) {
-          return stems;
+          return true;
         }
         // we took away a prefix, then a suffix: go look for another suffix
       }
 
-      stems.addAll(
-          stem(
-              strippedWord,
-              offset,
-              length,
-              context,
-              affix,
-              flag,
-              prefixId,
-              recursionDepth + 1,
-              doPrefix,
-              true,
-              prefix,
-              circumfix,
-              originalCase));
+      return stem(
+          strippedWord,
+          offset,
+          length,
+          context,
+          affix,
+          flag,
+          prefixId,
+          recursionDepth + 1,
+          doPrefix,
+          true,
+          prefix,
+          circumfix,
+          originalCase,
+          processor);
     }
 
-    return stems;
+    return true;
   }
 
   private boolean needsAnotherAffix(int affix, int previousAffix, boolean isSuffix) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/Stemmer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/Stemmer.java
@@ -102,8 +102,8 @@ final class Stemmer {
 
     List<CharsRef> list = new ArrayList<>();
     RootProcessor processor =
-        (buffer, offset, length1, forms, formID) -> {
-          list.add(newStem(buffer, offset, length1, forms, formID));
+        (stem, forms, formID) -> {
+          list.add(newStem(stem, forms, formID));
           return true;
         };
 
@@ -273,7 +273,7 @@ final class Stemmer {
             continue;
           }
         }
-        if (!processor.processRoot(word, offset, length, forms, i)) {
+        if (!processor.processRoot(new CharsRef(word, offset, length), forms, i)) {
           return false;
         }
       }
@@ -347,10 +347,10 @@ final class Stemmer {
 
   interface RootProcessor {
     /** @return whether the processing should be continued */
-    boolean processRoot(char[] buffer, int offset, int length, IntsRef forms, int formID);
+    boolean processRoot(CharsRef stem, IntsRef forms, int formID);
   }
 
-  private CharsRef newStem(char[] buffer, int offset, int length, IntsRef forms, int formID) {
+  private CharsRef newStem(CharsRef stem, IntsRef forms, int formID) {
     final String exception;
     if (dictionary.hasStemExceptions) {
       int exceptionID = forms.ints[forms.offset + formID + 1];
@@ -368,7 +368,7 @@ final class Stemmer {
       if (exception != null) {
         scratchSegment.append(exception);
       } else {
-        scratchSegment.append(buffer, offset, length);
+        scratchSegment.append(stem.chars, stem.offset, stem.length);
       }
       try {
         Dictionary.applyMappings(dictionary.oconv, scratchSegment);
@@ -382,7 +382,7 @@ final class Stemmer {
       if (exception != null) {
         return new CharsRef(exception);
       } else {
-        return new CharsRef(buffer, offset, length);
+        return stem;
       }
     }
   }
@@ -719,7 +719,7 @@ final class Stemmer {
               continue;
             }
           }
-          if (!processor.processRoot(strippedWord, offset, length, forms, i)) {
+          if (!processor.processRoot(new CharsRef(strippedWord, offset, length), forms, i)) {
             return false;
           }
         }


### PR DESCRIPTION
… found stem

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

`Stemmer.doStem` enumerates all possibilities, while in the spellchecker we only care if there are any roots found.

# Solution

Introduce a `RootProcessor` interface returning a boolean indicating whether to continue the search.

# Tests

No new functionality, no tests

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
