### PR TITLE
LUCENE-9976: Fix WANDScorer assertion error

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -56,6 +56,8 @@ Other
 ---------------------
 (No changes)
 
+* LUCENE-9976: Fix WANDScorer assertion error. (Zach Chen, Adrien Grand, Dawid Weiss)
+
 ======================= Lucene 8.9.0 =======================
 
 API Changes

--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -54,8 +54,6 @@ Bug Fixes
 
 Other
 ---------------------
-(No changes)
-
 * LUCENE-9976: Fix WANDScorer assertion error. (Zach Chen, Adrien Grand, Dawid Weiss)
 
 ======================= Lucene 8.9.0 =======================
@@ -160,6 +158,8 @@ Other
   instead of the no longer maintained "maven-ant-tasks".  (Uwe Schindler)
 
 * LUCENE-9985: Upgrade jetty to 9.4.41 (janhoy)
+
+* LUCENE-9976: Fix WANDScorer assertion error. (Zach Chen, Adrien Grand, Dawid Weiss)
 
 ======================= Lucene 8.8.2 =======================
 

--- a/lucene/core/src/java/org/apache/lucene/search/WANDScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/WANDScorer.java
@@ -216,7 +216,9 @@ final class WANDScorer extends Scorer {
       }
       assert maxScoreSum == leadMaxScore : maxScoreSum + " " + leadMaxScore;
 
-      assert minCompetitiveScore == 0 || tailMaxScore < minCompetitiveScore;
+      assert minCompetitiveScore == 0
+          || tailMaxScore < minCompetitiveScore
+          || tailSize < minShouldMatch;
       assert doc <= upTo;
     }
 


### PR DESCRIPTION
Backports changes from apache/lucene#171 into branch_8x