### PR TITLE
LUCENE-10032: Remove leafDocMaps from MergeState

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -4026,10 +4026,8 @@ public class IndexWriter implements Closeable, TwoPhaseCommit, Accountable,
       assert rld != null: "seg=" + info.info.name;
 
       MergeState.DocMap segDocMap = mergeState.docMaps[i];
-      MergeState.DocMap segLeafDocMap = mergeState.leafDocMaps[i];
-
       carryOverHardDeletes(mergedDeletesAndUpdates, maxDoc, mergeState.liveDocs[i],  merge.getMergeReader().get(i).hardLiveDocs, rld.getHardLiveDocs(),
-          segDocMap, segLeafDocMap);
+          segDocMap);
 
       // Now carry over all doc values updates that were resolved while we were merging, remapping the docIDs to the newly merged docIDs.
       // We only carry over packets that finished resolving; if any are still running (concurrently) they will detect that our merge completed
@@ -4072,7 +4070,7 @@ public class IndexWriter implements Closeable, TwoPhaseCommit, Accountable,
           DocValuesFieldUpdates.Iterator it = updates.iterator();
           int doc;
           while ((doc = it.nextDoc()) != NO_MORE_DOCS) {
-            int mappedDoc = segDocMap.get(segLeafDocMap.get(doc));
+            int mappedDoc = segDocMap.get(doc);
             if (mappedDoc != -1) {
               if (it.hasValue()) {
                 // not deleted
@@ -4123,7 +4121,7 @@ public class IndexWriter implements Closeable, TwoPhaseCommit, Accountable,
                                            Bits mergeLiveDocs, // the liveDocs used to build the segDocMaps
                                            Bits prevHardLiveDocs, // the hard deletes when the merge reader was pulled
                                            Bits currentHardLiveDocs, // the current hard deletes
-                                           MergeState.DocMap segDocMap, MergeState.DocMap segLeafDocMap) throws IOException {
+                                           MergeState.DocMap segDocMap) throws IOException {
 
     assert mergeLiveDocs == null || mergeLiveDocs.length() == maxDoc;
     // if we mix soft and hard deletes we need to make sure that we only carry over deletes
@@ -4163,7 +4161,7 @@ public class IndexWriter implements Closeable, TwoPhaseCommit, Accountable,
             assert currentHardLiveDocs.get(j) == false;
           } else if (carryOverDelete.test(j)) {
             // the document was deleted while we were merging:
-            mergedReadersAndUpdates.delete(segDocMap.get(segLeafDocMap.get(j)));
+            mergedReadersAndUpdates.delete(segDocMap.get(j));
           }
         }
       }
@@ -4173,7 +4171,7 @@ public class IndexWriter implements Closeable, TwoPhaseCommit, Accountable,
       // does:
       for (int j = 0; j < maxDoc; j++) {
         if (carryOverDelete.test(j)) {
-          mergedReadersAndUpdates.delete(segDocMap.get(segLeafDocMap.get(j)));
+          mergedReadersAndUpdates.delete(segDocMap.get(j));
         }
       }
     }


### PR DESCRIPTION
These maps are no longer useful after LUCENE-8505.