### PR TITLE
LUCENE-9322:  Add Vectors format to CodecReader accounting methods

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/CodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CodecReader.java
@@ -259,6 +259,11 @@ public abstract class CodecReader extends LeafReader implements Accountable {
       ramBytesUsed += getPointsReader().ramBytesUsed();
     }
 
+    // vectors
+    if (getVectorReader() != null) {
+      ramBytesUsed += getVectorReader().ramBytesUsed();
+    }
+
     return ramBytesUsed;
   }
 
@@ -295,6 +300,11 @@ public abstract class CodecReader extends LeafReader implements Accountable {
       resources.add(Accountables.namedAccountable("points", getPointsReader()));
     }
 
+    // vectors
+    if (getVectorReader() != null) {
+      resources.add(Accountables.namedAccountable("points", getVectorReader()));
+    }
+
     return Collections.unmodifiableList(resources);
   }
 
@@ -328,6 +338,11 @@ public abstract class CodecReader extends LeafReader implements Accountable {
     // points
     if (getPointsReader() != null) {
       getPointsReader().checkIntegrity();
+    }
+
+    // vectors
+    if (getVectorReader() != null) {
+      getVectorReader().checkIntegrity();
     }
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/CodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CodecReader.java
@@ -302,7 +302,7 @@ public abstract class CodecReader extends LeafReader implements Accountable {
 
     // vectors
     if (getVectorReader() != null) {
-      resources.add(Accountables.namedAccountable("points", getVectorReader()));
+      resources.add(Accountables.namedAccountable("vectors", getVectorReader()));
     }
 
     return Collections.unmodifiableList(resources);


### PR DESCRIPTION
Take into account the new Vectors format for methods:

- ramBytesUsed
- getChildResources
- checkIntegrity

This has surfaced after #2331 as there are some test fails when nightly flag is true:

```
./gradlew :lucene:core:test --tests "org.apache.lucene.codecs.lucene90.TestLucene90VectorFormat.testRamBytesUsed" -Ptests.jvms=4 -Ptests.jvmargs=-XX:TieredStopAtLevel=1 -Ptests.seed=38AB1FFD5F1E45F6 -Ptests.nightly=true -Ptests.file.encoding=ISO-8859-1
```