### PR TITLE
LUCENE-9680 - Backport to 8x - Remove deprecation from getFieldNames

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -7,7 +7,8 @@ http://s.apache.org/luceneversions
 
 API Changes
 ---------------------
-(No changes)
+
+* LUCENE-9680: Removed deprecation warning from IndexWriter#getFieldNames(). (Oren Ovadia)
 
 New Features
 ---------------------

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -1983,7 +1983,6 @@ public class IndexWriter implements Closeable, TwoPhaseCommit, Accountable,
    * @lucene.internal
    * @lucene.experimental
    */
-  @Deprecated
   public Set<String> getFieldNames() {
     return globalFieldNumberMap.getFieldNames(); // FieldNumbers#getFieldNames() returns an unmodifiableSet
   }


### PR DESCRIPTION
In [LUCENE-9680](https://issues.apache.org/jira/browse/LUCENE-9680) we re-added `IW::getFieldNames` back to `master`. The method still exists in 8x, so this simply removes the deprecation annotation. 
# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have developed this patch against the `master` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
