### PR TITLE
SOLR-16218: Fix bug in in-place update when failOnVersionConflicts=false

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -67,6 +67,8 @@ Bug Fixes
 * SOLR-16227: Solr SQL query parsing fails on multiple LIKE clauses and multiple terms
   (Kiran Chitturi via David Smiley)
 
+* SOLR-16218: failOnVersionConflicts option not working for in-place updates (Lamine Idjeraoui, Houston Putman, Anshum Gupta)
+
 ==================  8.11.1 ==================
 
 Consult the LUCENE_CHANGES.txt file for additional, low level, changes in this release.

--- a/solr/core/src/java/org/apache/solr/update/processor/DistributedUpdateProcessor.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/DistributedUpdateProcessor.java
@@ -715,6 +715,10 @@ public class DistributedUpdateProcessor extends UpdateRequestProcessor {
     if (oldRootDocWithChildren == null) {
       if (versionOnUpdate > 0
           || !rootDocIdString.equals(cmd.getChildDocIdStr())) {
+        if (cmd.getReq().getParams().getBool(CommonParams.FAIL_ON_VERSION_CONFLICTS, true)
+            == false) {
+          return false;
+        }
         // could just let the optimistic locking throw the error
         throw new SolrException(ErrorCode.CONFLICT, "Document not found for update.  id=" + rootDocIdString);
       }


### PR DESCRIPTION
Added more people to CHANGES to include folks who contributed to reviewing this fix. Will updated the CHANGES in main and 9x too.