### PR TITLE
SOLR-15130 take 2: Allow per-collection replica placement node sets

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/CreateCollectionCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/CreateCollectionCmd.java
@@ -133,6 +133,7 @@ public class CreateCollectionCmd implements CollApiCmds.CollectionApiCommand {
 
       ZkStateReader zkStateReader = ccc.getZkStateReader();
 
+      // this also creates the collection zk node as a side-effect
       CollectionHandlingUtils.createConfNode(stateManager, configName, collectionName);
 
       Map<String,String> collectionParams = new HashMap<>();

--- a/solr/core/src/java/org/apache/solr/cluster/SolrCollection.java
+++ b/solr/core/src/java/org/apache/solr/cluster/SolrCollection.java
@@ -62,7 +62,7 @@ public interface SolrCollection {
 
     /**
      * <p>Returns the value of a custom property name set on the {@link SolrCollection} or {@code null} when no such
-     * property was set. Properties are set through the Collection API. See for example {@code COLLECTIONPROP} in the Solr reference guide.
+     * property was set. Properties are set through the Collection API. See for example {@code MODIFYCOLLECTION} in the Solr reference guide.
      *
      * <p><b>{@link PlacementPlugin} related note:</b></p>
      * <p>Using custom properties in conjunction with ad hoc {@link PlacementPlugin} code allows customizing placement

--- a/solr/core/src/java/org/apache/solr/cluster/placement/impl/SimpleClusterAbstractionsImpl.java
+++ b/solr/core/src/java/org/apache/solr/cluster/placement/impl/SimpleClusterAbstractionsImpl.java
@@ -27,6 +27,7 @@ import org.apache.solr.cluster.*;
 import org.apache.solr.common.cloud.ClusterState;
 import org.apache.solr.common.cloud.DocCollection;
 import org.apache.solr.common.cloud.Slice;
+import org.apache.solr.common.params.CollectionAdminParams;
 import org.apache.solr.common.util.Pair;
 
 import javax.annotation.Nonnull;
@@ -180,8 +181,17 @@ class SimpleClusterAbstractionsImpl {
     }
 
     @Override
+    public String toString() {
+      return "SolrCollectionImpl{" +
+              "collectionName='" + collectionName + '\'' +
+              ", shards=" + shards.keySet() +
+              ", docCollection=" + docCollection +
+              '}';
+    }
+
+    @Override
     public String getCustomProperty(String customPropertyName) {
-      return docCollection.getStr(customPropertyName);
+      return docCollection.getStr(CollectionAdminParams.PROPERTY_PREFIX + customPropertyName);
     }
   }
 
@@ -291,6 +301,17 @@ class SimpleClusterAbstractionsImpl {
 
     public int hashCode() {
       return Objects.hash(shardName, collection, shardState);
+    }
+
+    @Override
+    public String toString() {
+      return "ShardImpl{" +
+              "shardName='" + shardName + '\'' +
+              ", collection='" + collection.getName() + '\'' +
+              ", shardState=" + shardState +
+              ", replicas=" + replicas.size() +
+              ", leader=" + leader +
+              '}';
     }
   }
 
@@ -431,6 +452,18 @@ class SimpleClusterAbstractionsImpl {
 
     public int hashCode() {
       return Objects.hash(replicaName, coreName, shard, replicaType, replicaState, node);
+    }
+
+    @Override
+    public String toString() {
+      return "ReplicaImpl{" +
+              "replicaName='" + replicaName + '\'' +
+              ", coreName='" + coreName + '\'' +
+              ", shard='" + shard.getShardName() + '\'' +
+              ", replicaType=" + replicaType +
+              ", replicaState=" + replicaState +
+              ", node='" + node + '\'' +
+              '}';
     }
   }
 }

--- a/solr/core/src/test/org/apache/solr/cluster/placement/Builders.java
+++ b/solr/core/src/test/org/apache/solr/cluster/placement/Builders.java
@@ -55,6 +55,7 @@ public class Builders {
         NodeBuilder nodeBuilder = new NodeBuilder().setNodeName("node_" + n); // Default name, can be changed
         nodeBuilder.setTotalDiskGB(10000.0);
         nodeBuilder.setFreeDiskGB(5000.0);
+        nodeBuilder.setCoreCount(0);
         nodeBuilders.add(nodeBuilder);
       }
       return this;

--- a/solr/core/src/test/org/apache/solr/cluster/placement/ClusterAbstractionsForTest.java
+++ b/solr/core/src/test/org/apache/solr/cluster/placement/ClusterAbstractionsForTest.java
@@ -312,5 +312,17 @@ class ClusterAbstractionsForTest {
     public int hashCode() {
       return Objects.hash(replicaName, coreName, shard, replicaType, replicaState, node);
     }
+
+    @Override
+    public String toString() {
+      return "ReplicaImpl{" +
+              "replicaName='" + replicaName + '\'' +
+              ", coreName='" + coreName + '\'' +
+              ", shard='" + shard + '\'' +
+              ", replicaType=" + replicaType +
+              ", replicaState=" + replicaState +
+              ", node=" + node +
+              '}';
+    }
   }
 }

--- a/solr/solr-ref-guide/src/replica-placement-plugins.adoc
+++ b/solr/solr-ref-guide/src/replica-placement-plugins.adoc
@@ -76,6 +76,10 @@ curl -X POST -H 'Content-type: application/json' -d '{
           "withCollections": {
             "A_primary": "A_secondary",
             "B_primary": "B_secondary"
+          },
+          "nodeType": {
+            "collection_A": "searchNode,indexNode",
+            "collection_B": "analyticsNode"
           }
         }
     }}'
@@ -119,9 +123,14 @@ The autoscaling specification in the configuration linked above aimed to do the 
 ** minimize cores per node, or
 ** minimize disk usage.
 
-Additionally, it supports the `withCollection` constraint that enforces the placement of
-co-located collections' replicas on the same nodes, and prevents deletions of collections and
-replicas that would break this constraint.
+It also supports additional per-collection constraints:
+
+* `withCollection` constraint enforces the placement of co-located collections' replicas on the
+same nodes, and prevents deletions of collections and replicas that would break this constraint.
+* `nodeType` constraint limits the nodes eligible for placement to only those that match one or
+more of the specified node types.
+
+See below for more details on these constraints.
 
 Overall strategy of this plugin:
 
@@ -170,6 +179,9 @@ The plugin preserves this co-location by rejecting delete operation of secondary
 removed from the co-located nodes, or the configuration must be changed to remove the
 co-location mapping for the primary collection.
 
+===== `nodeType` constraint
+
+
 ===== Configuration
 This plugin supports the following configuration parameters:
 
@@ -185,10 +197,18 @@ not an option, replicas can still be assigned to nodes with less than this amoun
 Default value is 100.
 
 `withCollection`::
-(optional, map) this property defines additional constraints that primary collections (keys)
+(optional, map) this property defines an additional constraint that primary collections (keys)
 must be located on the same nodes as the secondary collections (values). The plugin will
 assume that the secondary collection replicas are already in place and ignore candidate
 nodes where they are not already present. Default value is none.
+
+`nodeType`::
+(optional, map) this property defines an additional constraint that collections (keys)
+must be located only on the nodes that are labeled with one or more of the matching
+"node type" labels (values in the map are comma-separated labels). Nodes are labeled using the
+`node_type` system property with the value being an arbitrary comma-separated list of labels.
+Correspondingly, the plugin configuration can specify that a particular collection must be placed
+only on the nodes that match at least one of the (comma-separated) labels defined here.
 
 === Example configurations
 This is a simple configuration that uses default values:
@@ -232,6 +252,27 @@ curl -X POST -H 'Content-type: application/json' -d '{
           "withCollection": {
             "A_primary": "Common_secondary",
             "B_primary": "Common_secondary"
+          }
+        }
+    }}'
+  http://localhost:8983/api/cluster/plugin
+----
+
+This configuration defines that collection `collection_A` must be placed only on the nodes with
+the `node_type` system property containing either `searchNode` or `indexNode` (for example, a node
+may be labeled as `-Dnode_type=searchNode,indexNode,uiNode,zkNode`). Similarly, the
+collection `collection_B` must be placed only on the nodes that contain the `analyticsNode` label:
+
+[source,bash]
+----
+curl -X POST -H 'Content-type: application/json' -d '{
+    "add":{
+        "name": ".placement-plugin",
+        "class": "org.apache.solr.cluster.placement.plugins.AffinityPlacementFactory",
+        "config": {
+          "nodeType": {
+            "collection_A": "searchNode,indexNode",
+            "collection_B": "analyticsNode"
           }
         }
     }}'


### PR DESCRIPTION
This PR is based on master, it uses exclusively the plugin configuration properties to configure the placements (there are no traces of the config in collection properties).