### PR TITLE
SOLR-15162: Add some parameters to make MODIFYCOLLECTION v1 and v2 more similar.   

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -206,6 +206,8 @@ Bug Fixes
 * SOLR-14546: Fix for a relatively hard to hit issue in OverseerTaskProcessor that could lead to out of order execution
   of Collection API tasks competing for a lock (Ilan Ginzburg).
 
+* SOLR-15162: Allow readOnly parameter to be used with v2 modify collection command (Eric Pugh) 
+
 ==================  8.9.0 ==================
 
 Consult the LUCENE_CHANGES.txt file for additional, low level, changes in this release.

--- a/solr/solrj/src/resources/apispec/collections.collection.Commands.modify.json
+++ b/solr/solrj/src/resources/apispec/collections.collection.Commands.modify.json
@@ -6,6 +6,26 @@
     "replicationFactor": {
       "type": "integer",
       "description": "The number of replicas to be created for each shard. Replicas are physical copies of each shard, acting as failover for the shard. Note that changing this value on an existing collection does not automatically add more replicas to the collection. However, it will allow add-replica commands to succeed."
+    },
+    "collection.configName": {
+      "type": "string",
+      "description": "Defines the name of the configuration (which must already be stored in ZooKeeper) to use for this collection."
+    },
+    "rule": {
+      "type": "string",
+      "description": "I am unclear on if this is part of V2 or not.  I see a method called setRule."
+    },
+    "snitch": {
+      "type": "string",
+      "description": "I am unclear on if this is part of V2 or not.  I see a method called setSnitch."
+    },
+    "policy": {
+      "type": "string",
+      "description": "I am unclear on if this is part of V2 or not.  I see a method called setPolicy."
+    },
+    "readOnly": {
+      "type": "boolean",
+      "description": "Setting the readOnly attribute to true puts the collection in read-only mode, in which any index update requests are rejected. Other collection-level actions (e.g., adding / removing / moving replicas) are still available in this mode."
     }
 
   }

--- a/solr/solrj/src/resources/apispec/collections.collection.Commands.modify.json
+++ b/solr/solrj/src/resources/apispec/collections.collection.Commands.modify.json
@@ -7,10 +7,6 @@
       "type": "integer",
       "description": "The number of replicas to be created for each shard. Replicas are physical copies of each shard, acting as failover for the shard. Note that changing this value on an existing collection does not automatically add more replicas to the collection. However, it will allow add-replica commands to succeed."
     },
-    "collection.configName": {
-      "type": "string",
-      "description": "Defines the name of the configuration (which must already be stored in ZooKeeper) to use for this collection."
-    },
     "readOnly": {
       "type": "boolean",
       "description": "Setting the readOnly attribute to true puts the collection in read-only mode, in which any index update requests are rejected. Other collection-level actions (e.g., adding / removing / moving replicas) are still available in this mode."

--- a/solr/solrj/src/resources/apispec/collections.collection.Commands.modify.json
+++ b/solr/solrj/src/resources/apispec/collections.collection.Commands.modify.json
@@ -11,18 +11,6 @@
       "type": "string",
       "description": "Defines the name of the configuration (which must already be stored in ZooKeeper) to use for this collection."
     },
-    "rule": {
-      "type": "string",
-      "description": "I am unclear on if this is part of V2 or not.  I see a method called setRule."
-    },
-    "snitch": {
-      "type": "string",
-      "description": "I am unclear on if this is part of V2 or not.  I see a method called setSnitch."
-    },
-    "policy": {
-      "type": "string",
-      "description": "I am unclear on if this is part of V2 or not.  I see a method called setPolicy."
-    },
     "readOnly": {
       "type": "boolean",
       "description": "Setting the readOnly attribute to true puts the collection in read-only mode, in which any index update requests are rejected. Other collection-level actions (e.g., adding / removing / moving replicas) are still available in this mode."


### PR DESCRIPTION
Not sure on rule, snitch, and policy on if they are still real.

Wish we had docs for rule, snitch, and policy in the Solr Ref Guide page under CREATE, appears to be half fixed.

# Description

Adding some parameters to make V2 match V1.

# Solution

I tested the addition of `readOnly` and it worked great.  I didn't test `rule`, `snitch` or `policy` because I don't understand if they are still real or not, and it was unclear to me from reading the Ref Guide if they existed.   Some cleanup needed there!

# Tests

Manually tested `readOnly` being passed in.

# Checklist

Please review the following and check all that apply:

- [X ] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ X] I have created a Jira issue and added the issue ID to my pull request title.
- [ X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [X ] I have developed this patch against the `master` branch.
- [X ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ X] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
