### PR TITLE
SOLR-15762 Error on Join Query with sync cache

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/CaffeineCache.java
+++ b/solr/core/src/java/org/apache/solr/search/CaffeineCache.java
@@ -410,7 +410,7 @@ public class CaffeineCache<K, V> extends SolrCacheBase implements SolrCache<K, V
   }
 
   @Override
-  public boolean isAsync() {
+  public boolean isRecursionSupported() {
     return async;
   }
 

--- a/solr/core/src/java/org/apache/solr/search/CaffeineCache.java
+++ b/solr/core/src/java/org/apache/solr/search/CaffeineCache.java
@@ -409,6 +409,11 @@ public class CaffeineCache<K, V> extends SolrCacheBase implements SolrCache<K, V
         limit, initialSize, isAutowarmingOn() ? (", " + getAutowarmDescription()) : "");
   }
 
+  @Override
+  public boolean isAsync() {
+    return async;
+  }
+
   //////////////////////// SolrInfoBean methods //////////////////////
 
   @Override

--- a/solr/core/src/java/org/apache/solr/search/JoinQParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/search/JoinQParserPlugin.java
@@ -588,6 +588,10 @@ class JoinQuery extends Query {
             // use the filterCache to get a DocSet
             if (toTermsEnum.docFreq() >= minDocFreqTo || resultBits == null) {
               // use filter cache
+              if (! toSearcher.getFilterCache().isAsync()) {
+                throw new SolrException(SolrException.ErrorCode.INVALID_STATE,
+                    "Using join queries with synchronous filterCache is not supported! Details can be found in Solr Reference Guide under 'query-settings-in-solrconfig'.");
+              }
               DocSet toTermSet = toSearcher.getDocSet(toDeState);
               resultListDocs += toTermSet.size();
               if (resultBits != null) {

--- a/solr/core/src/java/org/apache/solr/search/JoinQParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/search/JoinQParserPlugin.java
@@ -588,7 +588,8 @@ class JoinQuery extends Query {
             // use the filterCache to get a DocSet
             if (toTermsEnum.docFreq() >= minDocFreqTo || resultBits == null) {
               // use filter cache
-              if (! toSearcher.getFilterCache().isAsync()) {
+              SolrCache<?, ?> filterCache = toSearcher.getFilterCache();
+              if (filterCache != null && !filterCache.isRecursionSupported()) {
                 throw new SolrException(SolrException.ErrorCode.INVALID_STATE,
                     "Using join queries with synchronous filterCache is not supported! Details can be found in Solr Reference Guide under 'query-settings-in-solrconfig'.");
               }

--- a/solr/core/src/java/org/apache/solr/search/SolrCache.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrCache.java
@@ -22,6 +22,7 @@ import org.apache.solr.util.IOFunction;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.function.Function;
 
 
 /**
@@ -176,10 +177,12 @@ public interface SolrCache<K,V> extends SolrInfoBean, SolrMetricProducer {
   void setMaxRamMB(int maxRamMB);
 
   /**
-   * Check if this SolrCache supports async queries - relevant when attempting to cache nested or recursive results.
-   * @return whether this cache is asynchronous
+   * Check if this SolrCache supports recursive calls to {@link #computeIfAbsent(Object, IOFunction)}.
+   * Caches backed by {@link java.util.concurrent.ConcurrentHashMap#computeIfAbsent(Object, Function)} explicitly do
+   * not support that, but other caches might.
+   * @return whether this cache allows recursive computations
    */
-  default boolean isAsync() {
+  default boolean isRecursionSupported() {
     return false;
   }
 }

--- a/solr/core/src/java/org/apache/solr/search/SolrCache.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrCache.java
@@ -174,4 +174,12 @@ public interface SolrCache<K,V> extends SolrInfoBean, SolrMetricProducer {
    * only on implementations that support it, it's a no-op otherwise.
    */
   void setMaxRamMB(int maxRamMB);
+
+  /**
+   * Check if this SolrCache supports async queries - relevant when attempting to cache nested or recursive results.
+   * @return whether this cache is asynchronous
+   */
+  default boolean isAsync() {
+    return false;
+  }
 }

--- a/solr/core/src/test/org/apache/solr/search/join/InvalidConfigJoinQueryTest.java
+++ b/solr/core/src/test/org/apache/solr/search/join/InvalidConfigJoinQueryTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.search.join;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.embedded.EmbeddedSolrServer;
+import org.apache.solr.client.solrj.request.UpdateRequest;
+import org.apache.solr.common.SolrException;
+import org.apache.solr.common.SolrInputDocument;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class InvalidConfigJoinQueryTest extends SolrTestCaseJ4 {
+
+  @BeforeClass
+  public static void before() throws Exception {
+    System.setProperty("solr.filterCache.async", "false");
+    initCore("solrconfig.xml", "schema.xml");
+  }
+
+  @Test
+  public void testInvalidFilterConfig() throws Exception {
+    UpdateRequest req = new UpdateRequest();
+    req.add(new SolrInputDocument("id", "0", "type_s", "org", "locid_s", "1"));
+    req.add(new SolrInputDocument("id", "1", "type_s", "loc", "orgid_s", "0"));
+
+    SolrClient client = new EmbeddedSolrServer(h.getCore());
+    req.commit(client, null);
+
+    assertThrows(SolrException.class, () -> assertJQ(req("q", "{!join from=id to=locid_s v=$q1}", "q1", "type_s:loc", "fl", "id", "sort", "id asc")));
+  }
+}

--- a/solr/core/src/test/org/apache/solr/search/join/InvalidConfigJoinQueryTest.java
+++ b/solr/core/src/test/org/apache/solr/search/join/InvalidConfigJoinQueryTest.java
@@ -16,9 +16,6 @@
  */
 package org.apache.solr.search.join;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.embedded.EmbeddedSolrServer;


### PR DESCRIPTION
When attempting to run a join query using a synchronous filtercache,
throw an error early with a link to docs rather than a mysterious
IllegalStateException.

Co-Authored-By: Thomas Wöckinger <two@silbergrau.com>