### PR TITLE
SOLR-14301: Remove external commons-codec usage in gradle validateJarChecksums

### DIFF
--- a/gradle/validation/jar-checks.gradle
+++ b/gradle/validation/jar-checks.gradle
@@ -20,21 +20,11 @@
 // 2) notice file
 // 3) checksum validation/ generation.
 
-import org.apache.commons.codec.digest.DigestUtils
+import java.nio.file.Files
+import java.security.MessageDigest
 
 // This should be false only for debugging.
 def failOnError = true
-
-// We're using commons-codec for computing checksums.
-buildscript {
-  repositories {
-    mavenCentral()
-  }
-
-  dependencies {
-    classpath "commons-codec:commons-codec:${scriptDepVersions['commons-codec']}"
-  }
-}
 
 // Configure license checksum folder for top-level projects.
 // (The file("licenses") inside the configure scope resolves
@@ -151,7 +141,8 @@ subprojects {
                   jarName        : file.toPath().getFileName().toString(),
                   path           : file,
                   module         : resolvedArtifact.moduleVersion,
-                  checksum       : provider { new DigestUtils(DigestUtils.sha1Digest).digestAsHex(file).trim() },
+                  checksum       : provider { String.format("%040x", new BigInteger(1 ,MessageDigest.getInstance("SHA-1").digest(Files.readAllBytes(file.toPath())))) },
+
                   // We keep track of the files referenced by this dependency (sha, license, notice, etc.)
                   // so that we can determine unused dangling files later on.
                   referencedFiles: []


### PR DESCRIPTION
…Checksums

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

Right now gradle calculates SHA-1 checksums using an external commons-codec library. We can calculate SHA-1 using Java 8 classes, no need for commons-codec here.

# Solution

Eliminate commons-codec usage in checksum validation.

# Tests

./gradlew validateJarChecksums

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
