### PR TITLE
LUCENE-9741: Add sequential optimization for stored fields

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/compressing/CompressingStoredFieldsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/compressing/CompressingStoredFieldsReader.java
@@ -582,7 +582,7 @@ public final class CompressingStoredFieldsReader extends StoredFieldsReader {
                   + "]");
         }
         if (range.getFromDocId() < range.getToDocId()) {
-          prefetch(range.getFromDocId(), range.getFromDocId());
+          prefetch(range.getFromDocId(), range.getToDocId());
         }
       }
     }
@@ -617,7 +617,7 @@ public final class CompressingStoredFieldsReader extends StoredFieldsReader {
             "Corrupted: expected fetch length = " + length + ", got " + bytes.length, fieldsStream);
       }
       fetchedFromDocId = fromDocId;
-      fetchedFromDocId = toDocId;
+      fetchedToDocId = toDocId;
     }
 
     /**

--- a/lucene/core/src/java/org/apache/lucene/codecs/compressing/CompressingStoredFieldsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/compressing/CompressingStoredFieldsReader.java
@@ -87,7 +87,7 @@ public final class CompressingStoredFieldsReader extends StoredFieldsReader {
   private final CompressionMode compressionMode;
   private final Decompressor decompressor;
   private final int numDocs;
-  private StoredFieldsReader.PrefetchOption prefetchOption;
+  private final StoredFieldsReader.PrefetchOption prefetchOption;
   private final BlockState state;
   private final long numDirtyChunks; // number of incomplete compressed blocks written
   private final long numDirtyDocs; // cumulative number of missing docs in incomplete chunks
@@ -111,7 +111,6 @@ public final class CompressingStoredFieldsReader extends StoredFieldsReader {
     this.prefetchOption = prefetchOption;
     this.state = new BlockState();
     this.closed = false;
-    this.prefetchOption = prefetchOption;
   }
 
   /** Sole constructor. */

--- a/lucene/test-framework/src/java/org/apache/lucene/index/BaseIndexFileFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/index/BaseIndexFileFormatTestCase.java
@@ -827,7 +827,7 @@ abstract class BaseIndexFileFormatTestCase extends LuceneTestCase {
             return fieldsReader.getInstanceWithPrefetchOptions(
                 (minDocId, maxDocId, currentDocId) -> {
                   final int fromDocId = minDocId + random().nextInt(currentDocId - minDocId + 1);
-                  final int toDocId = fromDocId + random().nextInt(maxDocId - fromDocId + 1);
+                  final int toDocId = currentDocId + random().nextInt(maxDocId - currentDocId + 1);
                   return new StoredFieldsReader.PrefetchRange(fromDocId, toDocId);
                 });
           }

--- a/lucene/test-framework/src/java/org/apache/lucene/index/BaseIndexFileFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/index/BaseIndexFileFormatTestCase.java
@@ -825,11 +825,11 @@ abstract class BaseIndexFileFormatTestCase extends LuceneTestCase {
           protected StoredFieldsReader initialValue() {
             final StoredFieldsReader fieldsReader = in.getFieldsReader();
             return fieldsReader.getInstanceWithPrefetchOptions(
-                    (minDocId, maxDocId, currentDocId) -> {
-                      final int fromDocId = minDocId + random().nextInt(currentDocId - minDocId + 1);
-                      final int toDocId = fromDocId + random().nextInt(maxDocId - fromDocId + 1);
-                      return new StoredFieldsReader.PrefetchRange(fromDocId, toDocId);
-                    });
+                (minDocId, maxDocId, currentDocId) -> {
+                  final int fromDocId = minDocId + random().nextInt(currentDocId - minDocId + 1);
+                  final int toDocId = fromDocId + random().nextInt(maxDocId - fromDocId + 1);
+                  return new StoredFieldsReader.PrefetchRange(fromDocId, toDocId);
+                });
           }
         };
 

--- a/lucene/test-framework/src/java/org/apache/lucene/index/BaseIndexFileFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/index/BaseIndexFileFormatTestCase.java
@@ -790,7 +790,7 @@ abstract class BaseIndexFileFormatTestCase extends LuceneTestCase {
     return r;
   }
 
