### PR TITLE
SOLR-15378 Suppress SimpleText codec in TestRestoreCore

### DIFF
--- a/solr/core/src/test/org/apache/solr/handler/TestRestoreCore.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestRestoreCore.java
@@ -31,6 +31,7 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.lucene.index.IndexFileNames;
+import org.apache.lucene.util.LuceneTestCase.SuppressCodecs;
 import org.apache.lucene.util.TestUtil;
 import org.apache.solr.SolrJettyTestBase;
 import org.apache.solr.SolrTestCaseJ4;
@@ -45,6 +46,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 @SolrTestCaseJ4.SuppressSSL     // Currently unknown why SSL does not work with this test
+@SuppressCodecs("SimpleText")
 public class TestRestoreCore extends SolrJettyTestBase {
 
   JettySolrRunner leaderJetty;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-15378

# Description

Backup/restore doesn't support SimpleTextCodec and because of this testFailedRestore in TestRestoreCore with given seed failed 100%.

# Solution

Adding SuppressCodecs annotation to the test with SimpleText solved the problem. I have developed this change against current branch_8x and ran unit tests.

# Tests

Run unit tests.

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [x] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have developed this patch against the `main` branch.
- [x] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)