### PR TITLE
Remove '-' between base.version and version.suffix and change common-build to allow the new format

### DIFF
--- a/lucene/common-build.xml
+++ b/lucene/common-build.xml
@@ -63,7 +63,7 @@
 
   <fail message="If you pass -Dversion=... to set a release version, it must match &quot;${version.base}&quot;, optionally followed by a suffix (e.g., &quot;-SNAPSHOT&quot;).">
     <condition>
-      <not><matches pattern="^\Q${version.base}\E(|.*)$" casesensitive="true" string="${version}"/></not>
+      <not><matches pattern="^\Q${version.base}\E(|\b.*)$" casesensitive="true" string="${version}"/></not>
     </condition>
   </fail>
   

--- a/lucene/common-build.xml
+++ b/lucene/common-build.xml
@@ -63,7 +63,7 @@
 
   <fail message="If you pass -Dversion=... to set a release version, it must match &quot;${version.base}&quot;, optionally followed by a suffix (e.g., &quot;-SNAPSHOT&quot;).">
     <condition>
-      <not><matches pattern="^\Q${version.base}\E(|\-.*)$" casesensitive="true" string="${version}"/></not>
+      <not><matches pattern="^\Q${version.base}\E(|.*)$" casesensitive="true" string="${version}"/></not>
     </condition>
   </fail>
   


### PR DESCRIPTION
This may still not be ideal/acceptable but allows for having internal version numbers in the `x.y.z.a` format instead of `x.y.z-a` format.