### PR TITLE
LUCENE-9964: Duplicate long values in a field should only be counted once when using SortedNumericDocValuesFields

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -76,6 +76,9 @@ Bug Fixes
 
 * LUCENE-9988: Fix DrillSideways correctness bug introduced in LUCENE-9944 (Greg Miller)
 
+* LUCENE-9964: Duplicate long values in a document field should only be counted once when using SortedNumericDocValuesFields
+  (Gautam Worah)
+
 * LUCENE-9999: CombinedFieldQuery can fail with an exception when document
   is missing some fields. (Jim Ferenczi, Julie Tibshirani)
 

--- a/lucene/facet/src/java/org/apache/lucene/facet/LongValueFacetCounts.java
+++ b/lucene/facet/src/java/org/apache/lucene/facet/LongValueFacetCounts.java
@@ -178,8 +178,14 @@ public class LongValueFacetCounts extends Facets {
           if (limit > 0) {
             totCount++;
           }
+          long previousValue = 0;
           for (int i = 0; i < limit; i++) {
-            increment(values.nextValue());
+            long value = values.nextValue();
+            // do not increment the count for duplicate values
+            if (i == 0 || value != previousValue) {
+              increment(value);
+          }
+            previousValue = value;
           }
         }
       }
@@ -244,8 +250,14 @@ public class LongValueFacetCounts extends Facets {
           if (limit > 0) {
             totCount++;
           }
+          long previousValue = 0;
           for (int i = 0; i < limit; i++) {
-            increment(values.nextValue());
+            long value = values.nextValue();
+            // do not increment the count for duplicate values
+            if (i == 0 || value != previousValue) {
+              increment(value);
+            }
+            previousValue = value;
           }
         }
       }

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestLongValueFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestLongValueFacetCounts.java
@@ -557,7 +557,7 @@ public class TestLongValueFacetCounts extends LuceneTestCase {
 
     IndexReader r = w.getReader();
     w.close();
-    LongValueFacetCounts facetCounts = new LongValueFacetCounts("field", r);
+    LongValueFacetCounts facetCounts = new LongValueFacetCounts("field", r, true);
 
     FacetResult fr = facetCounts.getAllChildrenSortByValue();
     for (LabelAndValue labelAndValue : fr.labelValues) {

--- a/lucene/facet/src/test/org/apache/lucene/facet/TestLongValueFacetCounts.java
+++ b/lucene/facet/src/test/org/apache/lucene/facet/TestLongValueFacetCounts.java
@@ -129,11 +129,11 @@ public class TestLongValueFacetCounts extends LuceneTestCase {
     d.close();
   }
 
-  public void testRandom() throws Exception {
+  public void testRandomSingleValued() throws Exception {
     Directory dir = newDirectory();
     RandomIndexWriter w = new RandomIndexWriter(random(), dir);
 
-    int valueCount = atLeast(1000);
+    int docCount = atLeast(1000);
     double missingChance = random().nextDouble();
     long maxValue;
     if (random().nextBoolean()) {
@@ -142,12 +142,12 @@ public class TestLongValueFacetCounts extends LuceneTestCase {
       maxValue = random().nextInt(1000);
     }
     if (VERBOSE) {
-      System.out.println("TEST: valueCount=" + valueCount + " valueRange=-" + maxValue +
+      System.out.println("TEST: valueCount=" + docCount + " valueRange=-" + maxValue +
                          "-" + maxValue + " missingChance=" + missingChance);
     }
-    Long[] values = new Long[valueCount];
+    Long[] values = new Long[docCount];
     int missingCount = 0;
-    for (int i = 0; i < valueCount; i++) {
+    for (int i = 0; i < docCount; i++) {
       Document doc = new Document();
       doc.add(new IntPoint("id", i));
       if (random().nextDouble() > missingChance) {
@@ -176,7 +176,7 @@ public class TestLongValueFacetCounts extends LuceneTestCase {
       // all docs
       Map<Long, Integer> expected = new HashMap<>();
       int expectedChildCount = 0;
-      for (int i = 0; i < valueCount; i++) {
+      for (int i = 0; i < docCount; i++) {
         if (values[i] != null) {
           Integer curCount = expected.get(values[i]);
           if (curCount == null) {
@@ -224,7 +224,7 @@ public class TestLongValueFacetCounts extends LuceneTestCase {
 
       FacetResult actual = facetCounts.getAllChildrenSortByValue();
       assertSame("all docs, sort facets by value", expectedCounts, expectedChildCount,
-                 valueCount - missingCount, actual, Integer.MAX_VALUE);
+          docCount - missingCount, actual, Integer.MAX_VALUE);
 
       // sort by count
       Collections.sort(expectedCounts,
@@ -238,19 +238,19 @@ public class TestLongValueFacetCounts extends LuceneTestCase {
                        });
       int topN;
       if (random().nextBoolean()) {
-        topN = valueCount;
+        topN = docCount;
       } else {
-        topN = random().nextInt(valueCount);
+        topN = random().nextInt(docCount);
       }
       if (VERBOSE) {
         System.out.println("  topN=" + topN);
       }
       actual = facetCounts.getTopChildrenSortByCount(topN);
-      assertSame("all docs, sort facets by count", expectedCounts, expectedChildCount, valueCount - missingCount, actual, topN);
+      assertSame("all docs, sort facets by count", expectedCounts, expectedChildCount, docCount - missingCount, actual, topN);
 
       // subset of docs
-      int minId = random().nextInt(valueCount);
-      int maxId = random().nextInt(valueCount);
+      int minId = random().nextInt(docCount);
+      int maxId = random().nextInt(docCount);
       if (minId > maxId) {
         int tmp = minId;
         minId = maxId;
@@ -308,9 +308,9 @@ public class TestLongValueFacetCounts extends LuceneTestCase {
                          return cmp;
                        });
       if (random().nextBoolean()) {
-        topN = valueCount;
+        topN = docCount;
       } else {
-        topN = random().nextInt(valueCount);
+        topN = random().nextInt(docCount);
       }
       actual = facetCounts.getTopChildrenSortByCount(topN);
       assertSame("id " + minId + "-" + maxId + ", sort facets by count", expectedCounts, expectedChildCount, totCount, actual, topN);
@@ -323,7 +323,7 @@ public class TestLongValueFacetCounts extends LuceneTestCase {
     Directory dir = newDirectory();
     RandomIndexWriter w = new RandomIndexWriter(random(), dir);
 
-    int valueCount = atLeast(1000);
+    int docCount = atLeast(1000);
     double missingChance = random().nextDouble();
 
     // sometimes exercise codec optimizations when a claimed multi valued field is in fact single valued:
@@ -336,13 +336,13 @@ public class TestLongValueFacetCounts extends LuceneTestCase {
       maxValue = random().nextInt(1000);
     }
     if (VERBOSE) {
-      System.out.println("TEST: valueCount=" + valueCount + " valueRange=-" + maxValue +
+      System.out.println("TEST: valueCount=" + docCount + " valueRange=-" + maxValue +
                          "-" + maxValue + " missingChance=" + missingChance + " allSingleValued=" + allSingleValued);
     }
     
-    long[][] values = new long[valueCount][];
+    long[][] values = new long[docCount][];
     int missingCount = 0;
-    for (int i = 0; i < valueCount; i++) {
+    for (int i = 0; i < docCount; i++) {
       Document doc = new Document();
       doc.add(new IntPoint("id", i));
       if (random().nextDouble() > missingChance) {
@@ -362,6 +362,8 @@ public class TestLongValueFacetCounts extends LuceneTestCase {
           System.out.println("  doc=" + i + " values=" + Arrays.toString(values[i]));
         }
 
+        // sort values to enable duplicate detection by comparing with the previous value
+        Arrays.sort(values[i]);
       } else {
         missingCount++;
 
@@ -387,23 +389,16 @@ public class TestLongValueFacetCounts extends LuceneTestCase {
 
       // all docs
       Map<Long, Integer> expected = new HashMap<>();
-      int expectedChildCount = 0;
       int expectedTotalCount = 0;
-      for (int i = 0; i < valueCount; i++) {
+      for (int i = 0; i < docCount; i++) {
         if (values[i] != null && values[i].length > 0) {
           expectedTotalCount++;
-          for (long value : values[i]) {
-            Integer curCount = expected.get(value);
-            if (curCount == null) {
-              curCount = 0;
-              expectedChildCount++;
-            }
-            expected.put(value, curCount + 1);
-          }
+          setExpectedFrequencies(values[i], expected);
         }
       }
 
       List<Map.Entry<Long, Integer>> expectedCounts = new ArrayList<>(expected.entrySet());
+      int expectedChildCount = expected.size();
 
       // sort by value
       Collections.sort(expectedCounts,
@@ -440,9 +435,9 @@ public class TestLongValueFacetCounts extends LuceneTestCase {
                        });
       int topN;
       if (random().nextBoolean()) {
-        topN = valueCount;
+        topN = docCount;
       } else {
-        topN = random().nextInt(valueCount);
+        topN = random().nextInt(docCount);
       }
       if (VERBOSE) {
         System.out.println("  topN=" + topN);
@@ -451,8 +446,8 @@ public class TestLongValueFacetCounts extends LuceneTestCase {
       assertSame("all docs, sort facets by count", expectedCounts, expectedChildCount, expectedTotalCount, actual, topN);
 
       // subset of docs
-      int minId = random().nextInt(valueCount);
-      int maxId = random().nextInt(valueCount);
+      int minId = random().nextInt(docCount);
+      int maxId = random().nextInt(docCount);
       if (minId > maxId) {
         int tmp = minId;
         minId = maxId;
@@ -468,29 +463,22 @@ public class TestLongValueFacetCounts extends LuceneTestCase {
       facetCounts = new LongValueFacetCounts("field", fc, true);
 
       expected = new HashMap<>();
-      expectedChildCount = 0;
-      int totCount = 0;
+      expectedTotalCount = 0;
       for (int i = minId; i <= maxId; i++) {
         if (values[i] != null && values[i].length > 0) {
-          totCount++;
-          for (long value : values[i]) {
-            Integer curCount = expected.get(value);
-            if (curCount == null) {
-              expectedChildCount++;
-              curCount = 0;
-            }
-            expected.put(value, curCount + 1);
-          }
+          expectedTotalCount++;
+          setExpectedFrequencies(values[i], expected);
         }
       }
       expectedCounts = new ArrayList<>(expected.entrySet());
+      expectedChildCount = expected.size();
 
       // sort by value
       Collections.sort(expectedCounts,
                        (a, b) -> (Long.compare(a.getKey(), b.getKey())));
       actual = facetCounts.getAllChildrenSortByValue();
       assertSame("id " + minId + "-" + maxId + ", sort facets by value", expectedCounts,
-                 expectedChildCount, totCount, actual, Integer.MAX_VALUE);
+                 expectedChildCount, expectedTotalCount, actual, Integer.MAX_VALUE);
 
       // sort by count
       Collections.sort(expectedCounts,
@@ -503,15 +491,26 @@ public class TestLongValueFacetCounts extends LuceneTestCase {
                          return cmp;
                        });
       if (random().nextBoolean()) {
-        topN = valueCount;
+        topN = docCount;
       } else {
-        topN = random().nextInt(valueCount);
+        topN = random().nextInt(docCount);
       }
       actual = facetCounts.getTopChildrenSortByCount(topN);
-      assertSame("id " + minId + "-" + maxId + ", sort facets by count", expectedCounts, expectedChildCount, totCount, actual, topN);
+      assertSame("id " + minId + "-" + maxId + ", sort facets by count", expectedCounts, expectedChildCount, expectedTotalCount, actual, topN);
     }
     r.close();
     dir.close();
+  }
+
+  private void setExpectedFrequencies(long[] values, Map<Long, Integer> expected) {
+    long previousValue = 0;
+    for (int j = 0; j < values.length; j++) {
+      if (j == 0 || previousValue != values[j]) {
+        Integer curCount = expected.getOrDefault(values[j], 0);
+        expected.put(values[j], curCount + 1);
+      }
+      previousValue = values[j];
+    }
   }
 
   private static void assertSame(String desc, List<Map.Entry<Long, Integer>> expectedCounts,
@@ -536,5 +535,36 @@ public class TestLongValueFacetCounts extends LuceneTestCase {
       assertEquals(desc + ": label[" + i + "]", Long.toString(expectedCounts.get(i).getKey()), actual.labelValues[i].label);
       assertEquals(desc + ": counts[" + i + "]", expectedCounts.get(i).getValue().intValue(), actual.labelValues[i].value.intValue());
     }
+  }
+
+  /**
+   * LUCENE-9964: Duplicate long values in a document field should only be counted once when using
+   * SortedNumericDocValuesFields
+   */
+  public void testDuplicateLongValues() throws Exception {
+    Directory dir = newDirectory();
+    RandomIndexWriter w = new RandomIndexWriter(random(), dir);
+
+    Document doc = new Document();
+    // these two values are not unique in a document
+    doc.add(new SortedNumericDocValuesField("field", 42));
+    doc.add(new SortedNumericDocValuesField("field", 42));
+    w.addDocument(doc);
+    doc = new Document();
+    doc.add(new SortedNumericDocValuesField("field", 43));
+    doc.add(new SortedNumericDocValuesField("field", 43));
+    w.addDocument(doc);
+
+    IndexReader r = w.getReader();
+    w.close();
+    LongValueFacetCounts facetCounts = new LongValueFacetCounts("field", r);
+
+    FacetResult fr = facetCounts.getAllChildrenSortByValue();
+    for (LabelAndValue labelAndValue : fr.labelValues) {
+      assert labelAndValue.value.equals(1);
+    }
+
+    r.close();
+    dir.close();
   }
 }


### PR DESCRIPTION
Backport