### PR TITLE
Make SolrInputField name optional

### DIFF
--- a/solr/core/src/test/org/apache/solr/update/processor/AddSchemaFieldsUpdateProcessorFactoryTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/AddSchemaFieldsUpdateProcessorFactoryTest.java
@@ -71,7 +71,7 @@ public class AddSchemaFieldsUpdateProcessorFactoryTest extends UpdateProcessorTe
     SolrInputDocument finalDoc = doc;
     expectThrows(AssertionError.class, () -> processAdd("add-fields-no-run-processor", finalDoc));
 
-    expectThrows(AssertionError.class, () -> processAdd("add-fields-no-run-processor", new SolrInputDocument(null , null)));
+    expectThrows(NullPointerException.class, () -> processAdd("add-fields-no-run-processor", new SolrInputDocument(null , null)));
   }
 
   public void testSingleField() throws Exception {

--- a/solr/solrj/src/java/org/apache/solr/common/SolrInputField.java
+++ b/solr/solrj/src/java/org/apache/solr/common/SolrInputField.java
@@ -20,6 +20,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.Objects;
 
 /**
  *
@@ -32,7 +33,7 @@ public class SolrInputField implements Iterable<Object>, Serializable
   
   public SolrInputField( String n )
   {
-    this.name = n;
+    this.name = Objects.requireNonNull(n);
   }
 
   //---------------------------------------------------------------
@@ -161,7 +162,7 @@ public class SolrInputField implements Iterable<Object>, Serializable
   }
 
   public void setName(String name) {
-    this.name = name;
+    this.name = Objects.requireNonNull(name);
   }
 
   @Override


### PR DESCRIPTION
Prevents other bugs by failing fast

Very minor change.