### PR TITLE
SOLR-14928: add exponential backoff for distributed cluster state updates

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/CollectionHandlingUtils.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/CollectionHandlingUtils.java
@@ -111,7 +111,7 @@ public class CollectionHandlingUtils {
       DocCollection.PER_REPLICA_STATE, null,
       ZkStateReader.PULL_REPLICAS, "0"));
 
-  protected static final Random RANDOM;
+  public static final Random RANDOM;
   static {
     // We try to make things reproducible in the context of our tests by initializing the random instance
     // based on the current seed


### PR DESCRIPTION
add exponential backoff wait time when Compare And Swap fails in distributed cluster state update due to concurrent update
