### PR TITLE
LUCENE-9945: Extend DrillSidewaysResult to expose drillDowns and drillSideways

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -58,6 +58,9 @@ Improvements
 * LUCENE-10030: Lazily evaluate score in DrillSidewaysScorer.doQueryFirstScoring
   (Grigoriy Troitskiy)
 
+* LUCENE-9945: Extend DrillSideways to support exposing FacetCollectors directly.
+  (Greg Miller, Sejal Pawar)
+
 Optimizations
 ---------------------
 


### PR DESCRIPTION
Backport from 9.0. Added `@deprecated` ctors to adhere to backwards compatibility [policy](https://cwiki.apache.org/confluence/display/LUCENE/BackwardsCompatibility)