### PR TITLE
LUCENE-9731: restore consistent random seed to HnswGraphBuilder

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90VectorWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90VectorWriter.java
@@ -218,7 +218,7 @@ public final class Lucene90VectorWriter extends VectorWriter {
       }
     }
     HnswGraphBuilder hnswGraphBuilder =
-        new HnswGraphBuilder(vectorValues, maxConn, beamWidth, System.currentTimeMillis());
+        new HnswGraphBuilder(vectorValues, maxConn, beamWidth, HnswGraphBuilder.randSeed);
     hnswGraphBuilder.setInfoStream(segmentWriteState.infoStream);
     HnswGraph graph = hnswGraphBuilder.build(vectorValues.randomAccess());
 


### PR DESCRIPTION
A recent change replaced a static constant random seed initialized to `System.currentTimeMillis()` with a call to `System.currentTimeMillis()`, invalidating tests that relied on the consistent random behavior for reproducibility. This just undoes that change, restoring the use of `HnswGraphBuilder.randSeed`