### PR TITLE
SOLR-15145: Additional fix for SolrJ back-compat

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/common/cloud/ZkNodeProps.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/ZkNodeProps.java
@@ -125,10 +125,15 @@ public class ZkNodeProps implements JSONWriter.Writable {
   @Override
   public void write(JSONWriter jsonWriter) {
     // don't write out the base_url if we have a node_name
-    if (!STORE_BASE_URL && propMap.containsKey(ZkStateReader.BASE_URL_PROP) && propMap.containsKey(ZkStateReader.NODE_NAME_PROP)) {
-      final Map<String,Object> filtered = new HashMap<>(propMap);
+    if (!STORE_BASE_URL && propMap.containsKey(ZkStateReader.BASE_URL_PROP) && propMap.get(ZkStateReader.NODE_NAME_PROP) != null) {
+      final Map<String, Object> filtered = new HashMap<>(propMap);
       filtered.remove(ZkStateReader.BASE_URL_PROP);
       jsonWriter.write(filtered);
+    } else if (STORE_BASE_URL && propMap.get(ZkStateReader.BASE_URL_PROP) == null && propMap.get(ZkStateReader.NODE_NAME_PROP) != null) {
+      // this is for back-compat with older SolrJ
+      final Map<String, Object> addBaseUrl = new HashMap<>(propMap);
+      addBaseUrl.put(ZkStateReader.BASE_URL_PROP, UrlScheme.INSTANCE.getBaseUrlForNodeName((String)propMap.get(ZkStateReader.NODE_NAME_PROP)));
+      jsonWriter.write(addBaseUrl);
     } else {
       jsonWriter.write(propMap);
     }


### PR DESCRIPTION
Found an additional problem when doing rolling upgrades related to base_url, so pulling this fix over from 8x
