### PR TITLE
SOLR-15169: SolrPaths.assertPathAllowed normalization problem

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/SolrPaths.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrPaths.java
@@ -71,7 +71,7 @@ public final class SolrPaths {
     }
     if (!path.isAbsolute()) return; // All relative paths are accepted
     if (allowPaths.contains(Paths.get("_ALL_"))) return; // Catch-all path "*"/"_ALL_" will allow all other paths
-    if (allowPaths.stream().noneMatch(p -> path.startsWith(Path.of(p.toString())))) {
+    if (allowPaths.stream().noneMatch(p -> path.startsWith(Path.of(p.toString()).normalize()))) {
       throw new SolrException(SolrException.ErrorCode.BAD_REQUEST,
           "Path " + path + " must be relative to SOLR_HOME, SOLR_DATA_HOME coreRootDirectory. Set system property 'solr.allowPaths' to add other allowed paths.");
     }

--- a/solr/core/src/test/org/apache/solr/core/TestSolrPaths.java
+++ b/solr/core/src/test/org/apache/solr/core/TestSolrPaths.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.core;
+
+import org.apache.solr.SolrTestCase;
+import org.junit.Test;
+
+import java.nio.file.Path;
+import java.util.Set;
+
+public class TestSolrPaths extends SolrTestCase {
+
+    @Test
+    public void testAssertPathAllowed() {
+        SolrPaths.assertPathAllowed(null, null);
+        SolrPaths.assertPathAllowed(Path.of("/a/b"), Set.of(Path.of("/a"), Path.of("/c")));
+        SolrPaths.assertPathAllowed(Path.of("/a/b/../b/d"), Set.of(Path.of("/a/b/../b"), Path.of("/c")));
+    }
+}


### PR DESCRIPTION
<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

In the SolrPaths.assertPathAllowed the normalize() method is only called for pathToAssert and not for the allowPaths elements

# Solution

Calling it for allowPaths elements

# Tests

Unit tests

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `./gradlew check`.
- [x] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
