### PR TITLE
SOLR-15087: Allow restoration to existing collections

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/OverseerCollectionMessageHandler.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/OverseerCollectionMessageHandler.java
@@ -563,7 +563,7 @@ public class OverseerCollectionMessageHandler implements OverseerMessageHandler,
   }
 
 
-  private void modifyCollection(ClusterState clusterState, ZkNodeProps message, @SuppressWarnings({"rawtypes"})NamedList results)
+  void modifyCollection(ClusterState clusterState, ZkNodeProps message, @SuppressWarnings({"rawtypes"})NamedList results)
       throws Exception {
 
     final String collectionName = message.getStr(ZkStateReader.COLLECTION_PROP);

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/RestoreCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/RestoreCmd.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -51,6 +52,7 @@ import org.apache.solr.common.cloud.Slice;
 import org.apache.solr.common.cloud.ZkNodeProps;
 import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.common.params.CollectionAdminParams;
+import org.apache.solr.common.params.CollectionParams;
 import org.apache.solr.common.params.CoreAdminParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.NamedList;
@@ -87,8 +89,8 @@ public class RestoreCmd implements OverseerCollectionMessageHandler.Cmd {
   public void call(ClusterState state, ZkNodeProps message, NamedList results) throws Exception {
     try (RestoreContext restoreContext = new RestoreContext(message, ocmh)) {
       if (state.hasCollection(restoreContext.restoreCollectionName)) {
-        throw new SolrException(ErrorCode.BAD_REQUEST, "Restoration collection [" + restoreContext.restoreCollectionName +
-                "] must be created by the backup process and cannot exist");
+        RestoreOnExistingCollection restoreOnExistingCollection = new RestoreOnExistingCollection(restoreContext);
+        restoreOnExistingCollection.process(restoreContext, results);
       } else {
         RestoreOnANewCollection restoreOnANewCollection = new RestoreOnANewCollection(message, restoreContext.backupCollectionState);
         restoreOnANewCollection.validate(restoreContext.backupCollectionState, restoreContext.nodeList.size());
@@ -194,8 +196,7 @@ public class RestoreCmd implements OverseerCollectionMessageHandler.Cmd {
   /**
    * Restoration 'strategy' that takes responsibility for creating the collection to restore to.
    *
-   * This is currently the only supported 'strategy' for backup restoration.  Though in-place restoration has been
-   * proposed and may be added soon (see SOLR-15087)
+   * @see RestoreOnExistingCollection
    */
   private class RestoreOnANewCollection {
     private int numNrtReplicas;
@@ -549,6 +550,56 @@ public class RestoreCmd implements OverseerCollectionMessageHandler.Cmd {
         ocmh.zkStateReader.aliasesManager
                 .applyModificationAndExportToZk(a -> a.cloneWithCollectionAlias(backupCollectionAlias, backupCollection));
       }
+    }
+  }
+
+  /**
+   * Restoration 'strategy' that ensures the collection being restored to already exists.
+   *
+   * @see RestoreOnANewCollection
+   */
+  private class RestoreOnExistingCollection {
+
+    private RestoreOnExistingCollection(RestoreContext rc) {
+      int numShardsOfBackup = rc.backupCollectionState.getSlices().size();
+      int numShards = rc.zkStateReader.getClusterState().getCollection(rc.restoreCollectionName).getSlices().size();
+
+      if (numShardsOfBackup != numShards) {
+        String msg = String.format(Locale.ROOT, "Unable to restoring since number of shards in backup " +
+                "and specified collection does not match, numShardsOfBackup:%d numShardsOfCollection:%d", numShardsOfBackup, numShards);
+        throw new SolrException(ErrorCode.BAD_REQUEST, msg);
+      }
+    }
+
+    public void process(RestoreContext rc, @SuppressWarnings({"rawtypes"}) NamedList results) throws Exception {
+      ClusterState clusterState = rc.zkStateReader.getClusterState();
+      DocCollection restoreCollection = clusterState.getCollection(rc.restoreCollectionName);
+
+      enableReadOnly(clusterState, restoreCollection);
+      try {
+        requestReplicasToRestore(results, restoreCollection, clusterState, rc.backupProperties,
+                rc.backupPath, rc.repo, rc.shardHandler, rc.asyncId);
+      } finally {
+        disableReadOnly(clusterState, restoreCollection);
+      }
+    }
+
+    private void disableReadOnly(ClusterState clusterState, DocCollection restoreCollection) throws Exception {
+      ZkNodeProps params = new ZkNodeProps(
+              Overseer.QUEUE_OPERATION, CollectionParams.CollectionAction.MODIFYCOLLECTION.toString(),
+              ZkStateReader.COLLECTION_PROP, restoreCollection.getName(),
+              ZkStateReader.READ_ONLY, null
+      );
+      ocmh.modifyCollection(clusterState, params, new NamedList<>());
+    }
+
+    private void enableReadOnly(ClusterState clusterState, DocCollection restoreCollection) throws Exception {
+      ZkNodeProps params = new ZkNodeProps(
+              Overseer.QUEUE_OPERATION, CollectionParams.CollectionAction.MODIFYCOLLECTION.toString(),
+              ZkStateReader.COLLECTION_PROP, restoreCollection.getName(),
+              ZkStateReader.READ_ONLY, "true"
+      );
+      ocmh.modifyCollection(clusterState, params, new NamedList<>());
     }
   }
 }

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/RestoreCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/RestoreCmd.java
@@ -17,26 +17,6 @@
 
 package org.apache.solr.cloud.api.collections;
 
-import java.io.Closeable;
-import java.io.IOException;
-import java.lang.invoke.MethodHandles;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
 import org.apache.solr.cloud.DistributedClusterStateUpdater;
 import org.apache.solr.cloud.Overseer;
 import org.apache.solr.cloud.api.collections.OverseerCollectionMessageHandler.ShardRequestTracker;
@@ -68,6 +48,26 @@ import org.apache.solr.handler.component.ShardHandler;
 import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.apache.solr.common.cloud.ZkStateReader.*;
 import static org.apache.solr.common.params.CollectionParams.CollectionAction.CREATE;

--- a/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/CollectionsHandler.java
@@ -1084,11 +1084,6 @@ public class CollectionsHandler extends RequestHandlerBase implements Permission
       req.getParams().required().check(NAME, COLLECTION_PROP);
 
       final String collectionName = SolrIdentifierValidator.validateCollectionName(req.getParams().get(COLLECTION_PROP));
-      final ClusterState clusterState = h.coreContainer.getZkController().getClusterState();
-      //We always want to restore into an collection name which doesn't  exist yet.
-      if (clusterState.hasCollection(collectionName)) {
-        throw new SolrException(ErrorCode.BAD_REQUEST, "Collection '" + collectionName + "' exists, no action taken.");
-      }
       if (h.coreContainer.getZkController().getZkStateReader().getAliases().hasAlias(collectionName)) {
         throw new SolrException(ErrorCode.BAD_REQUEST, "Collection '" + collectionName + "' is an existing alias, no action taken.");
       }

--- a/solr/core/src/java/org/apache/solr/handler/admin/RestoreCoreOp.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/RestoreCoreOp.java
@@ -65,9 +65,9 @@ class RestoreCoreOp implements CoreAdminHandler.CoreAdminOp {
       // this core must be the only replica in its shard otherwise
       // we cannot guarantee consistency between replicas because when we add data (or restore index) to this replica
       Slice slice = zkController.getClusterState().getCollection(cd.getCollectionName()).getSlice(cd.getShardId());
-      if (slice.getReplicas().size() != 1) {
+      if (slice.getReplicas().size() != 1 && !core.readOnly) {
         throw new SolrException(SolrException.ErrorCode.SERVER_ERROR,
-            "Failed to restore core=" + core.getName() + ", the core must be the only replica in its shard");
+                "Failed to restore core=" + core.getName() + ", the core must be the only replica in its shard or it must be read only");
       }
 
       RestoreCore restoreCore;

--- a/solr/solr-ref-guide/src/collection-management.adoc
+++ b/solr/solr-ref-guide/src/collection-management.adoc
@@ -1360,12 +1360,14 @@ POST http://localhost:8983/v2/collections/backups
 [[restore]]
 == RESTORE: Restore Collection
 
-Restores Solr indexes and associated configurations.
+Restores Solr indexes and associated configurations to a specified collection.
 
 `/admin/collections?action=RESTORE&name=myBackupName&location=/path/to/my/shared/drive&collection=myRestoredCollectionName`
 
-The RESTORE operation will create a collection with the specified name in the collection parameter. You cannot restore into the same collection the backup was taken from. Also the target collection should not be present at the time the API is called as Solr will create it for you.
+The RESTORE operation will replace the content of a collection with files from the specified backup.
 
+If the provided `collection` value matches an existing collection, Solr will use it for restoration, assuming it is compatible (same number of shards, etc.) with the stored backup files.
+If the provided `collection` value doesn't exist, a new collection with that name is created in a way compatible with the stored backup files.
 The collection created will be have the same number of shards and replicas as the original collection, preserving routing information, etc. Optionally, you can override some parameters documented below.
 
 While restoring, if a configset with the same name exists in ZooKeeper then Solr will reuse that, or else it will upload the backed up configset in ZooKeeper and use that.

--- a/solr/test-framework/src/java/org/apache/solr/cloud/api/collections/AbstractIncrementalBackupTest.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/api/collections/AbstractIncrementalBackupTest.java
@@ -23,7 +23,6 @@ import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
-import org.apache.lucene.util.TestUtil;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.embedded.JettySolrRunner;


### PR DESCRIPTION
# Description

As originally implemented, SolrCloud's `restore` operation only supported restoring to collections that didn't yet exist.  This was primarily done out of a fear of race conditions involving writes to the collection.  Since then the support for toggling a per-collection "readonly" property has made restoration to existing collections possible, but unimplemented.

# Solution

This PR adds a codepath to restore to an existing collection, assuming it is compatible with the stored backup files. (A backup with 2 shards can't be restored to a collection with 3, etc.).  If the collection doesn't exist, the restoration process continues to create it as it has done done in the past.

# Tests

Manual testing, and automated tests added to AbstractIncrementalBackupTest.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [x] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
