### PR TITLE
SOLR-16110 Using Schema/Config API breaks the File-Upload of Config Set File

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/ZkController.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ZkController.java
@@ -2503,7 +2503,8 @@ public class ZkController implements Closeable {
   public static void touchConfDir(ZkSolrResourceLoader zkLoader) {
     SolrZkClient zkClient = zkLoader.getZkController().getZkClient();
     try {
-      zkClient.setData(zkLoader.getConfigSetZkPath(), new byte[]{0}, true);
+      byte[] currentData = zkClient.getData(zkLoader.getConfigSetZkPath(), null, null, true);
+      zkClient.setData(zkLoader.getConfigSetZkPath(), currentData, true);
     } catch (Exception e) {
       if (e instanceof InterruptedException) {
         Thread.currentThread().interrupt(); // Restore the interrupted status


### PR DESCRIPTION
fix: touchConfDir keeps current data at config node (SOLR-16110)