### PR TITLE
LUCENE-9753: Hunspell: disallow compounds with parts present in dicti…

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/SpellChecker.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/SpellChecker.java
@@ -259,12 +259,16 @@ public class SpellChecker {
         return false;
       }
 
-      //noinspection RedundantIfStatement
       if (dictionary.checkCompoundRep
           && isMisspelledSimpleWord(length + nextPartLength, originalCase)) {
         return false;
       }
-      return true;
+
+      String spaceSeparated =
+          new String(tail.chars, tail.offset, length)
+              + " "
+              + new String(tail.chars, tail.offset + length, nextPartLength);
+      return !checkWord(spaceSeparated);
     }
 
     private boolean isMisspelledSimpleWord(int length, WordCase originalCase) {

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/SpellCheckerTest.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/SpellCheckerTest.java
@@ -132,6 +132,10 @@ public class SpellCheckerTest extends StemmerTestBase {
     doTest("checkcompoundrep");
   }
 
+  public void testDisallowCompoundsWhenDictionaryContainsSeparatedWordPair() throws Exception {
+    doTest("wordpair");
+  }
+
   public void testCompoundrule() throws Exception {
     doTest("compoundrule");
   }

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/wordpair.aff
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/wordpair.aff
@@ -1,0 +1,4 @@
+# a dictionary word pair separated by space
+# will avoid its recognition without space
+# at compound word analysis
+COMPOUNDFLAG Y

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/wordpair.dic
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/wordpair.dic
@@ -1,0 +1,4 @@
+3
+word/Y
+compound/Y
+compound word

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/wordpair.good
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/wordpair.good
@@ -1,0 +1,3 @@
+word
+compound
+wordcompound

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/wordpair.wrong
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/wordpair.wrong
@@ -1,0 +1,1 @@
+compoundword


### PR DESCRIPTION
…onary, space-separated

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

Don't accept `compoundword` when there's `compound word` in the dictionary

# Solution

Like Hunspell, handle this near CHECKCOMPOUNDREP pattern check

# Tests

`wordpair` from Hunspell repo

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
