### PR TITLE
SOLR-15205: don't mention (deprecated) CloudSolrClient.setIdField in javadocs

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/BaseCloudSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/BaseCloudSolrClient.java
@@ -91,6 +91,12 @@ import org.slf4j.MDC;
 import static org.apache.solr.common.params.CommonParams.ADMIN_PATHS;
 import static org.apache.solr.common.params.CommonParams.ID;
 
+/**
+ * If you don't call the {@link #setIdField(String)} method and
+ * if your collection's document router has no route field then
+ * this class assumes the id field for your documents is called
+ * 'id'.
+ */
 public abstract class BaseCloudSolrClient extends SolrClient {
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
@@ -32,10 +32,6 @@ import org.apache.solr.common.SolrException;
  * Solr endpoints for SolrCloud collections, and then use the
  * {@link LBHttp2SolrClient} to issue requests.
  *
- * This class assumes the id field for your documents is called
- * 'id' - if this is not the case, you must set the right name
- * with {@link #setIdField(String)}.
- *
  * @lucene.experimental
  * @since solr 8.0
  */

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudHttp2SolrClient.java
@@ -32,6 +32,8 @@ import org.apache.solr.common.SolrException;
  * Solr endpoints for SolrCloud collections, and then use the
  * {@link LBHttp2SolrClient} to issue requests.
  *
+ * {@inheritDoc}
+ *
  * @lucene.experimental
  * @since solr 8.0
  */

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudSolrClient.java
@@ -38,10 +38,6 @@ import org.apache.solr.common.util.NamedList;
  * Instances of this class communicate with Zookeeper to discover
  * Solr endpoints for SolrCloud collections, and then use the 
  * {@link LBHttpSolrClient} to issue requests.
- * 
- * This class assumes the id field for your documents is called
- * 'id' - if this is not the case, you must set the right name
- * with {@link #setIdField(String)}.
  */
 @SuppressWarnings("serial")
 public class CloudSolrClient extends BaseCloudSolrClient {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudSolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/CloudSolrClient.java
@@ -38,6 +38,8 @@ import org.apache.solr.common.util.NamedList;
  * Instances of this class communicate with Zookeeper to discover
  * Solr endpoints for SolrCloud collections, and then use the 
  * {@link LBHttpSolrClient} to issue requests.
+ *
+ * {@inheritDoc}
  */
 @SuppressWarnings("serial")
 public class CloudSolrClient extends BaseCloudSolrClient {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15205

deprecation illustration: https://github.com/apache/lucene-solr/blob/releases/lucene-solr%2F8.7.0/solr/solrj/src/java/org/apache/solr/client/solrj/impl/BaseCloudSolrClient.java#L297-L306