### PR TITLE
SOLR-15356: Deprecate UninvertDocValuesMergePolicyFactory

### DIFF
--- a/solr/core/src/java/org/apache/solr/index/UninvertDocValuesMergePolicyFactory.java
+++ b/solr/core/src/java/org/apache/solr/index/UninvertDocValuesMergePolicyFactory.java
@@ -48,7 +48,9 @@ import org.apache.solr.uninverting.UninvertingReader;
  * 
  * This merge policy will delegate to the wrapped merge policy for selecting merge segments
  * 
+ * @deprecated This class will be removed in Solr 9 due to changes in Lucene 9.
  */
+@Deprecated
 public class UninvertDocValuesMergePolicyFactory extends WrapperMergePolicyFactory {
   
   final private boolean skipIntegrityCheck;

--- a/solr/core/src/java/org/apache/solr/update/SolrIndexConfig.java
+++ b/solr/core/src/java/org/apache/solr/update/SolrIndexConfig.java
@@ -43,6 +43,7 @@ import org.apache.solr.index.DefaultMergePolicyFactory;
 import org.apache.solr.index.MergePolicyFactory;
 import org.apache.solr.index.MergePolicyFactoryArgs;
 import org.apache.solr.index.SortingMergePolicy;
+import org.apache.solr.index.UninvertDocValuesMergePolicyFactory;
 import org.apache.solr.schema.IndexSchema;
 import org.apache.solr.util.SolrPluginUtils;
 import org.slf4j.Logger;
@@ -302,6 +303,10 @@ public class SolrIndexConfig implements MapSerializable {
         NO_SUB_PACKAGES,
         new Class[] { SolrResourceLoader.class, MergePolicyFactoryArgs.class, IndexSchema.class },
         new Object[] {resourceLoader, mpfArgs, schema });
+
+    if (mpf instanceof UninvertDocValuesMergePolicyFactory) {
+      log.warn("UninvertDocValuesMergePolicyFactory will be removed in Solr 9 due to changes in Lucene 9.");
+    }
 
     return mpf.getMergePolicy();
   }

--- a/solr/core/src/java/org/apache/solr/update/SolrIndexConfig.java
+++ b/solr/core/src/java/org/apache/solr/update/SolrIndexConfig.java
@@ -304,10 +304,6 @@ public class SolrIndexConfig implements MapSerializable {
         new Class[] { SolrResourceLoader.class, MergePolicyFactoryArgs.class, IndexSchema.class },
         new Object[] {resourceLoader, mpfArgs, schema });
 
-    if (mpf instanceof UninvertDocValuesMergePolicyFactory) {
-      log.warn("UninvertDocValuesMergePolicyFactory will be removed in Solr 9 due to changes in Lucene 9.");
-    }
-
     return mpf.getMergePolicy();
   }
 

--- a/solr/core/src/java/org/apache/solr/update/SolrIndexConfig.java
+++ b/solr/core/src/java/org/apache/solr/update/SolrIndexConfig.java
@@ -43,7 +43,6 @@ import org.apache.solr.index.DefaultMergePolicyFactory;
 import org.apache.solr.index.MergePolicyFactory;
 import org.apache.solr.index.MergePolicyFactoryArgs;
 import org.apache.solr.index.SortingMergePolicy;
-import org.apache.solr.index.UninvertDocValuesMergePolicyFactory;
 import org.apache.solr.schema.IndexSchema;
 import org.apache.solr.util.SolrPluginUtils;
 import org.slf4j.Logger;


### PR DESCRIPTION
I think a `solr/CHANGES.txt` entry for Solr 8.x is not warranted given the specialised use of the class but it would seem nice to provide some indication to anyone using it w.r.t. the class being removed in future Solr 9 via the https://github.com/apache/solr/pull/83 change?

https://issues.apache.org/jira/browse/SOLR-15356