### PR TITLE
SOLR-15501: GCSBackupRepository operations without credentials - Branch 8 11

### DIFF
--- a/solr/contrib/gcs-repository/src/java/org/apache/solr/gcs/GCSBackupRepository.java
+++ b/solr/contrib/gcs-repository/src/java/org/apache/solr/gcs/GCSBackupRepository.java
@@ -83,14 +83,15 @@ public class GCSBackupRepository implements BackupRepository {
             return storage;
 
         try {
-            if (credentialPath == null) {
-                throw new IllegalArgumentException(GCSConfigParser.missingCredentialErrorMsg());
+            if (credentialPath != null) {
+                log.info("Creating GCS client using credential at {}", credentialPath);
+                // 'GoogleCredentials.fromStream' closes the input stream, so we don't
+                GoogleCredentials credential = GoogleCredentials.fromStream(new FileInputStream(credentialPath));
+                storageOptionsBuilder.setCredentials(credential);
+            } else {
+                // nowarn compile time string concatenation
+                log.info(GCSConfigParser.missingCredentialMsg()); //nowarn
             }
-
-            log.info("Creating GCS client using credential at {}", credentialPath);
-            // 'GoogleCredentials.fromStream' closes the input stream, so we don't
-            GoogleCredentials credential = GoogleCredentials.fromStream(new FileInputStream(credentialPath));
-            storageOptionsBuilder.setCredentials(credential);
             storage = storageOptionsBuilder.build().getService();
         } catch (IOException e) {
             throw new IllegalStateException(e);

--- a/solr/contrib/gcs-repository/src/java/org/apache/solr/gcs/GCSConfigParser.java
+++ b/solr/contrib/gcs-repository/src/java/org/apache/solr/gcs/GCSConfigParser.java
@@ -93,9 +93,11 @@ public class GCSConfigParser {
     return envVars.get(GCS_CREDENTIAL_ENV_VAR_NAME);
   }
 
-  public static String missingCredentialErrorMsg() {
-    return "GCSBackupRepository requires a credential for GCS communication, but none was provided.  Please specify a " +
-            "path to this GCS credential by adding a '" + GCS_CREDENTIAL_PARAM_NAME + "' property to the repository " +
+  public static String missingCredentialMsg() {
+    return "GCSBackupRepository credential path is missing. GCSBackupRepository will only work within GCP when role " +
+            "based access is configured for backup bucket." +
+            "If you'd like to use credentials, set path to this GCS credential by adding a '" +
+            GCS_CREDENTIAL_PARAM_NAME + "' property to the repository " +
             "definition in your solrconfig, or by setting the path value in an env-var named '" +
             GCS_CREDENTIAL_ENV_VAR_NAME + "'";
   }

--- a/solr/contrib/gcs-repository/src/java/org/apache/solr/gcs/GCSConfigParser.java
+++ b/solr/contrib/gcs-repository/src/java/org/apache/solr/gcs/GCSConfigParser.java
@@ -28,8 +28,8 @@ import java.util.Map;
  * Parses configuration for {@link GCSBackupRepository} from NamedList and environment variables
  */
 public class GCSConfigParser {
-  private static final String GCS_BUCKET_ENV_VAR_NAME = "GCS_BUCKET";
-  private static final String GCS_CREDENTIAL_ENV_VAR_NAME = "GCS_CREDENTIAL_PATH";
+  protected static final String GCS_BUCKET_ENV_VAR_NAME = "GCS_BUCKET";
+  protected static final String GCS_CREDENTIAL_ENV_VAR_NAME = "GCS_CREDENTIAL_PATH";
 
   private static final String GCS_BUCKET_PARAM_NAME = "gcsBucket";
   private static final String GCS_CREDENTIAL_PARAM_NAME = "gcsCredentialPath";

--- a/solr/contrib/gcs-repository/src/test/org/apache/solr/gcs/GCSBackupRepositoryTest.java
+++ b/solr/contrib/gcs-repository/src/test/org/apache/solr/gcs/GCSBackupRepositoryTest.java
@@ -68,4 +68,18 @@ public class GCSBackupRepositoryTest extends AbstractBackupRepositoryTest {
     protected URI getBaseUri() throws URISyntaxException {
         return new URI("tmp");
     }
+
+    @Test
+    public void testInitStoreDoesNotFailWithMissingCredentials()
+    {
+        Map<String, String> config = new HashMap<>();
+        config.put(GCS_BUCKET_ENV_VAR_NAME, "TestBucketName");
+        // explicitely setting credential name to null; will work inside google-cloud project
+        config.put(GCS_CREDENTIAL_ENV_VAR_NAME, null);
+        config.put(BACKUP_LOCATION, "/testPath");
+
+        BackupRepository gcsBackupRepository = getRepository();
+
+        gcsBackupRepository.init(new NamedList<>(config));
+    }
 }

--- a/solr/solr-ref-guide/src/making-and-restoring-backups.adoc
+++ b/solr/solr-ref-guide/src/making-and-restoring-backups.adoc
@@ -317,7 +317,7 @@ If both values are absent, the value `solrBackupsBucket` will be used as a defau
 `gcsCredentialPath`::
 A path on the local filesystem (accessible by Solr) to a https://cloud.google.com/iam/docs/creating-managing-service-account-keys[Google Cloud service account key] file.
 If not specified, GCSBackupRepository will use the value of the `GCS_CREDENTIAL_PATH` environment variable.
-If both values are absent, an error will be thrown as GCS requires credentials for most usage.
+If both values are absent, no error will be thrown as running solr in google cloud will handle authentication/authorization internally.
 
 `location`::
 A valid "directory" path in the given GCS bucket to us for backup strage and retrieval.


### PR DESCRIPTION
Solution for the GCS Backup Plugin to work without configured credentials as it is the default when running solr in google cloud as
mentioned in https://issues.apache.org/jira/browse/SOLR-15501