### PR TITLE
LUCENE-9507 Custom order for leaves

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -27,6 +27,9 @@ New Features
 * LUCENE-9694: New tool for creating a deterministic index to enable benchmarking changes
   on a consistent multi-segment index even when they require re-indexing. (Haoyu Zhai)
 
+* LUCENE-9507: Custom order for leaves in IndexReader and IndexWriter
+  (Mayya Sharipova, Mike McCandless, Jim Ferenczi)
+
 Improvements
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/index/BaseCompositeReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/BaseCompositeReader.java
@@ -20,6 +20,7 @@ package org.apache.lucene.index;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 /** Base class for implementing {@link CompositeReader}s based on an array
@@ -48,6 +49,8 @@ import java.util.List;
  */
 public abstract class BaseCompositeReader<R extends IndexReader> extends CompositeReader {
   private final R[] subReaders;
+  /** A comparator for sorting sub-readers */
+  protected final Comparator<R> subReadersSorter;
   private final int[] starts;       // 1st docno for each reader
   private final int maxDoc;
   private int numDocs = -1;         // computed lazily
@@ -63,9 +66,15 @@ public abstract class BaseCompositeReader<R extends IndexReader> extends Composi
    * subreader for docID-based methods. <b>Please note:</b> This array is <b>not</b>
    * cloned and not protected for modification, the subclass is responsible 
    * to do this.
+   * @param subReadersSorter – a comparator for sorting sub readers. If not {@code null}, this
+   * comparator is used to sort sub readers, before using the for resolving doc IDs.
    */
-  protected BaseCompositeReader(R[] subReaders) throws IOException {
+  protected BaseCompositeReader(R[] subReaders, Comparator<R> subReadersSorter) throws IOException {
+    if (subReadersSorter != null) {
+      Arrays.sort(subReaders, subReadersSorter);
+    }
     this.subReaders = subReaders;
+    this.subReadersSorter = subReadersSorter;
     this.subReadersList = Collections.unmodifiableList(Arrays.asList(subReaders));
     starts = new int[subReaders.length + 1];    // build starts array
     long maxDoc = 0;

--- a/lucene/core/src/java/org/apache/lucene/index/FilterDirectoryReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FilterDirectoryReader.java
@@ -88,7 +88,7 @@ public abstract class FilterDirectoryReader extends DirectoryReader {
    * @param wrapper the SubReaderWrapper to use to wrap subreaders
    */
   public FilterDirectoryReader(DirectoryReader in, SubReaderWrapper wrapper) throws IOException {
-    super(in.directory(), wrapper.wrap(in.getSequentialSubReaders()));
+    super(in.directory(), wrapper.wrap(in.getSequentialSubReaders()), null);
     this.in = in;
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriterConfig.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriterConfig.java
@@ -19,6 +19,7 @@ package org.apache.lucene.index;
 
 import java.io.PrintStream;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.stream.Collectors;
 
 import org.apache.lucene.analysis.Analyzer;
@@ -59,7 +60,7 @@ public final class IndexWriterConfig extends LiveIndexWriterConfig {
   /**
    * Specifies the open mode for {@link IndexWriter}.
    */
-  public static enum OpenMode {
+  public enum OpenMode {
     /** 
      * Creates a new index or overwrites an existing one. 
      */
@@ -492,7 +493,19 @@ public final class IndexWriterConfig extends LiveIndexWriterConfig {
     return this;
   }
 
-  @Override
+  /**
+   * Set the comparator for sorting leaf readers. A DirectoryReader opened from a IndexWriter with
+   * this configuration will have its leaf readers sorted with the provided leaf sorter.
+   *
+   * @param leafSorter – a comparator for sorting leaf readers
+   * @return IndexWriterConfig with leafSorter set.
+   */
+  public IndexWriterConfig setLeafSorter(Comparator<LeafReader> leafSorter) {
+    this.leafSorter = leafSorter;
+    return this;
+  }
+
+    @Override
   public String toString() {
     StringBuilder sb = new StringBuilder(super.toString());
     sb.append("writer=").append(writer.get()).append("\n");

--- a/lucene/core/src/java/org/apache/lucene/index/LiveIndexWriterConfig.java
+++ b/lucene/core/src/java/org/apache/lucene/index/LiveIndexWriterConfig.java
@@ -18,6 +18,7 @@ package org.apache.lucene.index;
 
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Set;
 
 import org.apache.lucene.analysis.Analyzer;
@@ -99,6 +100,9 @@ public class LiveIndexWriterConfig {
 
   /** The sort order to use to write merged segments. */
   protected Sort indexSort = null;
+
+  /** The comparator for sorting leaf readers. */
+  protected Comparator<LeafReader> leafSorter;
 
   /** The field names involved in the index sort */
   protected Set<String> indexSortFields = Collections.emptySet();
@@ -434,6 +438,17 @@ public class LiveIndexWriterConfig {
   }
 
   /**
+   * Returns a comparator for sorting leaf readers. If not {@code null}, this comparator is used to
+   * sort leaf readers within {@code DirectoryReader} opened from the {@code IndexWriter} of this
+   * configuration.
+   *
+   * @return a comparator for sorting leaf readers
+   */
+  public Comparator<LeafReader> getLeafSorter() {
+    return leafSorter;
+  }
+
+  /**
    * Expert: Returns if indexing threads check for pending flushes on update in order
    * to help our flushing indexing buffers to disk
    * @lucene.experimental
@@ -497,6 +512,7 @@ public class LiveIndexWriterConfig {
     sb.append("checkPendingFlushOnUpdate=").append(isCheckPendingFlushOnUpdate()).append("\n");
     sb.append("softDeletesField=").append(getSoftDeletesField()).append("\n");
     sb.append("maxFullFlushMergeWaitMillis=").append(getMaxFullFlushMergeWaitMillis()).append("\n");
+    sb.append("leafSorter=").append(getLeafSorter()).append("\n");
     return sb.toString();
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/index/MultiReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MultiReader.java
@@ -18,6 +18,7 @@ package org.apache.lucene.index;
 
 
 import java.io.IOException;
+import java.util.Comparator;
 
 /** A {@link CompositeReader} which reads multiple indexes, appending
  *  their content. It can be used to create a view on several
@@ -46,7 +47,7 @@ public class MultiReader extends BaseCompositeReader<IndexReader> {
   * @param subReaders set of (sub)readers
   */
   public MultiReader(IndexReader... subReaders) throws IOException {
-    this(subReaders, true);
+    this(subReaders, null, true);
   }
 
   /**
@@ -56,7 +57,22 @@ public class MultiReader extends BaseCompositeReader<IndexReader> {
    * when this MultiReader is closed
    */
   public MultiReader(IndexReader[] subReaders, boolean closeSubReaders) throws IOException {
-    super(subReaders.clone());
+    this(subReaders, null, closeSubReaders);
+  }
+
+  /**
+   * Construct a MultiReader aggregating the named set of (sub)readers.
+   *
+   * @param subReaders set of (sub)readers; this array will be cloned.
+   * @param subReadersSorter – a comparator, that if not {@code null} is used for sorting sub
+   *     readers.
+   * @param closeSubReaders indicates whether the subreaders should be closed when this MultiReader
+   *     is closed
+   */
+  public MultiReader(
+      IndexReader[] subReaders, Comparator<IndexReader> subReadersSorter, boolean closeSubReaders)
+      throws IOException {
+    super(subReaders.clone(), subReadersSorter);
     this.closeSubReaders = closeSubReaders;
     if (!closeSubReaders) {
       for (int i = 0; i < subReaders.length; i++) {

--- a/lucene/core/src/java/org/apache/lucene/index/ParallelCompositeReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/ParallelCompositeReader.java
@@ -69,7 +69,7 @@ public class ParallelCompositeReader extends BaseCompositeReader<LeafReader> {
    *  readers and storedFieldReaders; when a document is
    *  loaded, only storedFieldsReaders will be used. */
   public ParallelCompositeReader(boolean closeSubReaders, CompositeReader[] readers, CompositeReader[] storedFieldReaders) throws IOException {
-    super(prepareLeafReaders(readers, storedFieldReaders));
+    super(prepareLeafReaders(readers, storedFieldReaders), null);
     this.closeSubReaders = closeSubReaders;
     Collections.addAll(completeReaderSet, readers);
     Collections.addAll(completeReaderSet, storedFieldReaders);

--- a/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/UnifiedHighlighter.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/uhighlight/UnifiedHighlighter.java
@@ -1086,7 +1086,7 @@ public class UnifiedHighlighter {
           .map(LeafReaderContext::reader)
           .map(TermVectorReusingLeafReader::new)
           .toArray(LeafReader[]::new);
-      return new BaseCompositeReader<IndexReader>(leafReaders) {
+      return new BaseCompositeReader<IndexReader>(leafReaders, null) {
         @Override
         protected void doClose() { // don't close the underlying reader
         }

--- a/lucene/misc/src/java/org/apache/lucene/index/MultiPassIndexSplitter.java
+++ b/lucene/misc/src/java/org/apache/lucene/index/MultiPassIndexSplitter.java
@@ -179,7 +179,7 @@ public class MultiPassIndexSplitter {
   private static final class FakeDeleteIndexReader extends BaseCompositeReader<FakeDeleteLeafIndexReader> {
 
     public FakeDeleteIndexReader(IndexReader reader) throws IOException {
-      super(initSubReaders(reader));
+      super(initSubReaders(reader), null);
     }
     
     private static FakeDeleteLeafIndexReader[] initSubReaders(IndexReader reader) throws IOException {

--- a/lucene/replicator/src/java/org/apache/lucene/replicator/nrt/SegmentInfosSearcherManager.java
+++ b/lucene/replicator/src/java/org/apache/lucene/replicator/nrt/SegmentInfosSearcherManager.java
@@ -55,7 +55,7 @@ class SegmentInfosSearcherManager extends ReferenceManager<IndexSearcher> {
     this.searcherFactory = searcherFactory;
     currentInfos = infosIn;
     node.message("SegmentInfosSearcherManager.init: use incoming infos=" + infosIn.toString());
-    current = SearcherManager.getSearcher(searcherFactory, StandardDirectoryReader.open(dir, currentInfos, null), null);
+    current = SearcherManager.getSearcher(searcherFactory, StandardDirectoryReader.open(dir, currentInfos, null, null), null);
     addReaderClosedListener(current.getIndexReader());
   }
 
@@ -104,7 +104,7 @@ class SegmentInfosSearcherManager extends ReferenceManager<IndexSearcher> {
     }
 
     // Open a new reader, sharing any common segment readers with the old one:
-    DirectoryReader r = StandardDirectoryReader.open(dir, currentInfos, subs);
+    DirectoryReader r = StandardDirectoryReader.open(dir, currentInfos, subs, null);
     addReaderClosedListener(r);
     node.message("refreshed to version=" + currentInfos.getVersion() + " r=" + r);
     return SearcherManager.getSearcher(searcherFactory, r, old.getIndexReader());


### PR DESCRIPTION
Custom order for leaves in IndexReader and IndexWriter

1.Add an option to supply a custom leaf sorter for IndexWriter.
A DirectoryReader opened from this IndexWriter will have its leaf
readers sorted with the provided leaf sorter. This is useful for
indices on which it is expected to run many queries with particular
sort criteria (e.g. for time-based indices this is usually a
descending sort on timestamp). Providing leafSorter allows
to speed up early termination for this particular type of
sort queries.

2. Add an option to supply a custom sub-readers sorter for
BaseCompositeReader. In this case sub-readers will be sorted
according to the the provided leafSorter.

3. Add an option to supply a custom leaf sorter for
StandardDirectoryReader. The leaf readers of this
StandardDirectoryReader will be sorted according to
the the provided leaf sorter.

Backport for https://github.com/apache/lucene/pull/32