### PR TITLE
SOLR-15566: Clarify ref guide documentation about SQL queries with SELECT * requiring a LIMIT clause

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -602,7 +602,7 @@ Consult the LUCENE_CHANGES.txt file for additional, low level, changes in this r
 
 Bug Fixes
 ---------------------
-(No changes)
+* SOLR-15566: Clarify ref guide documentation about SQL queries with `SELECT *` requiring a `LIMIT` clause (Timothy Potter)
 
 ==================  8.6.2 ==================
 

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -58,6 +58,8 @@ Other Changes
 
 * SOLR-15502: Remove MetricsCollectorHandler deprecated warning from the logs. (Bernd Wahlen, ab)
 
+* SOLR-15566: Clarify ref guide documentation about SQL queries with `SELECT *` requiring a `LIMIT` clause (Timothy Potter)
+
 ==================  8.9.0 ==================
 
 Consult the LUCENE_CHANGES.txt file for additional, low level, changes in this release.
@@ -602,7 +604,7 @@ Consult the LUCENE_CHANGES.txt file for additional, low level, changes in this r
 
 Bug Fixes
 ---------------------
-* SOLR-15566: Clarify ref guide documentation about SQL queries with `SELECT *` requiring a `LIMIT` clause (Timothy Potter)
+(No changes)
 
 ==================  8.6.2 ==================
 

--- a/solr/core/src/test/org/apache/solr/handler/TestSQLHandler.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestSQLHandler.java
@@ -2267,4 +2267,18 @@ public class TestSQLHandler extends SolrCloudTestCase {
     String country = id % 2 == 0 ? "US" : "CA";
     return updateRequest.add("id", String.valueOf(id), "str_s", String.format(Locale.ROOT, padFmt, id % cardinality), "country_s", country);
   }
+
+  @Test
+  public void testSelectStarWithLimit() throws Exception {
+    new UpdateRequest()
+        .add("id", "1", "a_s", "hello-1", "b_s", "foo", "c_s", "bar", "d_s", "x")
+        .add("id", "2", "a_s", "world-2", "b_s", "foo", "a_i", "2", "d_s", "a")
+        .add("id", "3", "a_s", "hello-3", "b_s", "foo", "c_s", "bar", "d_s", "x")
+        .add("id", "4", "a_s", "world-4", "b_s", "foo", "a_i", "3", "d_s", "b")
+        .commit(cluster.getSolrClient(), COLLECTIONORALIAS);
+
+    expectResults("SELECT * FROM $ALIAS LIMIT 100", 4);
+    // select * w/o limit is not supported by Solr SQL
+    expectThrows(IOException.class, () -> expectResults("SELECT * FROM $ALIAS", -1));
+  }
 }

--- a/solr/solr-ref-guide/src/parallel-sql-interface.adoc
+++ b/solr/solr-ref-guide/src/parallel-sql-interface.adoc
@@ -163,10 +163,14 @@ Solr supports a broad range of SQL syntax.
 The SQL parser being used by Solr to translate the SQL statements is case insensitive. However, for ease of reading, all examples on this page use capitalized keywords.
 ====
 
-.SELECT * is not supported
+.SELECT * is only supported when using LIMIT
 [IMPORTANT]
 ====
-The SQL parser being used by Solr does not support the SELECT * syntax, you must specify each field you wish to return.
+In general, you should project the fields you need to return for each query explicitly and avoid using `select *`, which is generally considered a bad practice and
+can lead to unexpected results when the underlying Solr schema changes.
+However, Solr does support `select *` for queries that also include a `LIMIT` clause.
+All stored fields and the `score` will be included in the results.
+Without a `LIMIT` clause, only fields with docValues enabled can be returned.
 ====
 
 === Escaping Reserved Words

--- a/solr/solr-ref-guide/src/parallel-sql-interface.adoc
+++ b/solr/solr-ref-guide/src/parallel-sql-interface.adoc
@@ -31,7 +31,7 @@ In a standard `SELECT` statement such as `SELECT <expressions> FROM <table>`, th
 
 Column names in the SQL query map directly to fields in the Solr index for the collection being queried. These identifiers are case sensitive. Aliases are supported, and can be referenced in the `ORDER BY` clause.
 
-The `*` syntax to indicate all fields is not supported in either limited or unlimited queries. The `score` field can be used only with queries that contain a `LIMIT` clause.
+The `*` syntax to indicate all fields is only supported for queries with a `LIMIT` and includes the `score` field. The `score` field can be used only with queries that contain a `LIMIT` clause.
 
 For example, we could index Solr's sample documents and then construct an SQL query like this:
 


### PR DESCRIPTION
backport of https://github.com/apache/solr/pull/237