### PR TITLE
SOLR-15216 Fix for Invalid Reference to data.followers in Admin UI

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -40,7 +40,7 @@ Improvements
 * SOLR-15191: Enhance hash method of JSON faceting to support EnumFieldType and perhaps some other/custom field types
   too. (Thomas Wöckinger, David Smiley)
 
-* SOLR-15194: Allow Solr to make outbound non SSL calls to a JWT IDP via -Dsolr.auth.jwt.allowOutboundHttp=true property. (Eric Pugh)  
+* SOLR-15194: Allow Solr to make outbound non SSL calls to a JWT IDP via -Dsolr.auth.jwt.allowOutboundHttp=true property. (Eric Pugh)
 
 Optimizations
 ---------------------
@@ -61,6 +61,8 @@ Bug Fixes
 
 * SOLR-15191: Fix JSON Faceting on EnumFieldType if allBuckets, numBuckets or missing is set.
   (Thomas Wöckinger, David Smiley)
+
+* SOLR-15216: Fix for Invalid Reference to data.followers in Admin UI. (Dean Pearce)
 
 Other Changes
 ---------------------

--- a/solr/webapp/web/js/angular/controllers/replication.js
+++ b/solr/webapp/web/js/angular/controllers/replication.js
@@ -195,7 +195,7 @@ var getFollowerSettings = function(data) {
     } else if (!settings.isPollingDisabled && settings.pollInterval) {
         if( settings.nextExecutionAt ) {
             settings.nextExecutionAtEpoch = parseDateToEpoch(settings.nextExecutionAt);
-            settings.currentTime = parseDateToEpoch(data.follower.currentDate);
+            settings.currentTime = parseDateToEpoch(data.slave.currentDate);
 
             if( settings.nextExecutionAtEpoch > settings.currentTime) {
                 settings.isApprox = false;


### PR DESCRIPTION

# Description

Minor bug in the Admin UI Angular code introduced when switching to followers terminology, the underlying API for 8.x still refers to them as slave. In master 9.x branch this is resolved as full migration to new terminology is complete, but any future 8.x builds would have this issue.

This bug prevents the Replication UI for Legacy Replication from loading if polling is enabled and there has been a successful run.

# Solution

Changed to use the correct JavaScript attribute.

# Tests

Compiled and ran the UI against my development instance, verified that the UI loads correctly.

# Checklist

Please review the following and check all that apply:

- [X] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [X] I have created a Jira issue and added the issue ID to my pull request title.
- [X] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have developed this patch against the `master` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
