### PR TITLE
LUCENE-9762: FunctionScoreQuery must guard score() called twice

### DIFF
--- a/lucene/queries/src/java/org/apache/lucene/queries/function/FunctionScoreQuery.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/FunctionScoreQuery.java
@@ -234,9 +234,12 @@ public final class FunctionScoreQuery extends Query {
       }
       DoubleValues scores = valueSource.getValues(context, DoubleValuesSource.fromScorer(in));
       return new FilterScorer(in) {
+        int scoresDocId = -1; // remember the last docId we called score() on
         @Override
         public float score() throws IOException {
-          if (scores.advanceExact(docID())) {
+          int docId = docID();
+          if (scoresDocId == docId || scores.advanceExact(docId)) {
+            scoresDocId = docId;
             double factor = scores.doubleValue();
             if (factor >= 0) {
               return (float) (factor * boost);

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/FunctionScoreQuery.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/FunctionScoreQuery.java
@@ -19,7 +19,6 @@ package org.apache.lucene.queries.function;
 
 import java.io.IOException;
 import java.util.Objects;
-
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.BooleanClause;

--- a/lucene/queries/src/java/org/apache/lucene/queries/function/FunctionScoreQuery.java
+++ b/lucene/queries/src/java/org/apache/lucene/queries/function/FunctionScoreQuery.java
@@ -19,6 +19,7 @@ package org.apache.lucene.queries.function;
 
 import java.io.IOException;
 import java.util.Objects;
+
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.BooleanClause;
@@ -235,6 +236,7 @@ public final class FunctionScoreQuery extends Query {
       DoubleValues scores = valueSource.getValues(context, DoubleValuesSource.fromScorer(in));
       return new FilterScorer(in) {
         int scoresDocId = -1; // remember the last docId we called score() on
+
         @Override
         public float score() throws IOException {
           int docId = docID();

--- a/lucene/queries/src/test/org/apache/lucene/queries/function/TestFunctionScoreQuery.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/function/TestFunctionScoreQuery.java
@@ -20,13 +20,16 @@ package org.apache.lucene.queries.function;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
 import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.TextField;
 import org.apache.lucene.expressions.Expression;
 import org.apache.lucene.expressions.SimpleBindings;
 import org.apache.lucene.expressions.js.JavascriptCompiler;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
@@ -35,6 +38,7 @@ import org.apache.lucene.search.DoubleValuesSource;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.PhraseQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryUtils;
 import org.apache.lucene.search.ScoreMode;
@@ -331,5 +335,30 @@ public class TestFunctionScoreQuery extends FunctionTestSetup {
     FunctionScoreQuery fq = new FunctionScoreQuery(innerQ, valueSource);
     fq.createWeight(searcher, inputScoreMode, 1f);
     assertEquals(expectedScoreMode, scoreModeInWeight.get());
+  }
+
+  /**
+   * The FunctionScoreQuery's Scorer score() is going to be called twice for the same doc.
+   */
+  public void testScoreCalledTwice() throws Exception {
+    try (Directory dir = newDirectory()) {
+      IndexWriterConfig conf = newIndexWriterConfig();
+      IndexWriter indexWriter = new IndexWriter(dir, conf);
+      Document doc = new Document();
+      doc.add(new TextField("ExampleText", "periodic function", Field.Store.NO));
+      doc.add(new TextField("ExampleText", "plot of the original function", Field.Store.NO));
+      indexWriter.addDocument(doc);
+      indexWriter.commit();
+      indexWriter.close();
+
+      try (DirectoryReader reader = DirectoryReader.open(dir)) {
+        Query q = new TermQuery(new Term("ExampleText", "function"));
+
+        q = FunctionScoreQuery.boostByQuery(q, new PhraseQuery(1, "ExampleText", "function", "plot"), 2);
+        q = FunctionScoreQuery.boostByValue(q, DoubleValuesSource.SCORES);
+
+        assertEquals(1, new IndexSearcher(reader).search(q, 10).totalHits.value);
+      }
+    }
   }
 }

--- a/lucene/queries/src/test/org/apache/lucene/queries/function/TestFunctionScoreQuery.java
+++ b/lucene/queries/src/test/org/apache/lucene/queries/function/TestFunctionScoreQuery.java
@@ -337,9 +337,7 @@ public class TestFunctionScoreQuery extends FunctionTestSetup {
     assertEquals(expectedScoreMode, scoreModeInWeight.get());
   }
 
-  /**
-   * The FunctionScoreQuery's Scorer score() is going to be called twice for the same doc.
-   */
+  /** The FunctionScoreQuery's Scorer score() is going to be called twice for the same doc. */
   public void testScoreCalledTwice() throws Exception {
     try (Directory dir = newDirectory()) {
       IndexWriterConfig conf = newIndexWriterConfig();
@@ -354,7 +352,9 @@ public class TestFunctionScoreQuery extends FunctionTestSetup {
       try (DirectoryReader reader = DirectoryReader.open(dir)) {
         Query q = new TermQuery(new Term("ExampleText", "function"));
 
-        q = FunctionScoreQuery.boostByQuery(q, new PhraseQuery(1, "ExampleText", "function", "plot"), 2);
+        q =
+            FunctionScoreQuery.boostByQuery(
+                q, new PhraseQuery(1, "ExampleText", "function", "plot"), 2);
         q = FunctionScoreQuery.boostByValue(q, DoubleValuesSource.SCORES);
 
         assertEquals(1, new IndexSearcher(reader).search(q, 10).totalHits.value);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/LUCENE-9762

The score() may be called multiple times. It should take care to call DoubleValues.advanceExact only the first time, or risk faulty behavior including exceptions.

There isn't an 8.8.1 section in the CHANGES.txt on master branch but I can add it into branch_8x and branch_8_8 where eventually it will show up when the RM does a release?  Or I should just add it?