### PR TITLE
SOLR-15832: Clean-up after publish action in Schema Designer shouldn't fail if .system collection doesn't exist

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -39,6 +39,8 @@ Bug Fixes
 
 * SOLR-15833: Enable exists queries on spatial types. (Mike Drob, Houston Putman)
 
+* SOLR-15832: Clean-up after publish action in Schema Designer shouldn't fail if .system collection doesn't exist (Timothy Potter)
+
 ==================  8.11.0 ==================
 
 Consult the LUCENE_CHANGES.txt file for additional, low level, changes in this release.

--- a/solr/core/src/java/org/apache/solr/handler/designer/SchemaDesignerConfigSetHelper.java
+++ b/solr/core/src/java/org/apache/solr/handler/designer/SchemaDesignerConfigSetHelper.java
@@ -464,8 +464,9 @@ class SchemaDesignerConfigSetHelper implements SchemaDesignerConstants {
   void deleteStoredSampleDocs(String configSet) {
     try {
       cloudClient().deleteByQuery(BLOB_STORE_ID, "id:" + configSet + "_sample/*", 10);
-    } catch (IOException | SolrServerException exc) {
-      log.warn("Failed to delete sample docs from blob store for {}", configSet, exc);
+    } catch (IOException | SolrServerException | SolrException exc) {
+      final String excStr = exc.toString();
+      log.warn("Failed to delete sample docs from blob store for {} due to: {}", configSet, excStr);
     }
   }
 


### PR DESCRIPTION
backport of https://github.com/apache/solr/pull/451