### PR TITLE
LUCENE-9762: DoubleValuesSource.fromQuery bug

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -292,6 +292,10 @@ Bug Fixes
 * LUCENE-9744: NPE on a degenerate query in MinimumShouldMatchIntervalsSource
   $MinimumMatchesIterator.getSubMatches(). (Alan Woodward)
 
+* LUCENE-9762: DoubleValuesSource.fromQuery (also used by FunctionScoreQuery.boostByQuery) could
+  throw an exception when the query implements TwoPhaseIterator and when the score is requested
+  repeatedly. (David Smiley, hossman)
+
 Other
 ---------------------
 (No changes)


### PR DESCRIPTION
When same doc visited twice and when the query is TPI based, an exception can be thrown.  We need to ensure the internal TPI.matches() is never called repeatedly.