### PR TITLE
SOLR-15384 Zookeeper Status handler /admin/zookeeper/status not queryable from SolrJ

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -77,6 +77,8 @@ Bug Fixes
 * SOLR-15273: Fix NullPointerException in StoredFieldsShardResponseProcessor that happened when a field name alias is
   used for the unique key field in searches with distributed result grouping. (limingnihao via Christine Poerschke)
 
+* SOLR-15384: Zookeeper Status handler /admin/zookeeper/status not queryable from SolrJ (janhoy)
+
 * SOLR-11921: Move "cursorMark" logic from QueryComponent to SearchHandler so it can work with things like QueryElevationComponent
   that modify the SortSpec in prepare(), as well as possible custom "search" components other then QueryComponent.  (hossman)
 

--- a/solr/solrj/src/java/org/apache/solr/common/params/CommonParams.java
+++ b/solr/solrj/src/java/org/apache/solr/common/params/CommonParams.java
@@ -208,6 +208,8 @@ public interface CommonParams {
       HEALTH_CHECK_HANDLER_PATH,
       CONFIGSETS_HANDLER_PATH,
       SYSTEM_INFO_PATH,
+      ZK_PATH,
+      ZK_STATUS_PATH,
       AUTHC_PATH,
       AUTHZ_PATH,
       METRICS_PATH,


### PR DESCRIPTION
Backport of https://github.com/apache/solr/pull/105 targeting 8x (8.9)