### PR TITLE
LUCENE-9803: Hunspell: don't check second stage suffixes if the first…

### DIFF
--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/Dictionary.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/Dictionary.java
@@ -149,7 +149,7 @@ public class Dictionary {
    * All flags used in affix continuation classes. If an outer affix's flag isn't here, there's no
    * need to do 2-level affix stripping with it.
    */
-  private char[] secondStageAffixFlags;
+  private char[] secondStagePrefixFlags, secondStageSuffixFlags;
 
   char circumfix;
   char keepcase, forceUCase;
@@ -333,7 +333,8 @@ public class Dictionary {
       throws IOException, ParseException {
     TreeMap<String, List<Integer>> prefixes = new TreeMap<>();
     TreeMap<String, List<Integer>> suffixes = new TreeMap<>();
-    Set<Character> stage2Flags = new HashSet<>();
+    Set<Character> prefixContFlags = new HashSet<>();
+    Set<Character> suffixContFlags = new HashSet<>();
     Map<String, Integer> seenPatterns = new HashMap<>();
 
     // zero condition -> 0 ord
@@ -361,9 +362,9 @@ public class Dictionary {
       } else if ("AM".equals(firstWord)) {
         parseMorphAlias(line);
       } else if ("PFX".equals(firstWord)) {
-        parseAffix(prefixes, stage2Flags, line, reader, false, seenPatterns, seenStrips, flags);
+        parseAffix(prefixes, prefixContFlags, line, reader, false, seenPatterns, seenStrips, flags);
       } else if ("SFX".equals(firstWord)) {
-        parseAffix(suffixes, stage2Flags, line, reader, true, seenPatterns, seenStrips, flags);
+        parseAffix(suffixes, suffixContFlags, line, reader, true, seenPatterns, seenStrips, flags);
       } else if (line.equals("COMPLEXPREFIXES")) {
         complexPrefixes =
             true; // 2-stage prefix+1-stage suffix instead of 2-stage suffix+1-stage prefix
@@ -478,7 +479,8 @@ public class Dictionary {
 
     this.prefixes = affixFST(prefixes);
     this.suffixes = affixFST(suffixes);
-    secondStageAffixFlags = toSortedCharArray(stage2Flags);
+    secondStagePrefixFlags = toSortedCharArray(prefixContFlags);
+    secondStageSuffixFlags = toSortedCharArray(suffixContFlags);
 
     int totalChars = 0;
     for (String strip : seenStrips.keySet()) {
@@ -1624,8 +1626,12 @@ public class Dictionary {
     return chars;
   }
 
-  boolean isSecondStageAffix(char flag) {
-    return Arrays.binarySearch(secondStageAffixFlags, flag) >= 0;
+  boolean isSecondStagePrefix(char flag) {
+    return Arrays.binarySearch(secondStagePrefixFlags, flag) >= 0;
+  }
+
+  boolean isSecondStageSuffix(char flag) {
+    return Arrays.binarySearch(secondStageSuffixFlags, flag) >= 0;
   }
 
   /** folds single character (according to LANG if present) */

--- a/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/Stemmer.java
+++ b/lucene/analysis/common/src/java/org/apache/lucene/analysis/hunspell/Stemmer.java
@@ -635,11 +635,11 @@ final class Stemmer {
       if (recursionDepth == 0) {
         if (prefix) {
           prefixId = affix;
-          doPrefix = dictionary.complexPrefixes && dictionary.isSecondStageAffix(flag);
+          doPrefix = dictionary.complexPrefixes && dictionary.isSecondStagePrefix(flag);
           // we took away the first prefix.
           // COMPLEXPREFIXES = true:  combine with a second prefix and another suffix
           // COMPLEXPREFIXES = false: combine with a suffix
-        } else if (!dictionary.complexPrefixes && dictionary.isSecondStageAffix(flag)) {
+        } else if (!dictionary.complexPrefixes && dictionary.isSecondStageSuffix(flag)) {
           doPrefix = false;
           // we took away a suffix.
           // COMPLEXPREFIXES = true: we don't recurse! only one suffix allowed
@@ -652,7 +652,7 @@ final class Stemmer {
         if (prefix && dictionary.complexPrefixes) {
           prefixId = affix;
           // we took away the second prefix: go look for another suffix
-        } else if (prefix || dictionary.complexPrefixes || !dictionary.isSecondStageAffix(flag)) {
+        } else if (prefix || dictionary.complexPrefixes || !dictionary.isSecondStageSuffix(flag)) {
           return true;
         }
         // we took away a prefix, then a suffix: go look for another suffix

--- a/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestPerformance.java
+++ b/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/TestPerformance.java
@@ -77,7 +77,7 @@ public class TestPerformance extends LuceneTestCase {
 
   @Test
   public void fr() throws Exception {
-    checkAnalysisPerformance("fr", 80_000);
+    checkAnalysisPerformance("fr", 100_000);
   }
 
   @Test


### PR DESCRIPTION
<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Lucene or Solr:

* https://issues.apache.org/jira/projects/LUCENE
* https://issues.apache.org/jira/projects/SOLR

You will need to create an account in Jira in order to create an issue.

The title of the PR should reference the Jira issue number in the form:

* LUCENE-####: <short description of problem or changes>
* SOLR-####: <short description of problem or changes>

LUCENE and SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

… stage flag only occurs in prefixes

# Solution

Split prefix and suffix continuation flag indices, check the appropriate one

# Tests

No new tests. `TestPerformance.fr` has ~10% speedup for me.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
