### PR TITLE
LUCENE-10036: Add factory method to ScoreCachingWrappingScorer that ensures unnecessary wrapping doesn't occur

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -15,6 +15,9 @@ API Changes
   Users can now access the count of an ordinal directly without constructing an extra FacetLabel.
   Also use variable length arguments for the getOrdinal call in TaxonomyReader. (Gautam Worah)
 
+* LUCENE-10036: Replaced the ScoreCachingWrappingScorer ctor with a static factory method that
+  ensures unnecessary wrapping doesn't occur. (Greg Miller)
+
 New Features
 ---------------------
 (No changes)

--- a/lucene/core/src/java/org/apache/lucene/search/FieldComparator.java
+++ b/lucene/core/src/java/org/apache/lucene/search/FieldComparator.java
@@ -214,11 +214,7 @@ public abstract class FieldComparator<T> {
       // wrap with a ScoreCachingWrappingScorer so that successive calls to
       // score() will not incur score computation over and
       // over again.
-      if (!(scorer instanceof ScoreCachingWrappingScorer)) {
-        this.scorer = new ScoreCachingWrappingScorer(scorer);
-      } else {
-        this.scorer = scorer;
-      }
+      this.scorer = ScoreCachingWrappingScorer.wrap(scorer);
     }
     
     @Override

--- a/lucene/core/src/java/org/apache/lucene/search/MultiCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/MultiCollector.java
@@ -155,7 +155,7 @@ public class MultiCollector implements Collector {
     @Override
     public void setScorer(Scorable scorer) throws IOException {
       if (cacheScores) {
-        scorer = new ScoreCachingWrappingScorer(scorer);
+        scorer = ScoreCachingWrappingScorer.wrap(scorer);
       }
       if (skipNonCompetitiveScores) {
         for (int i = 0; i < collectors.length; ++i) {

--- a/lucene/core/src/java/org/apache/lucene/search/PositiveScoresOnlyCollector.java
+++ b/lucene/core/src/java/org/apache/lucene/search/PositiveScoresOnlyCollector.java
@@ -41,7 +41,7 @@ public class PositiveScoresOnlyCollector extends FilterCollector {
 
       @Override
       public void setScorer(Scorable scorer) throws IOException {
-        this.scorer = new ScoreCachingWrappingScorer(scorer);
+        this.scorer = ScoreCachingWrappingScorer.wrap(scorer);
         in.setScorer(this.scorer);
       }
 

--- a/lucene/core/src/java/org/apache/lucene/search/ScoreCachingWrappingScorer.java
+++ b/lucene/core/src/java/org/apache/lucene/search/ScoreCachingWrappingScorer.java
@@ -38,7 +38,24 @@ public final class ScoreCachingWrappingScorer extends Scorable {
   private float curScore;
   private final Scorable in;
 
-  /** Creates a new instance by wrapping the given scorer. */
+  /**
+   * Wraps the provided {@link Scorable} unless it's already an instance of
+   * {@code ScoreCachingWrappingScorer}, in which case it will just return the provided instance.
+   * @param scorer Underlying {@code Scorable} to wrap
+   * @return Instance of {@code ScoreCachingWrappingScorer} wrapping the underlying {@code scorer}
+   */
+  public static Scorable wrap(Scorable scorer) {
+    if (scorer instanceof ScoreCachingWrappingScorer) {
+      return scorer;
+    }
+    return new ScoreCachingWrappingScorer(scorer);
+  }
+
+  /**
+   * Creates a new instance by wrapping the given scorer.
+   * @deprecated Use {@link ScoreCachingWrappingScorer#wrap(Scorable)} instead
+   */
+  @Deprecated
   public ScoreCachingWrappingScorer(Scorable scorer) {
     this.in = scorer;
   }

--- a/lucene/core/src/test/org/apache/lucene/search/TestScoreCachingWrappingScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestScoreCachingWrappingScorer.java
@@ -96,7 +96,7 @@ public class TestScoreCachingWrappingScorer extends LuceneTestCase {
     }
 
     @Override public void setScorer(Scorable scorer) {
-      this.scorer = new ScoreCachingWrappingScorer(scorer);
+      this.scorer = ScoreCachingWrappingScorer.wrap(scorer);
     }
     
     @Override
@@ -134,5 +134,28 @@ public class TestScoreCachingWrappingScorer extends LuceneTestCase {
     ir.close();
     directory.close();
   }
-  
+
+  public void testNoUnnecessaryWrap() throws Exception {
+    Scorable base =
+        new Scorable() {
+          @Override
+          public float score() throws IOException {
+            return -1;
+          }
+
+          @Override
+          public int docID() {
+            return -1;
+          }
+        };
+
+    // Wrapping the first time should produce a different instance:
+    Scorable wrapped = ScoreCachingWrappingScorer.wrap(base);
+    assertNotEquals(base, wrapped);
+
+    // But if we try to wrap an instance of ScoreCachingWrappingScorer, it shouldn't unnecessarily
+    // wrap again:
+    Scorable doubleWrapped = ScoreCachingWrappingScorer.wrap(wrapped);
+    assertEquals(wrapped, doubleWrapped);
+  }
 }

--- a/lucene/core/src/test/org/apache/lucene/search/TestScoreCachingWrappingScorer.java
+++ b/lucene/core/src/test/org/apache/lucene/search/TestScoreCachingWrappingScorer.java
@@ -156,6 +156,6 @@ public class TestScoreCachingWrappingScorer extends LuceneTestCase {
     // But if we try to wrap an instance of ScoreCachingWrappingScorer, it shouldn't unnecessarily
     // wrap again:
     Scorable doubleWrapped = ScoreCachingWrappingScorer.wrap(wrapped);
-    assertEquals(wrapped, doubleWrapped);
+    assertSame(wrapped, doubleWrapped);
   }
 }


### PR DESCRIPTION
Backport from `lucene/main`.