### PR TITLE
LUCENE-9772: Hunspell: CHECKCOMPOUNDCASE shouldn't prohibit dash-sepa…

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/Hunspell.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/Hunspell.java
@@ -317,7 +317,9 @@ public class Hunspell {
 
   private boolean mayBreakIntoCompounds(char[] chars, int offset, int length, int breakPos) {
     if (dictionary.checkCompoundCase) {
-      if (Character.isUpperCase(chars[breakPos - 1]) || Character.isUpperCase(chars[breakPos])) {
+      char a = chars[breakPos - 1];
+      char b = chars[breakPos];
+      if ((Character.isUpperCase(a) || Character.isUpperCase(b)) && a != '-' && b != '-') {
         return false;
       }
     }

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/checkcompoundcase.aff
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/checkcompoundcase.aff
@@ -1,3 +1,4 @@
 # forbid upper case letters at word bounds in compounding
 CHECKCOMPOUNDCASE
+WORDCHARS -
 COMPOUNDFLAG A

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/checkcompoundcase.dic
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/checkcompoundcase.dic
@@ -1,5 +1,6 @@
-4
+5
 foo/A
 Bar/A
 BAZ/A
 -/A
+prefix-/A

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/checkcompoundcase.good
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/checkcompoundcase.good
@@ -3,3 +3,4 @@ foo-Bar
 foo-BAZ
 BAZ-foo
 BAZ-Bar
+prefix-BAZ


### PR DESCRIPTION
…rated uppercase compounds

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

Dutch words like `kandidaat-Kamerlid` weren't allowed

# Solution

Replicate Hunspell's logic of allowing mixed compound case if another char on the border is dash

# Tests

Added to `checkcompoundcase` 

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
