### PR TITLE
SOLR-15187: v2-POJO based SolrRequest classes

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/CollectionsAPI.java
+++ b/solr/core/src/java/org/apache/solr/handler/CollectionsAPI.java
@@ -102,8 +102,8 @@ public class CollectionsAPI {
             final Map<String, Object> v1Params = v2Body.toMap(new HashMap<>());
 
             v1Params.put(ACTION, CollectionAction.RESTORE.toLower());
-            if (v2Body.createCollectionParams != null && !v2Body.createCollectionParams.isEmpty()) {
-                final Map<String, Object> createCollParams = (Map<String, Object>) v1Params.remove(V2ApiConstants.CREATE_COLLECTION_KEY);
+            if (v2Body.createCollectionParams != null) {
+                final Map<String, Object> createCollParams = v2Body.createCollectionParams.toMap(new HashMap<>());
                 convertV2CreateCollectionMapToV1ParamMap(createCollParams);
                 v1Params.putAll(createCollParams);
             }

--- a/solr/core/src/test/org/apache/solr/cloud/api/collections/ShardSplitTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/api/collections/ShardSplitTest.java
@@ -633,8 +633,7 @@ public class ShardSplitTest extends BasicDistributedZkTest {
 
     log.info("Starting testSplitShardWithRule");
     String collectionName = "shardSplitWithRule_" + splitMethod.toLower();
-    CollectionAdminRequest.Create createRequest = CollectionAdminRequest.createCollection(collectionName, "conf1", 1, 2)
-        .setRule("shard:*,replica:<2,node:*");
+    CollectionAdminRequest.Create createRequest = CollectionAdminRequest.createCollection(collectionName, "conf1", 1, 2);
 
     CollectionAdminResponse response = createRequest.process(cloudClient);
     assertEquals(0, response.getStatus());

--- a/solr/core/src/test/org/apache/solr/handler/admin/V2CollectionsAPIMappingTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/V2CollectionsAPIMappingTest.java
@@ -216,6 +216,7 @@ public class V2CollectionsAPIMappingTest extends SolrTestCaseJ4 {
                         "'indexBackup': 'copy-files', " +
                         "'commitName': 'someSnapshotName', " +
                         "'incremental': true, " +
+                        "'maxNumBackupPoints': 3, " +
                         "'async': 'requestTrackingId' " +
                         "}}");
 
@@ -228,6 +229,7 @@ public class V2CollectionsAPIMappingTest extends SolrTestCaseJ4 {
         assertEquals("copy-files", v1Params.get(CollectionAdminParams.INDEX_BACKUP_STRATEGY));
         assertEquals("someSnapshotName", v1Params.get(CoreAdminParams.COMMIT_NAME));
         assertEquals(true, v1Params.getPrimitiveBool(CoreAdminParams.BACKUP_INCREMENTAL));
+        assertEquals(3, v1Params.getPrimitiveInt(CoreAdminParams.MAX_NUM_BACKUP_POINTS));
         assertEquals("requestTrackingId", v1Params.get(CommonAdminParams.ASYNC));
     }
 

--- a/solr/core/src/test/org/apache/solr/handler/admin/V2CollectionsAPIMappingTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/V2CollectionsAPIMappingTest.java
@@ -244,7 +244,6 @@ public class V2CollectionsAPIMappingTest extends SolrTestCaseJ4 {
                         "'backupId': 123, " +
                         "'async': 'requestTrackingId', " +
                         "'create-collection': {" +
-                        "     'numShards': 1, " +
                         "     'properties': {'foo': 'bar', 'foo2': 'bar2'}, " +
                         "     'replicationFactor': 3 " +
                         "}" +
@@ -259,10 +258,9 @@ public class V2CollectionsAPIMappingTest extends SolrTestCaseJ4 {
         assertEquals("requestTrackingId", v1Params.get(CommonAdminParams.ASYNC));
         // NOTE: Unlike other v2 APIs that have a nested object for collection-creation params, restore's v1 equivalent
         // for these properties doesn't have a "create-collection." prefix.
-        assertEquals(1, v1Params.getPrimitiveInt(CollectionAdminParams.NUM_SHARDS));
+        assertEquals(3, v1Params.getPrimitiveInt(ZkStateReader.REPLICATION_FACTOR));
         assertEquals("bar", v1Params.get("property.foo"));
         assertEquals("bar2", v1Params.get("property.foo2"));
-        assertEquals(3, v1Params.getPrimitiveInt(ZkStateReader.REPLICATION_FACTOR));
     }
 
     private SolrParams captureConvertedV1Params(String path, String method, String v2RequestBody) throws Exception {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/beans/AsyncPayloadBase.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/beans/AsyncPayloadBase.java
@@ -19,21 +19,8 @@ package org.apache.solr.client.solrj.request.beans;
 import org.apache.solr.common.annotation.JsonProperty;
 import org.apache.solr.common.util.ReflectMapWriter;
 
-import java.util.HashMap;
-import java.util.Map;
+public class AsyncPayloadBase implements ReflectMapWriter {
 
-public class SetAliasPropertyPayload implements ReflectMapWriter {
-
-    public SetAliasPropertyPayload() {
-        this.properties = new HashMap<>();
-    }
-
-    @JsonProperty(required = true)
-    public String name;
-
-    @JsonProperty
-    public String async;
-
-    @JsonProperty
-    public Map<String, Object> properties;
+  @JsonProperty
+  public String async;
 }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/beans/BackupCollectionPayload.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/beans/BackupCollectionPayload.java
@@ -24,7 +24,7 @@ import org.apache.solr.common.util.ReflectMapWriter;
  *
  * Analogous to the request parameters for v1 /admin/collections?action=BACKUP API.
  */
-public class BackupCollectionPayload implements ReflectMapWriter {
+public class BackupCollectionPayload extends AsyncPayloadBase implements ReflectMapWriter {
     @JsonProperty(required = true)
     public String collection;
 
@@ -51,7 +51,4 @@ public class BackupCollectionPayload implements ReflectMapWriter {
 
     @JsonProperty
     public Integer maxNumBackupPoints;
-
-    @JsonProperty
-    public String async;
 }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/beans/BackupCollectionPayload.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/beans/BackupCollectionPayload.java
@@ -50,5 +50,8 @@ public class BackupCollectionPayload implements ReflectMapWriter {
     public Boolean incremental;
 
     @JsonProperty
+    public Integer maxNumBackupPoints;
+
+    @JsonProperty
     public String async;
 }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/beans/CommonCreateCollectionPayloadBase.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/beans/CommonCreateCollectionPayloadBase.java
@@ -20,20 +20,42 @@ import org.apache.solr.common.annotation.JsonProperty;
 import org.apache.solr.common.util.ReflectMapWriter;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
-public class SetAliasPropertyPayload implements ReflectMapWriter {
+/**
+ * Collection creation parameters shared by all APIs that create a collection.
+ *
+ * While collection creation has its own dedicated API it also occurs in the process of several other API commands (e.g.
+ * "restore-backup").  This class defines a base class with only these shared parameters to enable reuse.
+ */
+public class CommonCreateCollectionPayloadBase implements ReflectMapWriter {
 
-    public SetAliasPropertyPayload() {
-        this.properties = new HashMap<>();
-    }
+  public CommonCreateCollectionPayloadBase() {
+    this.properties = new HashMap<>();
+  }
 
-    @JsonProperty(required = true)
-    public String name;
+  @JsonProperty
+  public String config;
 
-    @JsonProperty
-    public String async;
+  @JsonProperty
+  public Integer replicationFactor;
 
-    @JsonProperty
-    public Map<String, Object> properties;
+  @JsonProperty
+  public Integer nrtReplicas;
+
+  @JsonProperty
+  public Integer tlogReplicas;
+
+  @JsonProperty
+  public Integer pullReplicas;
+
+  @JsonProperty
+  public List<String> nodeSet;
+
+  @JsonProperty
+  public Boolean shuffleNodes;
+
+  @JsonProperty
+  public Map<String, Object> properties;
 }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/beans/CreateAliasPayload.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/beans/CreateAliasPayload.java
@@ -24,7 +24,12 @@ import java.util.Map;
 
 import static org.apache.solr.client.solrj.request.beans.V2ApiConstants.CREATE_COLLECTION_KEY;
 
-public class CreateAliasPayload implements ReflectMapWriter {
+public class CreateAliasPayload extends AsyncPayloadBase implements ReflectMapWriter {
+
+    public CreateAliasPayload() {
+        this.router = new AliasRouter();
+    }
+
     @JsonProperty(required = true)
     public String name;
 
@@ -39,9 +44,6 @@ public class CreateAliasPayload implements ReflectMapWriter {
 
     @JsonProperty(CREATE_COLLECTION_KEY)
     public Map<String, Object> createCollectionParams;
-
-    @JsonProperty
-    public String async;
 
     public static class AliasRouter implements ReflectMapWriter {
         @JsonProperty(required = true)

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/beans/CreatePayload.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/beans/CreatePayload.java
@@ -19,15 +19,18 @@ package org.apache.solr.client.solrj.request.beans;
 import org.apache.solr.common.annotation.JsonProperty;
 import org.apache.solr.common.util.ReflectMapWriter;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class CreatePayload implements ReflectMapWriter {
+public class CreatePayload extends CommonCreateCollectionPayloadBase implements ReflectMapWriter {
+    public CreatePayload() {
+        super();
+        this.router = new HashMap<>();
+    }
+
     @JsonProperty(required = true)
     public String name;
-
-    @JsonProperty
-    public String config;
 
     @JsonProperty
     public Map<String, Object> router;
@@ -39,27 +42,6 @@ public class CreatePayload implements ReflectMapWriter {
     public String shards;
 
     @JsonProperty
-    public Integer replicationFactor;
-
-    @JsonProperty
-    public Integer nrtReplicas;
-
-    @JsonProperty
-    public Integer tlogReplicas;
-
-    @JsonProperty
-    public Integer pullReplicas;
-
-    @JsonProperty
-    public List<String> nodeSet;
-
-    @JsonProperty
-    public Boolean shuffleNodes;
-
-    @JsonProperty
-    public Map<String, Object> properties;
-
-    @JsonProperty
     public String async;
 
     @JsonProperty
@@ -67,4 +49,7 @@ public class CreatePayload implements ReflectMapWriter {
 
     @JsonProperty
     public Boolean perReplicaState;
+
+    @JsonProperty
+    public String alias;
 }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/beans/RestoreCollectionPayload.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/beans/RestoreCollectionPayload.java
@@ -28,7 +28,11 @@ import static org.apache.solr.client.solrj.request.beans.V2ApiConstants.CREATE_C
  *
  * Analogous to the request parameters for v1 /admin/collections?action=RESTORE API.
  */
-public class RestoreCollectionPayload implements ReflectMapWriter {
+public class RestoreCollectionPayload extends AsyncPayloadBase implements ReflectMapWriter {
+
+    public RestoreCollectionPayload() {
+        this.createCollectionParams = new CommonCreateCollectionPayloadBase();
+    }
 
     @JsonProperty(required = true)
     public String collection;
@@ -46,8 +50,5 @@ public class RestoreCollectionPayload implements ReflectMapWriter {
     public Integer backupId;
 
     @JsonProperty(CREATE_COLLECTION_KEY)
-    public Map<String, Object> createCollectionParams;
-
-    @JsonProperty
-    public String async;
+    public CommonCreateCollectionPayloadBase createCollectionParams;
 }


### PR DESCRIPTION
# Description

The POJOs used for serialization/deserialization by some V2 APIs have a lot of duplication with the existing SolrRequest objects for those APIs.

# Solution

Since they share the same fields, SolrRequest objects can be implemented using their v2-POJO counterparts.

# Tests

None, yet.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [x] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) as appropriate (for Solr changes only).
