### PR TITLE
LUCENE-9756: Extend FieldInfosFormat tests to cover points and vectors

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/document/FieldType.java
+++ b/lucene/core/src/java/org/apache/lucene/document/FieldType.java
@@ -367,7 +367,8 @@ public class FieldType implements IndexableFieldType {
     return dimensionNumBytes;
   }
 
-  void setVectorDimensionsAndSearchStrategy(
+  /** Enable vector indexing, with the specified number of dimensions and distance function. */
+  public void setVectorDimensionsAndSearchStrategy(
       int numDimensions, VectorValues.SearchStrategy distFunc) {
     checkIfFrozen();
     if (numDimensions <= 0) {

--- a/lucene/test-framework/src/java/org/apache/lucene/index/BaseFieldInfoFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/index/BaseFieldInfoFormatTestCase.java
@@ -301,7 +301,7 @@ public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTes
     }
 
     if (r.nextBoolean()) {
-      DocValuesType values[] = getDocValuesTypes();
+      DocValuesType[] values = DocValuesType.values();
       type.setDocValuesType(values[r.nextInt(values.length)]);
     }
 
@@ -310,17 +310,6 @@ public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTes
 
   /** Hook to add any codec attributes to fieldinfo instances added in this test. */
   protected void addAttributes(FieldInfo fi) {}
-
-  /**
-   * Docvalues types to test.
-   *
-   * @deprecated only for Only available to ancient codecs can limit this to the subset of types
-   *     they support.
-   */
-  @Deprecated
-  protected DocValuesType[] getDocValuesTypes() {
-    return DocValuesType.values();
-  }
 
   /** equality for entirety of fieldinfos */
   protected void assertEquals(FieldInfos expected, FieldInfos actual) {

--- a/lucene/test-framework/src/java/org/apache/lucene/index/BaseFieldInfoFormatTestCase.java
+++ b/lucene/test-framework/src/java/org/apache/lucene/index/BaseFieldInfoFormatTestCase.java
@@ -16,6 +16,7 @@
  */
 package org.apache.lucene.index;
 
+import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
@@ -63,6 +64,9 @@ public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTes
     assertFalse(infos2.fieldInfo("field").omitsNorms());
     assertFalse(infos2.fieldInfo("field").hasPayloads());
     assertFalse(infos2.fieldInfo("field").hasVectors());
+    assertEquals(0, infos2.fieldInfo("field").getPointDimensionCount());
+    assertEquals(0, infos2.fieldInfo("field").getVectorDimension());
+    assertFalse(infos2.fieldInfo("field").isSoftDeletesField());
     dir.close();
   }
 
@@ -253,7 +257,12 @@ public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTes
     for (int i = 0; i < numFields; i++) {
       fieldNames.add(TestUtil.randomUnicodeString(random()));
     }
-    FieldInfos.Builder builder = new FieldInfos.Builder(new FieldInfos.FieldNumbers(null));
+
+    String softDeletesField =
+        random().nextBoolean() ? TestUtil.randomUnicodeString(random()) : null;
+    FieldInfos.Builder builder =
+        new FieldInfos.Builder(new FieldInfos.FieldNumbers(softDeletesField));
+
     for (String field : fieldNames) {
       IndexableFieldType fieldType = randomFieldType(random());
       FieldInfo fi = builder.getOrAdd(field);
@@ -271,6 +280,19 @@ public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTes
           fi.setStorePayloads();
         }
       }
+
+      if (fieldType.pointDimensionCount() > 0) {
+        fi.setPointDimensions(
+            fieldType.pointDimensionCount(),
+            fieldType.pointIndexDimensionCount(),
+            fieldType.pointNumBytes());
+      }
+
+      if (fieldType.vectorDimension() > 0) {
+        fi.setVectorDimensionAndSearchStrategy(
+            fieldType.vectorDimension(), fieldType.vectorSearchStrategy());
+      }
+
       addAttributes(fi);
     }
     FieldInfos infos = builder.finish();
@@ -280,11 +302,11 @@ public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTes
     dir.close();
   }
 
-  private final IndexableFieldType randomFieldType(Random r) {
+  private IndexableFieldType randomFieldType(Random r) {
     FieldType type = new FieldType();
 
     if (r.nextBoolean()) {
-      IndexOptions values[] = IndexOptions.values();
+      IndexOptions[] values = IndexOptions.values();
       type.setIndexOptions(values[r.nextInt(values.length)]);
       type.setOmitNorms(r.nextBoolean());
 
@@ -303,6 +325,20 @@ public abstract class BaseFieldInfoFormatTestCase extends BaseIndexFileFormatTes
     if (r.nextBoolean()) {
       DocValuesType[] values = DocValuesType.values();
       type.setDocValuesType(values[r.nextInt(values.length)]);
+    }
+
+    if (r.nextBoolean()) {
+      int dimension = 1 + r.nextInt(PointValues.MAX_DIMENSIONS);
+      int indexDimension = 1 + r.nextInt(Math.min(dimension, PointValues.MAX_INDEX_DIMENSIONS));
+      int dimensionNumBytes = 1 + r.nextInt(PointValues.MAX_NUM_BYTES);
+      type.setDimensions(dimension, indexDimension, dimensionNumBytes);
+    }
+
+    if (r.nextBoolean()) {
+      int dimension = 1 + r.nextInt(VectorValues.MAX_DIMENSIONS);
+      VectorValues.SearchStrategy searchStrategy =
+          RandomPicks.randomFrom(r, VectorValues.SearchStrategy.values());
+      type.setVectorDimensionsAndSearchStrategy(dimension, searchStrategy);
     }
 
     return type;


### PR DESCRIPTION
This commit adds coverage to `BaseFieldInfoFormatTestCase ` for points,
vectors, and the soft deletes field.