### PR TITLE
LUCENE-10091 Fix some old errors in the benchmark module

### DIFF
--- a/lucene/benchmark/conf/collector-small.alg
+++ b/lucene/benchmark/conf/collector-small.alg
@@ -21,7 +21,7 @@
 #    Fully Qualified Class Name of a Collector with a empty constructor
 #    topScoreDocOrdered - Creates a TopScoreDocCollector that requires in order docs
 #    topScoreDocUnordered - Like above, but allows out of order
-collector.class=coll:topScoreDocOrdered:topScoreDocUnordered:topScoreDocOrdered:topScoreDocUnordered
+collector.class=coll:topScoreDoc
 
 analyzer=org.apache.lucene.analysis.core.WhitespaceAnalyzer
 directory=FSDirectory

--- a/lucene/benchmark/conf/collector.alg
+++ b/lucene/benchmark/conf/collector.alg
@@ -21,7 +21,7 @@
 #    Fully Qualified Class Name of a Collector with a empty constructor
 #    topScoreDocOrdered - Creates a TopScoreDocCollector that requires in order docs
 #    topScoreDocUnordered - Like above, but allows out of order
-collector.class=coll:topScoreDocOrdered:topScoreDocUnordered:topScoreDocOrdered:topScoreDocUnordered
+collector.class=coll:topScoreDoc
 
 analyzer=org.apache.lucene.analysis.core.WhitespaceAnalyzer
 directory=FSDirectory

--- a/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/NewAnalyzerTask.java
+++ b/lucene/benchmark/src/java/org/apache/lucene/benchmark/byTask/tasks/NewAnalyzerTask.java
@@ -16,16 +16,17 @@
  */
 package org.apache.lucene.benchmark.byTask.tasks;
 
-import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.benchmark.byTask.PerfRunData;
-import org.apache.lucene.benchmark.byTask.utils.AnalyzerFactory;
-import org.apache.lucene.util.Version;
-
 import java.io.IOException;
 import java.io.StreamTokenizer;
 import java.io.StringReader;
-import java.util.*;
 import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.CharArraySet;
+import org.apache.lucene.benchmark.byTask.PerfRunData;
+import org.apache.lucene.benchmark.byTask.utils.AnalyzerFactory;
 
 /**
  * Create a new {@link org.apache.lucene.analysis.Analyzer} and set it in the getRunData() for use by all future tasks.
@@ -42,14 +43,13 @@ public class NewAnalyzerTask extends PerfTask {
   
   public static final Analyzer createAnalyzer(String className) throws Exception{
     final Class<? extends Analyzer> clazz = Class.forName(className).asSubclass(Analyzer.class);
-    try {
-      // first try to use a ctor with version parameter (needed for many new Analyzers that have no default one anymore
-      Constructor<? extends Analyzer> cnstr = clazz.getConstructor(Version.class);
-      return cnstr.newInstance(Version.LATEST);
-    } catch (NoSuchMethodException nsme) {
-      // otherwise use default ctor
-      return clazz.newInstance();
+    Constructor<? extends Analyzer> cnstr;
+    if (className.equals("org.apache.lucene.analysis.core.StopAnalyzer")) {
+      cnstr = clazz.getConstructor(CharArraySet.class);
+      return cnstr.newInstance(CharArraySet.EMPTY_SET);
     }
+    cnstr = clazz.getConstructor();
+    return cnstr.newInstance();
   }
 
   @Override


### PR DESCRIPTION
Hi, I found that the benchmark module hasn't been maintained for a long time. Some scripts were executed incorrectly, and some codes were outdated. I tried to fix a few small bugs, including:
collector-small.alg, collector.alg, NewAnalyzerTask.java.

Execute the following command to verify:
  ant run-task -Dtask.alg=conf/analyzer.alg
  ant run-task -Dtask.alg=conf/collector-small.alg
  ant run-task -Dtask.alg=conf/collector.alg -Dtask.mem=1024M