### PR TITLE
Fix some psuedo->pseudo typos in Solr Ref Guide.

### DIFF
--- a/solr/solr-ref-guide/src/indexing-nested-documents.adoc
+++ b/solr/solr-ref-guide/src/indexing-nested-documents.adoc
@@ -50,10 +50,10 @@ generate such IDs; you can let Solr populate them automatically.  It will concat
 parent with a separator and path information that should be unique.  Try it out for yourself!
 
 [#example-indexing-syntax]
-== Example Indexing Syntax: Psuedo-Fields
+== Example Indexing Syntax: Pseudo-Fields
 
 This example shows what it looks like to index two root "product" documents, each containing two
-different types of child documents specified in "psuedo-fields": "skus" and "manuals".  Two of the "sku" type documents have their own nested child "manuals" documents...
+different types of child documents specified in "pseudo-fields": "skus" and "manuals".  Two of the "sku" type documents have their own nested child "manuals" documents...
 
 [NOTE]
 ====
@@ -424,7 +424,7 @@ This simplified approach was common in older versions of Solr, and can still be 
 This approach should *NOT* be used when schemas include a `\_nest_path_` field, as the existence of that field triggers assumptions and changes in behavior in various query time functionality, such as the <<searching-nested-documents.adoc#child-doc-transformer,[child]>>, that will not work when nested documents do not have any intrinsic "nested path" information.
 
 The results of indexing anonymous nested children with a "Root-Only" schema are similar to what
-happens if you attempt to index "psuedo field" nested documents using a "Root-Only" schema.
+happens if you attempt to index "pseudo field" nested documents using a "Root-Only" schema.
 Notably: since there is no nested path information for the
 <<searching-nested-documents.adoc#child-doc-transformer,[child]>> transformer to use to reconstruct the structure of a nest
 of documents, it returns all matching children as a flat list, similar in structure to how they were originally indexed:

--- a/solr/solr-ref-guide/src/searching-nested-documents.adoc
+++ b/solr/solr-ref-guide/src/searching-nested-documents.adoc
@@ -53,7 +53,7 @@ $ curl 'http://localhost:8983/solr/gettingstarted/select?omitHeader=true&q=descr
   }}
 ----
 
-The same query with the addition of the `[child]` transformer is shown below.  Note that the `numFound` has not changed, we are still matching the same set of documents, but when returning those documents the nested children are also returned as psuedo-fields.
+The same query with the addition of the `[child]` transformer is shown below.  Note that the `numFound` has not changed, we are still matching the same set of documents, but when returning those documents the nested children are also returned as pseudo-fields.
 
 [source,curl]
 ----

--- a/solr/solr-ref-guide/src/transforming-result-documents.adoc
+++ b/solr/solr-ref-guide/src/transforming-result-documents.adoc
@@ -133,7 +133,7 @@ Note that this transformer can be used even when the query used to match the res
 q=book_title:Solr&fl=id,[child childFilter=doc_type:chapter limit=100]
 ----
 
-If the documents involved include a `\_nest_path_` field, then it is used to re-create the hierarchical structure of the descendent documents using the original psuedo-field names the documents were indexed with, otherwise the descendent documents are returned as a flat list of <<indexing-nested-documents#indexing-anonymous-children,anonymous children>>.
+If the documents involved include a `\_nest_path_` field, then it is used to re-create the hierarchical structure of the descendent documents using the original pseudo-field names the documents were indexed with, otherwise the descendent documents are returned as a flat list of <<indexing-nested-documents#indexing-anonymous-children,anonymous children>>.
 
 `childFilter`::
 A query to filter which child documents should be included. This can be particularly useful when you have multiple levels of hierarchical documents. The default is all children.
@@ -161,7 +161,7 @@ When a `\_nest_path_` field is defined, the `childFilter` option supports an exp
 
 *This syntax is triggered by including a `/` seperated path structure prior to a query that includes a `:` character.*
 
-When the "path" begins with a `/` character, it restricts matches to documents that have that exist "path" of nested psuedo-field documents, starting at the Root document of the block (even if the document being transformed is not a Root level document)
+When the "path" begins with a `/` character, it restricts matches to documents that have that exist "path" of nested pseudo-field documents, starting at the Root document of the block (even if the document being transformed is not a Root level document)
 
 Some Examples:
 

--- a/solr/solr-ref-guide/src/updating-parts-of-documents.adoc
+++ b/solr/solr-ref-guide/src/updating-parts-of-documents.adoc
@@ -156,7 +156,7 @@ curl -X POST 'http://localhost:8983/solr/gettingstarted/update?commit=true' -H '
 
 ==== Replacing All Child Documents
 
-As with normal (multiValued) fields, the `set` keyword can be used to replace all child documents in a psuedo-field:
+As with normal (multiValued) fields, the `set` keyword can be used to replace all child documents in a pseudo-field:
 
 [source,bash]
 ----
@@ -178,7 +178,7 @@ curl -X POST 'http://localhost:8983/solr/gettingstarted/update?commit=true' -H '
 
 ==== Adding a Child Document
 
-As with normal (multiValued) fields, the `add` keyword can be used to add additional child documents to a psuedo-field:
+As with normal (multiValued) fields, the `add` keyword can be used to add additional child documents to a pseudo-field:
 
 [source,bash]
 ----
@@ -196,7 +196,7 @@ curl -X POST 'http://localhost:8983/solr/gettingstarted/update?commit=true' -H '
 
 ==== Removing a Child Document
 
-As with normal (multiValued) fields, the `remove` keyword can be used to remove a child document (by `id`) from it's psuedo-field:
+As with normal (multiValued) fields, the `remove` keyword can be used to remove a child document (by `id`) from it's pseudo-field:
 
 [source,bash]
 ----


### PR DESCRIPTION
Since `solr/main` no longer has the equivalent typos this pull request is for `lucene-solr/branch_8x` only.