### PR TITLE
SOLR-15828: AuthTool (in SolrCLI) should include the config-read, collection-admin-read, core-admin-read, and all permissions in the initial security.json

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -30,6 +30,9 @@ Bug Fixes
 * SOLR-15825: Security UI 'hasPermission' check should check if the user has the "all" permission if the requested permission is not defined
   to match how the backend works (Timothy Potter)
 
+* SOLR-15828: AuthTool (in SolrCLI) should include the config-read, collection-admin-read, core-admin-read, and all permissions in the initial security.json
+  to avoid warnings in the security UI (Timothy Potter)
+
 ==================  8.11.0 ==================
 
 Consult the LUCENE_CHANGES.txt file for additional, low level, changes in this release.

--- a/solr/core/src/java/org/apache/solr/util/SolrCLI.java
+++ b/solr/core/src/java/org/apache/solr/util/SolrCLI.java
@@ -4422,8 +4422,12 @@ public class SolrCLI {
               "\n {\"name\":\"security-edit\", \"role\":\"admin\"}," +
               "\n {\"name\":\"security-read\", \"role\":\"admin\"}," +
               "\n {\"name\":\"config-edit\", \"role\":\"admin\"}," +
+              "\n {\"name\":\"config-read\", \"role\":\"admin\"}," +
               "\n {\"name\":\"collection-admin-edit\", \"role\":\"admin\"}," +
-              "\n {\"name\":\"core-admin-edit\", \"role\":\"admin\"}" +
+              "\n {\"name\":\"collection-admin-read\", \"role\":\"admin\"}," +
+              "\n {\"name\":\"core-admin-edit\", \"role\":\"admin\"}," +
+              "\n {\"name\":\"core-admin-read\", \"role\":\"admin\"}," +
+              "\n {\"name\":\"all\", \"role\":\"admin\"}" +
               "\n   ]," +
               "\n   \"user-role\":{\"" + username + "\":\"admin\"}" +
               "\n  }" +


### PR DESCRIPTION
backport of https://github.com/apache/solr/pull/438