### PR TITLE
SOLR-15620: Download Config button in Schema Designer screen should not require user to re-login when already authenticated

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -127,6 +127,8 @@ Bug Fixes
 
 * SOLR-14506: Fix NPE in COLSTATUS for collections using implicit routing. (Austin Weidler, ab)
 
+* SOLR-15620: Download Config button in Schema Designer screen should not require user to re-login when already authenticated (Timothy Potter)
+
 Other Changes
 ---------------------
 * SOLR-15355: Upgrade Hadoop from 3.2.0 to 3.2.2. (Antoine Gruzelle via David Smiley)

--- a/solr/webapp/web/js/angular/controllers/schema-designer.js
+++ b/solr/webapp/web/js/angular/controllers/schema-designer.js
@@ -1512,7 +1512,29 @@ solrAdminApp.controller('SchemaDesignerController', function ($scope, $timeout, 
   };
 
   $scope.downloadConfig = function () {
-    location.href = "/api/schema-designer/download/"+$scope.currentSchema+"_configset.zip?wt=raw&configSet=" + $scope.currentSchema;
+    // have to use an AJAX request so we can supply the Authorization header
+    if (sessionStorage.getItem("auth.header")) {
+      var fileName = $scope.currentSchema+"_configset.zip";
+      var xhr = new XMLHttpRequest();
+      xhr.open("GET", "/api/schema-designer/download/"+fileName+"?wt=raw&configSet="+$scope.currentSchema, true);
+      xhr.setRequestHeader('Authorization', sessionStorage.getItem("auth.header"));
+      xhr.responseType = 'blob';
+      xhr.addEventListener('load',function() {
+        if (xhr.status === 200) {
+          var url = window.URL.createObjectURL(xhr.response);
+          var a = document.createElement('a');
+          a.href = url;
+          a.download = fileName;
+          document.body.append(a);
+          a.click();
+          a.remove();
+          window.URL.revokeObjectURL(url);
+        }
+      })
+      xhr.send();
+    } else {
+      location.href = "/api/schema-designer/download/"+$scope.currentSchema+"_configset.zip?wt=raw&configSet=" + $scope.currentSchema;
+    }
   };
 
   function docsToTree(docs) {


### PR DESCRIPTION
backport of https://github.com/apache/solr/pull/291

Testing is manual on FF, Chrome & Safari ... w/ and w/o security enabled.