### PR TITLE
SOLR-13034: RTG sometimes didn't materialize LazyField

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -256,7 +256,12 @@ Optimizations
 Bug Fixes
 ---------------------
 * SOLR-15078: Fix ExpandComponent behavior when expanding on numeric fields to differentiate '0' group from null group (hossman)
+
 * SOLR-15149: Better exception handling for LTR model creation errors (Alessandro Benedetti, Christine Poerschke)
+
+* SOLR-13034: Partial (AKA Atomic) updates could encounter "LazyField" instances in the document
+  cache and not know hot to deal with them when writing the updated doc to the update log.
+  (David Smiley)
 
 
 Other Changes

--- a/solr/core/src/java/org/apache/solr/handler/component/RealTimeGetComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/RealTimeGetComponent.java
@@ -813,8 +813,8 @@ public class RealTimeGetComponent extends SearchComponent
         if ((!sf.hasDocValues() && !sf.stored()) || schema.isCopyFieldTarget(sf)) continue;
       }
       for (Object val: doc.getFieldValues(fname)) {
-        if (val instanceof Field) {
-          Field f = (Field) val;
+        if (val instanceof IndexableField) {
+          IndexableField f = materialize((IndexableField) val);
           if (sf != null) {
             val = sf.getType().toObject(f);   // object or external string?
           } else {

--- a/solr/core/src/java/org/apache/solr/handler/component/RealTimeGetComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/RealTimeGetComponent.java
@@ -814,7 +814,8 @@ public class RealTimeGetComponent extends SearchComponent
       }
       for (Object val: doc.getFieldValues(fname)) {
         if (val instanceof IndexableField) {
-          IndexableField f = materialize((IndexableField) val);
+          IndexableField f = (IndexableField) val;
+          // materialize:
           if (sf != null) {
             val = sf.getType().toObject(f);   // object or external string?
           } else {

--- a/solr/core/src/test/org/apache/solr/update/processor/AtomicUpdatesTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/AtomicUpdatesTest.java
@@ -1005,7 +1005,11 @@ public class AtomicUpdatesTest extends SolrTestCaseJ4 {
 
     assertU(commit());
 
-    assertQ(req("q", "cat:*", "indent", "true"), "//result[@numFound = '2']");
+    // note: by requesting only the id, the other field values will be LazyField instances in the
+    // document cache.
+    // This winds up testing that future fetches by RTG of this doc will handle it properly.
+    // See SOLR-13034
+    assertQ(req("q", "cat:*", "indent", "true", "fl", "id"), "//result[@numFound = '2']");
     assertQ(req("q", "cat:bbb", "indent", "true"), "//result[@numFound = '0']");
 
 


### PR DESCRIPTION
Partial (AKA Atomic) updates could encounter "LazyField" instances in the document
cache and not know hot to deal with them when writing the updated doc to the update log.

https://issues.apache.org/jira/browse/SOLR-13034