### PR TITLE
SOLR-2852: SolrJ: remove Woodstox dependency

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -91,6 +91,10 @@ when told to. The admin UI now tells it to. (Nazerke Seidan, David Smiley)
 * SOLR-15185: Various optimizations to the {!hash} QParser, typically used by the parallel()
   streaming expression.  The hash algorithm changed.  (David Smiley)
 
+* SOLR-2852: SolrJ: remove Woodstox dependency.  It was never truly required there.
+  Software doing lots of XML processing can choose to add it or alternatives if they wish.
+  (David Smiley)
+
 Other Changes
 ----------------------
 * SOLR-14656: Autoscaling framework removed (Ishan Chattopadhyaya, noble, Ilan Ginzburg)

--- a/solr/core/build.gradle
+++ b/solr/core/build.gradle
@@ -97,6 +97,11 @@ dependencies {
 
   implementation 'org.rrd4j:rrd4j'
 
+  // For faster XML processing than the JDK
+  implementation ('org.codehaus.woodstox:woodstox-core-asl', {
+    exclude group: "javax.xml.stream", module: "stax-api"
+  })
+
   implementation ('org.apache.calcite.avatica:avatica-core') { transitive = false }
   implementation ('org.apache.calcite:calcite-core') { transitive = false }
   implementation ('org.apache.calcite:calcite-linq4j') { transitive = false }

--- a/solr/solrj/build.gradle
+++ b/solr/solrj/build.gradle
@@ -55,10 +55,6 @@ dependencies {
     exclude group: "org.slf4j", module: "slf4j-log4j12"
   })
 
-  api('org.codehaus.woodstox:woodstox-core-asl', {
-    exclude group: "javax.xml.stream", module: "stax-api"
-  })
-
   testImplementation project(':solr:test-framework')
   testImplementation 'org.eclipse.jetty:jetty-webapp'
   testImplementation ('org.eclipse.jetty:jetty-alpn-java-server', {


### PR DESCRIPTION
It was never truly required there.
Pervasive use of "javabin" reduces the need to care about client-side XML speed.  Better to reduce dependencies and let clients use the libs they want.

https://issues.apache.org/jira/browse/SOLR-2852

BTW I couldn't set "runtimeOnly" for it's inclusion in solr-core because the text tagger explicitly uses it in XmlOffsetCorrector.  I wrote that.  I don't recall if it was performance reasons or if it was for access to location metadata that I otherwise didn't see how to get.