### PR TITLE
SOLR-15804 Allow content-types with ;charset in ShowFileRequestHandler

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -15,14 +15,6 @@ Bug Fixes
 
 * SOLR-15794: Switching a PRS collection from true -> false -> true results in INACTIVE replicas (noble)
 
-Build
----------------------
-(No changes)
-
-Other Changes
----------------------
-(No changes)
-
 * SOLR-15804: Admin UI once again can show files in the Core/Collection -> Files screen. Fixed regression from 8.11.0 (Karl Stoney, janhoy)
 
 ==================  8.11.0 ==================

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -23,6 +23,8 @@ Other Changes
 ---------------------
 (No changes)
 
+* SOLR-15804: Admin UI once again can show files in the Core/Collection -> Files screen. Fixed regression from 8.11.0 (Karl Stoney, janhoy)
+
 ==================  8.11.0 ==================
 
 Consult the LUCENE_CHANGES.txt file for additional, low level, changes in this release.

--- a/solr/core/src/java/org/apache/solr/handler/admin/ShowFileRequestHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/ShowFileRequestHandler.java
@@ -96,11 +96,16 @@ public class ShowFileRequestHandler extends RequestHandlerBase implements Permis
 {
   public static final String HIDDEN = "hidden";
   public static final String USE_CONTENT_TYPE = "contentType";
+  private static final Set<String> KNOWN_MIME_TYPES;
 
   protected Set<String> hiddenFiles;
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
+  static {
+    KNOWN_MIME_TYPES = new HashSet<>(MimeTypes.getKnownMimeTypes());
+    KNOWN_MIME_TYPES.add("text/xml");
+  }
 
   public ShowFileRequestHandler()
   {
@@ -265,10 +270,11 @@ public class ShowFileRequestHandler extends RequestHandlerBase implements Permis
       log.debug("No contentType specified");
       return null;
     }
-    if (!MimeTypes.getKnownMimeTypes().contains(contentType)) {
+    String rawContentType = contentType.split(";")[0].trim().toLowerCase(Locale.ROOT); // Strip away charset part
+    if (!KNOWN_MIME_TYPES.contains(rawContentType)) {
       throw new SolrException(ErrorCode.BAD_REQUEST, "Requested content type '" + contentType + "' is not supported.");
     }
-    if (contentType.toLowerCase(Locale.ROOT).contains("html")) {
+    if (rawContentType.contains("html")) {
       log.info("Using text/plain instead of {}", contentType);
       return "text/plain";
     }

--- a/solr/core/src/test/org/apache/solr/handler/admin/ShowFileRequestHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/ShowFileRequestHandlerTest.java
@@ -171,6 +171,13 @@ public class ShowFileRequestHandlerTest extends SolrJettyTestBase {
     assertEquals("text/plain", ShowFileRequestHandler.getSafeContentType("text/html"));
     assertEquals("text/plain", ShowFileRequestHandler.getSafeContentType("application/xhtml+xml"));
 
+    // Content-type with charset
+    assertEquals("text/csv ; charset=utf-8", ShowFileRequestHandler.getSafeContentType("text/csv ; charset=utf-8"));
+    assertEquals("text/xml;charset=utf-8", ShowFileRequestHandler.getSafeContentType("text/xml;charset=utf-8"));
+
+    // Null
+    assertNull(ShowFileRequestHandler.getSafeContentType(null));
+
     // Non-known content types are rejected with 400 error
     expectThrows(SolrException.class, () -> ShowFileRequestHandler.getSafeContentType("foo/bar"));
   }

--- a/solr/webapp/web/js/angular/controllers/files.js
+++ b/solr/webapp/web/js/angular/controllers/files.js
@@ -15,8 +15,8 @@
  limitations under the License.
 */
 
-var contentTypeMap = { xml : 'text/xml', html : 'text/html', js : 'text/javascript', json : 'application/json', 'css' : 'text/css' };
-var languages = {js: "javascript", xml:"xml", xsl:"xml", vm: "xml", html: "xml", json: "json", css: "css"};
+var contentTypeMap = { xml : 'application/xml', html : 'application/xml', js : 'application/javascript', json : 'application/json', css : 'text/plain' };
+var languages = {js: "javascript", xml:"xml", xsl:"xml", vm: "xml", html: "xml", json: "json"};
 
 solrAdminApp.controller('FilesController',
     function($scope, $rootScope, $routeParams, $location, Files, Constants) {
@@ -71,7 +71,7 @@ solrAdminApp.controller('FilesController',
             if ($scope.file && $scope.file !== '' && $scope.file.split('').pop()!=='/') {
                 var extension;
                 if ($scope.file === "managed-schema") {
-                  extension = contentTypeMap['xml'];
+                  extension = 'xml';
                 } else {
                   extension = $scope.file.match( /\.(\w+)$/)[1] || '';
                 }


### PR DESCRIPTION
* Request .html as text/xml, .css as text/plain and .js as application/javascript
* Highlight css as txt (crashed browser)
* Set extension to 'xml' for managed-schema instead of 'text/xml'