### PR TITLE
LUCENE-10464, LUCENE-10477: WeightedSpanTermExtractor.extractWeightedSpanTerms to rewrite sufficiently

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -9,6 +9,9 @@ Bug Fixes
 ---------------------
 * LUCENE-10564: Make sure SparseFixedBitSet#or updates ramBytesUsed. (Julie Tibshirani)
 
+* LUCENE-10477: Highlighter: WeightedSpanTermExtractor.extractWeightedSpanTerms to Query#rewrite
+  multiple times if necessary. (Christine Poerschke, Adrien Grand)
+
 Optimizations
 ---------------------
 

--- a/lucene/core/src/java/org/apache/lucene/search/Query.java
+++ b/lucene/core/src/java/org/apache/lucene/search/Query.java
@@ -69,6 +69,11 @@ public abstract class Query {
   /** Expert: called to re-write queries into primitive queries. For example,
    * a PrefixQuery will be rewritten into a BooleanQuery that consists
    * of TermQuerys.
+   *
+   * <p>Callers are expected to call <code>rewrite</code> multiple times if necessary, until the
+   * rewritten query is the same as the original query.
+   *
+   * @see IndexSearcher#rewrite(Query)
    */
   public Query rewrite(IndexReader reader) throws IOException {
     return this;

--- a/lucene/highlighter/src/java/org/apache/lucene/search/highlight/WeightedSpanTermExtractor.java
+++ b/lucene/highlighter/src/java/org/apache/lucene/search/highlight/WeightedSpanTermExtractor.java
@@ -306,11 +306,11 @@ public class WeightedSpanTermExtractor {
     final IndexSearcher searcher = new IndexSearcher(getLeafContext());
     searcher.setQueryCache(null);
     if (mustRewriteQuery) {
+      final SpanQuery rewrittenQuery = (SpanQuery) searcher.rewrite(spanQuery);
       for (final String field : fieldNames) {
-        final SpanQuery rewrittenQuery = (SpanQuery) spanQuery.rewrite(getLeafContext().reader());
         queries.put(field, rewrittenQuery);
-        rewrittenQuery.visit(QueryVisitor.termCollector(nonWeightedTerms));
       }
+      rewrittenQuery.visit(QueryVisitor.termCollector(nonWeightedTerms));
     } else {
       spanQuery.visit(QueryVisitor.termCollector(nonWeightedTerms));
     }


### PR DESCRIPTION
backport of https://github.com/apache/lucene/pull/737 and https://github.com/apache/lucene/pull/758

for https://issues.apache.org/jira/browse/LUCENE-10477 and https://issues.apache.org/jira/browse/LUCENE-10464
