### PR TITLE
SOLR-15576: Allow filtering on ISO-8601 formatted timestamp literals in SQL WHERE clause

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -45,6 +45,8 @@ Improvements
 
 * SOLR-15564: Improve filtering expressions in /admin/metrics. (ab)
 
+* SOLR-15576: Allow filtering on ISO-8601 formatted timestamp literals in SQL WHERE clause (Timothy Potter)
+
 Optimizations
 ---------------------
 * SOLR-15433: Replace transient core cache LRU by Caffeine cache. (Bruno Roustant)

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/JDBCStream.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/io/stream/JDBCStream.java
@@ -278,8 +278,7 @@ public class JDBCStream extends TupleStream implements Expressible {
       resultSet = statement.executeQuery(sqlQuery);
       resultSet.setFetchSize(fetchSize);
     } catch (SQLException e) {
-      throw new IOException(String.format(Locale.ROOT, "Failed to execute sqlQuery '%s' against JDBC connection '%s'.\n"
-          + e.getMessage(), sqlQuery, connectionUrl), e);
+      throw new IOException(String.format(Locale.ROOT, "Failed to execute sqlQuery '%s' against JDBC connection '%s'.%nCaused by: %s", sqlQuery, connectionUrl, e.getMessage()), e);
     }
     
     try{


### PR DESCRIPTION
backport of https://github.com/apache/solr/pull/247