### PR TITLE
LUCENE-10678: Fix potential overflow when computing the partition point on the BKD tree (#1065)

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -15,6 +15,9 @@ Bug Fixes
 
 * LUCENE-10563: Fix failure to tessellate complex polygon (Craig Taverner)
 
+* LUCENE-10678: Fix potential overflow when building a BKD tree with more than 4 billion points. The overflow
+  occurs when computing the partition point. (Ignacio Vera)
+
 ======================= Lucene 8.11.2 =======================
 
 Bug Fixes

--- a/lucene/core/src/java/org/apache/lucene/util/bkd/BKDWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/bkd/BKDWriter.java
@@ -1591,7 +1591,7 @@ public class BKDWriter implements Closeable {
       // How many leaves will be in the left tree:
       final int numLeftLeafNodes = getNumLeftLeafNodes(numLeaves);
       // How many points will be in the left tree:
-      final long leftCount = numLeftLeafNodes * config.maxPointsInLeafNode;
+      final long leftCount = numLeftLeafNodes * (long) config.maxPointsInLeafNode;
 
       BKDRadixSelector.PathSlice[] slices = new BKDRadixSelector.PathSlice[2];
 

--- a/lucene/core/src/test/org/apache/lucene/util/bkd/Test4BBKDPoints.java
+++ b/lucene/core/src/test/org/apache/lucene/util/bkd/Test4BBKDPoints.java
@@ -29,20 +29,20 @@ import org.apache.lucene.util.TimeUnits;
 
 import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
 
-// e.g. run like this: ant test -Dtestcase=Test2BBKDPoints -Dtests.nightly=true -Dtests.verbose=true -Dtests.monster=true
+// e.g. run like this: ant test -Dtestcase=Test4BBKDPoints -Dtests.nightly=true -Dtests.verbose=true -Dtests.monster=true
 // 
-//   or: python -u /l/util/src/python/repeatLuceneTest.py -heap 4g -once -nolog -tmpDir /b/tmp -logDir /l/logs Test2BBKDPoints.test2D -verbose
+//   or: python -u /l/util/src/python/repeatLuceneTest.py -heap 4g -once -nolog -tmpDir /b/tmp -logDir /l/logs Test4BBKDPoints.test2D -verbose
 
 @TimeoutSuite(millis = 365 * 24 * TimeUnits.HOUR) // hopefully ~1 year is long enough ;)
 @Monster("takes at least 4 hours and consumes many GB of temp disk space")
-public class Test2BBKDPoints extends LuceneTestCase {
+public class Test4BBKDPoints extends LuceneTestCase {
   public void test1D() throws Exception {
-    Directory dir = FSDirectory.open(createTempDir("2BBKDPoints1D"));
+    Directory dir = FSDirectory.open(createTempDir("4BBKDPoints1D"));
 
-    final int numDocs = (Integer.MAX_VALUE / 26) + 100;
+    final int numDocs = (Integer.MAX_VALUE / 13) + 100;
 
     BKDWriter w = new BKDWriter(numDocs, dir, "_0", new BKDConfig(1, 1, Long.BYTES, BKDConfig.DEFAULT_MAX_POINTS_IN_LEAF_NODE),
-                                BKDWriter.DEFAULT_MAX_MB_SORT_IN_HEAP, 26L * numDocs);
+        BKDWriter.DEFAULT_MAX_MB_SORT_IN_HEAP, 26L * numDocs);
     int counter = 0;
     byte[] packedBytes = new byte[Long.BYTES];
     for (int docID = 0; docID < numDocs; docID++) {
@@ -76,12 +76,12 @@ public class Test2BBKDPoints extends LuceneTestCase {
   }
 
   public void test2D() throws Exception {
-    Directory dir = FSDirectory.open(createTempDir("2BBKDPoints2D"));
+    Directory dir = FSDirectory.open(createTempDir("4BBKDPoints2D"));
 
-    final int numDocs = (Integer.MAX_VALUE / 26) + 100;
+    final int numDocs = (Integer.MAX_VALUE / 13) + 100;
 
     BKDWriter w = new BKDWriter(numDocs, dir, "_0", new BKDConfig(2, 2, Long.BYTES, BKDConfig.DEFAULT_MAX_POINTS_IN_LEAF_NODE),
-                                BKDWriter.DEFAULT_MAX_MB_SORT_IN_HEAP, 26L * numDocs);
+        BKDWriter.DEFAULT_MAX_MB_SORT_IN_HEAP, 26L * numDocs);
     int counter = 0;
     byte[] packedBytes = new byte[2*Long.BYTES];
     for (int docID = 0; docID < numDocs; docID++) {


### PR DESCRIPTION
We currently compute the partition point for a set of points by multiplying the number of nodes that needs to be on
the left of the BKD tree by the maxPointsInLeafNode. This multiplication is done on the integer space so if the partition point
is bigger than Integer.MAX_VALUE it will overflow.
This commit moves the multiplication to the long space so it doesn't overflow.