### PR TITLE
SOLR-16843: Replace timeNs by epochTimeNs in most of autoscaling

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/autoscaling/AutoScalingHandler.java
+++ b/solr/core/src/java/org/apache/solr/cloud/autoscaling/AutoScalingHandler.java
@@ -413,7 +413,7 @@ public class AutoScalingHandler extends RequestHandlerBase implements Permission
     if (timeout != null) {
       try {
         int timeoutSeconds = parseHumanTime(timeout);
-        resumeTime = new Date(TimeUnit.MILLISECONDS.convert(timeSource.getTimeNs(), TimeUnit.NANOSECONDS)
+        resumeTime = new Date(TimeUnit.MILLISECONDS.convert(timeSource.getEpochTimeNs(), TimeUnit.NANOSECONDS)
             + TimeUnit.MILLISECONDS.convert(timeoutSeconds, TimeUnit.SECONDS));
       } catch (IllegalArgumentException e) {
         op.addError("Invalid 'timeout' value for suspend trigger: " + triggerName);

--- a/solr/core/src/java/org/apache/solr/cloud/autoscaling/IndexSizeTrigger.java
+++ b/solr/core/src/java/org/apache/solr/cloud/autoscaling/IndexSizeTrigger.java
@@ -353,7 +353,7 @@ public class IndexSizeTrigger extends TriggerBase {
       return;
     }
 
-    long now = cloudManager.getTimeSource().getTimeNs();
+    long now = cloudManager.getTimeSource().getEpochTimeNs();
 
     // now check thresholds
 

--- a/solr/core/src/java/org/apache/solr/cloud/autoscaling/MetricTrigger.java
+++ b/solr/core/src/java/org/apache/solr/cloud/autoscaling/MetricTrigger.java
@@ -159,7 +159,7 @@ public class MetricTrigger extends TriggerBase {
       values.forEach((tag, rate) -> rates.computeIfAbsent(node, s -> (Number) rate));
     }
 
-    long now = cloudManager.getTimeSource().getTimeNs();
+    long now = cloudManager.getTimeSource().getEpochTimeNs();
     // check for exceeded rates and filter out those with less than waitFor from previous events
     Map<String, Number> hotNodes = rates.entrySet().stream()
         .filter(entry -> waitForElapsed(entry.getKey(), now, lastNodeEvent))

--- a/solr/core/src/java/org/apache/solr/cloud/autoscaling/NodeAddedTrigger.java
+++ b/solr/core/src/java/org/apache/solr/cloud/autoscaling/NodeAddedTrigger.java
@@ -93,7 +93,7 @@ public class NodeAddedTrigger extends TriggerBase {
         if (lastLiveNodes.contains(n) && !nodeNameVsTimeAdded.containsKey(n)) {
           // since {@code #restoreState(AutoScaling.Trigger)} is called first, the timeAdded for a node may also be restored
           log.debug("Adding node from marker path: {}", n);
-          nodeNameVsTimeAdded.put(n, cloudManager.getTimeSource().getTimeNs());
+          nodeNameVsTimeAdded.put(n, cloudManager.getTimeSource().getEpochTimeNs());
         }
       });
     } catch (NoSuchElementException e) {
@@ -192,7 +192,7 @@ public class NodeAddedTrigger extends TriggerBase {
       Set<String> copyOfNew = new HashSet<>(newLiveNodes);
       copyOfNew.removeAll(lastLiveNodes);
       copyOfNew.forEach(n -> {
-        long eventTime = cloudManager.getTimeSource().getTimeNs();
+        long eventTime = cloudManager.getTimeSource().getEpochTimeNs();
         log.debug("Tracking new node: {} at time {}", n, eventTime);
         nodeNameVsTimeAdded.put(n, eventTime);
       });
@@ -204,7 +204,7 @@ public class NodeAddedTrigger extends TriggerBase {
         Map.Entry<String, Long> entry = it.next();
         String nodeName = entry.getKey();
         Long timeAdded = entry.getValue();
-        long now = cloudManager.getTimeSource().getTimeNs();
+        long now = cloudManager.getTimeSource().getEpochTimeNs();
         if (TimeUnit.SECONDS.convert(now - timeAdded, TimeUnit.NANOSECONDS) >= getWaitForSecond()) {
           nodeNames.add(nodeName);
           times.add(timeAdded);
@@ -215,7 +215,7 @@ public class NodeAddedTrigger extends TriggerBase {
         if (processor != null) {
           if (log.isDebugEnabled()) {
             log.debug("NodeAddedTrigger {} firing registered processor for nodes: {} added at times {}, now={}", name,
-                nodeNames, times, cloudManager.getTimeSource().getTimeNs());
+                nodeNames, times, cloudManager.getTimeSource().getEpochTimeNs());
           }
           if (processor.process(new NodeAddedEvent(getEventType(), getName(), times, nodeNames, preferredOp, replicaType))) {
             // remove from tracking set only if the fire was accepted

--- a/solr/core/src/java/org/apache/solr/cloud/autoscaling/NodeLostTrigger.java
+++ b/solr/core/src/java/org/apache/solr/cloud/autoscaling/NodeLostTrigger.java
@@ -90,7 +90,7 @@ public class NodeLostTrigger extends TriggerBase {
         if (!lastLiveNodes.contains(n) && !nodeNameVsTimeRemoved.containsKey(n)) {
           // since {@code #restoreState(AutoScaling.Trigger)} is called first, the timeRemoved for a node may also be restored
           log.debug("Adding lost node from marker path: {}", n);
-          nodeNameVsTimeRemoved.put(n, cloudManager.getTimeSource().getTimeNs());
+          nodeNameVsTimeRemoved.put(n, cloudManager.getTimeSource().getEpochTimeNs());
         }
       });
     } catch (NoSuchElementException e) {
@@ -184,7 +184,7 @@ public class NodeLostTrigger extends TriggerBase {
       copyOfLastLiveNodes.removeAll(newLiveNodes);
       copyOfLastLiveNodes.forEach(n -> {
         log.debug("Tracking lost node: {}", n);
-        nodeNameVsTimeRemoved.put(n, cloudManager.getTimeSource().getTimeNs());
+        nodeNameVsTimeRemoved.put(n, cloudManager.getTimeSource().getEpochTimeNs());
       });
 
       // has enough time expired to trigger events for a node?
@@ -194,7 +194,7 @@ public class NodeLostTrigger extends TriggerBase {
         Map.Entry<String, Long> entry = it.next();
         String nodeName = entry.getKey();
         Long timeRemoved = entry.getValue();
-        long now = cloudManager.getTimeSource().getTimeNs();
+        long now = cloudManager.getTimeSource().getEpochTimeNs();
         long te = TimeUnit.SECONDS.convert(now - timeRemoved, TimeUnit.NANOSECONDS);
         if (te >= getWaitForSecond()) {
           nodeNames.add(nodeName);

--- a/solr/core/src/java/org/apache/solr/cloud/autoscaling/ScheduledTrigger.java
+++ b/solr/core/src/java/org/apache/solr/cloud/autoscaling/ScheduledTrigger.java
@@ -192,7 +192,7 @@ public class ScheduledTrigger extends TriggerBase {
       }
       // Even though we are skipping the event, we need to notify any listeners of the IGNORED stage
       // so we create a dummy event with the ignored=true flag and ScheduledTriggers will do the rest
-      if (processor != null && processor.process(new ScheduledEvent(getEventType(), getName(), timeSource.getTimeNs(),
+      if (processor != null && processor.process(new ScheduledEvent(getEventType(), getName(), timeSource.getEpochTimeNs(),
           preferredOp, now.toEpochMilli(), true))) {
         lastRunAt = nextRunTime;
         return;
@@ -204,7 +204,7 @@ public class ScheduledTrigger extends TriggerBase {
         log.debug("ScheduledTrigger {} firing registered processor for scheduled time {}, now={}", name,
             nextRunTime, now);
       }
-      if (processor.process(new ScheduledEvent(getEventType(), getName(), timeSource.getTimeNs(),
+      if (processor.process(new ScheduledEvent(getEventType(), getName(), timeSource.getEpochTimeNs(),
           preferredOp, now.toEpochMilli()))) {
         lastRunAt = nextRunTime; // set to nextRunTime instead of now to avoid drift
       }

--- a/solr/core/src/java/org/apache/solr/cloud/autoscaling/SearchRateTrigger.java
+++ b/solr/core/src/java/org/apache/solr/cloud/autoscaling/SearchRateTrigger.java
@@ -405,7 +405,7 @@ public class SearchRateTrigger extends TriggerBase {
         });
       });
     }
-    long now = cloudManager.getTimeSource().getTimeNs();
+    long now = cloudManager.getTimeSource().getEpochTimeNs();
     Map<String, Double> hotNodes = new HashMap<>();
     Map<String, Double> coldNodes = new HashMap<>();
 

--- a/solr/core/src/java/org/apache/solr/cloud/autoscaling/TriggerEventQueue.java
+++ b/solr/core/src/java/org/apache/solr/cloud/autoscaling/TriggerEventQueue.java
@@ -53,7 +53,7 @@ public class TriggerEventQueue {
   }
 
   public boolean offerEvent(TriggerEvent event) {
-    event.getProperties().put(ENQUEUE_TIME, timeSource.getTimeNs());
+    event.getProperties().put(ENQUEUE_TIME, timeSource.getEpochTimeNs());
     try {
       byte[] data = Utils.toJSON(event);
       delegate.offer(data);
@@ -116,7 +116,7 @@ public class TriggerEventQueue {
 
   private TriggerEvent fromMap(Map<String, Object> map) {
     TriggerEvent res = TriggerEvent.fromMap(map);
-    res.getProperties().put(DEQUEUE_TIME, timeSource.getTimeNs());
+    res.getProperties().put(DEQUEUE_TIME, timeSource.getEpochTimeNs());
     return res;
   }
 }

--- a/solr/core/src/test/org/apache/solr/cloud/autoscaling/ExecutePlanActionTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/autoscaling/ExecutePlanActionTest.java
@@ -183,7 +183,7 @@ public class ExecutePlanActionTest extends SolrCloudTestCase {
       List<CollectionAdminRequest.AsyncCollectionAdminRequest> operations = Lists.asList(moveReplica, new CollectionAdminRequest.AsyncCollectionAdminRequest[]{mockRequest});
       NodeLostTrigger.NodeLostEvent nodeLostEvent = new NodeLostTrigger.NodeLostEvent
         (TriggerEventType.NODELOST, "mock_trigger_name",
-         Collections.singletonList(cloudManager.getTimeSource().getTimeNs()),
+         Collections.singletonList(cloudManager.getTimeSource().getEpochTimeNs()),
          Collections.singletonList(sourceNodeName),
          CollectionParams.CollectionAction.MOVEREPLICA.toLower());
       ActionContext actionContext = new ActionContext(survivor.getCoreContainer().getZkController().getSolrCloudManager(), null,

--- a/solr/core/src/test/org/apache/solr/cloud/autoscaling/IndexSizeTriggerMixedBoundsTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/autoscaling/IndexSizeTriggerMixedBoundsTest.java
@@ -117,7 +117,7 @@ public class IndexSizeTriggerMixedBoundsTest extends SolrCloudTestCase {
     public synchronized void onEvent(TriggerEvent event, TriggerEventProcessorStage stage, String actionName,
                                      ActionContext context, Throwable error, String message) {
       List<CapturedEvent> lst = listenerEvents.computeIfAbsent(config.name, s -> new ArrayList<>());
-      CapturedEvent ev = new CapturedEvent(timeSource.getTimeNs(), context, config, stage, actionName, event, message);
+      CapturedEvent ev = new CapturedEvent(timeSource.getEpochTimeNs(), context, config, stage, actionName, event, message);
       log.info("=======> {}", ev);
       lst.add(ev);
     }

--- a/solr/core/src/test/org/apache/solr/cloud/autoscaling/IndexSizeTriggerSizeEstimationTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/autoscaling/IndexSizeTriggerSizeEstimationTest.java
@@ -119,7 +119,7 @@ public class IndexSizeTriggerSizeEstimationTest extends SolrCloudTestCase {
     public synchronized void onEvent(TriggerEvent event, TriggerEventProcessorStage stage, String actionName,
                                      ActionContext context, Throwable error, String message) {
       List<CapturedEvent> lst = listenerEvents.computeIfAbsent(config.name, s -> new ArrayList<>());
-      CapturedEvent ev = new CapturedEvent(timeSource.getTimeNs(), context, config, stage, actionName, event, message);
+      CapturedEvent ev = new CapturedEvent(timeSource.getEpochTimeNs(), context, config, stage, actionName, event, message);
       log.info("=======> {}", ev);
       lst.add(ev);
     }

--- a/solr/core/src/test/org/apache/solr/cloud/autoscaling/IndexSizeTriggerTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/autoscaling/IndexSizeTriggerTest.java
@@ -179,7 +179,7 @@ public class IndexSizeTriggerTest extends SolrCloudTestCase {
       trigger.setProcessor(event -> {
         if (fired.compareAndSet(false, true)) {
           eventRef.set(event);
-          long currentTimeNanos = timeSource.getTimeNs();
+          long currentTimeNanos = timeSource.getEpochTimeNs();
           long eventTimeNanos = event.getEventTime();
           long waitForNanos = TimeUnit.NANOSECONDS.convert(waitForSeconds, TimeUnit.SECONDS) - WAIT_FOR_DELTA_NANOS;
           if (currentTimeNanos - eventTimeNanos <= waitForNanos) {
@@ -244,7 +244,7 @@ public class IndexSizeTriggerTest extends SolrCloudTestCase {
     public synchronized void onEvent(TriggerEvent event, TriggerEventProcessorStage stage, String actionName,
                                      ActionContext context, Throwable error, String message) {
       List<CapturedEvent> lst = listenerEvents.computeIfAbsent(config.name, s -> new ArrayList<>());
-      CapturedEvent ev = new CapturedEvent(timeSource.getTimeNs(), context, config, stage, actionName, event, message);
+      CapturedEvent ev = new CapturedEvent(timeSource.getEpochTimeNs(), context, config, stage, actionName, event, message);
       log.info("=======> {}", ev);
       lst.add(ev);
     }
@@ -678,7 +678,7 @@ public class IndexSizeTriggerTest extends SolrCloudTestCase {
       trigger.setProcessor(event -> {
         if (fired.compareAndSet(false, true)) {
           eventRef.set(event);
-          long currentTimeNanos = timeSource.getTimeNs();
+          long currentTimeNanos = timeSource.getEpochTimeNs();
           long eventTimeNanos = event.getEventTime();
           long waitForNanos = TimeUnit.NANOSECONDS.convert(waitForSeconds, TimeUnit.SECONDS) - WAIT_FOR_DELTA_NANOS;
           if (currentTimeNanos - eventTimeNanos <= waitForNanos) {

--- a/solr/core/src/test/org/apache/solr/cloud/autoscaling/MetricTriggerIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/autoscaling/MetricTriggerIntegrationTest.java
@@ -154,7 +154,7 @@ public class MetricTriggerIntegrationTest extends SolrCloudTestCase {
     Thread.sleep(2000);
     assertEquals(listenerEvents.toString(), 4, listenerEvents.get("srt").size());
     CapturedEvent ev = listenerEvents.get("srt").get(0);
-    long now = timeSource.getTimeNs();
+    long now = timeSource.getEpochTimeNs();
     // verify waitFor
     assertTrue(TimeUnit.SECONDS.convert(waitForSeconds, TimeUnit.NANOSECONDS) - WAIT_FOR_DELTA_NANOS <= now - ev.event.getEventTime());
     assertEquals(collectionName, ev.event.getProperties().get("collection"));
@@ -197,7 +197,7 @@ public class MetricTriggerIntegrationTest extends SolrCloudTestCase {
     Thread.sleep(2000);
     assertEquals(listenerEvents.toString(), 4, listenerEvents.get("srt").size());
     ev = listenerEvents.get("srt").get(0);
-    now = timeSource.getTimeNs();
+    now = timeSource.getEpochTimeNs();
     // verify waitFor
     assertTrue(TimeUnit.SECONDS.convert(waitForSeconds, TimeUnit.NANOSECONDS) - WAIT_FOR_DELTA_NANOS <= now - ev.event.getEventTime());
     assertEquals(collectionName, ev.event.getProperties().get("collection"));
@@ -210,7 +210,7 @@ public class MetricTriggerIntegrationTest extends SolrCloudTestCase {
     @Override
     public void process(TriggerEvent event, ActionContext context) throws Exception {
       try {
-        long currentTimeNanos = context.getCloudManager().getTimeSource().getTimeNs();
+        long currentTimeNanos = context.getCloudManager().getTimeSource().getEpochTimeNs();
         long eventTimeNanos = event.getEventTime();
         long waitForNanos = TimeUnit.NANOSECONDS.convert(waitForSeconds, TimeUnit.SECONDS) - WAIT_FOR_DELTA_NANOS;
         if (currentTimeNanos - eventTimeNanos <= waitForNanos) {
@@ -236,7 +236,7 @@ public class MetricTriggerIntegrationTest extends SolrCloudTestCase {
     public synchronized void onEvent(TriggerEvent event, TriggerEventProcessorStage stage, String actionName,
                                      ActionContext context, Throwable error, String message) {
       List<CapturedEvent> lst = listenerEvents.computeIfAbsent(config.name, s -> new ArrayList<>());
-      lst.add(new CapturedEvent(timeSource.getTimeNs(), context, config, stage, actionName, event, message));
+      lst.add(new CapturedEvent(timeSource.getEpochTimeNs(), context, config, stage, actionName, event, message));
                                 
     }
   }

--- a/solr/core/src/test/org/apache/solr/cloud/autoscaling/NodeAddedTriggerIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/autoscaling/NodeAddedTriggerIntegrationTest.java
@@ -164,7 +164,7 @@ public class NodeAddedTriggerIntegrationTest extends SolrCloudTestCase {
     // since we know the nodeAdded event has been detected, we can recored the current timestamp
     // (relative to the cluster's time source) and later assert that (restored state) correctly
     // tracked that the event happened prior to "now"
-    final long maxEventTimeNs = cloudManager.getTimeSource().getTimeNs();
+    final long maxEventTimeNs = cloudManager.getTimeSource().getEpochTimeNs();
     
     //
     // now replace the trigger with a new instance to test that the state gets copied over correctly
@@ -282,7 +282,7 @@ public class NodeAddedTriggerIntegrationTest extends SolrCloudTestCase {
       try {
         if (triggerFired.compareAndSet(false, true)) {
           events.add(event);
-          long currentTimeNanos = actionContext.getCloudManager().getTimeSource().getTimeNs();
+          long currentTimeNanos = actionContext.getCloudManager().getTimeSource().getEpochTimeNs();
           long eventTimeNanos = event.getEventTime();
           long waitForNanos = TimeUnit.NANOSECONDS.convert(waitForSeconds, TimeUnit.SECONDS) - WAIT_FOR_DELTA_NANOS;
           if (currentTimeNanos - eventTimeNanos <= waitForNanos) {

--- a/solr/core/src/test/org/apache/solr/cloud/autoscaling/NodeAddedTriggerTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/autoscaling/NodeAddedTriggerTest.java
@@ -97,7 +97,7 @@ public class NodeAddedTriggerTest extends SolrCloudTestCase {
       trigger.setProcessor(event -> {
         if (fired.compareAndSet(false, true)) {
           eventRef.set(event);
-          long currentTimeNanos = cloudManager.getTimeSource().getTimeNs();
+          long currentTimeNanos = cloudManager.getTimeSource().getEpochTimeNs();
           long eventTimeNanos = event.getEventTime();
           long waitForNanos = TimeUnit.NANOSECONDS.convert(waitForSeconds, TimeUnit.SECONDS) - WAIT_FOR_DELTA_NANOS;
           if (currentTimeNanos - eventTimeNanos <= waitForNanos) {
@@ -144,7 +144,7 @@ public class NodeAddedTriggerTest extends SolrCloudTestCase {
       AtomicBoolean fired = new AtomicBoolean(false);
       trigger.setProcessor(event -> {
         if (fired.compareAndSet(false, true)) {
-          long currentTimeNanos = cloudManager.getTimeSource().getTimeNs();
+          long currentTimeNanos = cloudManager.getTimeSource().getEpochTimeNs();
           long eventTimeNanos = event.getEventTime();
           long waitForNanos = TimeUnit.NANOSECONDS.convert(waitForSeconds, TimeUnit.SECONDS) - WAIT_FOR_DELTA_NANOS;
           if (currentTimeNanos - eventTimeNanos <= waitForNanos) {
@@ -295,7 +295,7 @@ public class NodeAddedTriggerTest extends SolrCloudTestCase {
       AtomicReference<TriggerEvent> eventRef = new AtomicReference<>();
       newTrigger.setProcessor(event -> {
         //the processor may get called 2 times, for newly added node and initial nodes
-        long currentTimeNanos = cloudManager.getTimeSource().getTimeNs();
+        long currentTimeNanos = cloudManager.getTimeSource().getEpochTimeNs();
         long eventTimeNanos = event.getEventTime();
         long waitForNanos = TimeUnit.NANOSECONDS.convert(waitForSeconds, TimeUnit.SECONDS) - WAIT_FOR_DELTA_NANOS;
         if (currentTimeNanos - eventTimeNanos <= waitForNanos) {

--- a/solr/core/src/test/org/apache/solr/cloud/autoscaling/NodeLostTriggerIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/autoscaling/NodeLostTriggerIntegrationTest.java
@@ -180,7 +180,7 @@ public class NodeLostTriggerIntegrationTest extends SolrCloudTestCase {
     // since we know the nodeLost event has been detected, we can recored the current timestamp
     // (relative to the cluster's time source) and later assert that (restored state) correctly
     // tracked that the event happened prior to "now"
-    final long maxEventTimeNs = cloudManager.getTimeSource().getTimeNs();
+    final long maxEventTimeNs = cloudManager.getTimeSource().getEpochTimeNs();
     
     // even though our trigger has detected a lost node, the *action* we registered should not have
     // been run yet, due to the large waitFor configuration...
@@ -317,7 +317,7 @@ public class NodeLostTriggerIntegrationTest extends SolrCloudTestCase {
       try {
         if (triggerFired.compareAndSet(false, true)) {
           events.add(event);
-          long currentTimeNanos = actionContext.getCloudManager().getTimeSource().getTimeNs();
+          long currentTimeNanos = actionContext.getCloudManager().getTimeSource().getEpochTimeNs();
           long eventTimeNanos = event.getEventTime();
           long waitForNanos = TimeUnit.NANOSECONDS.convert(waitForSeconds, TimeUnit.SECONDS) - WAIT_FOR_DELTA_NANOS;
           if (currentTimeNanos - eventTimeNanos <= waitForNanos) {

--- a/solr/core/src/test/org/apache/solr/cloud/autoscaling/NodeLostTriggerTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/autoscaling/NodeLostTriggerTest.java
@@ -99,7 +99,7 @@ public class NodeLostTriggerTest extends SolrCloudTestCase {
       trigger.setProcessor(event -> {
         if (fired.compareAndSet(false, true)) {
           eventRef.set(event);
-          long currentTimeNanos = cloudManager.getTimeSource().getTimeNs();
+          long currentTimeNanos = cloudManager.getTimeSource().getEpochTimeNs();
           long eventTimeNanos = event.getEventTime();
           long waitForNanos = TimeUnit.NANOSECONDS.convert(waitForSeconds, TimeUnit.SECONDS) - WAIT_FOR_DELTA_NANOS;
           if (currentTimeNanos - eventTimeNanos <= waitForNanos) {
@@ -151,7 +151,7 @@ public class NodeLostTriggerTest extends SolrCloudTestCase {
       trigger.setProcessor(event -> {
         if (fired.compareAndSet(false, true)) {
           eventRef.set(event);
-          long currentTimeNanos = cloudManager.getTimeSource().getTimeNs();
+          long currentTimeNanos = cloudManager.getTimeSource().getEpochTimeNs();
           long eventTimeNanos = event.getEventTime();
           long waitForNanos = TimeUnit.NANOSECONDS.convert(waitTime, TimeUnit.SECONDS) - WAIT_FOR_DELTA_NANOS;
           if (currentTimeNanos - eventTimeNanos <= waitForNanos) {
@@ -346,7 +346,7 @@ public class NodeLostTriggerTest extends SolrCloudTestCase {
       newTrigger.setProcessor(event -> {
         if (fired.compareAndSet(false, true)) {
           eventRef.set(event);
-          long currentTimeNanos = cloudManager.getTimeSource().getTimeNs();
+          long currentTimeNanos = cloudManager.getTimeSource().getEpochTimeNs();
           long eventTimeNanos = event.getEventTime();
           long waitForNanos = TimeUnit.NANOSECONDS.convert(waitForSeconds, TimeUnit.SECONDS) - WAIT_FOR_DELTA_NANOS;
           if (currentTimeNanos - eventTimeNanos <= waitForNanos) {

--- a/solr/core/src/test/org/apache/solr/cloud/autoscaling/RestoreTriggerStateTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/autoscaling/RestoreTriggerStateTest.java
@@ -143,7 +143,7 @@ public class RestoreTriggerStateTest extends SolrCloudTestCase {
       try {
         if (triggerFired.compareAndSet(false, true))  {
           events.add(event);
-          long currentTimeNanos = actionContext.getCloudManager().getTimeSource().getTimeNs();
+          long currentTimeNanos = actionContext.getCloudManager().getTimeSource().getEpochTimeNs();
           long eventTimeNanos = event.getEventTime();
           long waitForNanos = TimeUnit.NANOSECONDS.convert(waitForSeconds, TimeUnit.SECONDS) - WAIT_FOR_DELTA_NANOS;
           if (currentTimeNanos - eventTimeNanos <= waitForNanos) {

--- a/solr/core/src/test/org/apache/solr/cloud/autoscaling/ScheduledMaintenanceTriggerTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/autoscaling/ScheduledMaintenanceTriggerTest.java
@@ -183,7 +183,7 @@ public class ScheduledMaintenanceTriggerTest extends SolrCloudTestCase {
     public synchronized void onEvent(TriggerEvent event, TriggerEventProcessorStage stage, String actionName,
                                      ActionContext context, Throwable error, String message) {
       List<CapturedEvent> lst = listenerEvents.computeIfAbsent(config.name, s -> new ArrayList<>());
-      CapturedEvent ev = new CapturedEvent(timeSource.getTimeNs(), context, config, stage, actionName, event, message);
+      CapturedEvent ev = new CapturedEvent(timeSource.getEpochTimeNs(), context, config, stage, actionName, event, message);
       log.info("=======> {}", ev);
       lst.add(ev);
     }

--- a/solr/core/src/test/org/apache/solr/cloud/autoscaling/SearchRateTriggerIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/autoscaling/SearchRateTriggerIntegrationTest.java
@@ -237,7 +237,7 @@ public class SearchRateTriggerIntegrationTest extends SolrCloudTestCase {
     assertNull(events.get(2).actionName);
 
     CapturedEvent ev = events.get(0);
-    long now = timeSource.getTimeNs();
+    long now = timeSource.getEpochTimeNs();
     // verify waitFor
     assertTrue(TimeUnit.SECONDS.convert(waitForSeconds, TimeUnit.NANOSECONDS) - WAIT_FOR_DELTA_NANOS <= now - ev.event.getEventTime());
     Map<String, Double> nodeRates = (Map<String, Double>) ev.event.getProperties().get(SearchRateTrigger.HOT_NODES);
@@ -715,7 +715,7 @@ public class SearchRateTriggerIntegrationTest extends SolrCloudTestCase {
     @Override
     public synchronized void onEvent(TriggerEvent event, TriggerEventProcessorStage stage, String actionName,
                                      ActionContext context, Throwable error, String message) {
-      CapturedEvent ev = new CapturedEvent(timeSource.getTimeNs(), context, config, stage, actionName, event, message);
+      CapturedEvent ev = new CapturedEvent(timeSource.getEpochTimeNs(), context, config, stage, actionName, event, message);
       final CountDownLatch latch = listenerEventLatch;
       synchronized (latch) {
         if (0 == latch.getCount()) {

--- a/solr/core/src/test/org/apache/solr/cloud/autoscaling/TriggerCooldownIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/autoscaling/TriggerCooldownIntegrationTest.java
@@ -187,7 +187,7 @@ public class TriggerCooldownIntegrationTest extends SolrCloudTestCase {
     public void process(TriggerEvent event, ActionContext actionContext) {
       try {
         if (triggerFired.compareAndSet(false, true)) {
-          long currentTimeNanos = actionContext.getCloudManager().getTimeSource().getTimeNs();
+          long currentTimeNanos = actionContext.getCloudManager().getTimeSource().getEpochTimeNs();
           long eventTimeNanos = event.getEventTime();
           long waitForNanos = TimeUnit.NANOSECONDS.convert(waitForSeconds, TimeUnit.SECONDS) - WAIT_FOR_DELTA_NANOS;
           if (currentTimeNanos - eventTimeNanos <= waitForNanos) {
@@ -222,7 +222,7 @@ public class TriggerCooldownIntegrationTest extends SolrCloudTestCase {
     public synchronized void onEvent(TriggerEvent event, TriggerEventProcessorStage stage, String actionName,
                                      ActionContext context, Throwable error, String message) {
       List<CapturedEvent> lst = listenerEvents.computeIfAbsent(config.name, s -> new ArrayList<>());
-      lst.add(new CapturedEvent(timeSource.getTimeNs(),
+      lst.add(new CapturedEvent(timeSource.getEpochTimeNs(),
                                 context, config, stage, actionName, event, message));
     }
   }

--- a/solr/core/src/test/org/apache/solr/cloud/autoscaling/TriggerEventQueueTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/autoscaling/TriggerEventQueueTest.java
@@ -64,7 +64,7 @@ public class TriggerEventQueueTest extends SolrTestCaseJ4 {
     hotHosts.put("host1", 1);
     hotHosts.put("host2", 1);
     TriggerEvent ev = new MetricTrigger.MetricBreachedEvent("testTrigger", "testCollection", "shard1",
-        CollectionParams.CollectionAction.ADDREPLICA.toLower(), cloudManager.getTimeSource().getTimeNs(),
+        CollectionParams.CollectionAction.ADDREPLICA.toLower(), cloudManager.getTimeSource().getEpochTimeNs(),
         "foo", hotHosts);
     queue.offerEvent(ev);
     ev = queue.pollEvent();

--- a/solr/core/src/test/org/apache/solr/cloud/autoscaling/TriggerIntegrationTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/autoscaling/TriggerIntegrationTest.java
@@ -8,7 +8,7 @@
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
+ * Unless requiCloudMLTQParserTestred by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
@@ -388,7 +388,7 @@ public class TriggerIntegrationTest extends SolrCloudTestCase {
       try {
         if (triggerFired.compareAndSet(false, true))  {
           events.add(event);
-          long currentTimeNanos = actionContext.getCloudManager().getTimeSource().getTimeNs();
+          long currentTimeNanos = actionContext.getCloudManager().getTimeSource().getEpochTimeNs();
           long eventTimeNanos = event.getEventTime();
           long waitForNanos = TimeUnit.NANOSECONDS.convert(waitForSeconds, TimeUnit.SECONDS) - WAIT_FOR_DELTA_NANOS;
           if (currentTimeNanos - eventTimeNanos <= waitForNanos) {
@@ -548,7 +548,7 @@ public class TriggerIntegrationTest extends SolrCloudTestCase {
     public synchronized void onEvent(TriggerEvent event, TriggerEventProcessorStage stage, String actionName,
                                      ActionContext context, Throwable error, String message) {
       List<CapturedEvent> lst = listenerEvents.computeIfAbsent(config.name, s -> new ArrayList<>());
-      CapturedEvent ev = new CapturedEvent(timeSource.getTimeNs(), context, config, stage, actionName, event, message);
+      CapturedEvent ev = new CapturedEvent(timeSource.getEpochTimeNs(), context, config, stage, actionName, event, message);
                                            
       lst.add(ev);
       allListenerEvents.add(ev);

--- a/solr/core/src/test/org/apache/solr/cloud/autoscaling/sim/TestSimExecutePlanAction.java
+++ b/solr/core/src/test/org/apache/solr/cloud/autoscaling/sim/TestSimExecutePlanAction.java
@@ -147,7 +147,7 @@ public class TestSimExecutePlanAction extends SimSolrCloudTestCase {
       };
       List<CollectionAdminRequest.AsyncCollectionAdminRequest> operations = Lists.asList(moveReplica, new CollectionAdminRequest.AsyncCollectionAdminRequest[]{mockRequest});
       NodeLostTrigger.NodeLostEvent nodeLostEvent = new NodeLostTrigger.NodeLostEvent(TriggerEventType.NODELOST,
-          "mock_trigger_name", Collections.singletonList(SIM_TIME_SOURCE.getTimeNs()),
+          "mock_trigger_name", Collections.singletonList(SIM_TIME_SOURCE.getEpochTimeNs()),
           Collections.singletonList(sourceNodeName), CollectionParams.CollectionAction.MOVEREPLICA.toLower());
       ActionContext actionContext = new ActionContext(cluster, null,
           new HashMap<>(Collections.singletonMap("operations", operations)));

--- a/solr/core/src/test/org/apache/solr/cloud/autoscaling/sim/TestSimLargeCluster.java
+++ b/solr/core/src/test/org/apache/solr/cloud/autoscaling/sim/TestSimLargeCluster.java
@@ -124,7 +124,7 @@ public class TestSimLargeCluster extends SimSolrCloudTestCase {
     @Override
     public synchronized void onEvent(TriggerEvent event, TriggerEventProcessorStage stage, String actionName,
                                      ActionContext context, Throwable error, String message) {
-      CapturedEvent ev = new CapturedEvent(cluster.getTimeSource().getTimeNs(), context, config, stage, actionName, event, message);
+      CapturedEvent ev = new CapturedEvent(cluster.getTimeSource().getEpochTimeNs(), context, config, stage, actionName, event, message);
       final CountDownLatch latch = listenerEventLatch;
       synchronized (latch) {
         if (0 == latch.getCount()) {

--- a/solr/core/src/test/org/apache/solr/cloud/autoscaling/sim/TestSimNodeAddedTrigger.java
+++ b/solr/core/src/test/org/apache/solr/cloud/autoscaling/sim/TestSimNodeAddedTrigger.java
@@ -93,7 +93,7 @@ public class TestSimNodeAddedTrigger extends SimSolrCloudTestCase {
       trigger.setProcessor(event -> {
         if (fired.compareAndSet(false, true)) {
           eventRef.set(event);
-          long currentTimeNanos = timeSource.getTimeNs();
+          long currentTimeNanos = timeSource.getEpochTimeNs();
           long eventTimeNanos = event.getEventTime();
           long waitForNanos = TimeUnit.NANOSECONDS.convert(waitForSeconds, TimeUnit.SECONDS) - WAIT_FOR_DELTA_NANOS;
           if (currentTimeNanos - eventTimeNanos <= waitForNanos) {
@@ -135,7 +135,7 @@ public class TestSimNodeAddedTrigger extends SimSolrCloudTestCase {
       AtomicBoolean fired = new AtomicBoolean(false);
       trigger.setProcessor(event -> {
         if (fired.compareAndSet(false, true)) {
-          long currentTimeNanos = timeSource.getTimeNs();
+          long currentTimeNanos = timeSource.getEpochTimeNs();
           long eventTimeNanos = event.getEventTime();
           long waitForNanos = TimeUnit.NANOSECONDS.convert(waitForSeconds, TimeUnit.SECONDS) - WAIT_FOR_DELTA_NANOS;
           if (currentTimeNanos - eventTimeNanos <= waitForNanos) {
@@ -282,7 +282,7 @@ public class TestSimNodeAddedTrigger extends SimSolrCloudTestCase {
       newTrigger.setProcessor(event -> {
         if (fired.compareAndSet(false, true)) {
           eventRef.set(event);
-          long currentTimeNanos = timeSource.getTimeNs();
+          long currentTimeNanos = timeSource.getEpochTimeNs();
           long eventTimeNanos = event.getEventTime();
           long waitForNanos = TimeUnit.NANOSECONDS.convert(waitForSeconds, TimeUnit.SECONDS) - WAIT_FOR_DELTA_NANOS;
           if (currentTimeNanos - eventTimeNanos <= waitForNanos) {

--- a/solr/core/src/test/org/apache/solr/cloud/autoscaling/sim/TestSimNodeLostTrigger.java
+++ b/solr/core/src/test/org/apache/solr/cloud/autoscaling/sim/TestSimNodeLostTrigger.java
@@ -95,7 +95,7 @@ public class TestSimNodeLostTrigger extends SimSolrCloudTestCase {
       trigger.setProcessor(event -> {
         if (fired.compareAndSet(false, true)) {
           eventRef.set(event);
-          long currentTimeNanos = timeSource.getTimeNs();
+          long currentTimeNanos = timeSource.getEpochTimeNs();
           long eventTimeNanos = event.getEventTime();
           long waitForNanos = TimeUnit.NANOSECONDS.convert(waitForSeconds, TimeUnit.SECONDS) - WAIT_FOR_DELTA_NANOS;
           if (currentTimeNanos - eventTimeNanos <= waitForNanos) {
@@ -138,7 +138,7 @@ public class TestSimNodeLostTrigger extends SimSolrCloudTestCase {
       AtomicBoolean fired = new AtomicBoolean(false);
       trigger.setProcessor(event -> {
         if (fired.compareAndSet(false, true)) {
-          long currentTimeNanos = timeSource.getTimeNs();
+          long currentTimeNanos = timeSource.getEpochTimeNs();
           long eventTimeNanos = event.getEventTime();
           long waitForNanos = TimeUnit.NANOSECONDS.convert(waitTime, TimeUnit.SECONDS) - WAIT_FOR_DELTA_NANOS;
           if (currentTimeNanos - eventTimeNanos <= waitForNanos) {
@@ -301,7 +301,7 @@ public class TestSimNodeLostTrigger extends SimSolrCloudTestCase {
       newTrigger.setProcessor(event -> {
         if (fired.compareAndSet(false, true)) {
           eventRef.set(event);
-          long currentTimeNanos = timeSource.getTimeNs();
+          long currentTimeNanos = timeSource.getEpochTimeNs();
           long eventTimeNanos = event.getEventTime();
           long waitForNanos = TimeUnit.NANOSECONDS.convert(waitForSeconds, TimeUnit.SECONDS) - WAIT_FOR_DELTA_NANOS;
           if (currentTimeNanos - eventTimeNanos <= waitForNanos) {

--- a/solr/core/src/test/org/apache/solr/cloud/autoscaling/sim/TestSimTriggerIntegration.java
+++ b/solr/core/src/test/org/apache/solr/cloud/autoscaling/sim/TestSimTriggerIntegration.java
@@ -341,7 +341,7 @@ public class TestSimTriggerIntegration extends SimSolrCloudTestCase {
     // since we know the nodeLost event has been detected, we can recored the current timestamp
     // (relative to the cluster's time source) and later assert that (restored state) correctly
     // tracked that the event happened prior to "now"
-    final long maxEventTimeNs = cluster.getTimeSource().getTimeNs();
+    final long maxEventTimeNs = cluster.getTimeSource().getEpochTimeNs();
     
     // even though our trigger has detected a lost node, the *action* we registered should not have
     // been run yet, due to the large waitFor configuration...
@@ -441,7 +441,7 @@ public class TestSimTriggerIntegration extends SimSolrCloudTestCase {
     // since we know the nodeAddded event has been detected, we can recored the current timestamp
     // (relative to the cluster's time source) and later assert that (restored state) correctly
     // tracked that the event happened prior to "now"
-    final long maxEventTimeNs = cluster.getTimeSource().getTimeNs();
+    final long maxEventTimeNs = cluster.getTimeSource().getEpochTimeNs();
     
     // even though our trigger has detected an added node, the *action* we registered should not have
     // been run yet, due to the large waitFor configuration...
@@ -670,7 +670,7 @@ public class TestSimTriggerIntegration extends SimSolrCloudTestCase {
       try {
         if (triggerFired.compareAndSet(false, true))  {
           events.add(event);
-          long currentTimeNanos = cluster.getTimeSource().getTimeNs();
+          long currentTimeNanos = cluster.getTimeSource().getEpochTimeNs();
           long eventTimeNanos = event.getEventTime();
           long waitForNanos = TimeUnit.NANOSECONDS.convert(waitForSeconds, TimeUnit.SECONDS) - WAIT_FOR_DELTA_NANOS;
           if (currentTimeNanos - eventTimeNanos <= waitForNanos) {
@@ -1093,7 +1093,7 @@ public class TestSimTriggerIntegration extends SimSolrCloudTestCase {
     @Override
     public synchronized void onEvent(TriggerEvent event, TriggerEventProcessorStage stage, String actionName,
                                      ActionContext context, Throwable error, String message) {
-      CapturedEvent ev = new CapturedEvent(cluster.getTimeSource().getTimeNs(), context, config, stage, actionName, event, message);
+      CapturedEvent ev = new CapturedEvent(cluster.getTimeSource().getEpochTimeNs(), context, config, stage, actionName, event, message);
       final CountDownLatch latch = listenerEventLatch;
       synchronized (latch) {
         if (0 == latch.getCount()) {
@@ -1358,7 +1358,7 @@ public class TestSimTriggerIntegration extends SimSolrCloudTestCase {
     public void process(TriggerEvent event, ActionContext context) throws Exception {
       try {
         events.add(event);
-        long currentTimeNanos = cluster.getTimeSource().getTimeNs();
+        long currentTimeNanos = cluster.getTimeSource().getEpochTimeNs();
         long eventTimeNanos = event.getEventTime();
         long waitForNanos = TimeUnit.NANOSECONDS.convert(waitForSeconds, TimeUnit.SECONDS) - WAIT_FOR_DELTA_NANOS;
         if (currentTimeNanos - eventTimeNanos <= waitForNanos) {
@@ -1459,7 +1459,7 @@ public class TestSimTriggerIntegration extends SimSolrCloudTestCase {
     assertNull(events.get(3).actionName);
 
     CapturedEvent ev = events.get(0);
-    long now = cluster.getTimeSource().getTimeNs();
+    long now = cluster.getTimeSource().getEpochTimeNs();
     // verify waitFor
     assertTrue(TimeUnit.SECONDS.convert(waitForSeconds, TimeUnit.NANOSECONDS) - WAIT_FOR_DELTA_NANOS <= now - ev.event.getEventTime());
     Map<String, Double> nodeRates = (Map<String, Double>)ev.event.getProperties().get(SearchRateTrigger.HOT_NODES);


### PR DESCRIPTION
[SOLR-16843](https://issues.apache.org/jira/browse/SOLR-16843)

<!--
_(If you are a project committer then you may remove some/all of the following template.)_

Before creating a pull request, please file an issue in the ASF Jira system for Solr:

* https://issues.apache.org/jira/projects/SOLR

For something minor (i.e. that wouldn't be worth putting in release notes), you can skip JIRA. 
To create a Jira issue, you will need to create an account there first.

The title of the PR should reference the Jira issue number in the form:

* SOLR-####: <short description of problem or changes>

SOLR must be fully capitalized. A short description helps people scanning pull requests for items they can work on.

Properly referencing the issue in the title ensures that Jira is correctly updated with code review comments and commits. -->


# Description

Autoscaling framework use timestamps returned by the JVM call System.nanoTime(), but according to the Javadoc, this is NOT an absolute timestamp. This is just a number relative to a random origin, and this origin will change each time the JVM is restarted.

This timestamp cannot be re-used across JVM instances (either in another Solr node or same node after JVM restart).

# Solution

For all timestamps that are either persisted at some point or used for event timestamps, use `getEpochTimeNs()` instead of `getTimeNs()`. Values returned by `getEpochTimeNs()` are absolute and can be safely compared.