-  private static class RandomPrefetchStoredFieldsCodecDirectoryReader
+  protected static class RandomPrefetchStoredFieldsCodecDirectoryReader
       extends FilterDirectoryReader {
     RandomPrefetchStoredFieldsCodecDirectoryReader(DirectoryReader in) throws IOException {
       super(
@@ -824,16 +824,12 @@ abstract class BaseIndexFileFormatTestCase extends LuceneTestCase {
           @Override
           protected StoredFieldsReader initialValue() {
             final StoredFieldsReader fieldsReader = in.getFieldsReader();
-            if (random().nextBoolean()) {
-              return fieldsReader.getInstanceWithPrefetchOptions(
-                  (minDocId, maxDocId, currentDocId) -> {
-                    final int fromDocId = minDocId + random().nextInt(currentDocId - minDocId + 1);
-                    final int toDocId = fromDocId + random().nextInt(maxDocId - fromDocId + 1);
-                    return new StoredFieldsReader.PrefetchRange(fromDocId, toDocId);
-                  });
-            } else {
-              return fieldsReader;
-            }
+            return fieldsReader.getInstanceWithPrefetchOptions(
+                    (minDocId, maxDocId, currentDocId) -> {
+                      final int fromDocId = minDocId + random().nextInt(currentDocId - minDocId + 1);
+                      final int toDocId = fromDocId + random().nextInt(maxDocId - fromDocId + 1);
+                      return new StoredFieldsReader.PrefetchRange(fromDocId, toDocId);
+                    });
           }
         };
 

--- a/lucene/test-framework/src/java/org/apache/lucene/index/BaseStoredFieldsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/index/BaseStoredFieldsFormatTestCase.java
@@ -857,7 +857,8 @@ public abstract class BaseStoredFieldsFormatTestCase extends BaseIndexFileFormat
       writer.addDocument(doc);
       docs.put(i, doc);
     }
-    final DirectoryReader reader = new RandomPrefetchStoredFieldsCodecDirectoryReader(DirectoryReader.open(writer));
+    final DirectoryReader reader =
+        new RandomPrefetchStoredFieldsCodecDirectoryReader(DirectoryReader.open(writer));
     int iters = atLeast(100);
     for (int i = 0; i < iters; i++) {
       int docId = random().nextInt(numDocs);

--- a/lucene/test-framework/src/java/org/apache/lucene/index/BaseStoredFieldsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/index/BaseStoredFieldsFormatTestCase.java
@@ -862,7 +862,9 @@ public abstract class BaseStoredFieldsFormatTestCase extends BaseIndexFileFormat
     int iters = atLeast(100);
     for (int i = 0; i < iters; i++) {
       int docId = random().nextInt(numDocs);
-      int numFields = Integer.parseInt(docs.get(docId).getField("num_fields").stringValue());
+      final IndexableField numFieldStr = docs.get(docId).getField("num_fields");
+      assertNotNull(numFieldStr);
+      int numFields = Integer.parseInt(numFieldStr.stringValue());
       Document doc = reader.document(docId);
       assertEquals(numFields, doc.getFields().size());
       for (int f = 0; f < numFields; f++) {

--- a/lucene/test-framework/src/java/org/apache/lucene/index/BaseStoredFieldsFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/index/BaseStoredFieldsFormatTestCase.java
@@ -863,7 +863,7 @@ public abstract class BaseStoredFieldsFormatTestCase extends BaseIndexFileFormat
     for (int i = 0; i < iters; i++) {
       int docId = random().nextInt(numDocs);
       final IndexableField numFieldStr = docs.get(docId).getField("num_fields");
-      assertNotNull(numFieldStr);
+      assert numFieldStr != null;
       int numFields = Integer.parseInt(numFieldStr.stringValue());
       Document doc = reader.document(docId);
       assertEquals(numFields, doc.getFields().size());


### PR DESCRIPTION
If we are reading the stored-fields of document ids (25, 27, 28, 26, 99), and doc-25 triggers the stored-fields reader to decompress a block containing document ids [10-50], then we can tell the reader to read not only 25, but 26, 27, and 28 to avoid decompressing that block multiple times.


This PR proposes adding a new optimized instance of stored-fields reader that allows users to select the preferred fetching range.