### PR TITLE
LUCENE-9775: Hunspell: make FORCEUCASE work when the first compound w…

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/CheckCompoundPattern.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/CheckCompoundPattern.java
@@ -94,7 +94,7 @@ class CheckCompoundPattern {
   CharsRef expandReplacement(CharsRef word, int breakPos) {
     if (replacement != null && charsMatch(word, breakPos, replacement)) {
       return new CharsRef(
-          word.subSequence(0, breakPos)
+          new String(word.chars, 0, word.offset + breakPos)
               + endChars
               + beginChars
               + word.subSequence(breakPos + replacement.length(), word.length));

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/Hunspell.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/Hunspell.java
@@ -171,6 +171,10 @@ public class Hunspell {
 
   private boolean checkCompounds(CharsRef word, WordCase originalCase, CompoundPart prev) {
     if (prev != null && prev.index > dictionary.compoundMax - 2) return false;
+    if (prev == null && word.offset != 0) {
+      // we check the word's beginning for FORCEUCASE and expect to find it at 0
+      throw new IllegalArgumentException();
+    }
 
     int limit = word.length - dictionary.compoundMin + 1;
     for (int breakPos = dictionary.compoundMin; breakPos < limit; breakPos++) {
@@ -231,7 +235,7 @@ public class Hunspell {
     if (lastRoot != null
         && !dictionary.hasFlag(lastRoot.entryId, dictionary.forbiddenword)
         && !(dictionary.checkCompoundDup && prev.root.equals(lastRoot))
-        && !hasForceUCaseProblem(lastRoot, originalCase)
+        && !hasForceUCaseProblem(lastRoot, originalCase, word.chars)
         && prev.mayCompound(lastRoot, remainingLength, originalCase)) {
       return true;
     }
@@ -240,8 +244,9 @@ public class Hunspell {
     return checkCompounds(tail, originalCase, prev);
   }
 
-  private boolean hasForceUCaseProblem(Root<?> root, WordCase originalCase) {
+  private boolean hasForceUCaseProblem(Root<?> root, WordCase originalCase, char[] wordChars) {
     if (originalCase == WordCase.TITLE || originalCase == WordCase.UPPER) return false;
+    if (originalCase == null && Character.isUpperCase(wordChars[0])) return false;
     return dictionary.hasFlag(root.entryId, dictionary.forceUCase);
   }
 

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/forceucase.dic
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/forceucase.dic
@@ -2,3 +2,4 @@
 foo/C
 bar/C
 baz/CA
+Upper/C

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/forceucase.good
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/forceucase.good
@@ -1,3 +1,4 @@
+Foobaz
 foo
 bar
 baz
@@ -5,3 +6,4 @@ foobar
 Foobaz
 foobazbar
 Foobarbaz
+Upperbaz


### PR DESCRIPTION
…ord is inherently title-case

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

Now it wouldn't work for Dutch `Jupiter`+`straat`=`Jupiterstraat`

# Solution

When the case is non-varied, check the first letter of the whole compound. Make sure the `CharsRef` still holds it.

# Tests

`forceucase` expanded

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
