### PR TITLE
Fix 8.9.0 < 8.10.0 comparison in smokeTestRelease.py script.

### DIFF
--- a/dev-tools/scripts/smokeTestRelease.py
+++ b/dev-tools/scripts/smokeTestRelease.py
@@ -450,7 +450,7 @@ def versionToTuple(version, name):
     versionTuple = versionTuple[:-2] + ('100',)
   elif versionTuple[-1].lower()[:2] == 'rc':
     versionTuple = versionTuple[:-2] + (versionTuple[-1][2:],)
-  return versionTuple
+  return tuple(int(x) if x is not None and x.isnumeric() else x for x in versionTuple)
 
 
 reUnixPath = re.compile(r'\b[a-zA-Z_]+=(?:"(?:\\"|[^"])*"' + '|(?:\\\\.|[^"\'\\s])*' + r"|'(?:\\'|[^'])*')" \


### PR DESCRIPTION
(Please note this pull request is for `lucene-solr/branch_8_9` branch and after merge the changes would have to be cherry-picked to `lucene-solr/branch_8x` branch and (I'm guessing) also `lucene/main` and `solr/main` branches.)

### Existing (broken) behaviour

As part of the 8.9.0 release process @mayya-sharipova reported on the [dev@lucene](https://lists.apache.org/thread.html/rc81568f9006701fb72f9f82f17b89e1be94d3f2a5595ff78186f3b69%40%3Cdev.lucene.apache.org%3E) list that smokeTestRelease.py fails:

> I've also looked at the failure on 8.x branch: "Future release 8.9.0 is
greater than 8.10.0", and it looks like smokeTestRelease.py fails to
correctly compare v8.10.0 > v8.9.0, as (('8', '10', '0') < ('8', '9', '0')).

### Local testing

#### Script
```
$ cat ./versionToTuple_test.py
#!/usr/bin/env python3

import re

reVersion = re.compile(r'(\d+)\.(\d+)(?:\.(\d+))?\s*(-alpha|-beta|final|RC\d+)?\s*(?:\[.*\])?', re.IGNORECASE)

priorVersionTuple1 = None
priorVersionTuple2 = None
for version in [ "4.0.0-beta", "8.9.0", "8.10.0" ]:
  versionMatch = reVersion.match(version)
  versionTuple = versionMatch.groups()

  if priorVersionTuple1 is not None:
    print("before: ({} < {}) evaluates to {}".format(priorVersionTuple1, versionTuple, (priorVersionTuple1 < versionTuple)))
  priorVersionTuple1 = versionTuple

  versionTuple = tuple(int(x) if x is not None and x.isnumeric() else x for x in versionTuple)

  if priorVersionTuple2 is not None:
    print(" after: ({} < {}) evaluates to {}".format(priorVersionTuple2, versionTuple, (priorVersionTuple2 < versionTuple)))
  priorVersionTuple2 = versionTuple
```

#### Output

```
$ ./versionToTuple_test.py
before: (('4', '0', '0', '-beta') < ('8', '9', '0', None)) evaluates to True
 after: ((4, 0, 0, '-beta') < (8, 9, 0, None)) evaluates to True
before: (('8', '9', '0', None) < ('8', '10', '0', None)) evaluates to False
 after: ((8, 9, 0, None) < (8, 10, 0, None)) evaluates to True
```