### PR TITLE
LUCENE-9322:  Lucene90VectorWriter can leak open files

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90VectorWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90VectorWriter.java
@@ -54,23 +54,25 @@ public final class Lucene90VectorWriter extends VectorWriter {
     String metaFileName =
         IndexFileNames.segmentFileName(
             state.segmentInfo.name, state.segmentSuffix, Lucene90VectorFormat.META_EXTENSION);
-    meta = state.directory.createOutput(metaFileName, state.context);
 
     String vectorDataFileName =
         IndexFileNames.segmentFileName(
             state.segmentInfo.name,
             state.segmentSuffix,
             Lucene90VectorFormat.VECTOR_DATA_EXTENSION);
-    vectorData = state.directory.createOutput(vectorDataFileName, state.context);
 
     String indexDataFileName =
         IndexFileNames.segmentFileName(
             state.segmentInfo.name,
             state.segmentSuffix,
             Lucene90VectorFormat.VECTOR_INDEX_EXTENSION);
-    vectorIndex = state.directory.createOutput(indexDataFileName, state.context);
 
+    boolean success = false;
     try {
+      meta = state.directory.createOutput(metaFileName, state.context);
+      vectorData = state.directory.createOutput(vectorDataFileName, state.context);
+      vectorIndex = state.directory.createOutput(indexDataFileName, state.context);
+
       CodecUtil.writeIndexHeader(
           meta,
           Lucene90VectorFormat.META_CODEC_NAME,
@@ -89,8 +91,11 @@ public final class Lucene90VectorWriter extends VectorWriter {
           Lucene90VectorFormat.VERSION_CURRENT,
           state.segmentInfo.getId(),
           state.segmentSuffix);
-    } catch (IOException e) {
-      IOUtils.closeWhileHandlingException(this);
+      success = true;
+    } finally {
+      if (success == false) {
+        IOUtils.closeWhileHandlingException(this);
+      }
     }
   }
 

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90VectorFormat.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLucene90VectorFormat.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.lucene90;
+
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.index.BaseVectorFormatTestCase;
+import org.apache.lucene.util.TestUtil;
+
+public class TestLucene90VectorFormat extends BaseVectorFormatTestCase {
+
+  @Override
+  protected Codec getCodec() {
+    return TestUtil.getDefaultCodec();
+  }
+}


### PR DESCRIPTION
While trying to add a test class for Vectors based on `BaseIndexFileFormatTestCase`, a bug surface on the Lucene90VectorWriter constructor. If there is an exception during construction, it might happen that files are not properly closed and therefore it might leak.

Here is the proposal, move the current `TestVectorValues` to a `BaseVectorFormatTestCase` which extends `BaseIndexFileFormatTestCase`.

Fix the constructor so it handle closing files on error properly.