### PR TITLE
SOLR-15575: Propagate request level basic auth creds from the top-level async CollectionAdminRequest to internally used async requests, such as async status checking

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -60,6 +60,9 @@ Bug Fixes
 
 * SOLR-15482: Cross-collection join fixed to ignore documents that do not contain value in "from" field (hossman)
 
+* SOLR-15575: Propagate request level basic auth creds from the top-level async CollectionAdminRequest to internally
+  used async requests, such as async status checking (Timothy Potter)
+
 Other Changes
 ---------------------
 * SOLR-15355: Upgrade Hadoop from 3.2.0 to 3.2.2. (Antoine Gruzelle via David Smiley)

--- a/solr/core/src/test/org/apache/solr/cloud/TestPullReplicaWithAuth.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestPullReplicaWithAuth.java
@@ -92,7 +92,7 @@ public class TestPullReplicaWithAuth extends SolrCloudTestCase {
         CollectionAdminRequest.createCollection(collectionName, "conf", 1, 1, 0, numPullReplicas);
     create.setMaxShardsPerNode(2);
     withBasicAuth(create)
-        .process(cluster.getSolrClient());
+        .processAndWait(cluster.getSolrClient(), 10);
     waitForState("Expected collection to be created with 1 shard and " + (numPullReplicas + 1) + " replicas",
         collectionName, clusterShape(1, numPullReplicas + 1));
     DocCollection docCollection =


### PR DESCRIPTION
backport of https://github.com/apache/solr/pull/246