### PR TITLE
Benchmark custom

### DIFF
--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/feeds/ReutersContentSource.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/feeds/ReutersContentSource.java
@@ -106,11 +106,18 @@ public class ReutersContentSource extends ContentSource {
     String name = null;
     int inputFilesSize = inputFiles.size();
 
-    /**
-     * synchronized (this) { if (nextFile >= inputFiles.size()) { // exhausted files, start a new
-     * round, unless forever set to false. if (!forever) { throw new NoMoreDataException(); }
-     * nextFile = 0; iteration++; } f = inputFiles.get(nextFile++); name = f.toRealPath() + "_" +
-     * iteration; }*
+    /*
+     * synchronized (this) { 
+     * if (nextFile >= inputFiles.size()) { // exhausted files, start a new round, unless forever set to false. 
+     * if (!forever) { 
+     *    throw new NoMoreDataException(); 
+     * }
+     * nextFile = 0; 
+     * iteration++; 
+     * } 
+     * f = inputFiles.get(nextFile++); 
+     * name = f.toRealPath() + "_" +iteration; 
+     * }*
      */
     if (!threadIndexCreated) {
       createThreadIndex();

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/TaskSequence.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/TaskSequence.java
@@ -334,6 +334,7 @@ public class TaskSequence extends PerfTask {
 
     initTasksArray();
     ParallelTask t[] = runningParallelTasks = new ParallelTask[repetitions * tasks.size()];
+    this.getRunData().getConfig().setNumThreads(t.length);
     // prepare threads
     int index = 0;
     for (int k = 0; k < repetitions; k++) {

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/utils/Config.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/utils/Config.java
@@ -54,6 +54,7 @@ public class Config {
   private HashMap<String, Object> valByRound = new HashMap<>();
   private HashMap<String, String> colForValByRound = new HashMap<>();
   private String algorithmText;
+  private int numThreads = 1;
 
   /**
    * Read both algorithm and config properties.
@@ -111,6 +112,14 @@ public class Config {
     if (Boolean.valueOf(props.getProperty("print.props", DEFAULT_PRINT_PROPS)).booleanValue()) {
       printProps();
     }
+  }
+
+  public void setNumThreads(int numThreads) {
+    this.numThreads = numThreads;
+  }
+
+  public int getNumThreads() {
+    return numThreads;
   }
 
   @SuppressWarnings({"unchecked", "rawtypes"})


### PR DESCRIPTION
# Description

Lucene Benchmark Scaling Problem with Reuters Corpus

While Indexing 1 million documents with reuters21578 (plain text Document derived from reuters21578 corpus), we observed that with higher number of Index threads, the Index throughput does not scale and degrades. Existing implementation with synchronization block allows only one thread to pick up a document/file from list, at any given time – this code is part of getNextDocData() in ReutersContentSource.java. With multiple index threads, this becomes a thread contention bottleneck and does not allow the system CPU resource to be used efficiently.

# Solution
We developed a strategy to distribute total number of files across multiple number of Indexing threads, so that these threads work independently and parallelly.

# Tests

We mainly modified existing getNextDocData(), which is not altering  functionality, hence not added any new test cases.

- Passed existing tests

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
   [ ] I have created a Jira issue and added the issue ID to my pull request title.
 - [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `./gradlew check`.
  [ ] I have added tests for my changes.
  [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
