### PR TITLE
SOLR-15161: Lets not encourage users to hack mime types on JSON responses.

### DIFF
--- a/solr/contrib/prometheus-exporter/src/test-files/solr/collection1/conf/solrconfig.xml
+++ b/solr/contrib/prometheus-exporter/src/test-files/solr/collection1/conf/solrconfig.xml
@@ -221,12 +221,4 @@
     <processor class="solr.RunUpdateProcessorFactory"/>
   </updateRequestProcessorChain>
 
-  <queryResponseWriter name="json" class="solr.JSONResponseWriter">
-    <!-- For the purposes of the tutorial, JSON responses are written as
-     plain text so that they are easy to read in *any* browser.
-     If you expect a MIME type of "application/json" just remove this override.
-    -->
-    <str name="content-type">text/plain; charset=UTF-8</str>
-  </queryResponseWriter>
-
 </config>

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-implicitproperties.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-implicitproperties.xml
@@ -66,11 +66,4 @@
 
   </requestHandler>
 
-  <queryResponseWriter name="json" class="solr.JSONResponseWriter">
-    <!-- For the purposes of the tutorial, JSON responses are written as
-     plain text so that they are easy to read in *any* browser.
-     If you expect a MIME type of "application/json" just remove this override.
-    -->
-    <str name="content-type">text/plain; charset=UTF-8</str>
-  </queryResponseWriter>
 </config>

--- a/solr/server/solr/configsets/sample_techproducts_configs/conf/solrconfig.xml
+++ b/solr/server/solr/configsets/sample_techproducts_configs/conf/solrconfig.xml
@@ -1331,16 +1331,6 @@
      <queryResponseWriter name="schema.xml" class="solr.SchemaXmlResponseWriter"/>
     -->
 
-  <!-- Overriding the content-type of the response writer.
-   -->
-  <queryResponseWriter name="json" class="solr.JSONResponseWriter">
-     <!-- For the purposes of the tutorial, JSON responses are written as
-      plain text so that they are easy to read in *any* browser.
-      If you expect a MIME type of "application/json" just remove this override.
-     -->
-    <str name="content-type">text/plain; charset=UTF-8</str>
-  </queryResponseWriter>
-
   <!-- XSLT response writer transforms the XML output by any xslt file found
        in Solr's conf/xslt directory.  Changes to xslt files are checked
        every xsltCacheLifetimeSeconds.  This is part of the Scripting contrib module.

--- a/solr/solr-ref-guide/src/response-writers.adoc
+++ b/solr/solr-ref-guide/src/response-writers.adoc
@@ -87,6 +87,9 @@ The default mime type for the JSON writer is `application/json`, however this ca
 </queryResponseWriter>
 ----
 
+WARNING: If you using the JSON formatted response with JSONP to query across boundaries, having Solr respond with `text/plain` mime type when the
+browser expects `application/json` will trigger the browser to block the request.
+
 === JSON-Specific Parameters
 
 ==== json.nl


### PR DESCRIPTION
# Description

Browsers now care if you are doing a JSONP call and they expect application/json, and block any text/plain mime type response.

In Quepid we communicate the API command to update your JSONResponseWriter during your setup process, but it's still very confusing.  It was a "cool hack" back when we first used it, but 10 years later, it's causing issues.

# Solution
Remove hack, and add warning in the docs if you choose to do it.

# Tests

Reran tests.

# Checklist

Please review the following and check all that apply:

- [X ] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ X] I have created a Jira issue and added the issue ID to my pull request title.
- [ X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ X] I have developed this patch against the `master` branch.
- [ X] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ X] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
