### PR TITLE
Widen version.base acceptance criteria to allow x.y.z.a (4 parts) format

### DIFF
--- a/lucene/common-build.xml
+++ b/lucene/common-build.xml
@@ -55,9 +55,9 @@
   <!-- include version number from property file (includes "version.*" properties) -->
   <loadproperties srcFile="${common.dir}/version.properties"/>
   
-  <fail message="'version.base' property must be 'x.y.z' (major, minor, bugfix) or 'x.y.z.1/2' (+ prerelease) and numeric only: ${version.base}">
+  <fail message="'version.base' property must be 'x.y.z' (major, minor, bugfix) or 'x.y.z.a' (+ prerelease) and numeric only: ${version.base}">
     <condition>
-      <not><matches pattern="^\d+\.\d+\.\d+(|\.1|\.2)$" casesensitive="true" string="${version.base}"/></not>
+      <not><matches pattern="^\d+\.\d+\.\d+(|\.\d+)$" casesensitive="true" string="${version.base}"/></not>
     </condition>
   </fail>
 


### PR DESCRIPTION
Having an internal build system that uses that last bit as a tracker is really useful. The other option is for folks to have this in an internal fork, but considering we allow 1 & 2 as valid values, I feel it makes sense to allow more. 

If there's something that I'm not seeing, I'd be happy to learn about it.