### PR TITLE
LUCENE-10477: SpanBoostQuery.rewrite was incomplete for boost==1 factor.

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -7,7 +7,8 @@ http://s.apache.org/luceneversions
 
 Bug Fixes
 ---------------------
-(No changes)
+
+* LUCENE-10477: SpanBoostQuery.rewrite was no-op for boost==1 factor. (Christine Poerschke)
 
 ======================= Lucene 8.11.1 =======================
 

--- a/lucene/core/src/java/org/apache/lucene/search/spans/SpanBoostQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/spans/SpanBoostQuery.java
@@ -78,11 +78,12 @@ public final class SpanBoostQuery extends SpanQuery {
 
   @Override
   public Query rewrite(IndexReader reader) throws IOException {
+    final SpanQuery rewritten = (SpanQuery) query.rewrite(reader);
+
     if (boost == 1f) {
-      return query;
+      return rewritten;
     }
 
-    final SpanQuery rewritten = (SpanQuery) query.rewrite(reader);
     if (query != rewritten) {
       return new SpanBoostQuery(rewritten, boost);
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/LUCENE-10477