### PR TITLE
LUCENE-9760: Hunspell: print total memory usage in TestAllDictionarie…

### DIFF
--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestAllDictionaries.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestAllDictionaries.java
@@ -37,6 +37,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -44,6 +45,7 @@ import org.apache.lucene.store.BaseDirectoryWrapper;
 import org.apache.lucene.util.LuceneTestCase;
 import org.apache.lucene.util.LuceneTestCase.SuppressSysoutChecks;
 import org.apache.lucene.util.NamedThreadFactory;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.RamUsageTester;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -147,28 +149,33 @@ public class TestAllDictionaries extends LuceneTestCase {
   }
 
   public void testDictionariesLoadSuccessfully() throws Exception {
+    AtomicLong totalMemory = new AtomicLong();
+    AtomicLong totalWords = new AtomicLong();
     int threads = Runtime.getRuntime().availableProcessors();
     ExecutorService executor =
         Executors.newFixedThreadPool(threads, new NamedThreadFactory("dictCheck-"));
-    try {
-      List<Path> failures = Collections.synchronizedList(new ArrayList<>());
-      Function<Path, Void> process =
-          (Path aff) -> {
-            try {
-              System.out.println(aff + "\t" + memoryUsage(loadDictionary(aff)));
-            } catch (Throwable e) {
-              failures.add(aff);
-              System.err.println("While checking " + aff + ":");
-              e.printStackTrace();
-            }
-            return null;
-          };
+    List<Path> failures = Collections.synchronizedList(new ArrayList<>());
+    Function<Path, Void> process =
+        (Path aff) -> {
+          try {
+            Dictionary dic = loadDictionary(aff);
+            totalMemory.addAndGet(RamUsageTester.sizeOf(dic));
+            totalWords.addAndGet(RamUsageTester.sizeOf(dic.words));
+            System.out.println(aff + "\t" + memoryUsageSummary(dic));
+          } catch (Throwable e) {
+            failures.add(aff);
+            System.err.println("While checking " + aff + ":");
+            e.printStackTrace();
+          }
+          return null;
+        };
 
-      for (Future<?> future :
-          executor.invokeAll(
-              findAllAffixFiles()
-                  .map(aff -> (Callable<?>) () -> process.apply(aff))
-                  .collect(Collectors.toList()))) {
+    List<Callable<Void>> tasks =
+        findAllAffixFiles()
+            .map(aff -> (Callable<Void>) () -> process.apply(aff))
+            .collect(Collectors.toList());
+    try {
+      for (Future<?> future : executor.invokeAll(tasks)) {
         future.get();
       }
 
@@ -181,11 +188,16 @@ public class TestAllDictionaries extends LuceneTestCase {
       }
     } finally {
       executor.shutdown();
-      executor.awaitTermination(1, TimeUnit.MINUTES);
+      assertTrue(executor.awaitTermination(1, TimeUnit.MINUTES));
     }
+
+    System.out.println("Total dictionaries loaded: " + tasks.size());
+    System.out.println("Total memory: " + RamUsageEstimator.humanReadableUnits(totalMemory.get()));
+    System.out.println(
+        "Total memory for word storage: " + RamUsageEstimator.humanReadableUnits(totalWords.get()));
   }
 
-  private static String memoryUsage(Dictionary dic) {
+  private static String memoryUsageSummary(Dictionary dic) {
     return RamUsageTester.humanSizeOf(dic)
         + "\t("
         + ("words=" + RamUsageTester.humanSizeOf(dic.words) + ", ")


### PR DESCRIPTION
…s, cleanup

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

We'd like Hunspell dictionaries not to take too much memory, especially when there's many of them loaded

# Solution

Print the memory usage of all known dictionaries together

# Tests

A test-only change

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
