### PR TITLE
Deprecate V2RequestSupport and accompanying methods

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/client/solrj/SolrRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/SolrRequest.java
@@ -77,15 +77,22 @@ public abstract class SolrRequest<T extends SolrResponse> implements Serializabl
 
   /**If set to true, every request that implements {@link V2RequestSupport} will be converted
    * to a V2 API call
+   *
+   * @deprecated
    */
+  @Deprecated
   @SuppressWarnings({"rawtypes"})
   public SolrRequest setUseV2(boolean flag){
     this.usev2 = flag;
     return this;
   }
 
-  /**If set to true use javabin instead of json (default)
+  /**
+   * If set to true use javabin instead of json (default)
+   *
+   * @deprecated
    */
+  @Deprecated
   @SuppressWarnings({"rawtypes"})
   public SolrRequest setUseBinaryV2(boolean flag){
     this.useBinaryV2 = flag;

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/V2RequestSupport.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/V2RequestSupport.java
@@ -20,12 +20,17 @@ package org.apache.solr.client.solrj;
 /**A a request object is able to convert itself to V2 Request
  * it should implement this interface
  *
+ * @deprecated
  */
+@Deprecated
 public interface V2RequestSupport {
-  /**If usev2 flag is set to true, return V2Request, if not,
+  /**
+   * If usev2 flag is set to true, return V2Request, if not,
    * return V1 request object
    *
+   * @deprecated
    */
+  @Deprecated
   @SuppressWarnings({"rawtypes"})
   SolrRequest getV2Request();
 }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/CollectionAdminRequest.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/CollectionAdminRequest.java
@@ -110,7 +110,7 @@ public abstract class CollectionAdminRequest<T extends CollectionAdminResponse> 
     super(METHOD.GET, path);
     this.action = checkNotNull(CoreAdminParams.ACTION, action);
   }
-
+  
   @Override
   @SuppressWarnings({"rawtypes"})
   public SolrRequest getV2Request() {


### PR DESCRIPTION
# Description

V2RequestSupport was intended to allow support for V2 requests in SolrJ, but never gained a critical mass of SolrRequest implementations.  Now that the V2 API is more mature there are better ways to support v2 requests in the API.

# Solution

Deprecate V2RequestSupport for subsequent removal in 9.0

# Tests

N/A

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have run `./gradlew check`.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
