### PR TITLE
SOLR-16019 Query parsing exception return HTTP 400 instead of 500

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -147,7 +147,7 @@ Other Changes
   - errorprone: 2.9.0
   - gcp-client: 1.32.1
   (Houston Putman)
-
+  
 * SOLR-15269: Upgrade httpclient and httpmime to 4.5.13.  (ventry)
 
 ==================  8.10.0 ==================

--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -27,6 +27,8 @@ Bug Fixes
 
 * SOLR-15974: Remove Calcite's ENUMERABLE_AGGREGATE_RULE as Solr only supports push-down for LogicalAggregate (Timothy Potter, Kiran Chitturi)
 
+* SOLR-16019: UTF-8 parsing errors for parameters should cause a HTTP 400 status code, not 500 (janhoy, Matthias Pigulla)
+
 ==================  8.11.1 ==================
 
 Consult the LUCENE_CHANGES.txt file for additional, low level, changes in this release.
@@ -145,7 +147,7 @@ Other Changes
   - errorprone: 2.9.0
   - gcp-client: 1.32.1
   (Houston Putman)
-  
+
 * SOLR-15269: Upgrade httpclient and httpmime to 4.5.13.  (ventry)
 
 ==================  8.10.0 ==================

--- a/solr/core/src/java/org/apache/solr/api/V2HttpCall.java
+++ b/solr/core/src/java/org/apache/solr/api/V2HttpCall.java
@@ -67,6 +67,7 @@ public class V2HttpCall extends HttpSolrCall {
   }
 
   protected void init() throws Exception {
+    queryParams = SolrRequestParsers.parseQueryString(req.getQueryString());
     String path = this.path;
     final String fullPath = path = path.substring(7);//strip off '/____v2'
     try {

--- a/solr/core/src/java/org/apache/solr/servlet/HttpSolrCall.java
+++ b/solr/core/src/java/org/apache/solr/servlet/HttpSolrCall.java
@@ -165,7 +165,7 @@ public class HttpSolrCall {
   protected SolrQueryRequest solrReq = null;
   private boolean mustClearSolrRequestInfo = false;
   protected SolrRequestHandler handler = null;
-  protected final SolrParams queryParams;
+  protected SolrParams queryParams;
   protected String path;
   protected Action action;
   protected String coreUrl;
@@ -191,7 +191,6 @@ public class HttpSolrCall {
     this.retry = retry;
     this.requestType = RequestType.UNKNOWN;
     req.setAttribute(HttpSolrCall.class.getName(), this);
-    queryParams = SolrRequestParsers.parseQueryString(req.getQueryString());
     // set a request timer which can be reused by requests if needed
     req.setAttribute(SolrRequestParsers.REQUEST_TIMER_SERVLET_ATTRIBUTE, new RTimerTree());
     // put the core container in request attribute
@@ -230,6 +229,8 @@ public class HttpSolrCall {
     if (alternate != null && path.startsWith(alternate)) {
       path = path.substring(0, alternate.length());
     }
+
+    queryParams = SolrRequestParsers.parseQueryString(req.getQueryString());
 
     // unused feature ?
     int idx = path.indexOf(':');

--- a/solr/core/src/test/org/apache/solr/servlet/HttpSolrCallCloudTest.java
+++ b/solr/core/src/test/org/apache/solr/servlet/HttpSolrCallCloudTest.java
@@ -27,6 +27,7 @@ import java.net.URL;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.client.solrj.embedded.JettySolrRunner;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
 import org.apache.solr.cloud.AbstractDistribZkTestBase;
@@ -37,6 +38,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 // commented 4-Sep-2018 @LuceneTestCase.BadApple(bugUrl="https://issues.apache.org/jira/browse/SOLR-12028") // 2-Aug-2018
+@SolrTestCaseJ4.SuppressSSL
 public class HttpSolrCallCloudTest extends SolrCloudTestCase {
   private static final String COLLECTION = "collection1";
   private static final int NUM_SHARD = 3;

--- a/solr/core/src/test/org/apache/solr/servlet/HttpSolrCallCloudTest.java
+++ b/solr/core/src/test/org/apache/solr/servlet/HttpSolrCallCloudTest.java
@@ -22,6 +22,8 @@ import javax.servlet.ServletInputStream;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.WriteListener;
 import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -35,7 +37,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 // commented 4-Sep-2018 @LuceneTestCase.BadApple(bugUrl="https://issues.apache.org/jira/browse/SOLR-12028") // 2-Aug-2018
-public class HttpSolrCallGetCoreTest extends SolrCloudTestCase {
+public class HttpSolrCallCloudTest extends SolrCloudTestCase {
   private static final String COLLECTION = "collection1";
   private static final int NUM_SHARD = 3;
   private static final int REPLICA_FACTOR = 2;
@@ -56,10 +58,19 @@ public class HttpSolrCallGetCoreTest extends SolrCloudTestCase {
   }
 
   @Test
-  public void test() throws Exception {
+  public void testCoreChosen() throws Exception {
     assertCoreChosen(NUM_SHARD, new TestRequest("/collection1/update"));
     assertCoreChosen(NUM_SHARD, new TestRequest("/collection1/update/json"));
     assertCoreChosen(NUM_SHARD * REPLICA_FACTOR, new TestRequest("/collection1/select"));
+  }
+
+  // https://issues.apache.org/jira/browse/SOLR-16019
+  @Test
+  public void testWrongUtf8InQ() throws Exception {
+    URL baseUrl = cluster.getJettySolrRunner(0).getBaseUrl();
+    URL request = new URL(baseUrl.toString() + "/" + COLLECTION + "/select?q=%C0"); // Illegal UTF-8 string
+    HttpURLConnection connection = (HttpURLConnection) request.openConnection();
+    assertEquals(400, connection.getResponseCode());
   }
 
   private void assertCoreChosen(int numCores, TestRequest testRequest) {


### PR DESCRIPTION
(Back-ported from https://github.com/apache/solr/commit/cb49a7d855e222dfebe373a0c0dfa7c95989ea8e)

https://issues.apache.org/jira/browse/SOLR-16019