### PR TITLE
LUCENE-9385: (Backporting) Add FacetsConfig option to control which drill-down terms are indexed for a FacetLabel

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -27,6 +27,9 @@ New Features
 * LUCENE-9694: New tool for creating a deterministic index to enable benchmarking changes
   on a consistent multi-segment index even when they require re-indexing. (Haoyu Zhai)
 
+* LUCENE-9385: Add FacetsConfig option to control which drill-down
+  terms are indexed for a FacetLabel (Zachary Chen)
+
 Improvements
 ---------------------
 


### PR DESCRIPTION
This PR backports changes from https://github.com/apache/lucene/pull/25 into Lucene 8x

I have run `ant clean; ant precommit; ant test` to validate the changes. 