### PR TITLE
Fix tests.profile output to not run many many times

### DIFF
--- a/gradle/testing/profiling.gradle
+++ b/gradle/testing/profiling.gradle
@@ -42,16 +42,16 @@ allprojects {
           }
         }
       }
-
-      gradle.buildFinished {
-        if (!recordings.isEmpty()) {
-          ProfileResults.printReport(recordings.getFiles().collect { it.toString() },
-              propertyOrDefault(ProfileResults.MODE_KEY, ProfileResults.MODE_DEFAULT) as String,
-              Integer.parseInt(propertyOrDefault(ProfileResults.STACKSIZE_KEY, ProfileResults.STACKSIZE_DEFAULT)),
-              Integer.parseInt(propertyOrDefault(ProfileResults.COUNT_KEY, ProfileResults.COUNT_DEFAULT)),
-              Boolean.parseBoolean(propertyOrDefault(ProfileResults.LINENUMBERS_KEY, ProfileResults.LINENUMBERS_DEFAULT)))
-        }
-      }
     }
+  }
+}
+
+gradle.buildFinished {
+  if (!recordings.isEmpty()) {
+    ProfileResults.printReport(recordings.getFiles().collect { it.toString() },
+        propertyOrDefault(ProfileResults.MODE_KEY, ProfileResults.MODE_DEFAULT) as String,
+        Integer.parseInt(propertyOrDefault(ProfileResults.STACKSIZE_KEY, ProfileResults.STACKSIZE_DEFAULT)),
+        Integer.parseInt(propertyOrDefault(ProfileResults.COUNT_KEY, ProfileResults.COUNT_DEFAULT)),
+        Boolean.parseBoolean(propertyOrDefault(ProfileResults.LINENUMBERS_KEY, ProfileResults.LINENUMBERS_DEFAULT)))
   }
 }


### PR DESCRIPTION
The profiler should only be invoked once at the end of the build. During refactoring the buildFinished() hook became nested underneath stuff such as allProjects which causes it to run too many times.
