### PR TITLE
Re-introduce ant precommit github action in 8x branch

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -1,0 +1,32 @@
+name: Ant precommit
+
+on:
+  pull_request:
+    branches:
+      - 'branch_8x'
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Cache Ivy packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.ivy2/cache/
+          key: ${{ runner.os }}-ant-precommit-${{ hashFiles('**/ivy-versions.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-ant-precommit-
+            ${{ runner.os }}-ant-
+
+      - name: Ivy bootstrap
+        run: ant ivy-bootstrap
+
+      - name: Precommit
+        run: ant precommit


### PR DESCRIPTION
This PR re-introduces the `ant precommit` github action for branch_8x, which was removed when "wiping" master branch after the split.