### PR TITLE
LUCENE-9743: Hunspell: ignore original tests which are out of scope

### DIFF
--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/SpellCheckerTest.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/SpellCheckerTest.java
@@ -182,11 +182,10 @@ public class SpellCheckerTest extends StemmerTestBase {
 
   protected void doTest(String name) throws Exception {
     checkSpellCheckerExpectations(
-        Path.of(getClass().getResource(name + ".aff").toURI()).getParent().resolve(name), true);
+        Path.of(getClass().getResource(name + ".aff").toURI()).getParent().resolve(name));
   }
 
-  static void checkSpellCheckerExpectations(Path basePath, boolean checkSuggestions)
-      throws IOException, ParseException {
+  static void checkSpellCheckerExpectations(Path basePath) throws IOException, ParseException {
     InputStream affixStream = Files.newInputStream(Path.of(basePath.toString() + ".aff"));
     InputStream dictStream = Files.newInputStream(Path.of(basePath.toString() + ".dic"));
 
@@ -214,7 +213,7 @@ public class SpellCheckerTest extends StemmerTestBase {
       for (String word : wrongWords) {
         assertFalse("Unexpectedly considered correct: " + word, speller.spell(word.trim()));
       }
-      if (Files.exists(sug) && checkSuggestions) {
+      if (Files.exists(sug)) {
         String suggestions =
             wrongWords.stream()
                 .map(s -> String.join(", ", speller.suggest(s)))

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestHunspellRepositoryTestCases.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestHunspellRepositoryTestCases.java
@@ -20,13 +20,14 @@ import java.io.IOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.text.ParseException;
 import java.util.Collection;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
+import org.junit.Assert;
 import org.junit.AssumptionViolatedException;
 import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -36,9 +37,18 @@ import org.junit.runners.Parameterized;
  */
 @RunWith(Parameterized.class)
 public class TestHunspellRepositoryTestCases {
+  private static final Set<String> IGNORED =
+      Set.of(
+          "hu", // Hungarian is hard: a lot of its rules are hardcoded in Hunspell code, not aff/dic
+          "morph", // we don't do morphological analysis yet
+          "nepali", // not supported yet
+          "phone" // not supported yet, used only for suggestions in en_ZA
+          );
+  private final String testName;
   private final Path pathPrefix;
 
   public TestHunspellRepositoryTestCases(String testName, Path pathPrefix) {
+    this.testName = testName;
     this.pathPrefix = pathPrefix;
   }
 
@@ -64,7 +74,12 @@ public class TestHunspellRepositoryTestCases {
   }
 
   @Test
-  public void test() throws IOException, ParseException {
-    SpellCheckerTest.checkSpellCheckerExpectations(pathPrefix, false);
+  public void test() throws Throwable {
+    ThrowingRunnable test = () -> SpellCheckerTest.checkSpellCheckerExpectations(pathPrefix);
+    if (IGNORED.contains(testName)) {
+      Assert.assertThrows(Throwable.class, test);
+    } else {
+      test.run();
+    }
   }
 }

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestHunspellRepositoryTestCases.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestHunspellRepositoryTestCases.java
@@ -37,7 +37,7 @@ import org.junit.runners.Parameterized;
  */
 @RunWith(Parameterized.class)
 public class TestHunspellRepositoryTestCases {
-  private static final Set<String> IGNORED =
+  private static final Set<String> EXPECTED_FAILURES =
       Set.of(
           "hu", // Hungarian is hard: a lot of its rules are hardcoded in Hunspell code, not aff/dic
           "morph", // we don't do morphological analysis yet
@@ -76,7 +76,7 @@ public class TestHunspellRepositoryTestCases {
   @Test
   public void test() throws Throwable {
     ThrowingRunnable test = () -> SpellCheckerTest.checkSpellCheckerExpectations(pathPrefix);
-    if (IGNORED.contains(testName)) {
+    if (EXPECTED_FAILURES.contains(testName)) {
       Assert.assertThrows(Throwable.class, test);
     } else {
       test.run();


### PR DESCRIPTION
<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

Some of the original Hunspell's tests are out of scope of LUCENE-9687: Hunspell support improvements

# Solution

Make their failures expected for now. Plus check suggestions in `TestHunspellRepositoryTestCases`.

# Tests

The change itself is only about tests. `TestHunspellRepositoryTestCases` still fails and needs to be fixed.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
