### PR TITLE
LUCENE-10035: Simple text codec add multi level skip list data (#224)

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -29,6 +29,9 @@ New Features
 ---------------------
 * LUCENE-10083: Analyzer and stemmer for Telugu language (Vinod Singh)
 
+* LUCENE-10035: The SimpleText codec now writes skip lists.
+  (wuda via Adrien Grand)
+
 Improvements
 ---------------------
 

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextSkipReader.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextSkipReader.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.simpletext;
+
+import static org.apache.lucene.codecs.simpletext.SimpleTextSkipWriter.CHILD_POINTER;
+import static org.apache.lucene.codecs.simpletext.SimpleTextSkipWriter.FREQ;
+import static org.apache.lucene.codecs.simpletext.SimpleTextSkipWriter.IMPACT;
+import static org.apache.lucene.codecs.simpletext.SimpleTextSkipWriter.IMPACTS;
+import static org.apache.lucene.codecs.simpletext.SimpleTextSkipWriter.IMPACTS_END;
+import static org.apache.lucene.codecs.simpletext.SimpleTextSkipWriter.LEVEL_LENGTH;
+import static org.apache.lucene.codecs.simpletext.SimpleTextSkipWriter.NORM;
+import static org.apache.lucene.codecs.simpletext.SimpleTextSkipWriter.SKIP_DOC;
+import static org.apache.lucene.codecs.simpletext.SimpleTextSkipWriter.SKIP_DOC_FP;
+import static org.apache.lucene.codecs.simpletext.SimpleTextSkipWriter.SKIP_LIST;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.lucene.codecs.MultiLevelSkipListReader;
+import org.apache.lucene.index.Impact;
+import org.apache.lucene.index.Impacts;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.store.BufferedChecksumIndexInput;
+import org.apache.lucene.store.ChecksumIndexInput;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.BytesRefBuilder;
+import org.apache.lucene.util.CharsRefBuilder;
+import org.apache.lucene.util.StringHelper;
+
+/**
+ * This class reads skip lists with multiple levels.
+ *
+ * <p>See {@link SimpleTextFieldsWriter} for the information about the encoding of the multi level
+ * skip lists.
+ *
+ * @lucene.experimental
+ */
+class SimpleTextSkipReader extends MultiLevelSkipListReader {
+
+  private final CharsRefBuilder scratchUTF16 = new CharsRefBuilder();
+  private final BytesRefBuilder scratch = new BytesRefBuilder();
+  private Impacts impacts;
+  private List<List<Impact>> perLevelImpacts;
+  private long nextSkipDocFP = -1;
+  private int numLevels = 1;
+  private boolean hasSkipList = false;
+
+  SimpleTextSkipReader(IndexInput skipStream) {
+    super(
+        skipStream,
+        SimpleTextSkipWriter.maxSkipLevels,
+        SimpleTextSkipWriter.BLOCK_SIZE,
+        SimpleTextSkipWriter.skipMultiplier);
+    impacts =
+        new Impacts() {
+          @Override
+          public int numLevels() {
+            return numLevels;
+          }
+
+          @Override
+          public int getDocIdUpTo(int level) {
+            return skipDoc[level];
+          }
+
+          @Override
+          public List<Impact> getImpacts(int level) {
+            assert level < numLevels;
+            return perLevelImpacts.get(level);
+          }
+        };
+    init();
+  }
+
+  @Override
+  public int skipTo(int target) throws IOException {
+    if (!hasSkipList) {
+      return -1;
+    }
+    int result = super.skipTo(target);
+    if (numberOfSkipLevels > 0) {
+      numLevels = numberOfSkipLevels;
+    } else {
+      // End of postings don't have skip data anymore, so we fill with dummy data
+      // like SlowImpactsEnum.
+      numLevels = 1;
+      perLevelImpacts.add(0, Collections.singletonList(new Impact(Integer.MAX_VALUE, 1L)));
+    }
+    return result;
+  }
+
+  @Override
+  protected int readSkipData(int level, IndexInput skipStream) throws IOException {
+    perLevelImpacts.get(level).clear();
+    int skipDoc = DocIdSetIterator.NO_MORE_DOCS;
+    ChecksumIndexInput input = new BufferedChecksumIndexInput(skipStream);
+    int freq = 1;
+    while (true) {
+      SimpleTextUtil.readLine(input, scratch);
+      if (scratch.get().equals(SimpleTextFieldsWriter.END)) {
+        SimpleTextUtil.checkFooter(input);
+        break;
+      } else if (scratch.get().equals(IMPACTS_END)
+          || scratch.get().equals(SimpleTextFieldsWriter.TERM)
+          || scratch.get().equals(SimpleTextFieldsWriter.FIELD)) {
+        break;
+      } else if (StringHelper.startsWith(scratch.get(), SKIP_LIST)) {
+        // continue
+      } else if (StringHelper.startsWith(scratch.get(), SKIP_DOC)) {
+        scratchUTF16.copyUTF8Bytes(
+            scratch.bytes(), SKIP_DOC.length, scratch.length() - SKIP_DOC.length);
+        skipDoc = ArrayUtil.parseInt(scratchUTF16.chars(), 0, scratchUTF16.length());
+        // Because the MultiLevelSkipListReader stores doc id delta,but simple text codec stores doc
+        // id
+        skipDoc = skipDoc - super.skipDoc[level];
+      } else if (StringHelper.startsWith(scratch.get(), SKIP_DOC_FP)) {
+        scratchUTF16.copyUTF8Bytes(
+            scratch.bytes(), SKIP_DOC_FP.length, scratch.length() - SKIP_DOC_FP.length);
+        nextSkipDocFP = ArrayUtil.parseInt(scratchUTF16.chars(), 0, scratchUTF16.length());
+      } else if (StringHelper.startsWith(scratch.get(), IMPACTS)
+          || StringHelper.startsWith(scratch.get(), IMPACT)) {
+        // continue;
+      } else if (StringHelper.startsWith(scratch.get(), FREQ)) {
+        scratchUTF16.copyUTF8Bytes(scratch.bytes(), FREQ.length, scratch.length() - FREQ.length);
+        freq = ArrayUtil.parseInt(scratchUTF16.chars(), 0, scratchUTF16.length());
+      } else if (StringHelper.startsWith(scratch.get(), NORM)) {
+        scratchUTF16.copyUTF8Bytes(scratch.bytes(), NORM.length, scratch.length() - NORM.length);
+        long norm = Long.parseLong(scratchUTF16.toString());
+        Impact impact = new Impact(freq, norm);
+        perLevelImpacts.get(level).add(impact);
+      }
+    }
+    return skipDoc;
+  }
+
+  @Override
+  protected long readLevelLength(IndexInput skipStream) throws IOException {
+    SimpleTextUtil.readLine(skipStream, scratch);
+    scratchUTF16.copyUTF8Bytes(
+        scratch.bytes(), LEVEL_LENGTH.length, scratch.length() - LEVEL_LENGTH.length);
+    return Long.parseLong(scratchUTF16.toString());
+  }
+
+  @Override
+  protected long readChildPointer(IndexInput skipStream) throws IOException {
+    SimpleTextUtil.readLine(skipStream, scratch);
+    scratchUTF16.copyUTF8Bytes(
+        scratch.bytes(), CHILD_POINTER.length, scratch.length() - CHILD_POINTER.length);
+    return Long.parseLong(scratchUTF16.toString());
+  }
+
+  void reset(long skipPointer, int docFreq) throws IOException {
+    init();
+    if (skipPointer > 0) {
+      super.init(skipPointer, docFreq);
+      hasSkipList = true;
+    }
+  }
+
+  private void init() {
+    nextSkipDocFP = -1;
+    numLevels = 1;
+    perLevelImpacts = new ArrayList<>(maxNumberOfSkipLevels);
+    for (int level = 0; level < maxNumberOfSkipLevels; level++) {
+      List<Impact> impacts = new ArrayList<>();
+      impacts.add(new Impact(Integer.MAX_VALUE, 1L));
+      perLevelImpacts.add(level, impacts);
+    }
+    hasSkipList = false;
+  }
+
+  Impacts getImpacts() {
+    return impacts;
+  }
+
+  long getNextSkipDocFP() {
+    return nextSkipDocFP;
+  }
+
+  int getNextSkipDoc() {
+    if (!hasSkipList) {
+      return DocIdSetIterator.NO_MORE_DOCS;
+    }
+    return skipDoc[0];
+  }
+
+  boolean hasSkipList() {
+    return hasSkipList;
+  }
+}

--- a/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextSkipWriter.java
+++ b/lucene/codecs/src/java/org/apache/lucene/codecs/simpletext/SimpleTextSkipWriter.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.simpletext;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.lucene.codecs.CompetitiveImpactAccumulator;
+import org.apache.lucene.codecs.MultiLevelSkipListWriter;
+import org.apache.lucene.index.Impact;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.store.DataOutput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefBuilder;
+
+/**
+ * plain text skip data.
+ *
+ * @lucene.experimental
+ */
+class SimpleTextSkipWriter extends MultiLevelSkipListWriter {
+
+  static final int skipMultiplier = 3;
+  static final int maxSkipLevels = 4;
+
+  static final int BLOCK_SIZE = 8;
+  private Map<Integer, Boolean> wroteHeaderPerLevelMap = new HashMap<>();
+  private int curDoc;
+  private long curDocFilePointer;
+  private CompetitiveImpactAccumulator[] curCompetitiveFreqNorms;
+  private final BytesRefBuilder scratch = new BytesRefBuilder();
+
+  static final BytesRef SKIP_LIST = new BytesRef("    skipList ");
+  static final BytesRef LEVEL_LENGTH = new BytesRef("      levelLength ");
+  static final BytesRef LEVEL = new BytesRef("      level ");
+  static final BytesRef SKIP_DOC = new BytesRef("        skipDoc ");
+  static final BytesRef SKIP_DOC_FP = new BytesRef("        skipDocFP ");
+  static final BytesRef IMPACTS = new BytesRef("        impacts ");
+  static final BytesRef IMPACT = new BytesRef("          impact ");
+  static final BytesRef FREQ = new BytesRef("            freq ");
+  static final BytesRef NORM = new BytesRef("            norm ");
+  static final BytesRef IMPACTS_END = new BytesRef("        impactsEnd ");
+  static final BytesRef CHILD_POINTER = new BytesRef("        childPointer ");
+
+  SimpleTextSkipWriter(SegmentWriteState writeState) throws IOException {
+    super(BLOCK_SIZE, skipMultiplier, maxSkipLevels, writeState.segmentInfo.maxDoc());
+    curCompetitiveFreqNorms = new CompetitiveImpactAccumulator[maxSkipLevels];
+    for (int i = 0; i < maxSkipLevels; ++i) {
+      curCompetitiveFreqNorms[i] = new CompetitiveImpactAccumulator();
+    }
+    resetSkip();
+  }
+
+  @Override
+  protected void writeSkipData(int level, IndexOutput skipBuffer) throws IOException {
+    Boolean wroteHeader = wroteHeaderPerLevelMap.get(level);
+    if (wroteHeader == null || !wroteHeader) {
+      SimpleTextUtil.write(skipBuffer, LEVEL);
+      SimpleTextUtil.write(skipBuffer, level + "", scratch);
+      SimpleTextUtil.writeNewline(skipBuffer);
+
+      wroteHeaderPerLevelMap.put(level, true);
+    }
+    SimpleTextUtil.write(skipBuffer, SKIP_DOC);
+    SimpleTextUtil.write(skipBuffer, curDoc + "", scratch);
+    SimpleTextUtil.writeNewline(skipBuffer);
+
+    SimpleTextUtil.write(skipBuffer, SKIP_DOC_FP);
+    SimpleTextUtil.write(skipBuffer, curDocFilePointer + "", scratch);
+    SimpleTextUtil.writeNewline(skipBuffer);
+
+    CompetitiveImpactAccumulator competitiveFreqNorms = curCompetitiveFreqNorms[level];
+    Collection<Impact> impacts = competitiveFreqNorms.getCompetitiveFreqNormPairs();
+    assert impacts.size() > 0;
+    if (level + 1 < numberOfSkipLevels) {
+      curCompetitiveFreqNorms[level + 1].addAll(competitiveFreqNorms);
+    }
+    SimpleTextUtil.write(skipBuffer, IMPACTS);
+    SimpleTextUtil.writeNewline(skipBuffer);
+    for (Impact impact : impacts) {
+      SimpleTextUtil.write(skipBuffer, IMPACT);
+      SimpleTextUtil.writeNewline(skipBuffer);
+      SimpleTextUtil.write(skipBuffer, FREQ);
+      SimpleTextUtil.write(skipBuffer, impact.freq + "", scratch);
+      SimpleTextUtil.writeNewline(skipBuffer);
+      SimpleTextUtil.write(skipBuffer, NORM);
+      SimpleTextUtil.write(skipBuffer, impact.norm + "", scratch);
+      SimpleTextUtil.writeNewline(skipBuffer);
+    }
+    SimpleTextUtil.write(skipBuffer, IMPACTS_END);
+    SimpleTextUtil.writeNewline(skipBuffer);
+    competitiveFreqNorms.clear();
+  }
+
+  @Override
+  protected void resetSkip() {
+    super.resetSkip();
+    wroteHeaderPerLevelMap.clear();
+    this.curDoc = -1;
+    this.curDocFilePointer = -1;
+    for (CompetitiveImpactAccumulator acc : curCompetitiveFreqNorms) {
+      acc.clear();
+    }
+  }
+
+  @Override
+  public long writeSkip(IndexOutput output) throws IOException {
+    long skipOffset = output.getFilePointer();
+    SimpleTextUtil.write(output, SKIP_LIST);
+    SimpleTextUtil.writeNewline(output);
+    super.writeSkip(output);
+    return skipOffset;
+  }
+
+  void bufferSkip(
+      int doc,
+      long docFilePointer,
+      int numDocs,
+      final CompetitiveImpactAccumulator competitiveImpactAccumulator)
+      throws IOException {
+    assert doc > curDoc;
+    this.curDoc = doc;
+    this.curDocFilePointer = docFilePointer;
+    this.curCompetitiveFreqNorms[0].addAll(competitiveImpactAccumulator);
+    bufferSkip(numDocs);
+  }
+
+  @Override
+  protected void writeLevelLength(long levelLength, IndexOutput output) throws IOException {
+    SimpleTextUtil.write(output, LEVEL_LENGTH);
+    SimpleTextUtil.write(output, levelLength + "", scratch);
+    SimpleTextUtil.writeNewline(output);
+  }
+
+  @Override
+  protected void writeChildPointer(long childPointer, DataOutput skipBuffer) throws IOException {
+    SimpleTextUtil.write(skipBuffer, CHILD_POINTER);
+    SimpleTextUtil.write(skipBuffer, childPointer + "", scratch);
+    SimpleTextUtil.writeNewline(skipBuffer);
+  }
+}


### PR DESCRIPTION
I felt bad that we did not backport LUCENE-10035 to 8.x!

Just because 9.0 is coming soon, I don't think we should cut back on backporting "safe" changes.  Else we get ourselves into this awkward and possibly long-lasting and hard to predict lull leading up to the major release ...

The `git cherry-pick` hit a few interesting conflicts, mostly due to `tidy` styling changes, but a few due to `IndexOutput`/`DataOutput` change that was main-only.  I think I safely resolved all of them, and `ant precommit` and `ant test` inside `lucene` sub-directory pass.  Maybe @wuda0112 or @jpountz wants to take a quick look?

I tried running `ant test -Dtests.codec=SimpleText` in `lucene/core` and all tests (slowly) passed!