### PR TITLE
LUCENE-10141: Add the next minor version on Lucene's main branch in the split repo so the backcompat_master task works

### DIFF
--- a/dev-tools/scripts/releaseWizard.yaml
+++ b/dev-tools/scripts/releaseWizard.yaml
@@ -1308,7 +1308,11 @@ groups:
       commands_text: Edit DOAP files
       commands:
       - !Command
-        cmd: git remote add lucene https://gitbox.apache.org/repos/asf/lucene.git && git fetch lucene && git checkout lucene/main
+        cmd: git remote add lucene https://gitbox.apache.org/repos/asf/lucene.git || true
+        stdout: true
+        comment: Goto lucene main branch
+      - !Command
+        cmd: git fetch lucene && git checkout lucene/main
         stdout: true
         comment: Goto lucene main branch
       - !Command

--- a/dev-tools/scripts/releaseWizard.yaml
+++ b/dev-tools/scripts/releaseWizard.yaml
@@ -530,23 +530,25 @@ groups:
       commands_text: Run these commands to add the new minor version {{ next_version }} to Lucene's main branch in the split repo
       commands:
       - !Command
-        cmd: git remote add lucene https://gitbox.apache.org/repos/asf/lucene.git || true
+        cmd: git remote add lucene https://gitbox.apache.org/repos/asf/lucene.git -f -m main
         stdout: true
         comment: Goto lucene main branch
+        logfile: lucene-main-updates.log
       - !Command
-        cmd: git fetch lucene && git checkout main && git pull && git clean -df && git checkout -- .
+        cmd: git checkout main && git pull lucene main && git clean -df && git checkout -- .
         tee: true
-        logfile: checkout.log
+        logfile: lucene-main-updates.log
       - !Command
         cmd: python3 -u dev-tools/scripts/addVersion.py {{ next_version }}
         tee: true
       - !Command
         comment: Make sure the edits done by `addVersion.py` are ok, then push
-        cmd: git add -u .  && git commit -m "Add next minor version {{ next_version }}"  && git push lucene HEAD:main
+        cmd: git add -u . && git commit -m "Add next minor version {{ next_version }}" && git push lucene HEAD:main
         stdout: true
-        logfile: commit.log
+        logfile: lucene-main-updates.log
       - !Command
         comment: Back to stable branch in shared repo
+        logfile: lucene-main-updates.log
         cmd: git checkout {{ stable_branch }} && git clean -df && git checkout -- .
         tee: true
   - !Todo
@@ -1308,11 +1310,11 @@ groups:
       commands_text: Edit DOAP files
       commands:
       - !Command
-        cmd: git remote add lucene https://gitbox.apache.org/repos/asf/lucene.git || true
+        cmd: git remote add lucene https://gitbox.apache.org/repos/asf/lucene.git -f -m main
         stdout: true
         comment: Goto lucene main branch
       - !Command
-        cmd: git fetch lucene && git checkout lucene/main
+        cmd: git checkout lucene/main
         stdout: true
         comment: Goto lucene main branch
       - !Command
@@ -1324,14 +1326,14 @@ groups:
         logfile: commit-lucene.log
         stdout: true
       - !Command
-        cmd: git remote add solr https://gitbox.apache.org/repos/asf/solr.git && git fetch solr && git checkout solr/main
-        stdout: true
-        comment: Goto solr main branch
-      - !Command
         cmd: git push lucene HEAD:main
         logfile: push-lucene.log
         stdout: true
         comment: Push the main branch
+      - !Command
+        cmd: git remote add solr https://gitbox.apache.org/repos/asf/solr.git -f -m main && git checkout solr/main
+        stdout: true
+        comment: Goto solr main branch
       - !Command
         cmd: "{{ editor }} dev-tools/doap/solr.rdf"
         comment: Edit Solr DOAP, add version {{ release_version }}

--- a/dev-tools/scripts/releaseWizard.yaml
+++ b/dev-tools/scripts/releaseWizard.yaml
@@ -1310,10 +1310,6 @@ groups:
       commands_text: Edit DOAP files
       commands:
       - !Command
-        cmd: git remote add lucene https://gitbox.apache.org/repos/asf/lucene.git -f -m main
-        stdout: true
-        comment: Goto lucene main branch
-      - !Command
         cmd: git checkout lucene/main
         stdout: true
         comment: Goto lucene main branch

--- a/dev-tools/scripts/releaseWizard.yaml
+++ b/dev-tools/scripts/releaseWizard.yaml
@@ -517,6 +517,39 @@ groups:
         cmd: git add -u .  && git commit -m "Add next minor version {{ next_version }}"  && git push
         logfile: commit-stable.log
   - !Todo
+    id: add_version_minor_on_main
+    title: Add a new minor version on Lucene's main branch
+    types:
+    - major
+    - minor
+    depends: clean_git_checkout
+    vars:
+      next_version: "{{ release_version_major }}.{{ release_version_minor + 1 }}.0"
+    commands: !Commands
+      root_folder: '{{ git_checkout_folder }}'
+      commands_text: Run these commands to add the new minor version {{ next_version }} to Lucene's main branch in the split repo
+      commands:
+      - !Command
+        cmd: git remote add lucene https://gitbox.apache.org/repos/asf/lucene.git || true
+        stdout: true
+        comment: Goto lucene main branch
+      - !Command
+        cmd: git fetch lucene && git checkout main && git pull && git clean -df && git checkout -- .
+        tee: true
+        logfile: checkout.log
+      - !Command
+        cmd: python3 -u dev-tools/scripts/addVersion.py {{ next_version }}
+        tee: true
+      - !Command
+        comment: Make sure the edits done by `addVersion.py` are ok, then push
+        cmd: git add -u .  && git commit -m "Add next minor version {{ next_version }}"  && git push lucene HEAD:main
+        stdout: true
+        logfile: commit.log
+      - !Command
+        comment: Back to stable branch in shared repo
+        cmd: git checkout {{ stable_branch }} && git clean -df && git checkout -- .
+        tee: true
+  - !Todo
     id: sanity_check_doap
     title: Sanity check the DOAP files
     description: |-


### PR DESCRIPTION
I think the reason the `addBackcompatIndexes.py` script failed (`backcompat_master` step) when I built 8.10 was the missing Version info for 8_11, see: https://issues.apache.org/jira/browse/LUCENE-10131

So this PR adds a task to run the `addVersion.py` script for Lucene's main branch (in the split-out repo) so that the `backcompat_master` step works later in the release process.