### PR TITLE
LUCENE-9639: Implements SimpleTextVectorReader#ramBytesUsed

### DIFF
--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextVectorReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextVectorReader.java
@@ -37,7 +37,11 @@ import org.apache.lucene.store.BufferedChecksumIndexInput;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
-import org.apache.lucene.util.*;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefBuilder;
+import org.apache.lucene.util.IOUtils;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.apache.lucene.util.StringHelper;
 
 /**
  * Reads vector values from a simple text format. All vectors are read up front and cached in RAM in

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextVectorReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextVectorReader.java
@@ -37,10 +37,7 @@ import org.apache.lucene.store.BufferedChecksumIndexInput;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
-import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.BytesRefBuilder;
-import org.apache.lucene.util.IOUtils;
-import org.apache.lucene.util.StringHelper;
+import org.apache.lucene.util.*;
 
 /**
  * Reads vector values from a simple text format. All vectors are read up front and cached in RAM in
@@ -49,6 +46,10 @@ import org.apache.lucene.util.StringHelper;
  * @lucene.experimental
  */
 public class SimpleTextVectorReader extends VectorReader {
+  // shallowSizeOfInstance for fieldEntries map is included in ramBytesUsed() calculation
+  private static final long BASE_RAM_BYTES_USED =
+      RamUsageEstimator.shallowSizeOfInstance(SimpleTextVectorReader.class)
+          + RamUsageEstimator.shallowSizeOfInstance(BytesRef.class);
 
   private static final BytesRef EMPTY = new BytesRef("");
 
@@ -174,7 +175,16 @@ public class SimpleTextVectorReader extends VectorReader {
 
   @Override
   public long ramBytesUsed() {
-    return 0;
+    // mirror implementation of Lucene90VectorReader#ramBytesUsed
+    long totalBytes = BASE_RAM_BYTES_USED;
+    totalBytes += RamUsageEstimator.sizeOf(scratch.bytes());
+    totalBytes +=
+        RamUsageEstimator.sizeOfMap(
+            fieldEntries, RamUsageEstimator.shallowSizeOfInstance(FieldEntry.class));
+    for (FieldEntry entry : fieldEntries.values()) {
+      totalBytes += RamUsageEstimator.sizeOf(entry.ordToDoc);
+    }
+    return totalBytes;
   }
 
   @Override


### PR DESCRIPTION
# Description

Fix nightly test failure by implementing  SimpleTextVectorReader#ramBytesUsed

# Tests
Passed nightly tests in `TestSimpleTextVectorFormat`
```
xichen@Xis-MacBook-Pro lucene-solr % ./gradlew  :lucene:codecs:test --tests="org.apache.lucene.codecs.simpletext.TestSimpleTextVectorFormat" -Ptests.nightly=true

> Task :randomizationInfo
Running tests with randomization seed: tests.seed=7B222A36847DE944

> Task :lucene:codecs:test
:lucene:codecs:test (SUCCESS): 40 test(s), 1 skipped
The slowest tests (exceeding 500 ms) during this run:
   5.71s TestSimpleTextVectorFormat.testRamBytesUsed (:lucene:codecs)

BUILD SUCCESSFUL in 12s
16 actionable tasks: 9 executed, 7 up-to-date
```

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `master` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
