### PR TITLE
SOLR-15219: Fix TestPointFields integer overflow

### DIFF
--- a/solr/core/src/test/org/apache/solr/schema/TestPointFields.java
+++ b/solr/core/src/test/org/apache/solr/schema/TestPointFields.java
@@ -364,7 +364,7 @@ public class TestPointFields extends SolrTestCaseJ4 {
     int bucketNum = 0;
     int minBucketVal = min;
     for (PosVal<Integer> value : sortedValues) {
-      while (value.val - minBucketVal >= gap) {
+      while ((long)value.val - (long)minBucketVal >= gap) {
         ++bucketNum;
         minBucketVal += gap;
       }
@@ -2215,17 +2215,20 @@ public class TestPointFields extends SolrTestCaseJ4 {
     });
   }
 
-  private List<Integer> getRandomInts(int length, boolean missingVals, int bound) {
-    return getRandomList(length, missingVals, () -> random().nextInt(bound));
+  private List<Integer> getRandomInts(int length, boolean missingVals, int boundPosNeg) {
+    assert boundPosNeg > 0L;
+    return getRandomList(length, missingVals,
+        () -> (random().nextBoolean() ? 1 : -1) * random().nextInt(boundPosNeg));
   }
 
   private List<Integer> getRandomInts(int length, boolean missingVals) {
     return getRandomList(length, missingVals, () -> random().nextInt());
   }
 
-  private List<Long> getRandomLongs(int length, boolean missingVals, long bound) {
-    assert bound > 0L;
-    return getRandomList(length, missingVals, () -> random().nextLong() % bound); // see Random.nextInt(int bound)
+  private List<Long> getRandomLongs(int length, boolean missingVals, long boundPosNeg) {
+    assert boundPosNeg > 0L;
+    return getRandomList(length, missingVals,
+        () -> random().nextLong() % boundPosNeg); // see Random.nextInt(int bound)
   }
 
   private List<Long> getRandomLongs(int length, boolean missingVals) {


### PR DESCRIPTION
And also restore it's getRandomInts(..,..,bound) semantics to what it was -- positive or negative random values.

https://issues.apache.org/jira/browse/SOLR-15219

@madrob about a year ago you added a static analysis checker and made various changes to comply with its recommendations.  That did not introduce the bug I'm fixing here but nonetheless I can tell that the change recommended by "errorprone" (that you performed) was not the intention of the original code.  The original code wanted random integers within a "bound" that is positive *or negative*.  To make this clearer, I changed the parameter name to `boundPosNeg` and I changed the code to reflect "errorprone" recommendation if you intended the original semantics.