### PR TITLE
SOLR-15212: Update Ref Guide URLs for new Solr TLP

### DIFF
--- a/solr/solr-ref-guide/build.gradle
+++ b/solr/solr-ref-guide/build.gradle
@@ -107,7 +107,7 @@ ext {
     // the "MAJOR.MINOR" version of solr this guide is about (guides aren't specific to BUGFIX releases)
     // So on 'branch_9_9' where 'version' may be 9.9.0, 9.9.1, 9.9.9, etc..;  solrDocsVersion = 9.9
     solrDocsVersion = "${version}".replaceAll(/^(\d+\.\d+)(|\..*)$/, "\$1")
-    
+
     // the "MAJOR_MINOR" version as a path for publishing the guide
     // So on 'branch_9_9' where solrDocsVersion = 9.9; solrGuideVersionPath => 9_9
     solrGuideVersionPath = "${solrDocsVersion}".replaceAll(/^(\d+)\.(\d+)$/, "\$1_\$2")
@@ -120,7 +120,7 @@ ext {
          path: 'html-site',
          desc: 'HTML Site for publishing to the Solr website',
          props: [
-            htmlSolrJavadocs: "https://lucene.apache.org/solr/${solrGuideVersionPath}_0/",
+            htmlSolrJavadocs: "https://solr.apache.org/${solrGuideVersionPath}_0/",
             htmlLuceneJavadocs: "https://lucene.apache.org/core/${solrGuideVersionPath}_0/"
         ]
     ]
@@ -128,7 +128,7 @@ ext {
         [name: 'LocalJavadocLinksSite',
          path: 'local-jdoc-links-site',
          desc: 'Local Site for checking javadoc links',
-         
+
          // NOTE: extra '../' because we'll in a sub-dir of buildDir that will be built later...
          props: [
             htmlSolrJavadocs : 'link:../' + buildDir.toPath().relativize(project(':solr:documentation').docroot.toPath()).toString().replace(File.separator, '/'),
@@ -143,12 +143,12 @@ ext {
     final def htmlDir = file("${buildDir}/${details.path}")
     final def extraProps = details.props.clone()
     extraProps.htmlOutDir = "../${details.path}"
-    
+
     task "prepare${details.name}Sources"(type: PrepareSources) {
         outDir contentDir
         props extraProps
     }
-    
+
     task "build${details.name}"(type: com.github.jrubygradle.JRubyExec) {
         dependsOn "prepare${details.name}Sources"
         group "Documentation"
@@ -179,21 +179,21 @@ ext {
 // Hook in our dependency on all top level documentation in order to check local javadoc links
 checkLocalJavadocLinksSite.dependsOn ':documentation'
 
-// Hook up custom tasks with standard tasks. 
+// Hook up custom tasks with standard tasks.
 check.dependsOn checkLocalJavadocLinksSite, checkSite
 
 // Hook site building to assemble.
-assemble.dependsOn buildSite 
+assemble.dependsOn buildSite
 
 abstract class PrepareSources extends DefaultTask {
-    
+
     /** Original Source files we'll be syncing <b>FROM</b> */
     @InputDirectory
     public File getSrcDir() {
         return getProject().file("src")
     }
 
-    /** 
+    /**
      * Where we sync the source files <b>TO</b>
      */
     public void setOutDir(File outDir) {
@@ -237,19 +237,19 @@ abstract class PrepareSources extends DefaultTask {
         final Project p = getProject();
         dependsOn(p.getConfigurations().getByName('depVer'))
         dependsOn(p.getTasksByName('classes', false))
-        
+
     }
 
     @TaskAction
     public void doCopy() {
         final Project p = getProject();
         final Configuration depVer = p.getConfigurations().getByName('depVer');
-        
+
         // start with any task (instance) specific props.
         final def props = getProps().clone();
         // then add/override with anystandard props that should alwasy be used
         getStandardProps().each { k, v -> props[k] = v };
-        
+
         // These properties have to be resolved after the configuration phase is complete
         // (palantir's constraint) so we can't use them as input for caches. But as this task
         // depends on the configuration, it's used correctly
@@ -263,22 +263,22 @@ abstract class PrepareSources extends DefaultTask {
         ].each { prop, depGroup, depId ->
             props[prop] = p.getVersion(depGroup, depId, depVer)
         }
-        
+
         final File intoDir = this.outDir;
-        
+
         // Emit info about properties for clarity.
         logger.lifecycle('Syncing source files to {} using props:\n{}',
                          intoDir, props.collect({ k, v -> "  ${k} -> ${v}" }).join('\n'))
-        
+
         // Escape all the properties, so they can be inserted into YAML templates.
         final def escapedProps = props.collectEntries{k, v -> [k, v.replace("'","''")]}
-        
+
         final WorkResult syncResult = p.sync({ copySpec ->
             copySpec.setFilteringCharset('UTF-8');
-            copySpec.from(getSrcDir(), { raw -> 
+            copySpec.from(getSrcDir(), { raw ->
                 raw.exclude('**/*.template')
             })
-            
+
             copySpec.from(getSrcDir(), { templated ->
                 templated.include('**/*.template')
                 templated.rename('(.+)\\.template', '$1')

--- a/solr/solr-ref-guide/src/_config.yml.template
+++ b/solr/solr-ref-guide/src/_config.yml.template
@@ -54,7 +54,7 @@ defaults:
       search: true
 
 # needed for sitemap.xml
-url: https://lucene.apache.org/solr/guide/
+url: https://solr.apache.org/guide/
 
 # Asciidoc settings - disabled so we can use asciidoctor instead
 asciidoc: {}

--- a/solr/solr-ref-guide/src/_includes/sidebar.html
+++ b/solr/solr-ref-guide/src/_includes/sidebar.html
@@ -4,7 +4,7 @@
   {% if "" != site.solr-attributes.solr-guide-draft-status %}
   <p class="draft-notice">
     This is an unofficial DRAFT of the Guide for {{ site.solr-attributes.solr-docs-version }}.
-    <a href="https://lucene.apache.org/solr/guide/">Official releases are available from the Solr website</a>.
+    <a href="https://solr.apache.org/guide/">Official releases are available from the Solr website</a>.
   </p>
   {% endif %}
 

--- a/solr/solr-ref-guide/src/_includes/topnav.html
+++ b/solr/solr-ref-guide/src/_includes/topnav.html
@@ -11,13 +11,13 @@
         <div class="collapse navbar-collapse justify-content-end" id="bs-example-navbar-collapse-1">
             <ul class="nav navbar-nav navbar-right">
                 <!-- Link to Solr website -->
-                <li><a href="https://lucene.apache.org/solr/" target="_blank">Solr Website</a></li>
+                <li><a href="https://solr.apache.org/" target="_blank">Solr Website</a></li>
                 <!-- Other Guide Formats dropdown -->
                 <li class="dropdown">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">Other Formats<b class="caret"></b></a>
                     <ul class="dropdown-menu">
                        <li><a href="https://archive.apache.org/dist/lucene/solr/ref-guide/" target="_blank">Archived PDFs</a></li>
-                       <li><a href="https://lucene.apache.org/solr/guide/" target="_blank">Other Versions Online</a></li>
+                       <li><a href="https://solr.apache.org/guide/" target="_blank">Other Versions Online</a></li>
                     </ul>
                 </li>
                 <!-- Solr Resources dropdown -->
@@ -25,8 +25,8 @@
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">Solr Resources<b class="caret"></b></a>
                     <ul class="dropdown-menu">
                        <li><a href="{{site.solr-attributes.solr-javadocs}}/solr-core/index.html" target="_blank">Solr Javadocs</a></li>
-                       <li><a href="https://lucene.apache.org/solr/community.html#version-control" target="_blank">Lucene/Solr Source Code</a></li>
-                       <li><a href="https://lucene.apache.org/solr/community.html" target="_blank">Solr Community Links</a></li>
+                       <li><a href="https://solr.apache.org/community.html#version-control" target="_blank">Lucene/Solr Source Code</a></li>
+                       <li><a href="https://solr.apache.org/community.html" target="_blank">Solr Community Links</a></li>
                     </ul>
                 </li>
 

--- a/solr/solr-ref-guide/src/about-this-guide.adoc
+++ b/solr/solr-ref-guide/src/about-this-guide.adoc
@@ -18,7 +18,7 @@
 
 This guide describes all of the important features and functions of Apache Solr.
 
-Solr is free to download from http://lucene.apache.org/solr/.
+Solr is free to download from http://solr.apache.org/.
 
 Designed to provide high-level documentation, this guide is intended to be more encyclopedic and less of a cookbook. It is structured to address a broad spectrum of needs, ranging from new developers getting started to well-experienced developers extending their application or troubleshooting. It will be of use at any point in the application life cycle, for whenever you need authoritative information about Solr.
 

--- a/solr/solr-ref-guide/src/further-assistance.adoc
+++ b/solr/solr-ref-guide/src/further-assistance.adoc
@@ -18,4 +18,4 @@
 
 There is a very active user community around Solr and Lucene. The solr-user mailing list, and #solr IRC channel are both great resources for asking questions.
 
-To view the mailing list archives, subscribe to the list, or join the IRC channel, please see https://lucene.apache.org/solr/community.html.
+To view the mailing list archives, subscribe to the list, or join the IRC channel, please see https://solr.apache.org/community.html.

--- a/solr/solr-ref-guide/src/index.adoc
+++ b/solr/solr-ref-guide/src/index.adoc
@@ -54,7 +54,7 @@ Solr is the fast open source search platform built on Apache Lucene(TM) that pro
 This Reference Guide is the official Solr documentation, written and published by Lucene/Solr committers.
 
 ++++
-<p><a class="btn btn-home btn-lg" href="https://lucene.apache.org/solr/downloads.html" role="button">Download Solr</a></p>
+<p><a class="btn btn-home btn-lg" href="https://solr.apache.org/downloads.html" role="button">Download Solr</a></p>
 ++++
 ****
 

--- a/solr/solr-ref-guide/src/installing-solr.adoc
+++ b/solr/solr-ref-guide/src/installing-solr.adoc
@@ -23,7 +23,7 @@ Please be sure to review the <<solr-system-requirements.adoc#,Solr System Requir
 
 == Available Solr Packages
 
-Solr is available from the Solr website. Download the latest release https://lucene.apache.org/solr/downloads.html.
+Solr is available from the Solr website. Download the latest release https://solr.apache.org/downloads.html.
 
 There are three separate packages:
 

--- a/solr/solr-ref-guide/src/major-changes-in-solr-9.adoc
+++ b/solr/solr-ref-guide/src/major-changes-in-solr-9.adoc
@@ -159,7 +159,7 @@ escaping because it's inconsistent with the rest of Solr and was limiting.  This
 older format and no longer supports migrating collections from the older format to the current format (previously known
 as stateFormat=2).
 Upgrade is to be done using Collection API MIGRATESTATEFORMAT action using a previous version of Solr.
-See for example https://lucene.apache.org/solr/guide/8_5/cluster-node-management.html#migratestateforma[Solr 8.5 Ref Guide].
+See for example https://solr.apache.org/guide/8_8/cluster-node-management.html#migratestateforma[Solr 8.8 Ref Guide].
 // Can't link directly to .adoc file, need to link to 8.something ref guide as MIGRATESTATEFORMAT no longer exists in 9.0.
 
 === Rolling Upgrades with Solr 9

--- a/solr/solr-ref-guide/src/meta-docs/asciidoc-syntax.adoc
+++ b/solr/solr-ref-guide/src/meta-docs/asciidoc-syntax.adoc
@@ -133,7 +133,7 @@ When converting content to HTML, Asciidoctor will automatically render many link
 However, you can add a name to a link by adding the URI followed by square brackets:
 
 [source]
-http://lucene.apache.org/solr[Solr Website]
+http://solr.apache.org/[Solr Website]
 
 === Link to Other Pages/Sections of the Guide
 A warning up front, linking to other pages can be a little bit painful. There are slightly different rules depending on the type of link you want to create, and where you are linking from.

--- a/solr/solr-ref-guide/src/meta-docs/publish.adoc
+++ b/solr/solr-ref-guide/src/meta-docs/publish.adoc
@@ -57,7 +57,7 @@ Push the Guide directly to production via Subversion `import` from where you bui
 svn -m "Add Ref Guide for Solr 7.7" import <checkoutroot>/solr/solr-ref-guide/build/html-site https://svn.apache.org/repos/infra/websites/production/lucene/content/solr/guide/7_7
 
 Confirm you can browse to Guide manually by going to the new URL. For example:
-https://lucene.apache.org/solr/guide/7_7
+https://solr.apache.org/guide/7_7
 
 == Publish the Final Guide
 

--- a/solr/solr-ref-guide/src/overview-of-the-solr-admin-ui.adoc
+++ b/solr/solr-ref-guide/src/overview-of-the-solr-admin-ui.adoc
@@ -73,7 +73,7 @@ These icons include the following links.
 [cols="25,75",options="header"]
 |===
 |Link |Description
-|Documentation |Navigates to the Apache Solr documentation hosted on https://lucene.apache.org/solr/.
+|Documentation |Navigates to the Apache Solr documentation hosted on https://solr.apache.org/.
 |Issue Tracker |Navigates to the JIRA issue tracking server for the Apache Solr project. This server resides at https://issues.apache.org/jira/browse/SOLR.
 |IRC Channel |Navigates to Solr's http://en.wikipedia.org/wiki/Internet_Relay_Chat[IRC] live-chat room: http://webchat.freenode.net/?channels=#solr.
 |Community forum |Navigates to the Apache Wiki page which has further information about ways to engage in the Solr User community mailing lists: https://cwiki.apache.org/confluence/display/solr/UsingMailingLists.

--- a/solr/solr-ref-guide/src/solr-system-requirements.adoc
+++ b/solr/solr-ref-guide/src/solr-system-requirements.adoc
@@ -60,7 +60,7 @@ Each Lucene/Solr release has an extensively tested minimum Java version. For ins
 * Java 8 has been extensively tested by both automated tests and users through Solr 8. Long Term Support (LTS) for Java 8 is provided by some sources, see https://medium.com/@javachampions/java-is-still-free-2-0-0-6b9aa8d6d244[Java is still free].
 * The project's testing infrastructure continuously tests with the minimum and greater versions of Java for each development branch.
 * Java 9 and 10 have no LTS. For this reason, Java 11 is preferred over 9 or 10 when upgrading Java.
-* For specific questions the http://lucene.apache.org/solr/community.html#mailing-lists-irc[Solr User's List] is a great resource.
+* For specific questions the http://solr.apache.org/community.html#mailing-lists-chat[Solr User's List] is a great resource.
 
 === Project Testing of Java-Solr Combinations
 Solr and Lucene run a continuous integration model, running automated unit and integration tests using several versions of Java. In addition, some organizations also maintain their own test infrastructure and feed their results back to the community.

--- a/solr/solr-ref-guide/src/solr-tutorial.adoc
+++ b/solr/solr-ref-guide/src/solr-tutorial.adoc
@@ -34,7 +34,7 @@ To follow along with this tutorial, you will need...
 
 // TODO possibly remove this system requirements or only replace the link
 . To meet the {solr-javadocs}/SYSTEM_REQUIREMENTS.html[system requirements]
-. An Apache Solr release http://lucene.apache.org/solr/downloads.html[download]. This tutorial is designed for Apache Solr {solr-docs-version}.
+. An Apache Solr release http://solr.apache.org/downloads.html[download]. This tutorial is designed for Apache Solr {solr-docs-version}.
 
 For best results, please run the browser showing this tutorial and the Solr server on the same machine so tutorial links will correctly point to your Solr server.
 
@@ -976,4 +976,4 @@ As you work through this tutorial, you may want to stop Solr and reset the envir
 
 This Guide will be your best resource for learning more about Solr.
 
-Solr also has a robust community made up of people happy to help you get started. For more information, check out the Solr website's http://lucene.apache.org/solr/resources.html[Resources page].
+Solr also has a robust community made up of people happy to help you get started. For more information, check out the Solr website's http://solr.apache.org/resources.html[Resources page].

--- a/solr/solr-ref-guide/src/solr-upgrade-notes.adoc
+++ b/solr/solr-ref-guide/src/solr-upgrade-notes.adoc
@@ -293,7 +293,7 @@ Work to replace DIH with a community-supported plugin is underway and may be ava
 A community-supported version of this may be available as a plugin in the future.
 For more details, please see https://issues.apache.org/jira/browse/SOLR-14021[SOLR-14021^].
 
-Users interested in maintaining a feature as a plugin are encouraged to join the https://lucene.apache.org/solr/community.html#mailing-lists-irc[developer mailing list^] to find out more about how to help.
+Users interested in maintaining a feature as a plugin are encouraged to join the https://solr.apache.org/community.html#mailing-lists-chat[developer mailing list^] to find out more about how to help.
 
 === Solr 8.5
 

--- a/solr/solr-ref-guide/src/suggester.adoc
+++ b/solr/solr-ref-guide/src/suggester.adoc
@@ -20,7 +20,7 @@ The SuggestComponent in Solr provides users with automatic suggestions for query
 
 You can use this to implement a powerful auto-suggest feature in your search application.
 
-Although it is possible to use the <<spell-checking.adoc#,Spell Checking>> functionality to power autosuggest behavior, Solr has a dedicated http://lucene.apache.org/solr/api/solr-core/org/apache/solr/handler/component/SuggestComponent.html[SuggestComponent] designed for this functionality.
+Although it is possible to use the <<spell-checking.adoc#,Spell Checking>> functionality to power autosuggest behavior, Solr has a dedicated {solr-javadocs}/core/org/apache/solr/handler/component/SuggestComponent.html[SuggestComponent] designed for this functionality.
 
 This approach utilizes Lucene's Suggester implementation and supports all of the lookup implementations available in Lucene.
 


### PR DESCRIPTION
Updates most URLs in the Ref Guide header and text to `solr.apache.org`. 

There are a few cases of the old URL left in the text, but they are part of code snippets that reflect what's in config files shipped with Solr. I thought those should stay as is until a general code sweep happens to update the old URLs.
