### PR TITLE
Install ACL package for Solr Docker tests Github action

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         java-version: 11
     - name: Install ACL
-      run: apt-get install acl
+      run: sudo apt-get install acl
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - uses: actions/cache@v2

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -45,4 +45,4 @@ jobs:
     - name: Build Docker image with Gradle
       run: ./gradlew solr:docker:docker
     - name: Run tests on Docker image
-      run: ./gradlew solr:docker:testDocker -Psolr.docker.tests.include=empty-varsolr-dir-ramdomuser-rootgroup
+      run: ./gradlew solr:docker:testDocker

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -28,6 +28,8 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
+    - name: Install ACL
+      run: apt-get install acl
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - uses: actions/cache@v2

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -43,4 +43,4 @@ jobs:
     - name: Build Docker image with Gradle
       run: ./gradlew solr:docker:docker
     - name: Run tests on Docker image
-      run: ./gradlew solr:docker:testDocker
+      run: ./gradlew solr:docker:testDocker -Psolr.docker.tests.include=create_core

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -43,4 +43,4 @@ jobs:
     - name: Build Docker image with Gradle
       run: ./gradlew solr:docker:docker
     - name: Run tests on Docker image
-      run: ./gradlew solr:docker:testDocker -Psolr.docker.tests.include=create_core
+      run: ./gradlew solr:docker:testDocker -Psolr.docker.tests.include=empty_varsolr_dir_ramdomuser_rootgroup

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -43,4 +43,4 @@ jobs:
     - name: Build Docker image with Gradle
       run: ./gradlew solr:docker:docker
     - name: Run tests on Docker image
-      run: ./gradlew solr:docker:testDocker -Psolr.docker.tests.include=empty_varsolr_dir_ramdomuser_rootgroup
+      run: ./gradlew solr:docker:testDocker -Psolr.docker.tests.include=empty-varsolr-dir-ramdomuser-rootgroup

--- a/solr/docker/Dockerfile
+++ b/solr/docker/Dockerfile
@@ -64,8 +64,6 @@ RUN set -ex; \
   mv /opt/solr/bin/solr.in.cmd /opt/solr/bin/solr.in.cmd.orig; \
   chmod 0664 /etc/default/solr.in.sh; \
   mkdir -p -m0770 /var/solr; \
-  sed -i -e "s/\"\$(whoami)\" == \"root\"/\$(id -u) == 0/" /opt/solr/bin/solr; \
-  sed -i -e 's/lsof -PniTCP:/lsof -t -PniTCP:/' /opt/solr/bin/solr; \
   chown -R "$SOLR_USER:0" /var/solr;
 
 VOLUME /var/solr

--- a/solr/docker/build.gradle
+++ b/solr/docker/build.gradle
@@ -18,7 +18,7 @@
 import com.google.common.base.Preconditions
 import com.google.common.base.Strings
 
-description = 'Solr Docker image'
+description = 'Solr Docker image' 
 
 apply plugin: 'base'
 

--- a/solr/docker/build.gradle
+++ b/solr/docker/build.gradle
@@ -18,7 +18,7 @@
 import com.google.common.base.Preconditions
 import com.google.common.base.Strings
 
-description = 'Solr Docker image' 
+description = 'Solr Docker image'
 
 apply plugin: 'base'
 

--- a/solr/docker/scripts/init-var-solr
+++ b/solr/docker/scripts/init-var-solr
@@ -23,6 +23,7 @@ fi
 
 function check_dir_writability {
     local dir="$1"
+        ls -ld "$dir"
     if [ ! -w "$dir" ]; then
         echo "Cannot write to $dir as $(id -u):$(id -g)"
         ls -ld "$dir"

--- a/solr/docker/scripts/init-var-solr
+++ b/solr/docker/scripts/init-var-solr
@@ -23,7 +23,6 @@ fi
 
 function check_dir_writability {
     local dir="$1"
-        ls -ld "$dir"
     if [ ! -w "$dir" ]; then
         echo "Cannot write to $dir as $(id -u):$(id -g)"
         ls -ld "$dir"

--- a/solr/docker/tests/cases/empty-varsolr-vol-ramdomuser-rootgroup/test.sh
+++ b/solr/docker/tests/cases/empty-varsolr-vol-ramdomuser-rootgroup/test.sh
@@ -16,7 +16,7 @@ docker volume create "$myvarsolr"
 
 echo "Running $container_name"
 docker run \
-  --user 777:0 \
+  --user 7777:0 \
   -v "$myvarsolr:/var/solr" \
   --name "$container_name" \
   -d "$tag" solr-precreate getting-started

--- a/solr/docker/tests/shared.sh
+++ b/solr/docker/tests/shared.sh
@@ -58,6 +58,7 @@ function wait_for_server_started {
       break
     fi
 
+    docker inspect "$container_name"
     local container_status
     container_status=$(docker inspect --format='{{.State.Status}}' "$container_name")
     if [[ $container_status == 'exited' ]]; then

--- a/solr/docker/tests/shared.sh
+++ b/solr/docker/tests/shared.sh
@@ -53,6 +53,7 @@ function wait_for_server_started {
   local log
   log="${BUILD_DIR}/${container_name}.log"
   while true; do
+    docker logs "$container_name"
     docker logs "$container_name" > "${log}" 2>&1
     if grep -E -q '(o\.e\.j\.s\.Server Started|Started SocketConnector)' "${log}" ; then
       break

--- a/solr/docker/tests/shared.sh
+++ b/solr/docker/tests/shared.sh
@@ -59,7 +59,6 @@ function wait_for_server_started {
       break
     fi
 
-    docker inspect "$container_name"
     local container_status
     container_status=$(docker inspect --format='{{.State.Status}}' "$container_name")
     if [[ $container_status == 'exited' ]]; then

--- a/solr/docker/tests/shared.sh
+++ b/solr/docker/tests/shared.sh
@@ -91,6 +91,7 @@ function prepare_dir_to_mount {
   fi
   rm -fr "$folder" >/dev/null 2>&1
   mkdir "$folder"
+  ls -ld "$folder"
   #echo "***** Created varsolr folder $BUILD_DIR / $folder"
 
   # The /var/solr mountpoint is owned by solr, so when we bind mount there our directory,

--- a/solr/docker/tests/shared.sh
+++ b/solr/docker/tests/shared.sh
@@ -53,9 +53,9 @@ function wait_for_server_started {
   local log
   log="${BUILD_DIR}/${container_name}.log"
   while true; do
-    docker logs "$container_name"
     docker logs "$container_name" > "${log}" 2>&1
     if grep -E -q '(o\.e\.j\.s\.Server Started|Started SocketConnector)' "${log}" ; then
+      docker logs "$container_name"
       break
     fi
 
@@ -91,7 +91,6 @@ function prepare_dir_to_mount {
   fi
   rm -fr "$folder" >/dev/null 2>&1
   mkdir "$folder"
-  ls -ld "$folder"
   #echo "***** Created varsolr folder $BUILD_DIR / $folder"
 
   # The /var/solr mountpoint is owned by solr, so when we bind mount there our directory,


### PR DESCRIPTION
There is currently an issue on the Ubuntu 20.04 github runner, with incorrect ownership being set for the `/var/solr` directory in the docker image.