### PR TITLE
LUCENE-9729: Hunspell: support CHECKCOMPOUNDREP flags

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/Dictionary.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/Dictionary.java
@@ -152,7 +152,7 @@ public class Dictionary {
   char forbiddenword;
   char onlyincompound, compoundBegin, compoundMiddle, compoundEnd, compoundFlag;
   char compoundPermit, compoundForbid;
-  boolean checkCompoundCase, checkCompoundDup;
+  boolean checkCompoundCase, checkCompoundDup, checkCompoundRep;
   boolean checkCompoundTriple, simplifiedTriple;
   int compoundMin = 3, compoundMax = Integer.MAX_VALUE;
   List<CompoundRule> compoundRules; // nullable
@@ -425,6 +425,8 @@ public class Dictionary {
         checkCompoundCase = true;
       } else if ("CHECKCOMPOUNDDUP".equals(firstWord)) {
         checkCompoundDup = true;
+      } else if ("CHECKCOMPOUNDREP".equals(firstWord)) {
+        checkCompoundRep = true;
       } else if ("CHECKCOMPOUNDTRIPLE".equals(firstWord)) {
         checkCompoundTriple = true;
       } else if ("SIMPLIFIEDTRIPLE".equals(firstWord)) {

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/RepEntry.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/RepEntry.java
@@ -35,6 +35,10 @@ class RepEntry {
     patternLen = pattern.length();
   }
 
+  boolean isMiddle() {
+    return !mustStart && !mustEnd;
+  }
+
   List<String> substitute(String word) {
     if (mustStart) {
       boolean matches = mustEnd ? word.equals(pattern) : word.startsWith(pattern);

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/SpellChecker.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/SpellChecker.java
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Predicate;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.CharsRef;
 import org.apache.lucene.util.IntsRef;
@@ -150,7 +149,7 @@ public class SpellChecker {
     }
 
     if (dictionary.compoundBegin != FLAG_UNSET || dictionary.compoundFlag != FLAG_UNSET) {
-      return checkCompounds(new CharsRef(wordChars, 0, length), originalCase, 0, __ -> true);
+      return checkCompounds(new CharsRef(wordChars, 0, length), originalCase, null);
     }
 
     return false;
@@ -172,13 +171,12 @@ public class SpellChecker {
     return result[0];
   }
 
-  private boolean checkCompounds(
-      CharsRef word, WordCase originalCase, int depth, Predicate<CharsRef> checkPatterns) {
-    if (depth > dictionary.compoundMax - 2) return false;
+  private boolean checkCompounds(CharsRef word, WordCase originalCase, CompoundPart prev) {
+    if (prev != null && prev.index > dictionary.compoundMax - 2) return false;
 
     int limit = word.length - dictionary.compoundMin + 1;
     for (int breakPos = dictionary.compoundMin; breakPos < limit; breakPos++) {
-      WordContext context = depth == 0 ? COMPOUND_BEGIN : COMPOUND_MIDDLE;
+      WordContext context = prev == null ? COMPOUND_BEGIN : COMPOUND_MIDDLE;
       int breakOffset = word.offset + breakPos;
       if (mayBreakIntoCompounds(word.chars, word.offset, word.length, breakOffset)) {
         CharsRef stem = findStem(word.chars, word.offset, breakPos, originalCase, context);
@@ -187,15 +185,15 @@ public class SpellChecker {
             && word.chars[breakOffset - 1] == word.chars[breakOffset]) {
           stem = findStem(word.chars, word.offset, breakPos + 1, originalCase, context);
         }
-        if (stem != null && checkPatterns.test(stem)) {
-          Predicate<CharsRef> nextCheck = checkNextPatterns(word, breakPos, stem);
-          if (checkCompoundsAfter(word, breakPos, originalCase, depth, stem, nextCheck)) {
+        if (stem != null && (prev == null || prev.checkPatterns(stem))) {
+          CompoundPart part = new CompoundPart(prev, word, breakPos, stem, null);
+          if (checkCompoundsAfter(originalCase, part)) {
             return true;
           }
         }
       }
 
-      if (checkCompoundPatternReplacements(word, breakPos, originalCase, depth)) {
+      if (checkCompoundPatternReplacements(word, breakPos, originalCase, prev)) {
         return true;
       }
     }
@@ -204,17 +202,16 @@ public class SpellChecker {
   }
 
   private boolean checkCompoundPatternReplacements(
-      CharsRef word, int pos, WordCase originalCase, int depth) {
+      CharsRef word, int pos, WordCase originalCase, CompoundPart prev) {
     for (CheckCompoundPattern pattern : dictionary.checkCompoundPatterns) {
       CharsRef expanded = pattern.expandReplacement(word, pos);
       if (expanded != null) {
-        WordContext context = depth == 0 ? COMPOUND_BEGIN : COMPOUND_MIDDLE;
+        WordContext context = prev == null ? COMPOUND_BEGIN : COMPOUND_MIDDLE;
         int breakPos = pos + pattern.endLength();
         CharsRef stem = findStem(expanded.chars, expanded.offset, breakPos, originalCase, context);
         if (stem != null) {
-          Predicate<CharsRef> nextCheck =
-              next -> pattern.prohibitsCompounding(expanded, breakPos, stem, next);
-          if (checkCompoundsAfter(expanded, breakPos, originalCase, depth, stem, nextCheck)) {
+          CompoundPart part = new CompoundPart(prev, expanded, breakPos, stem, pattern);
+          if (checkCompoundsAfter(originalCase, part)) {
             return true;
           }
         }
@@ -223,32 +220,22 @@ public class SpellChecker {
     return false;
   }
 
-  private Predicate<CharsRef> checkNextPatterns(CharsRef word, int breakPos, CharsRef stems) {
-    return nextStem ->
-        dictionary.checkCompoundPatterns.stream()
-            .noneMatch(p -> p.prohibitsCompounding(word, breakPos, stems, nextStem));
-  }
-
-  private boolean checkCompoundsAfter(
-      CharsRef word,
-      int breakPos,
-      WordCase originalCase,
-      int depth,
-      CharsRef prevStem,
-      Predicate<CharsRef> checkPatterns) {
+  private boolean checkCompoundsAfter(WordCase originalCase, CompoundPart prev) {
+    CharsRef word = prev.tail;
+    int breakPos = prev.length;
     int remainingLength = word.length - breakPos;
     int breakOffset = word.offset + breakPos;
     CharsRef tailStem =
         findStem(word.chars, breakOffset, remainingLength, originalCase, COMPOUND_END);
     if (tailStem != null
-        && !(dictionary.checkCompoundDup && equalsIgnoreCase(prevStem, tailStem))
+        && !(dictionary.checkCompoundDup && equalsIgnoreCase(prev.stem, tailStem))
         && !hasForceUCaseProblem(word.chars, breakOffset, remainingLength, originalCase)
-        && checkPatterns.test(tailStem)) {
+        && prev.checkPatterns(tailStem)) {
       return true;
     }
 
     CharsRef tail = new CharsRef(word.chars, breakOffset, remainingLength);
-    return checkCompounds(tail, originalCase, depth + 1, checkPatterns);
+    return checkCompounds(tail, originalCase, prev);
   }
 
   private boolean hasForceUCaseProblem(
@@ -260,12 +247,39 @@ public class SpellChecker {
     return forms != null && dictionary.hasFlag(forms, dictionary.forceUCase, scratch);
   }
 
-  private boolean intersectIgnoreCase(List<CharsRef> stems1, List<CharsRef> stems2) {
-    return stems1.stream().anyMatch(s1 -> stems2.stream().anyMatch(s2 -> equalsIgnoreCase(s1, s2)));
-  }
-
   private boolean equalsIgnoreCase(CharsRef cr1, CharsRef cr2) {
     return cr1.toString().equalsIgnoreCase(cr2.toString());
+  }
+
+  private class CompoundPart {
+    final CompoundPart prev;
+    final int index, length;
+    final CharsRef tail, stem;
+    final CheckCompoundPattern enablingPattern;
+
+    CompoundPart(
+        CompoundPart prev, CharsRef tail, int length, CharsRef stem, CheckCompoundPattern enabler) {
+      this.prev = prev;
+      this.tail = tail;
+      this.length = length;
+      this.stem = stem;
+      index = prev == null ? 1 : prev.index + 1;
+      enablingPattern = enabler;
+    }
+
+    @Override
+    public String toString() {
+      return (prev == null ? "" : prev + "+") + tail.subSequence(0, length);
+    }
+
+    boolean checkPatterns(CharsRef nextStem) {
+      if (enablingPattern != null) {
+        return enablingPattern.prohibitsCompounding(tail, length, stem, nextStem);
+      }
+
+      return dictionary.checkCompoundPatterns.stream()
+          .noneMatch(p -> p.prohibitsCompounding(tail, length, stem, nextStem));
+    }
   }
 
   private boolean mayBreakIntoCompounds(char[] chars, int offset, int length, int breakPos) {

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/SpellCheckerTest.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/SpellCheckerTest.java
@@ -120,6 +120,10 @@ public class SpellCheckerTest extends StemmerTestBase {
     doTest("breakoff");
   }
 
+  public void testCheckCompoundRep() throws Exception {
+    doTest("checkcompoundrep");
+  }
+
   public void testCompoundrule() throws Exception {
     doTest("compoundrule");
   }

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/checkcompoundrep.aff
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/checkcompoundrep.aff
@@ -1,0 +1,8 @@
+// forbid compound word, if it is also a non-compound word with a REP fault
+// In example: Hungarian `szervíz' (szer+víz) compound word is forbidden, because 
+// this word is also a dictionary word (szerviz) with typical fault (i->í)
+CHECKCOMPOUNDREP
+COMPOUNDFLAG A
+
+REP 1
+REP í i

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/checkcompoundrep.dic
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/checkcompoundrep.dic
@@ -1,0 +1,5 @@
+3
+szer/A
+víz/A
+szerviz
+kocsi/A

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/checkcompoundrep.good
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/checkcompoundrep.good
@@ -1,0 +1,2 @@
+vízszer
+szerkocsi

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/checkcompoundrep.wrong
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/checkcompoundrep.wrong
@@ -1,0 +1,3 @@
+szervíz
+szervízkocsi
+kocsiszervíz


### PR DESCRIPTION
<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

> CHECKCOMPOUNDREP

> Forbid compounding, if the (usually bad) compound word may be a non-compound word with a REP fault. Useful for languages with ‘compound friendly’ orthography.

# Solution

When a new compound word part is about to appear, check that together with the previous one they don't form a misspelled simple word. For that, first introduce `CompoundPart` class (in a separate commit for easier review) to combine this new logic with similar `CHECKCOMPOUNDPATTERN` stuff.

# Tests

`checkcompoundrep` from Hunspell/C++

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
