### PR TITLE
SOLR-15383 Solr Zookeeper status page shows green even when a ZK is down

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -82,6 +82,8 @@ Bug Fixes
 
 * SOLR-15317: Correctly handle user principals with whitespace in PKIAuthPlugin (Dominik Dresel, Mike Drob)
 
+* SOLR-15383: Solr Zookeeper status page shows green even when some Zookeepers are not serving requests (janhoy)
+
 Other Changes
 ---------------------
 * SOLR-15118: Deprecate CollectionAdminRequest.getV2Request(). (Jason Gerlowski)

--- a/solr/core/src/java/org/apache/solr/handler/admin/ZookeeperStatusHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/ZookeeperStatusHandler.java
@@ -313,6 +313,9 @@ public class ZookeeperStatusHandler extends RequestHandlerBase {
           "configuration file on each zookeeper node: '4lw.commands.whitelist=mntr,conf,ruok'. See also chapter " +
           "'Setting Up an External ZooKeeper Ensemble' in the Solr Reference Guide.");
     }
+    if (response.size() == 1 && response.get(0).contains("not currently serving requests")) {
+      throw new SolrException(SolrException.ErrorCode.SERVER_ERROR, "Zookeeper " + zkHostPort + " is not currently serving requests.");
+    }
     return true;
   }
 }

--- a/solr/core/src/test/org/apache/solr/handler/admin/ZookeeperStatusHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/ZookeeperStatusHandlerTest.java
@@ -177,6 +177,16 @@ public class ZookeeperStatusHandlerTest extends SolrCloudTestCase {
     }
   }
 
+  @Test(expected = SolrException.class)
+  public void validateNotServingRequestsResponse() {
+    try (ZookeeperStatusHandler zsh = new ZookeeperStatusHandler(null)) {
+      zsh.validateZkRawResponse(Collections.singletonList("This ZooKeeper instance is not currently serving requests"),
+          "zoo1:2181", "mntr");
+    }  catch (IOException e) {
+      fail("Error closing ZookeeperStatusHandler");
+    }
+  }
+
   @Test
   public void testMntrBugZk36Solr14463() {
     assumeWorkingMockito();


### PR DESCRIPTION
This is a backport to 8.9 of https://github.com/apache/solr/pull/103

See https://issues.apache.org/jira/browse/SOLR-15383