### PR TITLE
LUCENE-9976: Fix WANDScorer assertion error

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -106,6 +106,8 @@ Other
 
 * LUCENE-9985: Upgrade jetty to 9.4.41 (janhoy)
 
+* LUCENE-9976: Fix WANDScorer assertion error. (Zach Chen, Adrien Grand, Dawid Weiss)
+
 ======================= Lucene 8.8.2 =======================
 
 Bug Fixes

--- a/lucene/core/src/java/org/apache/lucene/search/WANDScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/WANDScorer.java
@@ -216,7 +216,9 @@ final class WANDScorer extends Scorer {
       }
       assert maxScoreSum == leadMaxScore : maxScoreSum + " " + leadMaxScore;
 
-      assert minCompetitiveScore == 0 || tailMaxScore < minCompetitiveScore;
+      assert minCompetitiveScore == 0
+          || tailMaxScore < minCompetitiveScore
+          || tailSize < minShouldMatch;
       assert doc <= upTo;
     }
 


### PR DESCRIPTION
Backports changes from https://github.com/apache/lucene/pull/171 into branch_8_9