### PR TITLE
LUCENE-9774: TestDirectIODirectory fails with EINVAL on some filesystems

### DIFF
--- a/lucene/misc/src/java/org/apache/lucene/misc/store/DirectIODirectory.java
+++ b/lucene/misc/src/java/org/apache/lucene/misc/store/DirectIODirectory.java
@@ -206,8 +206,9 @@ public class DirectIODirectory extends FilterDirectory {
      * Creates a new instance of DirectIOIndexOutput for writing index output with direct IO
      * bypassing OS buffer
      *
-     * @throws UnsupportedOperationException if the operating system, file system or JDK does not
-     *     support Direct I/O or a sufficient equivalent.
+     * @throws UnsupportedOperationException if the JDK does not support Direct I/O
+     * @throws IOException if the operating system or filesystem does not support support Direct I/O
+     *     or a sufficient equivalent.
      */
     public DirectIOIndexOutput(Path path, String name, int blockSize, int bufferSize)
         throws IOException {
@@ -300,8 +301,9 @@ public class DirectIODirectory extends FilterDirectory {
      * Creates a new instance of DirectIOIndexInput for reading index input with direct IO bypassing
      * OS buffer
      *
-     * @throws UnsupportedOperationException if the operating system, file system or JDK does not
-     *     support Direct I/O or a sufficient equivalent.
+     * @throws UnsupportedOperationException if the JDK does not support Direct I/O
+     * @throws IOException if the operating system or filesystem does not support support Direct I/O
+     *     or a sufficient equivalent.
      */
     public DirectIOIndexInput(Path path, int blockSize, int bufferSize) throws IOException {
       super("DirectIOIndexInput(path=\"" + path + "\")");


### PR DESCRIPTION
TestDirectIODirectory will currently fail if run on an unsupported filesystem (e.g. tmpfs). Add an "assume" that probes if the filesystem supports Direct I/O.

Also tweak javadocs to indicate correct @throws clauses for the IndexInput and IndexOutput. You'll get an IOException (translated from EINVAL) if the filesystem doesn't support it, not a UOE.

cc: @zacharymorn I think you helped on this Directory, if you have time to review, thank you. I know Uwe is currently busy. Mainly I want the lucene tests passing on my machine again :)